### PR TITLE
Add helix/infinity loading state with morph transition to orb

### DIFF
--- a/apps/desktop/src/renderer/components/geometric-orb.tsx
+++ b/apps/desktop/src/renderer/components/geometric-orb.tsx
@@ -20,6 +20,12 @@ const POINTS_PER_LINE = 96;
 const LINE_WIDTH = 2;
 const BACKGROUND = "#0a0a0a";
 const INITIAL_COLOR_INT = new THREE.Color("#eeeeee").getHex();
+const PI2 = Math.PI * 2;
+
+// Helix (infinity/figure-8 curve) parameters
+const HELIX_LENGTH = RADIUS * 2.0;
+const HELIX_AMPLITUDE = RADIUS * 0.4;
+const RIBBON_WIDTH = 0.3;
 
 // ---------------------------------------------------------------------------
 // Dynamic parameters — interpolated per-frame toward the active mood
@@ -30,6 +36,8 @@ type Mood = {
   squiggleAmount: number;
   squiggleFrequency: number;
   squiggleSpeed: number;
+  morphProgress: number; // 0 = helix, 1 = sphere
+  helixSpin: number; // X-axis rotation speed in helix mode
   r: number;
   g: number;
   b: number;
@@ -43,6 +51,8 @@ const moods: Record<SessionStatus, Mood> = {
     squiggleAmount: 0.04,
     squiggleFrequency: 4,
     squiggleSpeed: 2,
+    morphProgress: 1,
+    helixSpin: 0,
     ...rgb("#eeeeee"),
   },
   busy: {
@@ -50,6 +60,8 @@ const moods: Record<SessionStatus, Mood> = {
     squiggleAmount: 0.08,
     squiggleFrequency: 6,
     squiggleSpeed: 5,
+    morphProgress: 1,
+    helixSpin: 0,
     ...rgb("#66bbff"),
   },
   error: {
@@ -57,13 +69,17 @@ const moods: Record<SessionStatus, Mood> = {
     squiggleAmount: 0.12,
     squiggleFrequency: 8,
     squiggleSpeed: 7,
+    morphProgress: 1,
+    helixSpin: 0,
     ...rgb("#ff6666"),
   },
   starting: {
     speed: 25,
-    squiggleAmount: 0.02,
-    squiggleFrequency: 3,
+    squiggleAmount: 0.01,
+    squiggleFrequency: 2,
     squiggleSpeed: 1,
+    morphProgress: 0,
+    helixSpin: 0.035,
     ...rgb("#888888"),
   },
 };
@@ -81,9 +97,34 @@ function lerpMood(current: Mood, target: Mood, alpha: number): void {
   current.squiggleAmount += (target.squiggleAmount - current.squiggleAmount) * alpha;
   current.squiggleFrequency += (target.squiggleFrequency - current.squiggleFrequency) * alpha;
   current.squiggleSpeed += (target.squiggleSpeed - current.squiggleSpeed) * alpha;
+  current.morphProgress += (target.morphProgress - current.morphProgress) * alpha;
+  current.helixSpin += (target.helixSpin - current.helixSpin) * alpha;
   current.r += (target.r - current.r) * alpha;
   current.g += (target.g - current.g) * alpha;
   current.b += (target.b - current.b) * alpha;
+}
+
+// ---------------------------------------------------------------------------
+// Helix (infinity/figure-8 curve) — adapted from the reference implementation
+// ---------------------------------------------------------------------------
+
+function helixPoint(
+  percent: number,
+  ribbonOffset: number,
+): [number, number, number] {
+  const x = HELIX_LENGTH * Math.sin(PI2 * percent);
+  const y = HELIX_AMPLITUDE * Math.cos(PI2 * 3 * percent);
+
+  // Z-crossing correction (creates proper over/under weaving)
+  let t = (percent % 0.25) / 0.25;
+  t = (percent % 0.25) - (2 * (1 - t) * t * -0.0185 + t * t * 0.25);
+  if (Math.floor(percent / 0.25) === 0 || Math.floor(percent / 0.25) === 2) {
+    t *= -1;
+  }
+  const z = HELIX_AMPLITUDE * Math.sin(PI2 * 2 * (percent - t));
+
+  // Ribbon offset — spread lines perpendicular to the curve for thickness
+  return [x, y + ribbonOffset * RIBBON_WIDTH, z + ribbonOffset * RIBBON_WIDTH * 0.3];
 }
 
 // ---------------------------------------------------------------------------
@@ -92,7 +133,9 @@ function lerpMood(current: Mood, target: Mood, alpha: number): void {
 
 function LatitudeLines({ status }: { status: SessionStatus }) {
   const groupRefs = useRef<(THREE.Group | null)[]>([]);
+  const parentGroupRef = useRef<THREE.Group>(null);
   const camDirRef = useRef(new THREE.Vector3());
+  const helixRotationRef = useRef(0);
   const { size } = useThree();
 
   const moodRef = useRef<Mood>({ ...moods[status] });
@@ -103,8 +146,7 @@ function LatitudeLines({ status }: { status: SessionStatus }) {
     () =>
       Array.from({ length: NUM_LINES }, (_, i) => ({
         longitudeRotation: (i / NUM_LINES) * Math.PI,
-        cosR: Math.cos((i / NUM_LINES) * Math.PI),
-        sinR: Math.sin((i / NUM_LINES) * Math.PI),
+        ribbonOffset: i / (NUM_LINES - 1) - 0.5, // -0.5 to 0.5
       })),
     [],
   );
@@ -156,12 +198,31 @@ function LatitudeLines({ status }: { status: SessionStatus }) {
     const mood = moodRef.current;
     const time = state.clock.elapsedTime;
     const camDir = camDirRef.current.copy(state.camera.position).normalize();
+    const morph = mood.morphProgress;
+
+    // Accumulate helix rotation (slows as helixSpin lerps to 0)
+    helixRotationRef.current += mood.helixSpin;
+    if (parentGroupRef.current) {
+      // Apply helix spin, fading out as morph approaches 1 (sphere)
+      parentGroupRef.current.rotation.x = helixRotationRef.current * (1 - morph);
+    }
 
     for (let lineIdx = 0; lineIdx < NUM_LINES; lineIdx++) {
       const group = groupRefs.current[lineIdx];
       if (!group) continue;
 
-      const { longitudeRotation, cosR, sinR } = lineConstants[lineIdx];
+      const { longitudeRotation, ribbonOffset } = lineConstants[lineIdx];
+
+      // In helix mode (morph=0), all lines share orientation (rotation=0)
+      // In sphere mode (morph=1), lines fan out by longitudeRotation
+      const groupRotY = longitudeRotation * morph;
+      group.rotation.y = groupRotY;
+
+      // Precompute cos/sin for depth calculation
+      const cosRotY = Math.cos(groupRotY);
+      const sinRotY = Math.sin(groupRotY);
+
+      // Sphere sweep parameters
       const timeOffset = (lineIdx / NUM_LINES) * mood.speed;
       const progress = ((time + timeOffset) % mood.speed) / mood.speed;
       const latitude = progress * Math.PI;
@@ -169,7 +230,10 @@ function LatitudeLines({ status }: { status: SessionStatus }) {
       const yPosition = Math.cos(latitude) * RADIUS;
 
       for (let i = 0; i < POINTS_PER_LINE; i++) {
-        const angle = (i / POINTS_PER_LINE) * Math.PI * 2;
+        const t = i / POINTS_PER_LINE;
+        const angle = t * PI2;
+
+        // --- Sphere position ---
         const squiggle =
           Math.sin(angle * mood.squiggleFrequency + time * mood.squiggleSpeed + lineIdx * 0.5) *
           mood.squiggleAmount;
@@ -183,17 +247,26 @@ function LatitudeLines({ status }: { status: SessionStatus }) {
           mood.squiggleAmount *
           0.4;
 
-        const x = Math.cos(angle) * displacedRadius;
-        const y = yPosition + ySquiggle * circleRadius;
-        const z = Math.sin(angle) * displacedRadius;
+        const sx = Math.cos(angle) * displacedRadius;
+        const sy = yPosition + ySquiggle * circleRadius;
+        const sz = Math.sin(angle) * displacedRadius;
+
+        // --- Helix position ---
+        const [hx, hy, hz] = helixPoint(t, ribbonOffset);
+
+        // --- Lerp between helix and sphere ---
+        const x = hx + (sx - hx) * morph;
+        const y = hy + (sy - hy) * morph;
+        const z = hz + (sz - hz) * morph;
 
         const offset = i * 3;
         positionBuffer[offset] = x;
         positionBuffer[offset + 1] = y;
         positionBuffer[offset + 2] = z;
 
-        const worldX = x * cosR + z * sinR;
-        const worldZ = -x * sinR + z * cosR;
+        // Depth-based opacity using dynamic group rotation
+        const worldX = x * cosRotY + z * sinRotY;
+        const worldZ = -x * sinRotY + z * cosRotY;
         const dot = worldX * camDir.x + y * camDir.y + worldZ * camDir.z;
         const depthFactor = (dot / RADIUS + 1) / 2;
         const opacity = depthFactor * 0.85 + 0.15;
@@ -203,6 +276,7 @@ function LatitudeLines({ status }: { status: SessionStatus }) {
         colorBuffer[offset + 2] = mood.b * opacity;
       }
 
+      // Close the loop
       const last = POINTS_PER_LINE * 3;
       positionBuffer[last] = positionBuffer[0];
       positionBuffer[last + 1] = positionBuffer[1];
@@ -213,12 +287,11 @@ function LatitudeLines({ status }: { status: SessionStatus }) {
 
       geometries[lineIdx].setPositions(positionBuffer);
       geometries[lineIdx].setColors(colorBuffer);
-      group.rotation.y = longitudeRotation;
     }
   });
 
   return (
-    <>
+    <group ref={parentGroupRef}>
       {Array.from({ length: NUM_LINES }, (_, lineIdx) => (
         <OrbLine
           key={lineIdx}
@@ -228,7 +301,7 @@ function LatitudeLines({ status }: { status: SessionStatus }) {
           material={materials[lineIdx]}
         />
       ))}
-    </>
+    </group>
   );
 }
 

--- a/apps/desktop/src/renderer/components/geometric-orb.tsx
+++ b/apps/desktop/src/renderer/components/geometric-orb.tsx
@@ -23,7 +23,7 @@ const INITIAL_COLOR_INT = new THREE.Color("#eeeeee").getHex();
 const PI2 = Math.PI * 2;
 
 // Helix (infinity/figure-8 curve) parameters
-const HELIX_LENGTH = RADIUS * 2.0;
+const HELIX_LENGTH = RADIUS * 2;
 const HELIX_AMPLITUDE = RADIUS * 0.4;
 const RIBBON_WIDTH = 0.3;
 
@@ -115,10 +115,15 @@ function helixPoint(
   const x = HELIX_LENGTH * Math.sin(PI2 * percent);
   const y = HELIX_AMPLITUDE * Math.cos(PI2 * 3 * percent);
 
-  // Z-crossing correction (creates proper over/under weaving)
-  let t = (percent % 0.25) / 0.25;
-  t = (percent % 0.25) - (2 * (1 - t) * t * -0.0185 + t * t * 0.25);
-  if (Math.floor(percent / 0.25) === 0 || Math.floor(percent / 0.25) === 2) {
+  // Z-crossing correction — adjusts the phase per quarter-segment so the
+  // curve weaves over/under itself at the center crossing point.
+  // The 0.0185 nudge is an empirical fudge from the reference implementation
+  // that prevents the strands from visually intersecting at the crossover.
+  const quarter = percent % 0.25;
+  const tNorm = quarter / 0.25;
+  const segment = Math.floor(percent / 0.25);
+  let t = quarter - (2 * (1 - tNorm) * tNorm * -0.0185 + tNorm * tNorm * 0.25);
+  if (segment === 0 || segment === 2) {
     t *= -1;
   }
   const z = HELIX_AMPLITUDE * Math.sin(PI2 * 2 * (percent - t));
@@ -150,6 +155,23 @@ function LatitudeLines({ status }: { status: SessionStatus }) {
       })),
     [],
   );
+
+  // Pre-compute helix positions — they only depend on point index and line
+  // index, so they're fully static and don't need per-frame recalculation.
+  const helixCache = useMemo(() => {
+    const cache = new Float32Array(NUM_LINES * POINTS_PER_LINE * 3);
+    for (let lineIdx = 0; lineIdx < NUM_LINES; lineIdx++) {
+      const ribbonOffset = lineIdx / (NUM_LINES - 1) - 0.5;
+      for (let i = 0; i < POINTS_PER_LINE; i++) {
+        const [hx, hy, hz] = helixPoint(i / POINTS_PER_LINE, ribbonOffset);
+        const idx = (lineIdx * POINTS_PER_LINE + i) * 3;
+        cache[idx] = hx;
+        cache[idx + 1] = hy;
+        cache[idx + 2] = hz;
+      }
+    }
+    return cache;
+  }, []);
 
   const materials = useMemo(
     () =>
@@ -201,7 +223,7 @@ function LatitudeLines({ status }: { status: SessionStatus }) {
     const morph = mood.morphProgress;
 
     // Accumulate helix rotation (slows as helixSpin lerps to 0)
-    helixRotationRef.current += mood.helixSpin;
+    helixRotationRef.current = (helixRotationRef.current + mood.helixSpin) % PI2;
     if (parentGroupRef.current) {
       // Apply helix spin, fading out as morph approaches 1 (sphere)
       parentGroupRef.current.rotation.x = helixRotationRef.current * (1 - morph);
@@ -211,7 +233,7 @@ function LatitudeLines({ status }: { status: SessionStatus }) {
       const group = groupRefs.current[lineIdx];
       if (!group) continue;
 
-      const { longitudeRotation, ribbonOffset } = lineConstants[lineIdx];
+      const { longitudeRotation } = lineConstants[lineIdx];
 
       // In helix mode (morph=0), all lines share orientation (rotation=0)
       // In sphere mode (morph=1), lines fan out by longitudeRotation
@@ -251,8 +273,11 @@ function LatitudeLines({ status }: { status: SessionStatus }) {
         const sy = yPosition + ySquiggle * circleRadius;
         const sz = Math.sin(angle) * displacedRadius;
 
-        // --- Helix position ---
-        const [hx, hy, hz] = helixPoint(t, ribbonOffset);
+        // --- Helix position (from cache) ---
+        const hIdx = (lineIdx * POINTS_PER_LINE + i) * 3;
+        const hx = helixCache[hIdx];
+        const hy = helixCache[hIdx + 1];
+        const hz = helixCache[hIdx + 2];
 
         // --- Lerp between helix and sphere ---
         const x = hx + (sx - hx) * morph;


### PR DESCRIPTION
The starting state now renders lines in a helix (figure-8/infinity)
formation that spins on the X-axis. When transitioning to idle/busy/error,
lines smoothly morph into the spherical orb form as they fan out.

- Add morphProgress (0=helix, 1=sphere) and helixSpin to Mood type
- Implement infinity curve math adapted from reference Three.js sample
- Lerp positions between helix and sphere per-vertex each frame
- Parent group rotation handles helix spin, fading as morph completes
- Ribbon offset spreads lines for thickness in helix mode

https://claude.ai/code/session_01U9Y9T3ray1Vna6DsNvwQiC