### PR TITLE
redesign messaging UI: left sidebar thread + floating input

### DIFF
--- a/apps/desktop/src/renderer/app.tsx
+++ b/apps/desktop/src/renderer/app.tsx
@@ -92,14 +92,22 @@ export function AppLayout() {
   const voiceState = useVoiceStore((s) => s.sessionState);
   const orbStatus = phaseToOrbStatus(appState.phase, voiceState);
 
+  const isChatPage = pathname === "/";
+  const isSettings = pathname === "/settings";
+
   return (
-    <div className="relative h-full w-full font-mono">
-      <div className={`pointer-events-none absolute inset-0 left-72 -z-10 grid place-items-center ${pathname === "/settings" ? "left-0 hidden" : pathname !== "/" ? "left-0" : ""}`}>
-        <div className="h-48 w-48">
-          <GeometricOrb status={orbStatus} />
+    <div className={`h-full w-full font-mono ${isChatPage ? "grid grid-cols-[18rem_1fr]" : ""}`}>
+      {/* Orb — sits in the right column on chat, centered on other pages */}
+      {!isSettings && (
+        <div className={`pointer-events-none -z-10 grid place-items-center ${isChatPage ? "col-start-2 row-start-1" : "absolute inset-0"}`}>
+          <div className="h-48 w-48">
+            <GeometricOrb status={orbStatus} />
+          </div>
         </div>
-      </div>
-      <div className="flex h-full flex-col">
+      )}
+
+      {/* Page content — spans full grid on chat page */}
+      <div className={`flex flex-col ${isChatPage ? "col-span-full row-start-1" : "h-full"}`}>
         <Outlet />
       </div>
     </div>

--- a/apps/desktop/src/renderer/app.tsx
+++ b/apps/desktop/src/renderer/app.tsx
@@ -94,7 +94,7 @@ export function AppLayout() {
 
   return (
     <div className="relative h-full w-full font-mono">
-      <div className={`pointer-events-none absolute inset-0 -z-10 grid place-items-center ${pathname === "/settings" ? "hidden" : ""}`}>
+      <div className={`pointer-events-none absolute inset-0 left-72 -z-10 grid place-items-center ${pathname === "/settings" ? "left-0 hidden" : pathname !== "/" ? "left-0" : ""}`}>
         <div className="h-48 w-48">
           <GeometricOrb status={orbStatus} />
         </div>

--- a/apps/desktop/src/renderer/app.tsx
+++ b/apps/desktop/src/renderer/app.tsx
@@ -92,22 +92,19 @@ export function AppLayout() {
   const voiceState = useVoiceStore((s) => s.sessionState);
   const orbStatus = phaseToOrbStatus(appState.phase, voiceState);
 
-  const isChatPage = pathname === "/";
   const isSettings = pathname === "/settings";
 
   return (
-    <div className={`h-full w-full font-mono ${isChatPage ? "grid grid-cols-[18rem_1fr]" : ""}`}>
-      {/* Orb — sits in the right column on chat, centered on other pages */}
+    <div className="relative h-full w-full font-mono">
       {!isSettings && (
-        <div className={`pointer-events-none -z-10 grid place-items-center ${isChatPage ? "col-start-2 row-start-1" : "absolute inset-0"}`}>
+        <div className="pointer-events-none absolute inset-0 -z-10 grid place-items-center">
           <div className="h-48 w-48">
             <GeometricOrb status={orbStatus} />
           </div>
         </div>
       )}
 
-      {/* Page content — spans full grid on chat page */}
-      <div className={`flex flex-col ${isChatPage ? "col-span-full row-start-1" : "h-full"}`}>
+      <div className="flex h-full flex-col">
         <Outlet />
       </div>
     </div>

--- a/apps/desktop/src/renderer/chat/chat-input.tsx
+++ b/apps/desktop/src/renderer/chat/chat-input.tsx
@@ -1,22 +1,45 @@
-import { useCallback, useState, type ChangeEvent, type FormEvent, type KeyboardEvent } from "react";
+import { useCallback, useState } from "react";
+import type { FormEvent, KeyboardEvent } from "react";
 
-import { Button } from "@repo/ui/button";
-import { Input } from "@repo/ui/input";
+import {
+  InputGroup,
+  InputGroupAddon,
+  InputGroupButton,
+  InputGroupInput,
+} from "@repo/ui/input-group";
+import { MicIcon, MicOffIcon, SendIcon, SquareIcon, Volume2Icon } from "lucide-react";
 
 import { useAgentStore } from "@/renderer/stores/agent-store";
+import { useVoiceStore } from "@/renderer/stores/voice-store";
 
 export function ChatInput() {
   const [input, setInput] = useState("");
-  const busy = useAgentStore((s) => s.appState.phase === "ready" && s.appState.agent === "busy");
+
+  const busy = useAgentStore(
+    (s) => s.appState.phase === "ready" && s.appState.agent === "busy",
+  );
   const sendMessage = useAgentStore((s) => s.sendMessage);
   const steer = useAgentStore((s) => s.steer);
   const interrupt = useAgentStore((s) => s.interrupt);
   const clearMessages = useAgentStore((s) => s.clearMessages);
 
-  const handleChange = useCallback(
-    (e: ChangeEvent<HTMLInputElement>) => setInput(e.target.value),
-    [],
-  );
+  const sessionState = useVoiceStore((s) => s.sessionState);
+  const toggleVoice = useVoiceStore((s) => s.toggleVoice);
+
+  const voiceActive = sessionState !== "inactive";
+  const voiceSpeaking = sessionState === "speaking";
+
+  const VoiceIcon = voiceSpeaking
+    ? Volume2Icon
+    : voiceActive
+      ? MicIcon
+      : MicOffIcon;
+
+  const voiceTitle = voiceSpeaking
+    ? "Interrupt"
+    : voiceActive
+      ? "Stop voice"
+      : "Start voice";
 
   const send = useCallback(
     (e: FormEvent) => {
@@ -35,14 +58,11 @@ export function ChatInput() {
 
   const handleKeyDown = useCallback(
     (e: KeyboardEvent<HTMLInputElement>) => {
-      // Cmd+K / Ctrl+K — clear messages
       if (e.key === "k" && (e.metaKey || e.ctrlKey)) {
         e.preventDefault();
         clearMessages();
         return;
       }
-
-      // Escape — interrupt agent or clear input
       if (e.key === "Escape") {
         e.preventDefault();
         if (busy) {
@@ -50,34 +70,47 @@ export function ChatInput() {
         } else if (input.length > 0) {
           setInput("");
         }
-        return;
       }
     },
     [busy, input, interrupt, clearMessages],
   );
 
   return (
-    <form onSubmit={send} className="flex shrink-0 gap-2 px-6 pt-3 pb-6">
-      <Input
-        value={input}
-        onChange={handleChange}
-        onKeyDown={handleKeyDown}
-        placeholder={busy ? "Redirect the agent..." : "Send a message..."}
-        className="flex-1"
-      />
-      {busy ? (
-        input.trim() ? (
-          <Button type="submit">Steer</Button>
-        ) : (
-          <Button type="button" variant="destructive" onClick={interrupt}>
-            Stop
-          </Button>
-        )
-      ) : (
-        <Button type="submit" disabled={input.trim() === ""}>
-          Send
-        </Button>
-      )}
-    </form>
+    <div className="pointer-events-auto w-full max-w-md">
+      <form onSubmit={send}>
+        <InputGroup className="bg-background/80 text-foreground text-sm shadow-lg backdrop-blur-md">
+          <InputGroupInput
+            value={input}
+            onChange={(e) => setInput(e.target.value)}
+            onKeyDown={handleKeyDown}
+            placeholder={busy ? "Redirect..." : "Message..."}
+          />
+          <InputGroupAddon align="inline-end" className="mt-auto gap-1">
+            <InputGroupButton
+              type="button"
+              size="icon-xs"
+              onClick={toggleVoice}
+              title={voiceTitle}
+              className={voiceSpeaking ? "animate-pulse" : ""}
+            >
+              <VoiceIcon />
+            </InputGroupButton>
+            {busy && !input.trim() ? (
+              <InputGroupButton
+                type="button"
+                size="icon-xs"
+                onClick={interrupt}
+              >
+                <SquareIcon />
+              </InputGroupButton>
+            ) : (
+              <InputGroupButton type="submit" size="icon-xs">
+                <SendIcon />
+              </InputGroupButton>
+            )}
+          </InputGroupAddon>
+        </InputGroup>
+      </form>
+    </div>
   );
 }

--- a/apps/desktop/src/renderer/chat/chat-input.tsx
+++ b/apps/desktop/src/renderer/chat/chat-input.tsx
@@ -76,7 +76,7 @@ export function ChatInput() {
   );
 
   return (
-    <div className="pointer-events-auto w-full max-w-md">
+    <div className="w-full max-w-md">
       <form onSubmit={send}>
         <InputGroup className="bg-background/80 text-foreground text-sm shadow-lg backdrop-blur-md">
           <InputGroupInput

--- a/apps/desktop/src/renderer/chat/chat-message.tsx
+++ b/apps/desktop/src/renderer/chat/chat-message.tsx
@@ -8,7 +8,7 @@ export function ChatMessageView({ message }: { message: ChatMessage }) {
   switch (message.kind) {
     case "user":
       return (
-        <div className="ml-20">
+        <div className="ml-8">
           <div className="bg-foreground/20 rounded-md px-3 py-1.5 text-sm">
             {message.text}
           </div>
@@ -17,7 +17,7 @@ export function ChatMessageView({ message }: { message: ChatMessage }) {
 
     case "steer":
       return (
-        <div className="ml-20">
+        <div className="ml-8">
           <div className="rounded-md px-3 py-1.5 text-sm italic text-muted-foreground">
             {message.text}
           </div>
@@ -26,7 +26,7 @@ export function ChatMessageView({ message }: { message: ChatMessage }) {
 
     case "assistant":
       return (
-        <div className={cn("mr-20")}>
+        <div className={cn("mr-8")}>
           <div className="bg-foreground/10 text-foreground/80 rounded-md px-3 py-1.5 text-sm">
             {message.text ? <Markdown content={message.text} /> : "..."}
           </div>
@@ -35,7 +35,7 @@ export function ChatMessageView({ message }: { message: ChatMessage }) {
 
     case "tool":
       return (
-        <div className="mr-20">
+        <div className="mr-8">
           <ToolExecutionView execution={message.execution} />
         </div>
       );

--- a/apps/desktop/src/renderer/chat/chat-page.tsx
+++ b/apps/desktop/src/renderer/chat/chat-page.tsx
@@ -9,15 +9,18 @@ export function ChatPage() {
   useEffect(() => initVoice(), [initVoice]);
 
   return (
-    <div className="flex h-full">
-      {/* Left: message thread spanning full height */}
-      <MessageThread />
+    <div className="grid h-full grid-cols-[18rem_1fr] grid-rows-[1fr_auto]">
+      {/* Left: message thread spanning both rows */}
+      <div className="row-span-2">
+        <MessageThread />
+      </div>
 
-      {/* Right: main area with floating input at center bottom */}
-      <div className="relative flex-1">
-        <div className="pointer-events-none absolute inset-0 flex items-end justify-center p-6">
-          <ChatInput />
-        </div>
+      {/* Right top: empty space (orb shows through from AppLayout) */}
+      <div />
+
+      {/* Right bottom: floating input */}
+      <div className="flex items-end justify-center p-6">
+        <ChatInput />
       </div>
     </div>
   );

--- a/apps/desktop/src/renderer/chat/chat-page.tsx
+++ b/apps/desktop/src/renderer/chat/chat-page.tsx
@@ -1,139 +1,23 @@
-import { useCallback, useEffect, useState } from "react";
-import type { FormEvent, KeyboardEvent } from "react";
+import { useEffect } from "react";
 
-import {
-  Conversation,
-  ConversationContent,
-  ConversationScrollButton,
-} from "@repo/ui/conversation";
-import {
-  InputGroup,
-  InputGroupAddon,
-  InputGroupButton,
-  InputGroupInput,
-} from "@repo/ui/input-group";
-import { MessageSquareIcon, MicIcon, SendIcon, SquareIcon } from "lucide-react";
-
-import { ChatMessageView } from "@/renderer/chat/chat-message";
-import { VoiceButton } from "@/renderer/chat/voice-button";
-import { VoiceIndicator } from "@/renderer/chat/voice-indicator";
-import { useAgentStore } from "@/renderer/stores/agent-store";
+import { ChatInput } from "@/renderer/chat/chat-input";
+import { MessageThread } from "@/renderer/chat/message-thread";
 import { useVoiceStore } from "@/renderer/stores/voice-store";
 
-type Mode = "voice" | "text";
-
 export function ChatPage() {
-  const messages = useAgentStore((s) => s.messages);
-  const busy = useAgentStore(
-    (s) => s.appState.phase === "ready" && s.appState.agent === "busy",
-  );
-  const sendMessage = useAgentStore((s) => s.sendMessage);
-  const steer = useAgentStore((s) => s.steer);
-  const interrupt = useAgentStore((s) => s.interrupt);
-
   const initVoice = useVoiceStore((s) => s.init);
   useEffect(() => initVoice(), [initVoice]);
 
-  const [input, setInput] = useState("");
-  const [mode, setMode] = useState<Mode>("voice");
-
-  const send = useCallback(
-    (e: FormEvent) => {
-      e.preventDefault();
-      const text = input.trim();
-      if (!text) return;
-      setInput("");
-      if (busy) {
-        steer(text);
-      } else {
-        sendMessage(text);
-      }
-    },
-    [input, busy, sendMessage, steer],
-  );
-
-  const handleKeyDown = useCallback(
-    (e: KeyboardEvent<HTMLInputElement>) => {
-      if (e.key === "Escape") {
-        e.preventDefault();
-        if (busy) {
-          interrupt();
-        } else if (input.length > 0) {
-          setInput("");
-        }
-      }
-    },
-    [busy, input, interrupt],
-  );
-
   return (
-    <div className="pointer-events-none absolute inset-0 flex flex-col justify-end p-4">
-      {/* Messages (text mode only) */}
-      {mode === "text" && messages.length > 0 && (
-        <Conversation className="pointer-events-auto mb-2 max-h-[50%] w-full max-w-sm">
-          <ConversationContent className="space-y-1 pb-2">
-            {messages.map((msg) => (
-              <ChatMessageView key={msg.id} message={msg} />
-            ))}
-          </ConversationContent>
-          <ConversationScrollButton />
-        </Conversation>
-      )}
+    <div className="flex h-full">
+      {/* Left: message thread spanning full height */}
+      <MessageThread />
 
-      {/* Voice status (voice mode only) */}
-      {mode === "voice" && <VoiceIndicator />}
-
-      {/* Controls */}
-      <div className="pointer-events-auto max-w-sm">
-        {mode === "text" ? (
-          <form onSubmit={send}>
-            <InputGroup className="text-foreground text-sm">
-              <InputGroupAddon>
-                <InputGroupButton
-                  type="button"
-                  size="icon-xs"
-                  onClick={() => setMode("voice")}
-                  title="Switch to voice"
-                >
-                  <MicIcon />
-                </InputGroupButton>
-              </InputGroupAddon>
-              <InputGroupInput
-                value={input}
-                onChange={(e) => setInput(e.target.value)}
-                onKeyDown={handleKeyDown}
-                placeholder={busy ? "Redirect..." : "Message..."}
-              />
-              <InputGroupAddon align="inline-end" className="mt-auto">
-                {busy && !input.trim() ? (
-                  <InputGroupButton
-                    type="button"
-                    size="icon-xs"
-                    onClick={interrupt}
-                  >
-                    <SquareIcon />
-                  </InputGroupButton>
-                ) : (
-                  <InputGroupButton type="submit" size="icon-xs">
-                    <SendIcon />
-                  </InputGroupButton>
-                )}
-              </InputGroupAddon>
-            </InputGroup>
-          </form>
-        ) : (
-          <div className="flex gap-2">
-            <button
-              type="button"
-              className="bg-input/40 text-muted-foreground hover:text-foreground rounded-md p-2 backdrop-blur-sm transition"
-              onClick={() => setMode("text")}
-              title="Switch to text"
-            >
-              <MessageSquareIcon className="size-4" />
-            </button>
-            <VoiceButton />
-          </div>
-        )}
+      {/* Right: main area with floating input at center bottom */}
+      <div className="relative flex-1">
+        <div className="pointer-events-none absolute inset-0 flex items-end justify-center p-6">
+          <ChatInput />
+        </div>
       </div>
     </div>
   );

--- a/apps/desktop/src/renderer/chat/chat-page.tsx
+++ b/apps/desktop/src/renderer/chat/chat-page.tsx
@@ -1,7 +1,7 @@
 import { useEffect } from "react";
 
 import { ChatInput } from "@/renderer/chat/chat-input";
-import { MessageThread } from "@/renderer/chat/message-thread";
+import { DraggableThread } from "@/renderer/chat/draggable-thread";
 import { useVoiceStore } from "@/renderer/stores/voice-store";
 
 export function ChatPage() {
@@ -9,17 +9,11 @@ export function ChatPage() {
   useEffect(() => initVoice(), [initVoice]);
 
   return (
-    <div className="grid h-full grid-cols-[18rem_1fr] grid-rows-[1fr_auto]">
-      {/* Left: message thread spanning both rows */}
-      <div className="row-span-2">
-        <MessageThread />
-      </div>
+    <div className="relative h-full">
+      <DraggableThread />
 
-      {/* Right top: empty space (orb shows through from AppLayout) */}
-      <div />
-
-      {/* Right bottom: floating input */}
-      <div className="flex items-end justify-center p-6">
+      {/* Floating input at center bottom */}
+      <div className="absolute inset-x-0 bottom-0 flex justify-center p-6">
         <ChatInput />
       </div>
     </div>

--- a/apps/desktop/src/renderer/chat/draggable-thread.tsx
+++ b/apps/desktop/src/renderer/chat/draggable-thread.tsx
@@ -1,0 +1,161 @@
+import { useCallback, useRef, useState } from "react";
+import { motion, useMotionValue, useTransform, animate } from "motion/react";
+import { GripVerticalIcon, PanelLeftCloseIcon } from "lucide-react";
+
+import { MessageThread } from "@/renderer/chat/message-thread";
+
+type ThreadPosition = "left" | "center" | "right";
+
+const positionStyles: Record<ThreadPosition, string> = {
+  left: "left-0 top-0 bottom-0",
+  center: "left-1/2 top-0 bottom-0 -translate-x-1/2",
+  right: "right-0 top-0 bottom-0",
+};
+
+const dropZonePositions: Record<ThreadPosition, string> = {
+  left: "left-0 top-0 bottom-0",
+  center: "left-1/2 top-0 bottom-0 -translate-x-1/2",
+  right: "right-0 top-0 bottom-0",
+};
+
+export function DraggableThread() {
+  const [position, setPosition] = useState<ThreadPosition>("left");
+  const [visible, setVisible] = useState(true);
+  const [dragging, setDragging] = useState(false);
+  const [hoverZone, setHoverZone] = useState<ThreadPosition | null>(null);
+  const containerRef = useRef<HTMLDivElement>(null);
+  const x = useMotionValue(0);
+  const y = useMotionValue(0);
+
+  // Subtle shadow scaling with drag distance
+  const dragDistance = useTransform(() => Math.abs(x.get()) + Math.abs(y.get()));
+  const boxShadow = useTransform(
+    dragDistance,
+    [0, 100],
+    ["0 0 0 0 rgba(0,0,0,0)", "0 8px 32px 0 rgba(0,0,0,0.2)"],
+  );
+
+  const getSnapZone = useCallback(
+    (pointerX: number): ThreadPosition => {
+      const container = containerRef.current?.parentElement;
+      if (!container) return position;
+      const { width } = container.getBoundingClientRect();
+      const third = width / 3;
+      if (pointerX < third) return "left";
+      if (pointerX > third * 2) return "right";
+      return "center";
+    },
+    [position],
+  );
+
+  const handleDrag = useCallback(
+    (_: unknown, info: { point: { x: number } }) => {
+      const container = containerRef.current?.parentElement;
+      if (!container) return;
+      const rect = container.getBoundingClientRect();
+      const relativeX = info.point.x - rect.left;
+      setHoverZone(getSnapZone(relativeX));
+    },
+    [getSnapZone],
+  );
+
+  const handleDragStart = useCallback(() => {
+    setDragging(true);
+  }, []);
+
+  const handleDragEnd = useCallback(
+    (_: unknown, info: { point: { x: number } }) => {
+      const container = containerRef.current?.parentElement;
+      if (!container) {
+        setDragging(false);
+        setHoverZone(null);
+        return;
+      }
+      const rect = container.getBoundingClientRect();
+      const relativeX = info.point.x - rect.left;
+      const newPosition = getSnapZone(relativeX);
+      setPosition(newPosition);
+      setDragging(false);
+      setHoverZone(null);
+      void animate(x, 0, { type: "spring", stiffness: 500, damping: 30 });
+      void animate(y, 0, { type: "spring", stiffness: 500, damping: 30 });
+    },
+    [getSnapZone, x, y],
+  );
+
+  if (!visible) {
+    return (
+      <button
+        type="button"
+        onClick={() => setVisible(true)}
+        className="absolute left-2 top-2 z-20 rounded-md bg-background/80 p-1.5 text-muted-foreground shadow-sm backdrop-blur-sm transition hover:text-foreground"
+        title="Show messages"
+      >
+        <GripVerticalIcon className="size-3.5" />
+      </button>
+    );
+  }
+
+  return (
+    <>
+      {/* Drop zone indicators — visible while dragging */}
+      {dragging &&
+        (["left", "center", "right"] as const).map((zone) => (
+          <div
+            key={zone}
+            className={`pointer-events-none absolute z-10 w-72 ${dropZonePositions[zone]}`}
+          >
+            <div
+              className={`mx-2 h-full rounded-lg border-2 border-dashed transition-colors ${
+                hoverZone === zone
+                  ? "border-foreground/30 bg-foreground/5"
+                  : "border-border/40"
+              }`}
+            />
+          </div>
+        ))}
+
+      {/* Draggable thread panel */}
+      <motion.div
+        ref={containerRef}
+        className={`absolute z-20 h-full w-72 ${positionStyles[position]}`}
+        style={{ x, y, boxShadow }}
+        layout
+        transition={{ type: "spring", stiffness: 400, damping: 30 }}
+      >
+        <div className="flex h-full flex-col bg-background/60 backdrop-blur-sm">
+          {/* Header with drag handle + hide button */}
+          <div className="flex shrink-0 items-center gap-1 px-2 py-2">
+            <motion.button
+              type="button"
+              drag
+              dragMomentum={false}
+              dragElastic={0.1}
+              onDragStart={handleDragStart}
+              onDrag={handleDrag}
+              onDragEnd={handleDragEnd}
+              style={{ x, y }}
+              className="cursor-grab rounded p-1 text-muted-foreground transition hover:text-foreground active:cursor-grabbing"
+              title="Drag to reposition"
+            >
+              <GripVerticalIcon className="size-3.5" />
+            </motion.button>
+            <button
+              type="button"
+              onClick={() => setVisible(false)}
+              className="rounded p-1 text-muted-foreground transition hover:text-foreground"
+              title="Hide messages"
+            >
+              <PanelLeftCloseIcon className="size-3.5" />
+            </button>
+            <span className="ml-1 text-xs font-medium text-muted-foreground">
+              Messages
+            </span>
+          </div>
+
+          <MessageThread />
+        </div>
+      </motion.div>
+    </>
+  );
+}

--- a/apps/desktop/src/renderer/chat/message-thread.tsx
+++ b/apps/desktop/src/renderer/chat/message-thread.tsx
@@ -12,11 +12,7 @@ export function MessageThread() {
   const messages = useAgentStore((s) => s.messages);
 
   return (
-    <div className="flex h-full flex-col border-r border-border bg-background/60 backdrop-blur-sm">
-      <div className="shrink-0 px-4 py-3 text-xs font-medium text-muted-foreground">
-        Messages
-      </div>
-
+    <>
       <Conversation className="flex-1 px-3">
         <ConversationContent className="space-y-1 pb-2">
           {messages.length === 0 ? (
@@ -33,6 +29,6 @@ export function MessageThread() {
       </Conversation>
 
       <StatusBar />
-    </div>
+    </>
   );
 }

--- a/apps/desktop/src/renderer/chat/message-thread.tsx
+++ b/apps/desktop/src/renderer/chat/message-thread.tsx
@@ -1,0 +1,38 @@
+import {
+  Conversation,
+  ConversationContent,
+  ConversationScrollButton,
+} from "@repo/ui/conversation";
+
+import { ChatMessageView } from "@/renderer/chat/chat-message";
+import { StatusBar } from "@/renderer/chat/status-bar";
+import { useAgentStore } from "@/renderer/stores/agent-store";
+
+export function MessageThread() {
+  const messages = useAgentStore((s) => s.messages);
+
+  return (
+    <div className="flex h-full w-72 shrink-0 flex-col border-r border-border bg-background/60 backdrop-blur-sm">
+      <div className="shrink-0 px-4 py-3 text-xs font-medium text-muted-foreground">
+        Messages
+      </div>
+
+      <Conversation className="flex-1 px-3">
+        <ConversationContent className="space-y-1 pb-2">
+          {messages.length === 0 ? (
+            <div className="px-1 py-4 text-center text-xs text-muted-foreground/60">
+              No messages yet
+            </div>
+          ) : (
+            messages.map((msg) => (
+              <ChatMessageView key={msg.id} message={msg} />
+            ))
+          )}
+        </ConversationContent>
+        <ConversationScrollButton />
+      </Conversation>
+
+      <StatusBar />
+    </div>
+  );
+}

--- a/apps/desktop/src/renderer/chat/message-thread.tsx
+++ b/apps/desktop/src/renderer/chat/message-thread.tsx
@@ -12,7 +12,7 @@ export function MessageThread() {
   const messages = useAgentStore((s) => s.messages);
 
   return (
-    <div className="flex h-full w-72 shrink-0 flex-col border-r border-border bg-background/60 backdrop-blur-sm">
+    <div className="flex h-full flex-col border-r border-border bg-background/60 backdrop-blur-sm">
       <div className="shrink-0 px-4 py-3 text-xs font-medium text-muted-foreground">
         Messages
       </div>


### PR DESCRIPTION
- Extract MessageThread component as full-height left sidebar with
  message list and status bar
- Redesign ChatInput as floating center-bottom input with integrated
  voice toggle button (no more voice/text mode switching)
- Simplify ChatPage to a clean layout composing the two components
- Offset orb to center in the main content area (right of sidebar)
- Adjust message margins for narrower thread width

https://claude.ai/code/session_013CTFoGVfD8Sjb8ZLkH6gCd