### PR TITLE
Update site copy for exa.ai clone

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,19 @@
-# Inteligir
+# OpenWebsets
 
-> Make lifelong learning as natural as checking your phone
+> Open source alternative to Exa Websets - Create, manage, and share web search collections
+
+## About
+
+OpenWebsets is an open source alternative to [Exa Websets](https://exa.ai/websets), inspired by tools like [Juicebox.ai](https://juicebox.ai/). It provides a platform for creating, organizing, and sharing web search collections with advanced filtering and collaboration features.
+
+## Features
+
+- Create and organize web search collections
+- Collaborate and share collections with others
+- Advanced search and filtering capabilities
+- Export and import collection data
+- Self-hosted and open source
+
+## Getting Started
+
+[Add setup instructions here]ne

--- a/apps/nextjs/public/favicon/site.webmanifest
+++ b/apps/nextjs/public/favicon/site.webmanifest
@@ -1,6 +1,6 @@
 {
-  "name": "Inteligir",
-  "short_name": "Inteligir",
+  "name": "OpenWebsets",
+  "short_name": "OpenWebsets",
   "icons": [
     {
       "src": "/favicon/web-app-manifest-192x192.png",

--- a/apps/nextjs/src/app/(marketing)/page.tsx
+++ b/apps/nextjs/src/app/(marketing)/page.tsx
@@ -3,27 +3,33 @@ import { WaitlistForm } from "./_components/waitlist-form";
 const Page = () => {
   return (
     <main className="mt-8 flex flex-col gap-4">
-      <h1>Make lifelong learning as natural as checking your phone.</h1>
+      <h1>Open source alternative to Exa Websets</h1>
       <p>
-        Turn your social feed into your personal university. Inteligir
-        transforms trending topics from your world into engaging, bite-sized
-        lessons delivered right to your phone.
+        Create, manage, and share powerful web search collections. OpenWebsets
+        gives you the tools to organize your research, build knowledge bases,
+        and collaborate on curated web content - all with complete control over your data.
       </p>
       <WaitlistForm />
       <div className="mt-3">
-        <p>How it works:</p>
+        <p>Key features:</p>
         <ol className="mt-2 list-inside list-decimal">
-          <li>Connect your social accounts (or your favorite news feeds)</li>
-          <li>Our AI identifies trending topics you care about</li>
-          <li>Receive personalized deep dives on the trending topics</li>
+          <li>Create and organize web search collections</li>
+          <li>Collaborate and share collections with others</li>
+          <li>Advanced search and filtering capabilities</li>
+          <li>Export and import collection data</li>
         </ol>
       </div>
       <p>
-        Perfect for curious minds who want to stay informed without information
-        overload. Whether it's the latest AI breakthrough, market trends, or
-        cultural phenomena – learn about what's happening in your world,
-        explained clearly and concisely.
+        Perfect for researchers, content creators, and teams who need to organize
+        web research. Whether you're building a knowledge base, curating resources
+        for a project, or collaborating on research - OpenWebsets provides the
+        open source foundation you need.
       </p>
+      <div className="mt-4 p-4 bg-muted rounded-lg">
+        <p className="text-sm text-muted-foreground">
+          <strong>Inspired by:</strong> <a href="https://exa.ai/websets" className="underline hover:no-underline" target="_blank" rel="noopener noreferrer">Exa Websets</a> and <a href="https://juicebox.ai/" className="underline hover:no-underline" target="_blank" rel="noopener noreferrer">Juicebox.ai</a>
+        </p>
+      </div>
     </main>
   );
 };

--- a/apps/nextjs/src/lib/site-config.ts
+++ b/apps/nextjs/src/lib/site-config.ts
@@ -1,7 +1,7 @@
 export const siteConfig = {
-  name: "Inteligir",
-  shortName: "Inteligir",
-  description: "Make lifelong learning as natural as checking your phone.",
+  name: "OpenWebsets",
+  shortName: "OpenWebsets",
+  description: "Open source alternative to Exa Websets - Create, manage, and share web search collections.",
   url:
     process.env.NODE_ENV === "development"
       ? "http://localhost:3000"

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "inteligir",
+  "name": "openwebsets",
   "private": true,
   "packageManager": "pnpm@10.18.0",
   "scripts": {


### PR DESCRIPTION
Rebrand the application to "OpenWebsets" and update all site copy to position it as an open-source alternative to Exa Websets for web search collection management.

---
<a href="https://cursor.com/background-agent?bcId=bc-351e9f91-afab-40ff-a8ff-774b9350038b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-351e9f91-afab-40ff-a8ff-774b9350038b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

