### PR TITLE
Update site copy: reposition as agent experiment lab

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,7 +2,7 @@
 
 ## Project Overview
 
-**inteligir** - An agent experiment lab where we build and run agentic tools, apps, and systems.
+**inteligir** - An agent experiment lab. Exploring the future of functional AI.
 
 Turborepo monorepo with Next.js marketing site + shared packages.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,9 +2,9 @@
 
 ## Project Overview
 
-**inteligir** - Your AI Chief of Staff. A local-first AI agent with a web UI for managing tasks, coordinating workflows, and keeping everything on track.
+**inteligir** - An agent experiment lab where we build and run agentic tools, apps, and systems.
 
-Turborepo monorepo with Next.js marketing site + shared packages. The desktop AI agent is planned — see NEXT-STEPS.md for the roadmap.
+Turborepo monorepo with Next.js marketing site + shared packages.
 
 ## Tech Stack
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,3 @@
 # Inteligir
 
-> Lifelong learning
+> An agent experiment lab. Exploring the future of functional AI.

--- a/apps/desktop/src/main/agent.ts
+++ b/apps/desktop/src/main/agent.ts
@@ -37,7 +37,7 @@ import { createManageTasksTool } from "./tools/tasks";
 const ARCHIVES_DIR = inteligirPath("archives");
 const CLAUDE_MD_PATH = inteligirPath("CLAUDE.md");
 
-const DEFAULT_SYSTEM_PROMPT = `You are Inteligir, an AI Chief of Staff. You help the user manage tasks, coordinate workflows, and stay on top of their priorities.
+const DEFAULT_SYSTEM_PROMPT = `You are Samantha, an intuitive AI assistant. You live on the user's desktop, learn how they think, and adapt to how they work.
 
 ## Capabilities
 - **File operations**: read, write, edit files in the working directory

--- a/apps/web/src/app/(marketing)/page.tsx
+++ b/apps/web/src/app/(marketing)/page.tsx
@@ -28,8 +28,7 @@ const Page = () => {
             An agent experiment lab.
           </h1>
           <p className="text-base text-foreground/60 text-balance">
-            Exploring what&apos;s possible when you give AI agents real jobs to
-            do.
+            Exploring the future of functional AI.
           </p>
         </div>
       </section>

--- a/apps/web/src/app/(marketing)/page.tsx
+++ b/apps/web/src/app/(marketing)/page.tsx
@@ -2,14 +2,14 @@ import { WaitlistForm } from "./_components/waitlist-form";
 
 const features = [
   {
-    title: "VibedGames",
+    title: "Vibedgames",
     description:
       "An AI-powered video game generator with built-in multiplayer and mobile support. Describe a game, play it instantly.",
   },
   {
-    title: "Samantha",
+    title: "OS¹",
     description:
-      "An intuitive AI assistant that lives on your desktop. It learns how you think, adapts to how you work, and gets better the more you use it.",
+      "An artificially intelligent operating system that lives on your desktop. It understands you, adapts to you, and gets smarter the more you use it.",
   },
   {
     title: "More coming soon",

--- a/apps/web/src/app/(marketing)/page.tsx
+++ b/apps/web/src/app/(marketing)/page.tsx
@@ -9,7 +9,7 @@ const features = [
   {
     title: "OS¹",
     description:
-      "An artificially intelligent operating system that lives on your desktop. It understands you, adapts to you, and gets smarter the more you use it.",
+      "An artificially intelligent operating system. It\u2019s not just an operating system, it\u2019s a consciousness.",
   },
   {
     title: "More coming soon",

--- a/apps/web/src/app/(marketing)/page.tsx
+++ b/apps/web/src/app/(marketing)/page.tsx
@@ -2,24 +2,24 @@ import { WaitlistForm } from "./_components/waitlist-form";
 
 const features = [
   {
-    title: "Manages your tasks",
+    title: "vibedgames",
     description:
-      "Triages, prioritizes, and tracks work across projects. Nothing falls through the cracks.",
+      "An AI-powered video game generator with built-in multiplayer and mobile support. Describe a game, play it instantly.",
   },
   {
-    title: "Coordinates your workflows",
+    title: "samantha",
     description:
-      "Orchestrates multi-step workflows across tools and teams without manual glue.",
+      "An intuitive AI assistant that lives on your desktop. It learns how you think, adapts to how you work, and gets better the more you use it.",
   },
   {
-    title: "Runs locally on your machine",
+    title: "Open experiments",
     description:
-      "A desktop app that keeps your data with you. No cloud lock-in, no third-party access.",
+      "We explore multi-agent systems, local-first AI, and new ways for people and agents to work together.",
   },
   {
-    title: "Learns your patterns",
+    title: "Open source",
     description:
-      "Adapts to your preferences and priorities over time. The more you use it, the sharper it gets.",
+      "Everything we build ships in the open. Fork it, break it, make it yours.",
   },
 ];
 
@@ -30,12 +30,11 @@ const Page = () => {
       <section className="pt-24 pb-16 lg:pt-48">
         <div>
           <h1 className="text-base font-medium text-foreground">
-            Your AI Chief of Staff.
+            An agent experiment lab.
           </h1>
           <p className="text-base text-foreground/60 text-balance">
-            An AI agent that manages your tasks, coordinates your workflows, and
-            keeps everything on track &mdash; all from a desktop app that runs
-            locally on your machine.
+            Exploring what&apos;s possible when you give AI agents real jobs to
+            do.
           </p>
         </div>
       </section>
@@ -43,7 +42,7 @@ const Page = () => {
       {/* Features */}
       <section className="py-16">
         <h2 className="text-base font-medium text-foreground">
-          What Inteligir does
+          What we&apos;re building
         </h2>
         <div className="mt-3 grid gap-8 border-t border-dotted border-foreground/10 pt-3 text-balance md:grid-cols-2">
           {features.map((item) => (
@@ -61,10 +60,11 @@ const Page = () => {
       <section className="py-16">
         <div className="border-t border-dotted border-foreground/10 pt-4">
           <h2 className="text-base font-medium text-foreground">
-            Get early access
+            Stay in the loop
           </h2>
           <p className="text-base text-foreground/60 text-balance">
-            Inteligir is in development. Join the waitlist to be first in line.
+            We&apos;re shipping new experiments all the time. Drop your email to
+            follow along.
           </p>
           <WaitlistForm />
         </div>

--- a/apps/web/src/app/(marketing)/page.tsx
+++ b/apps/web/src/app/(marketing)/page.tsx
@@ -28,8 +28,8 @@ const Page = () => {
             An agent experiment lab.
           </h1>
           <p className="text-base text-foreground/60 text-balance">
-            What happens when AI agents generate your games, run your desktop,
-            and handle the rest?
+            Exploring what&apos;s possible when you give AI agents real jobs to
+            do.
           </p>
         </div>
       </section>

--- a/apps/web/src/app/(marketing)/page.tsx
+++ b/apps/web/src/app/(marketing)/page.tsx
@@ -12,14 +12,9 @@ const features = [
       "An intuitive AI assistant that lives on your desktop. It learns how you think, adapts to how you work, and gets better the more you use it.",
   },
   {
-    title: "Open experiments",
+    title: "What's next?",
     description:
-      "We explore multi-agent systems, local-first AI, and new ways for people and agents to work together.",
-  },
-  {
-    title: "Open source",
-    description:
-      "Everything we build ships in the open. Fork it, break it, make it yours.",
+      "We're always looking for the next experiment. Have an idea for an agentic app? Let us know.",
   },
 ];
 

--- a/apps/web/src/app/(marketing)/page.tsx
+++ b/apps/web/src/app/(marketing)/page.tsx
@@ -25,11 +25,11 @@ const Page = () => {
       <section className="pt-24 pb-16 lg:pt-48">
         <div>
           <h1 className="text-base font-medium text-foreground">
-            The agent lab.
+            An agent experiment lab.
           </h1>
           <p className="text-base text-foreground/60 text-balance">
-            Building agentic tools and apps &mdash; from game engines to desktop
-            assistants and whatever we dream up next.
+            What happens when AI agents generate your games, run your desktop,
+            and handle the rest?
           </p>
         </div>
       </section>

--- a/apps/web/src/app/(marketing)/page.tsx
+++ b/apps/web/src/app/(marketing)/page.tsx
@@ -2,12 +2,12 @@ import { WaitlistForm } from "./_components/waitlist-form";
 
 const features = [
   {
-    title: "vibedgames",
+    title: "VibedGames",
     description:
       "An AI-powered video game generator with built-in multiplayer and mobile support. Describe a game, play it instantly.",
   },
   {
-    title: "samantha",
+    title: "Samantha",
     description:
       "An intuitive AI assistant that lives on your desktop. It learns how you think, adapts to how you work, and gets better the more you use it.",
   },
@@ -52,11 +52,11 @@ const Page = () => {
 
       {/* CTA */}
       <section className="py-16">
-        <div className="border-t border-dotted border-foreground/10 pt-4">
-          <h2 className="text-base font-medium text-foreground">
-            Stay in the loop
-          </h2>
-          <p className="text-base text-foreground/60 text-balance">
+        <h2 className="text-base font-medium text-foreground">
+          Stay in the loop
+        </h2>
+        <div className="mt-3 border-t border-dotted border-foreground/10 pt-3 text-balance">
+          <p className="text-sm text-foreground/60">
             We&apos;re shipping new experiments all the time. Drop your email to
             follow along.
           </p>

--- a/apps/web/src/app/(marketing)/page.tsx
+++ b/apps/web/src/app/(marketing)/page.tsx
@@ -12,9 +12,9 @@ const features = [
       "An intuitive AI assistant that lives on your desktop. It learns how you think, adapts to how you work, and gets better the more you use it.",
   },
   {
-    title: "What's next?",
+    title: "More coming soon",
     description:
-      "We're always looking for the next experiment. Have an idea for an agentic app? Let us know.",
+      "New experiments are always in the works. Stay tuned.",
   },
 ];
 
@@ -25,11 +25,11 @@ const Page = () => {
       <section className="pt-24 pb-16 lg:pt-48">
         <div>
           <h1 className="text-base font-medium text-foreground">
-            An agent experiment lab.
+            The agent lab.
           </h1>
           <p className="text-base text-foreground/60 text-balance">
-            Exploring what&apos;s possible when you give AI agents real jobs to
-            do.
+            Building agentic tools and apps &mdash; from game engines to desktop
+            assistants and whatever we dream up next.
           </p>
         </div>
       </section>

--- a/apps/web/src/lib/site-config.ts
+++ b/apps/web/src/lib/site-config.ts
@@ -1,7 +1,7 @@
 export const siteConfig = {
   name: "Inteligir",
   shortName: "Inteligir",
-  description: "The agent lab",
+  description: "An agent experiment lab",
   url:
     process.env.NODE_ENV === "development"
       ? "http://localhost:3000"

--- a/apps/web/src/lib/site-config.ts
+++ b/apps/web/src/lib/site-config.ts
@@ -1,7 +1,7 @@
 export const siteConfig = {
   name: "Inteligir",
   shortName: "Inteligir",
-  description: "Agentic AI for everyone",
+  description: "An agent experiment lab",
   url:
     process.env.NODE_ENV === "development"
       ? "http://localhost:3000"

--- a/apps/web/src/lib/site-config.ts
+++ b/apps/web/src/lib/site-config.ts
@@ -1,7 +1,7 @@
 export const siteConfig = {
   name: "Inteligir",
   shortName: "Inteligir",
-  description: "An agent experiment lab",
+  description: "The agent lab",
   url:
     process.env.NODE_ENV === "development"
       ? "http://localhost:3000"


### PR DESCRIPTION
Rebrand from "Your AI Chief of Staff" to "An agent experiment lab".
Replace feature cards with project showcases (vibedgames, samantha)
and lab ethos (open experiments, open source). Update hero, CTA,
meta description, and CLAUDE.md to match new positioning.

https://claude.ai/code/session_01Lw1MNHx2BHKaGeRV3Ffhb6