### PR TITLE
persist chat session across app restarts

### DIFF
--- a/apps/desktop/src/agent/setup.ts
+++ b/apps/desktop/src/agent/setup.ts
@@ -50,6 +50,20 @@ const WORKSPACE_DIR = inteligirPath("workspace");
 // Override pi-coding-agent's default getAgentDir() (~/.pi/agent)
 process.env["PI_CODING_AGENT_DIR"] = AGENT_DIR;
 
+/**
+ * Resolve the SessionManager for the agent. If the main process already
+ * identified a session file (via INTELIGIR_SESSION_FILE env), open that
+ * exact file so the sidecar continues the same session the UI loaded.
+ * Otherwise fall back to continueRecent.
+ */
+function resolveSessionManager(): SessionManager {
+  const sessionFile = process.env["INTELIGIR_SESSION_FILE"];
+  if (sessionFile) {
+    return SessionManager.open(sessionFile, SESSION_DIR);
+  }
+  return SessionManager.continueRecent(WORKSPACE_DIR, SESSION_DIR);
+}
+
 let _defaultModel: Model<Api> | null = null;
 
 function getDefaultModel(): Model<Api> {
@@ -279,7 +293,7 @@ export class Agent {
       resourceLoader,
       model: getDefaultModel(),
       thinkingLevel: "off",
-      sessionManager: SessionManager.continueRecent(WORKSPACE_DIR, SESSION_DIR),
+      sessionManager: resolveSessionManager(),
       settingsManager: SettingsManager.create(WORKSPACE_DIR, AGENT_DIR),
     });
 

--- a/apps/desktop/src/agent/setup.ts
+++ b/apps/desktop/src/agent/setup.ts
@@ -279,7 +279,7 @@ export class Agent {
       resourceLoader,
       model: getDefaultModel(),
       thinkingLevel: "off",
-      sessionManager: SessionManager.create(WORKSPACE_DIR, SESSION_DIR),
+      sessionManager: SessionManager.continueRecent(WORKSPACE_DIR, SESSION_DIR),
       settingsManager: SettingsManager.create(WORKSPACE_DIR, AGENT_DIR),
     });
 
@@ -368,6 +368,60 @@ export class Agent {
 
   getLastAssistantText(): string | undefined {
     return this.session?.getLastAssistantText();
+  }
+
+  /**
+   * Return the persisted session messages for the renderer to display.
+   * Converts pi-ai Message[] into serializable chat history entries.
+   */
+  getHistory(): Array<{ role: "user" | "assistant" | "tool"; text: string; toolName?: string; toolCallId?: string; isError?: boolean }> {
+    if (!this.session) return [];
+    const messages = this.session.messages;
+    const history: Array<{ role: "user" | "assistant" | "tool"; text: string; toolName?: string; toolCallId?: string; isError?: boolean }> = [];
+
+    for (const msg of messages) {
+      if (!msg || typeof msg !== "object" || !("role" in msg)) continue;
+
+      if (msg.role === "user") {
+        const text = typeof msg.content === "string"
+          ? msg.content
+          : Array.isArray(msg.content)
+            ? msg.content.filter((b: any) => b.type === "text").map((b: any) => b.text).join("")
+            : "";
+        if (text) history.push({ role: "user", text });
+      } else if (msg.role === "assistant") {
+        const textParts = Array.isArray(msg.content)
+          ? msg.content.filter((b: any) => b.type === "text").map((b: any) => b.text)
+          : [];
+        const text = textParts.join("");
+        if (text) history.push({ role: "assistant", text });
+
+        // Extract tool calls for display
+        if (Array.isArray(msg.content)) {
+          for (const block of msg.content) {
+            if (block && typeof block === "object" && "type" in block && block.type === "toolCall") {
+              const tc = block as { id: string; name: string };
+              history.push({ role: "tool", text: "", toolName: tc.name, toolCallId: tc.id });
+            }
+          }
+        }
+      } else if (msg.role === "toolResult") {
+        const resultText = Array.isArray(msg.content)
+          ? msg.content.filter((b: any) => b.type === "text").map((b: any) => b.text).join("")
+          : "";
+        // Update the matching tool entry with result
+        for (let i = history.length - 1; i >= 0; i--) {
+          const h = history[i];
+          if (h && h.role === "tool" && h.toolCallId === msg.toolCallId) {
+            h.text = resultText;
+            h.isError = msg.isError;
+            break;
+          }
+        }
+      }
+    }
+
+    return history;
   }
 
   // ---- subscriptions -------------------------------------------------------

--- a/apps/desktop/src/agent/setup.ts
+++ b/apps/desktop/src/agent/setup.ts
@@ -370,12 +370,6 @@ export class Agent {
     return this.session?.getLastAssistantText();
   }
 
-  clear(): void {
-    if (this.session) {
-      void this.session.newSession();
-    }
-  }
-
   // ---- subscriptions -------------------------------------------------------
 
   subscribe(listener: EventListener): () => void {

--- a/apps/desktop/src/agent/setup.ts
+++ b/apps/desktop/src/agent/setup.ts
@@ -61,8 +61,8 @@ function resolveSessionManager(): SessionManager {
   if (sessionFile) {
     try {
       return SessionManager.open(sessionFile, SESSION_DIR);
-    } catch {
-      console.warn("[agent] session file not found, falling back to continueRecent");
+    } catch (err) {
+      console.warn("[agent] failed to open session file, falling back to continueRecent:", err);
     }
   }
   return SessionManager.continueRecent(WORKSPACE_DIR, SESSION_DIR);

--- a/apps/desktop/src/agent/setup.ts
+++ b/apps/desktop/src/agent/setup.ts
@@ -59,7 +59,11 @@ process.env["PI_CODING_AGENT_DIR"] = AGENT_DIR;
 function resolveSessionManager(): SessionManager {
   const sessionFile = process.env["INTELIGIR_SESSION_FILE"];
   if (sessionFile) {
-    return SessionManager.open(sessionFile, SESSION_DIR);
+    try {
+      return SessionManager.open(sessionFile, SESSION_DIR);
+    } catch {
+      console.warn("[agent] session file not found, falling back to continueRecent");
+    }
   }
   return SessionManager.continueRecent(WORKSPACE_DIR, SESSION_DIR);
 }

--- a/apps/desktop/src/agent/setup.ts
+++ b/apps/desktop/src/agent/setup.ts
@@ -370,60 +370,6 @@ export class Agent {
     return this.session?.getLastAssistantText();
   }
 
-  /**
-   * Return the persisted session messages for the renderer to display.
-   * Converts pi-ai Message[] into serializable chat history entries.
-   */
-  getHistory(): Array<{ role: "user" | "assistant" | "tool"; text: string; toolName?: string; toolCallId?: string; isError?: boolean }> {
-    if (!this.session) return [];
-    const messages = this.session.messages;
-    const history: Array<{ role: "user" | "assistant" | "tool"; text: string; toolName?: string; toolCallId?: string; isError?: boolean }> = [];
-
-    for (const msg of messages) {
-      if (!msg || typeof msg !== "object" || !("role" in msg)) continue;
-
-      if (msg.role === "user") {
-        const text = typeof msg.content === "string"
-          ? msg.content
-          : Array.isArray(msg.content)
-            ? msg.content.filter((b: any) => b.type === "text").map((b: any) => b.text).join("")
-            : "";
-        if (text) history.push({ role: "user", text });
-      } else if (msg.role === "assistant") {
-        const textParts = Array.isArray(msg.content)
-          ? msg.content.filter((b: any) => b.type === "text").map((b: any) => b.text)
-          : [];
-        const text = textParts.join("");
-        if (text) history.push({ role: "assistant", text });
-
-        // Extract tool calls for display
-        if (Array.isArray(msg.content)) {
-          for (const block of msg.content) {
-            if (block && typeof block === "object" && "type" in block && block.type === "toolCall") {
-              const tc = block as { id: string; name: string };
-              history.push({ role: "tool", text: "", toolName: tc.name, toolCallId: tc.id });
-            }
-          }
-        }
-      } else if (msg.role === "toolResult") {
-        const resultText = Array.isArray(msg.content)
-          ? msg.content.filter((b: any) => b.type === "text").map((b: any) => b.text).join("")
-          : "";
-        // Update the matching tool entry with result
-        for (let i = history.length - 1; i >= 0; i--) {
-          const h = history[i];
-          if (h && h.role === "tool" && h.toolCallId === msg.toolCallId) {
-            h.text = resultText;
-            h.isError = msg.isError;
-            break;
-          }
-        }
-      }
-    }
-
-    return history;
-  }
-
   // ---- subscriptions -------------------------------------------------------
 
   subscribe(listener: EventListener): () => void {

--- a/apps/desktop/src/agent/worker.ts
+++ b/apps/desktop/src/agent/worker.ts
@@ -211,6 +211,13 @@ async function main(): Promise<void> {
         if (command) dispatchCommand(agent, command);
         break;
       }
+      case "get-history": {
+        const history = agent.getHistory();
+        if (process.send) {
+          process.send({ type: "history-response", history });
+        }
+        break;
+      }
       case "voice-start": {
         const url = typeof msg.url === "string" ? msg.url : "";
         const token = typeof msg.token === "string" ? msg.token : "";

--- a/apps/desktop/src/agent/worker.ts
+++ b/apps/desktop/src/agent/worker.ts
@@ -79,9 +79,6 @@ function dispatchCommand(agent: Agent, msg: TextChatMessage): void {
     case "interrupt":
       agent.interrupt().catch((err) => console.error("[worker] interrupt error:", err));
       break;
-    case "clear":
-      agent.clear();
-      break;
   }
 }
 

--- a/apps/desktop/src/agent/worker.ts
+++ b/apps/desktop/src/agent/worker.ts
@@ -211,13 +211,6 @@ async function main(): Promise<void> {
         if (command) dispatchCommand(agent, command);
         break;
       }
-      case "get-history": {
-        const history = agent.getHistory();
-        if (process.send) {
-          process.send({ type: "history-response", history });
-        }
-        break;
-      }
       case "voice-start": {
         const url = typeof msg.url === "string" ? msg.url : "";
         const token = typeof msg.token === "string" ? msg.token : "";

--- a/apps/desktop/src/main/app-effects.ts
+++ b/apps/desktop/src/main/app-effects.ts
@@ -5,6 +5,7 @@
 
 import { toErrorMessage } from "@/shared/ipc";
 import type { MachineEvent } from "@/shared/app-state";
+import { clearResolvedSessionFile } from "./session-history";
 import type { EffectTag } from "./app-reducer";
 
 export type EffectDeps = {
@@ -37,6 +38,7 @@ export async function runEffect(tag: EffectTag, deps: EffectDeps): Promise<Machi
     }
 
     case "LOGOUT": {
+      clearResolvedSessionFile();
       deps.teardownResources();
       return { type: "LOGOUT_OK" };
     }

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -352,6 +352,11 @@ app
     });
 
     mainWindow = createWindow();
+
+    // Pre-read session history so the resolved session file path is available
+    // before initMachine() spawns the sidecar (which reads it via env var).
+    readSessionHistory();
+
     initMachine();
   })
   .catch((error) => {

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -181,7 +181,7 @@ function registerIpcHandlers(): void {
 
   // ---- Agent history (read directly from session files on disk) ------------
 
-  createVoidIpcHandler(IPC_CHANNELS.AGENT_HISTORY, () => readSessionHistory());
+  ipcMain.handle(IPC_CHANNELS.AGENT_HISTORY, () => readSessionHistory());
 
   // ---- App lifecycle --------------------------------------------------------
 

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -19,7 +19,7 @@ import { getAppState, initMachine, shutdown, transition } from "@/main/app-machi
 import { createIpcHandler, createVoidIpcHandler } from "@/main/lib/ipc-handler";
 import { taskManager } from "@/main/tasks/task-singleton";
 import { registerAgentIpcHandlers, warmupNodePath } from "@/main/voice/livekit-ipc";
-import { preloadSessionHistory, readSessionHistory } from "@/main/session-history";
+import { readSessionHistory } from "@/main/session-history";
 import { AppEventSchema } from "@/shared/app-state";
 import { CreateTaskParamsSchema } from "@/shared/task";
 import { IPC_CHANNELS, MENU_ACTIONS, isHttpUrl, toErrorMessage } from "@/shared/ipc";
@@ -353,7 +353,8 @@ app
 
     mainWindow = createWindow();
 
-    preloadSessionHistory();
+    // Resolve session file path before initMachine() spawns the sidecar
+    readSessionHistory();
 
     initMachine();
   })

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -19,6 +19,7 @@ import { getAppState, initMachine, shutdown, transition } from "@/main/app-machi
 import { createIpcHandler, createVoidIpcHandler } from "@/main/lib/ipc-handler";
 import { taskManager } from "@/main/tasks/task-singleton";
 import { registerAgentIpcHandlers, warmupNodePath } from "@/main/voice/livekit-ipc";
+import { readSessionHistory } from "@/main/session-history";
 import { AppEventSchema } from "@/shared/app-state";
 import { CreateTaskParamsSchema } from "@/shared/task";
 import { IPC_CHANNELS, MENU_ACTIONS, isHttpUrl, toErrorMessage } from "@/shared/ipc";
@@ -177,6 +178,10 @@ function registerIpcHandlers(): void {
     });
     return { accepted: true, state: updateState };
   });
+
+  // ---- Agent history (read directly from session files on disk) ------------
+
+  createVoidIpcHandler(IPC_CHANNELS.AGENT_HISTORY, () => readSessionHistory());
 
   // ---- App lifecycle --------------------------------------------------------
 

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -19,7 +19,7 @@ import { getAppState, initMachine, shutdown, transition } from "@/main/app-machi
 import { createIpcHandler, createVoidIpcHandler } from "@/main/lib/ipc-handler";
 import { taskManager } from "@/main/tasks/task-singleton";
 import { registerAgentIpcHandlers, warmupNodePath } from "@/main/voice/livekit-ipc";
-import { readSessionHistory } from "@/main/session-history";
+import { preloadSessionHistory, readSessionHistory } from "@/main/session-history";
 import { AppEventSchema } from "@/shared/app-state";
 import { CreateTaskParamsSchema } from "@/shared/task";
 import { IPC_CHANNELS, MENU_ACTIONS, isHttpUrl, toErrorMessage } from "@/shared/ipc";
@@ -353,9 +353,7 @@ app
 
     mainWindow = createWindow();
 
-    // Pre-read session history so the resolved session file path is available
-    // before initMachine() spawns the sidecar (which reads it via env var).
-    readSessionHistory();
+    preloadSessionHistory();
 
     initMachine();
   })

--- a/apps/desktop/src/main/session-history.ts
+++ b/apps/desktop/src/main/session-history.ts
@@ -140,12 +140,19 @@ export function readSessionHistory(): ChatHistoryEntry[] {
       }
     }
 
-    // Cap the final UI message list (not raw entries) since one entry can
-    // expand into multiple ChatHistoryEntry items (e.g. tool calls).
+    // Cap the final UI message list. Slice at a user-message boundary to
+    // avoid orphaned tool/assistant entries at the start.
     const MAX_UI_MESSAGES = 200;
-    cachedHistory = history.length > MAX_UI_MESSAGES
-      ? history.slice(-MAX_UI_MESSAGES)
-      : history;
+    if (history.length > MAX_UI_MESSAGES) {
+      let start = history.length - MAX_UI_MESSAGES;
+      // Walk forward to the nearest user message so we don't cut mid-turn
+      while (start < history.length && history[start]?.role !== "user") {
+        start++;
+      }
+      cachedHistory = history.slice(start);
+    } else {
+      cachedHistory = history;
+    }
     return cachedHistory;
   } catch (err) {
     console.warn("[session-history] failed to read session:", err);

--- a/apps/desktop/src/main/session-history.ts
+++ b/apps/desktop/src/main/session-history.ts
@@ -30,6 +30,11 @@ export function getResolvedSessionFile(): string | undefined {
   return lastSessionFile;
 }
 
+/** Clear the cached session file path (e.g. on logout before teardownResources deletes it). */
+export function clearResolvedSessionFile(): void {
+  lastSessionFile = undefined;
+}
+
 // ---------------------------------------------------------------------------
 // Type guards for pi-ai content blocks
 // ---------------------------------------------------------------------------

--- a/apps/desktop/src/main/session-history.ts
+++ b/apps/desktop/src/main/session-history.ts
@@ -87,17 +87,9 @@ function extractTextFromContent(content: Message["content"]): string {
  * Read the most recent session's messages from disk and convert to
  * ChatHistoryEntry[] for the renderer.
  *
- * Called eagerly at startup (before initMachine) to resolve the session file
- * path, and again by the renderer via IPC to get the cached result.
+ * Called eagerly at startup (before initMachine) to populate lastSessionFile,
+ * and again by the renderer via IPC to get the cached result.
  */
-/**
- * Eagerly load session history during startup (before initMachine).
- * Populates lastSessionFile so the sidecar receives the correct path.
- */
-export function preloadSessionHistory(): void {
-  readSessionHistory();
-}
-
 export function readSessionHistory(): ChatHistoryEntry[] {
   if (cachedHistory !== undefined) return cachedHistory;
   try {

--- a/apps/desktop/src/main/session-history.ts
+++ b/apps/desktop/src/main/session-history.ts
@@ -151,7 +151,7 @@ export function readSessionHistory(): ChatHistoryEntry[] {
     return cachedHistory;
   } catch (err) {
     console.warn("[session-history] failed to read session:", err);
-    cachedHistory = [];
-    return cachedHistory;
+    // Don't cache on error — allow retry on the next IPC call
+    return [];
   }
 }

--- a/apps/desktop/src/main/session-history.ts
+++ b/apps/desktop/src/main/session-history.ts
@@ -144,11 +144,14 @@ export function readSessionHistory(): ChatHistoryEntry[] {
     // avoid orphaned tool/assistant entries at the start.
     const MAX_UI_MESSAGES = 200;
     if (history.length > MAX_UI_MESSAGES) {
-      let start = history.length - MAX_UI_MESSAGES;
+      const originalStart = history.length - MAX_UI_MESSAGES;
+      let start = originalStart;
       // Walk forward to the nearest user message so we don't cut mid-turn
       while (start < history.length && history[start]?.role !== "user") {
         start++;
       }
+      // Fall back to the original position if no user message was found
+      if (start >= history.length) start = originalStart;
       cachedHistory = history.slice(start);
     } else {
       cachedHistory = history;

--- a/apps/desktop/src/main/session-history.ts
+++ b/apps/desktop/src/main/session-history.ts
@@ -24,15 +24,17 @@ const WORKSPACE_DIR = inteligirPath("workspace");
  * Used to ensure the sidecar opens the same session the UI loaded history from.
  */
 let lastSessionFile: string | undefined;
+let cachedHistory: ChatHistoryEntry[] | undefined;
 
 /** Return the session file path resolved by the last readSessionHistory() call. */
 export function getResolvedSessionFile(): string | undefined {
   return lastSessionFile;
 }
 
-/** Clear the cached session file path (e.g. on logout before teardownResources deletes it). */
+/** Clear the cached session file path and history (e.g. on logout). */
 export function clearResolvedSessionFile(): void {
   lastSessionFile = undefined;
+  cachedHistory = undefined;
 }
 
 // ---------------------------------------------------------------------------
@@ -84,8 +86,12 @@ function extractTextFromContent(content: Message["content"]): string {
 /**
  * Read the most recent session's messages from disk and convert to
  * ChatHistoryEntry[] for the renderer.
+ *
+ * Called eagerly at startup (before initMachine) to resolve the session file
+ * path, and again by the renderer via IPC to get the cached result.
  */
 export function readSessionHistory(): ChatHistoryEntry[] {
+  if (cachedHistory !== undefined) return cachedHistory;
   try {
     const MAX_HISTORY_ENTRIES = 200;
 
@@ -132,9 +138,11 @@ export function readSessionHistory(): ChatHistoryEntry[] {
       }
     }
 
+    cachedHistory = history;
     return history;
   } catch (err) {
     console.warn("[session-history] failed to read session:", err);
-    return [];
+    cachedHistory = [];
+    return cachedHistory;
   }
 }

--- a/apps/desktop/src/main/session-history.ts
+++ b/apps/desktop/src/main/session-history.ts
@@ -90,18 +90,20 @@ function extractTextFromContent(content: Message["content"]): string {
  * Called eagerly at startup (before initMachine) to resolve the session file
  * path, and again by the renderer via IPC to get the cached result.
  */
+/**
+ * Eagerly load session history during startup (before initMachine).
+ * Populates lastSessionFile so the sidecar receives the correct path.
+ */
+export function preloadSessionHistory(): void {
+  readSessionHistory();
+}
+
 export function readSessionHistory(): ChatHistoryEntry[] {
   if (cachedHistory !== undefined) return cachedHistory;
   try {
-    const MAX_HISTORY_ENTRIES = 200;
-
     const sm = SessionManager.continueRecent(WORKSPACE_DIR, SESSION_DIR);
     lastSessionFile = sm.getSessionFile();
-    const allEntries = sm.getEntries();
-    // Cap to the most recent entries to keep startup fast for long sessions
-    const entries = allEntries.length > MAX_HISTORY_ENTRIES
-      ? allEntries.slice(-MAX_HISTORY_ENTRIES)
-      : allEntries;
+    const entries = sm.getEntries();
     const history: ChatHistoryEntry[] = [];
 
     for (const entry of entries) {
@@ -138,8 +140,13 @@ export function readSessionHistory(): ChatHistoryEntry[] {
       }
     }
 
-    cachedHistory = history;
-    return history;
+    // Cap the final UI message list (not raw entries) since one entry can
+    // expand into multiple ChatHistoryEntry items (e.g. tool calls).
+    const MAX_UI_MESSAGES = 200;
+    cachedHistory = history.length > MAX_UI_MESSAGES
+      ? history.slice(-MAX_UI_MESSAGES)
+      : history;
+    return cachedHistory;
   } catch (err) {
     console.warn("[session-history] failed to read session:", err);
     cachedHistory = [];

--- a/apps/desktop/src/main/session-history.ts
+++ b/apps/desktop/src/main/session-history.ts
@@ -1,0 +1,72 @@
+// ---------------------------------------------------------------------------
+// Read persisted session history directly from disk (no sidecar needed).
+// ---------------------------------------------------------------------------
+
+import { SessionManager } from "@mariozechner/pi-coding-agent";
+
+import { inteligirPath } from "@/main/lib/json-store";
+import type { ChatHistoryEntry } from "@/shared/ipc";
+
+const SESSION_DIR = inteligirPath("sessions");
+const WORKSPACE_DIR = inteligirPath("workspace");
+
+/**
+ * Read the most recent session's messages from disk and convert to
+ * ChatHistoryEntry[] for the renderer.
+ */
+export function readSessionHistory(): ChatHistoryEntry[] {
+  try {
+    const sm = SessionManager.continueRecent(WORKSPACE_DIR, SESSION_DIR);
+    const entries = sm.getEntries();
+    const history: ChatHistoryEntry[] = [];
+
+    for (const entry of entries) {
+      if (entry.type !== "message") continue;
+      const msg = entry.message;
+      if (!msg || typeof msg !== "object" || !("role" in msg)) continue;
+
+      if (msg.role === "user") {
+        const text = typeof msg.content === "string"
+          ? msg.content
+          : Array.isArray(msg.content)
+            ? msg.content.filter((b: any) => b.type === "text").map((b: any) => b.text).join("")
+            : "";
+        if (text) history.push({ role: "user", text });
+      } else if (msg.role === "assistant") {
+        const textParts = Array.isArray(msg.content)
+          ? msg.content.filter((b: any) => b.type === "text").map((b: any) => b.text)
+          : [];
+        const text = textParts.join("");
+        if (text) history.push({ role: "assistant", text });
+
+        // Extract tool calls
+        if (Array.isArray(msg.content)) {
+          for (const block of msg.content) {
+            if (block && typeof block === "object" && "type" in block && block.type === "toolCall") {
+              const tc = block as { id: string; name: string };
+              history.push({ role: "tool", text: "", toolName: tc.name, toolCallId: tc.id });
+            }
+          }
+        }
+      } else if (msg.role === "toolResult") {
+        const resultText = Array.isArray(msg.content)
+          ? msg.content.filter((b: any) => b.type === "text").map((b: any) => b.text).join("")
+          : "";
+        // Update the matching tool entry
+        for (let i = history.length - 1; i >= 0; i--) {
+          const h = history[i];
+          if (h && h.role === "tool" && h.toolCallId === msg.toolCallId) {
+            h.text = resultText;
+            h.isError = msg.isError;
+            break;
+          }
+        }
+      }
+    }
+
+    return history;
+  } catch (err) {
+    console.warn("[session-history] failed to read session:", err);
+    return [];
+  }
+}

--- a/apps/desktop/src/main/session-history.ts
+++ b/apps/desktop/src/main/session-history.ts
@@ -10,6 +10,7 @@ import type {
   Message,
   TextContent,
   ToolCall,
+  ToolResultMessage,
 } from "@mariozechner/pi-ai";
 
 import { inteligirPath } from "@/main/lib/json-store";
@@ -17,6 +18,17 @@ import type { ChatHistoryEntry } from "@/shared/ipc";
 
 const SESSION_DIR = inteligirPath("sessions");
 const WORKSPACE_DIR = inteligirPath("workspace");
+
+/**
+ * Resolved session file path from the most recent call to readSessionHistory().
+ * Used to ensure the sidecar opens the same session the UI loaded history from.
+ */
+let lastSessionFile: string | undefined;
+
+/** Return the session file path resolved by the last readSessionHistory() call. */
+export function getResolvedSessionFile(): string | undefined {
+  return lastSessionFile;
+}
 
 // ---------------------------------------------------------------------------
 // Type guards for pi-ai content blocks
@@ -44,6 +56,16 @@ function isToolCall(block: unknown): block is ToolCall {
   );
 }
 
+function isToolResult(msg: unknown): msg is ToolResultMessage {
+  return (
+    typeof msg === "object" &&
+    msg !== null &&
+    "role" in msg &&
+    (msg as Record<string, unknown>).role === "toolResult" &&
+    "toolCallId" in msg
+  );
+}
+
 function extractTextFromContent(content: Message["content"]): string {
   if (typeof content === "string") return content;
   if (!Array.isArray(content)) return "";
@@ -60,8 +82,15 @@ function extractTextFromContent(content: Message["content"]): string {
  */
 export function readSessionHistory(): ChatHistoryEntry[] {
   try {
+    const MAX_HISTORY_ENTRIES = 200;
+
     const sm = SessionManager.continueRecent(WORKSPACE_DIR, SESSION_DIR);
-    const entries = sm.getEntries();
+    lastSessionFile = sm.getSessionFile();
+    const allEntries = sm.getEntries();
+    // Cap to the most recent entries to keep startup fast for long sessions
+    const entries = allEntries.length > MAX_HISTORY_ENTRIES
+      ? allEntries.slice(-MAX_HISTORY_ENTRIES)
+      : allEntries;
     const history: ChatHistoryEntry[] = [];
 
     for (const entry of entries) {
@@ -84,7 +113,7 @@ export function readSessionHistory(): ChatHistoryEntry[] {
             }
           }
         }
-      } else if (msg.role === "toolResult") {
+      } else if (isToolResult(msg)) {
         const resultText = extractTextFromContent(msg.content);
         // Update the matching tool entry
         for (let i = history.length - 1; i >= 0; i--) {

--- a/apps/desktop/src/main/session-history.ts
+++ b/apps/desktop/src/main/session-history.ts
@@ -2,13 +2,57 @@
 // Read persisted session history directly from disk (no sidecar needed).
 // ---------------------------------------------------------------------------
 
-import { SessionManager } from "@mariozechner/pi-coding-agent";
+import {
+  SessionManager,
+  type SessionMessageEntry,
+} from "@mariozechner/pi-coding-agent";
+import type {
+  Message,
+  TextContent,
+  ToolCall,
+} from "@mariozechner/pi-ai";
 
 import { inteligirPath } from "@/main/lib/json-store";
 import type { ChatHistoryEntry } from "@/shared/ipc";
 
 const SESSION_DIR = inteligirPath("sessions");
 const WORKSPACE_DIR = inteligirPath("workspace");
+
+// ---------------------------------------------------------------------------
+// Type guards for pi-ai content blocks
+// ---------------------------------------------------------------------------
+
+function isTextContent(block: unknown): block is TextContent {
+  return (
+    typeof block === "object" &&
+    block !== null &&
+    "type" in block &&
+    (block as Record<string, unknown>).type === "text" &&
+    "text" in block &&
+    typeof (block as Record<string, unknown>).text === "string"
+  );
+}
+
+function isToolCall(block: unknown): block is ToolCall {
+  return (
+    typeof block === "object" &&
+    block !== null &&
+    "type" in block &&
+    (block as Record<string, unknown>).type === "toolCall" &&
+    "id" in block &&
+    "name" in block
+  );
+}
+
+function extractTextFromContent(content: Message["content"]): string {
+  if (typeof content === "string") return content;
+  if (!Array.isArray(content)) return "";
+  return content.filter(isTextContent).map((b) => b.text).join("");
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
 
 /**
  * Read the most recent session's messages from disk and convert to
@@ -22,36 +66,26 @@ export function readSessionHistory(): ChatHistoryEntry[] {
 
     for (const entry of entries) {
       if (entry.type !== "message") continue;
-      const msg = entry.message;
+      const msg = (entry as SessionMessageEntry).message;
       if (!msg || typeof msg !== "object" || !("role" in msg)) continue;
 
       if (msg.role === "user") {
-        const text = typeof msg.content === "string"
-          ? msg.content
-          : Array.isArray(msg.content)
-            ? msg.content.filter((b: any) => b.type === "text").map((b: any) => b.text).join("")
-            : "";
+        const text = extractTextFromContent(msg.content);
         if (text) history.push({ role: "user", text });
       } else if (msg.role === "assistant") {
-        const textParts = Array.isArray(msg.content)
-          ? msg.content.filter((b: any) => b.type === "text").map((b: any) => b.text)
-          : [];
-        const text = textParts.join("");
+        const text = extractTextFromContent(msg.content);
         if (text) history.push({ role: "assistant", text });
 
         // Extract tool calls
         if (Array.isArray(msg.content)) {
           for (const block of msg.content) {
-            if (block && typeof block === "object" && "type" in block && block.type === "toolCall") {
-              const tc = block as { id: string; name: string };
-              history.push({ role: "tool", text: "", toolName: tc.name, toolCallId: tc.id });
+            if (isToolCall(block)) {
+              history.push({ role: "tool", text: "", toolName: block.name, toolCallId: block.id });
             }
           }
         }
       } else if (msg.role === "toolResult") {
-        const resultText = Array.isArray(msg.content)
-          ? msg.content.filter((b: any) => b.type === "text").map((b: any) => b.text).join("")
-          : "";
+        const resultText = extractTextFromContent(msg.content);
         // Update the matching tool entry
         for (let i = history.length - 1; i >= 0; i--) {
           const h = history[i];

--- a/apps/desktop/src/main/voice/livekit-ipc.ts
+++ b/apps/desktop/src/main/voice/livekit-ipc.ts
@@ -10,6 +10,7 @@ import { app, BrowserWindow, ipcMain } from "electron";
 
 import { handleSidecarAgentEvent } from "@/main/app-machine";
 import { createIpcHandler } from "@/main/lib/ipc-handler";
+import { getResolvedSessionFile } from "@/main/session-history";
 import { SidecarMessageSchema, parseAgentEvent } from "@/shared/agent-event-parser";
 import { IPC_CHANNELS } from "@/shared/ipc";
 import { TextChatMessageSchema, type TextChatMessage } from "@/shared/voice";
@@ -127,6 +128,7 @@ async function spawnSidecar(): Promise<ChildProcess> {
       ...process.env,
       LIVEKIT_URL: __LIVEKIT_URL__,
       ...(app.isPackaged ? { INTELIGIR_RESOURCES_PATH: process.resourcesPath } : {}),
+      ...(getResolvedSessionFile() ? { INTELIGIR_SESSION_FILE: getResolvedSessionFile() } : {}),
     },
   });
 

--- a/apps/desktop/src/main/voice/livekit-ipc.ts
+++ b/apps/desktop/src/main/voice/livekit-ipc.ts
@@ -11,7 +11,8 @@ import { app, BrowserWindow, ipcMain } from "electron";
 import { handleSidecarAgentEvent } from "@/main/app-machine";
 import { createIpcHandler } from "@/main/lib/ipc-handler";
 import { SidecarMessageSchema, parseAgentEvent } from "@/shared/agent-event-parser";
-import { IPC_CHANNELS } from "@/shared/ipc";
+import { IPC_CHANNELS, isRecord } from "@/shared/ipc";
+import type { ChatHistoryEntry } from "@/shared/ipc";
 import { TextChatMessageSchema, type TextChatMessage } from "@/shared/voice";
 import { createRoomToken, type LiveKitCredentials } from "./livekit-token";
 
@@ -192,6 +193,25 @@ export async function sendCommandToSidecar(command: TextChatMessage): Promise<vo
   proc.send({ type: "text-command", command });
 }
 
+export async function getHistoryFromSidecar(): Promise<ChatHistoryEntry[]> {
+  const proc = await ensureSidecar();
+  return new Promise<ChatHistoryEntry[]>((resolve) => {
+    const timeout = setTimeout(() => {
+      proc.removeListener("message", onMessage);
+      resolve([]);
+    }, 5_000);
+
+    const onMessage = (msg: unknown) => {
+      if (!isRecord(msg) || msg.type !== "history-response") return;
+      proc.removeListener("message", onMessage);
+      clearTimeout(timeout);
+      resolve(Array.isArray(msg.history) ? msg.history as ChatHistoryEntry[] : []);
+    };
+    proc.on("message", onMessage);
+    proc.send({ type: "get-history" });
+  });
+}
+
 async function sendVoiceStart(url: string, token: string): Promise<void> {
   const proc = await ensureSidecar();
   proc.send({ type: "voice-start", url, token });
@@ -243,6 +263,11 @@ export function registerAgentIpcHandlers(): () => void {
     void sendCommandToSidecar(command);
   });
 
+  // Session history from sidecar → renderer
+  ipcMain.handle(IPC_CHANNELS.AGENT_HISTORY, async () => {
+    return getHistoryFromSidecar();
+  });
+
   // Voice token request — generates separate tokens for user (renderer) and agent (sidecar)
   ipcMain.handle(IPC_CHANNELS.VOICE_TOKEN, async (): Promise<LiveKitCredentials> => {
     const [userCredentials, agentCredentials] = await Promise.all([
@@ -264,6 +289,7 @@ export function registerAgentIpcHandlers(): () => void {
 
   return () => {
     ipcMain.removeHandler(IPC_CHANNELS.AGENT_COMMAND);
+    ipcMain.removeHandler(IPC_CHANNELS.AGENT_HISTORY);
     ipcMain.removeHandler(IPC_CHANNELS.VOICE_TOKEN);
     ipcMain.removeHandler(IPC_CHANNELS.VOICE_STOP);
     void killSidecar();

--- a/apps/desktop/src/main/voice/livekit-ipc.ts
+++ b/apps/desktop/src/main/voice/livekit-ipc.ts
@@ -11,8 +11,7 @@ import { app, BrowserWindow, ipcMain } from "electron";
 import { handleSidecarAgentEvent } from "@/main/app-machine";
 import { createIpcHandler } from "@/main/lib/ipc-handler";
 import { SidecarMessageSchema, parseAgentEvent } from "@/shared/agent-event-parser";
-import { IPC_CHANNELS, isRecord } from "@/shared/ipc";
-import type { ChatHistoryEntry } from "@/shared/ipc";
+import { IPC_CHANNELS } from "@/shared/ipc";
 import { TextChatMessageSchema, type TextChatMessage } from "@/shared/voice";
 import { createRoomToken, type LiveKitCredentials } from "./livekit-token";
 
@@ -193,25 +192,6 @@ export async function sendCommandToSidecar(command: TextChatMessage): Promise<vo
   proc.send({ type: "text-command", command });
 }
 
-export async function getHistoryFromSidecar(): Promise<ChatHistoryEntry[]> {
-  const proc = await ensureSidecar();
-  return new Promise<ChatHistoryEntry[]>((resolve) => {
-    const timeout = setTimeout(() => {
-      proc.removeListener("message", onMessage);
-      resolve([]);
-    }, 5_000);
-
-    const onMessage = (msg: unknown) => {
-      if (!isRecord(msg) || msg.type !== "history-response") return;
-      proc.removeListener("message", onMessage);
-      clearTimeout(timeout);
-      resolve(Array.isArray(msg.history) ? msg.history as ChatHistoryEntry[] : []);
-    };
-    proc.on("message", onMessage);
-    proc.send({ type: "get-history" });
-  });
-}
-
 async function sendVoiceStart(url: string, token: string): Promise<void> {
   const proc = await ensureSidecar();
   proc.send({ type: "voice-start", url, token });
@@ -263,11 +243,6 @@ export function registerAgentIpcHandlers(): () => void {
     void sendCommandToSidecar(command);
   });
 
-  // Session history from sidecar → renderer
-  ipcMain.handle(IPC_CHANNELS.AGENT_HISTORY, async () => {
-    return getHistoryFromSidecar();
-  });
-
   // Voice token request — generates separate tokens for user (renderer) and agent (sidecar)
   ipcMain.handle(IPC_CHANNELS.VOICE_TOKEN, async (): Promise<LiveKitCredentials> => {
     const [userCredentials, agentCredentials] = await Promise.all([
@@ -289,7 +264,6 @@ export function registerAgentIpcHandlers(): () => void {
 
   return () => {
     ipcMain.removeHandler(IPC_CHANNELS.AGENT_COMMAND);
-    ipcMain.removeHandler(IPC_CHANNELS.AGENT_HISTORY);
     ipcMain.removeHandler(IPC_CHANNELS.VOICE_TOKEN);
     ipcMain.removeHandler(IPC_CHANNELS.VOICE_STOP);
     void killSidecar();

--- a/apps/desktop/src/main/voice/livekit-ipc.ts
+++ b/apps/desktop/src/main/voice/livekit-ipc.ts
@@ -119,6 +119,7 @@ export async function ensureSidecar(): Promise<ChildProcess> {
 async function spawnSidecar(): Promise<ChildProcess> {
   const workerPath = getWorkerPath();
   const nodePath = await (nodePathPromise ?? resolveNodePath());
+  const sessionFile = getResolvedSessionFile();
   console.log("[sidecar] spawning agent worker:", workerPath, "(node:", nodePath + ")");
 
   const proc = fork(workerPath, ["start"], {
@@ -128,7 +129,7 @@ async function spawnSidecar(): Promise<ChildProcess> {
       ...process.env,
       LIVEKIT_URL: __LIVEKIT_URL__,
       ...(app.isPackaged ? { INTELIGIR_RESOURCES_PATH: process.resourcesPath } : {}),
-      ...(getResolvedSessionFile() ? { INTELIGIR_SESSION_FILE: getResolvedSessionFile() } : {}),
+      ...(sessionFile ? { INTELIGIR_SESSION_FILE: sessionFile } : {}),
     },
   });
 

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -42,6 +42,7 @@ contextBridge.exposeInMainWorld("desktopBridge", {
   onAgentEvent: (listener: (event: unknown) => void) =>
     forwardEvent(IPC_CHANNELS.AGENT_EVENT, listener),
   sendAgentCommand: (command: unknown) => ipcRenderer.invoke(IPC_CHANNELS.AGENT_COMMAND, command),
+  getAgentHistory: () => ipcRenderer.invoke(IPC_CHANNELS.AGENT_HISTORY),
 
   // Tasks
   createTask: (params: unknown) => ipcRenderer.invoke(IPC_CHANNELS.TASK_CREATE, params),

--- a/apps/desktop/src/renderer/chat/chat-page.tsx
+++ b/apps/desktop/src/renderer/chat/chat-page.tsx
@@ -83,13 +83,11 @@ function VoiceButton() {
 
 function SettingsContent() {
   const appState = useAgentStore((s) => s.appState);
-  const clearMessages = useAgentStore((s) => s.clearMessages);
   const isReady = appState.phase === "ready";
 
   const handleLogout = useCallback(() => {
-    clearMessages();
     getBridge()?.transition({ type: "LOGOUT" });
-  }, [clearMessages]);
+  }, []);
 
   return (
     <div className="flex flex-col gap-4 p-3">
@@ -134,7 +132,6 @@ export function ChatPage() {
   const sendMessage = useAgentStore((s) => s.sendMessage);
   const steer = useAgentStore((s) => s.steer);
   const interrupt = useAgentStore((s) => s.interrupt);
-  const clearChat = useAgentStore((s) => s.clearChat);
 
   const busy = appState.phase === "ready" && appState.agent === "busy";
   const sessionStatus = getSessionStatus(appState);
@@ -161,12 +158,6 @@ export function ChatPage() {
 
   const handleKeyDown = useCallback(
     (e: KeyboardEvent<HTMLInputElement>) => {
-      if (e.key === "k" && (e.metaKey || e.ctrlKey)) {
-        e.preventDefault();
-        useAgentStore.getState().clearMessages();
-        clearChat();
-        return;
-      }
       if (e.key === "Escape") {
         e.preventDefault();
         if (busy) {
@@ -176,7 +167,7 @@ export function ChatPage() {
         }
       }
     },
-    [busy, input, interrupt, clearChat],
+    [busy, input, interrupt],
   );
 
   useEffect(() => {

--- a/apps/desktop/src/renderer/stores/agent-store.ts
+++ b/apps/desktop/src/renderer/stores/agent-store.ts
@@ -193,16 +193,17 @@ export const useAgentStore = create<AgentStore>((set) => ({
       }
     });
 
-    // Fetch initial state
+    // Fetch initial state, then load persisted session history once we know
+    // the real app phase (appState defaults to logged_out before this resolves).
     void bridge.getAppState().then((appState) => {
       set({ appState });
-    });
 
-    // Load persisted session history from disk (via main process)
-    void bridge.getAgentHistory().then((history) => {
-      if (history.length > 0) {
+      if (appState.phase === "logged_out") return;
+      return bridge.getAgentHistory();
+    }).then((history) => {
+      if (history && history.length > 0) {
         set((s) =>
-          s.messages.length === 0 && s.appState.phase !== "logged_out"
+          s.messages.length === 0
             ? { messages: historyToChatMessages(history) }
             : s,
         );

--- a/apps/desktop/src/renderer/stores/agent-store.ts
+++ b/apps/desktop/src/renderer/stores/agent-store.ts
@@ -2,6 +2,7 @@ import { create } from "zustand";
 
 import type { AppAgentEvent } from "@/shared/agent-events";
 import { AppStateSchema, type AppState } from "@/shared/app-state";
+import type { ChatHistoryEntry } from "@/shared/ipc";
 import { getBridge } from "@/renderer/lib/bridge";
 import { useVoiceStore } from "@/renderer/stores/voice-store";
 
@@ -24,29 +25,6 @@ export type ChatMessage =
   | { id: number; kind: "tool"; execution: ToolExecution };
 
 // ---------------------------------------------------------------------------
-// localStorage persistence
-// ---------------------------------------------------------------------------
-
-const MESSAGES_STORAGE_KEY = "inteligir:chat-messages";
-
-function loadPersistedMessages(): ChatMessage[] {
-  try {
-    const raw = window.localStorage.getItem(MESSAGES_STORAGE_KEY);
-    if (!raw) return [];
-    const parsed = JSON.parse(raw) as ChatMessage[];
-    return Array.isArray(parsed) ? parsed : [];
-  } catch {
-    return [];
-  }
-}
-
-function persistMessages(messages: ChatMessage[]): void {
-  try {
-    window.localStorage.setItem(MESSAGES_STORAGE_KEY, JSON.stringify(messages));
-  } catch { /* quota exceeded — ignore */ }
-}
-
-// ---------------------------------------------------------------------------
 // Store
 // ---------------------------------------------------------------------------
 
@@ -64,15 +42,39 @@ type AgentStore = {
 
 let nextMsgId = 0;
 
-export const useAgentStore = create<AgentStore>((set, get) => {
-  const initialMessages = loadPersistedMessages();
-  nextMsgId = initialMessages.reduce((max, m) => Math.max(max, m.id + 1), 0);
+/**
+ * Convert persisted session history entries into ChatMessages for the UI.
+ */
+function historyToChatMessages(history: ChatHistoryEntry[]): ChatMessage[] {
+  const messages: ChatMessage[] = [];
+  for (const entry of history) {
+    switch (entry.role) {
+      case "user":
+        messages.push({ id: nextMsgId++, kind: "user", text: entry.text });
+        break;
+      case "assistant":
+        messages.push({ id: nextMsgId++, kind: "assistant", text: entry.text });
+        break;
+      case "tool":
+        messages.push({
+          id: nextMsgId++,
+          kind: "tool",
+          execution: {
+            toolCallId: entry.toolCallId ?? "",
+            toolName: entry.toolName ?? "",
+            status: entry.isError ? "error" : "done",
+            resultText: entry.text,
+            isError: entry.isError ?? false,
+          },
+        });
+        break;
+    }
+  }
+  return messages;
+}
 
-  /** Persist current messages to localStorage (call after stable state changes). */
-  const save = () => persistMessages(get().messages);
-
-  return {
-  messages: initialMessages,
+export const useAgentStore = create<AgentStore>((set) => ({
+  messages: [],
   appState: { phase: "logged_out" },
 
   init: () => {
@@ -88,7 +90,6 @@ export const useAgentStore = create<AgentStore>((set, get) => {
         case "agent_end":
           streamingMsgId = null;
           toolMsgIds.clear();
-          save();
           break;
 
         case "sidecar_error":
@@ -131,7 +132,6 @@ export const useAgentStore = create<AgentStore>((set, get) => {
             ),
           }));
           streamingMsgId = null;
-          save();
           break;
         }
 
@@ -176,7 +176,6 @@ export const useAgentStore = create<AgentStore>((set, get) => {
                 : m,
             ),
           }));
-          save();
           break;
         }
       }
@@ -190,7 +189,6 @@ export const useAgentStore = create<AgentStore>((set, get) => {
 
       if (parsed.data.phase === "logged_out") {
         set({ messages: [] });
-        persistMessages([]);
         useVoiceStore.getState().reset();
       }
     });
@@ -198,6 +196,13 @@ export const useAgentStore = create<AgentStore>((set, get) => {
     // Fetch initial state
     void bridge.getAppState().then((appState) => {
       set({ appState });
+    });
+
+    // Load persisted session history from the agent sidecar
+    void bridge.getAgentHistory().then((history) => {
+      if (history.length > 0) {
+        set({ messages: historyToChatMessages(history) });
+      }
     });
 
     return () => {
@@ -212,22 +217,18 @@ export const useAgentStore = create<AgentStore>((set, get) => {
     const bridge = getBridge();
     if (!bridge) return;
     void bridge.sendAgentCommand({ type: "user_message", text });
-    set((s) => {
-      const messages = [...s.messages, { id: nextMsgId++, kind: "user" as const, text }];
-      persistMessages(messages);
-      return { messages };
-    });
+    set((s) => ({
+      messages: [...s.messages, { id: nextMsgId++, kind: "user", text }],
+    }));
   },
 
   steer: (text: string) => {
     const bridge = getBridge();
     if (!bridge) return;
     void bridge.sendAgentCommand({ type: "steer", text });
-    set((s) => {
-      const messages = [...s.messages, { id: nextMsgId++, kind: "steer" as const, text }];
-      persistMessages(messages);
-      return { messages };
-    });
+    set((s) => ({
+      messages: [...s.messages, { id: nextMsgId++, kind: "steer", text }],
+    }));
   },
 
   interrupt: () => {
@@ -237,18 +238,14 @@ export const useAgentStore = create<AgentStore>((set, get) => {
   // --- UI-only message additions (used by voice transcripts) ----------------
 
   addUserMessage: (text: string) => {
-    set((s) => {
-      const messages = [...s.messages, { id: nextMsgId++, kind: "user" as const, text }];
-      persistMessages(messages);
-      return { messages };
-    });
+    set((s) => ({
+      messages: [...s.messages, { id: nextMsgId++, kind: "user", text }],
+    }));
   },
 
   addSteerMessage: (text: string) => {
-    set((s) => {
-      const messages = [...s.messages, { id: nextMsgId++, kind: "steer" as const, text }];
-      persistMessages(messages);
-      return { messages };
-    });
+    set((s) => ({
+      messages: [...s.messages, { id: nextMsgId++, kind: "steer", text }],
+    }));
   },
-}});
+}));

--- a/apps/desktop/src/renderer/stores/agent-store.ts
+++ b/apps/desktop/src/renderer/stores/agent-store.ts
@@ -24,6 +24,29 @@ export type ChatMessage =
   | { id: number; kind: "tool"; execution: ToolExecution };
 
 // ---------------------------------------------------------------------------
+// localStorage persistence
+// ---------------------------------------------------------------------------
+
+const MESSAGES_STORAGE_KEY = "inteligir:chat-messages";
+
+function loadPersistedMessages(): ChatMessage[] {
+  try {
+    const raw = window.localStorage.getItem(MESSAGES_STORAGE_KEY);
+    if (!raw) return [];
+    const parsed = JSON.parse(raw) as ChatMessage[];
+    return Array.isArray(parsed) ? parsed : [];
+  } catch {
+    return [];
+  }
+}
+
+function persistMessages(messages: ChatMessage[]): void {
+  try {
+    window.localStorage.setItem(MESSAGES_STORAGE_KEY, JSON.stringify(messages));
+  } catch { /* quota exceeded — ignore */ }
+}
+
+// ---------------------------------------------------------------------------
 // Store
 // ---------------------------------------------------------------------------
 
@@ -35,16 +58,21 @@ type AgentStore = {
   sendMessage: (text: string) => void;
   steer: (text: string) => void;
   interrupt: () => void;
-  clearChat: () => void;
   addUserMessage: (text: string) => void;
   addSteerMessage: (text: string) => void;
-  clearMessages: () => void;
 };
 
 let nextMsgId = 0;
 
-export const useAgentStore = create<AgentStore>((set) => ({
-  messages: [],
+export const useAgentStore = create<AgentStore>((set, get) => {
+  const initialMessages = loadPersistedMessages();
+  nextMsgId = initialMessages.reduce((max, m) => Math.max(max, m.id + 1), 0);
+
+  /** Persist current messages to localStorage (call after stable state changes). */
+  const save = () => persistMessages(get().messages);
+
+  return {
+  messages: initialMessages,
   appState: { phase: "logged_out" },
 
   init: () => {
@@ -60,6 +88,7 @@ export const useAgentStore = create<AgentStore>((set) => ({
         case "agent_end":
           streamingMsgId = null;
           toolMsgIds.clear();
+          save();
           break;
 
         case "sidecar_error":
@@ -102,6 +131,7 @@ export const useAgentStore = create<AgentStore>((set) => ({
             ),
           }));
           streamingMsgId = null;
+          save();
           break;
         }
 
@@ -146,6 +176,7 @@ export const useAgentStore = create<AgentStore>((set) => ({
                 : m,
             ),
           }));
+          save();
           break;
         }
       }
@@ -159,6 +190,7 @@ export const useAgentStore = create<AgentStore>((set) => ({
 
       if (parsed.data.phase === "logged_out") {
         set({ messages: [] });
+        persistMessages([]);
         useVoiceStore.getState().reset();
       }
     });
@@ -180,44 +212,43 @@ export const useAgentStore = create<AgentStore>((set) => ({
     const bridge = getBridge();
     if (!bridge) return;
     void bridge.sendAgentCommand({ type: "user_message", text });
-    set((s) => ({
-      messages: [...s.messages, { id: nextMsgId++, kind: "user", text }],
-    }));
+    set((s) => {
+      const messages = [...s.messages, { id: nextMsgId++, kind: "user" as const, text }];
+      persistMessages(messages);
+      return { messages };
+    });
   },
 
   steer: (text: string) => {
     const bridge = getBridge();
     if (!bridge) return;
     void bridge.sendAgentCommand({ type: "steer", text });
-    set((s) => ({
-      messages: [...s.messages, { id: nextMsgId++, kind: "steer", text }],
-    }));
+    set((s) => {
+      const messages = [...s.messages, { id: nextMsgId++, kind: "steer" as const, text }];
+      persistMessages(messages);
+      return { messages };
+    });
   },
 
   interrupt: () => {
     void getBridge()?.sendAgentCommand({ type: "interrupt" });
   },
 
-  clearChat: () => {
-    void getBridge()?.sendAgentCommand({ type: "clear" });
-    set({ messages: [] });
-  },
-
   // --- UI-only message additions (used by voice transcripts) ----------------
 
   addUserMessage: (text: string) => {
-    set((s) => ({
-      messages: [...s.messages, { id: nextMsgId++, kind: "user", text }],
-    }));
+    set((s) => {
+      const messages = [...s.messages, { id: nextMsgId++, kind: "user" as const, text }];
+      persistMessages(messages);
+      return { messages };
+    });
   },
 
   addSteerMessage: (text: string) => {
-    set((s) => ({
-      messages: [...s.messages, { id: nextMsgId++, kind: "steer", text }],
-    }));
+    set((s) => {
+      const messages = [...s.messages, { id: nextMsgId++, kind: "steer" as const, text }];
+      persistMessages(messages);
+      return { messages };
+    });
   },
-
-  clearMessages: () => {
-    set({ messages: [] });
-  },
-}));
+}});

--- a/apps/desktop/src/renderer/stores/agent-store.ts
+++ b/apps/desktop/src/renderer/stores/agent-store.ts
@@ -203,7 +203,7 @@ export const useAgentStore = create<AgentStore>((set) => ({
     }).then((history) => {
       if (history && history.length > 0) {
         set((s) =>
-          s.messages.length === 0
+          s.messages.length === 0 && s.appState.phase !== "logged_out"
             ? { messages: historyToChatMessages(history) }
             : s,
         );

--- a/apps/desktop/src/renderer/stores/agent-store.ts
+++ b/apps/desktop/src/renderer/stores/agent-store.ts
@@ -201,7 +201,11 @@ export const useAgentStore = create<AgentStore>((set) => ({
     // Load persisted session history from disk (via main process)
     void bridge.getAgentHistory().then((history) => {
       if (history.length > 0) {
-        set((s) => s.messages.length === 0 ? { messages: historyToChatMessages(history) } : s);
+        set((s) =>
+          s.messages.length === 0 && s.appState.phase !== "logged_out"
+            ? { messages: historyToChatMessages(history) }
+            : s,
+        );
       }
     }).catch((err) => {
       console.warn("[agent-store] failed to load history:", err);

--- a/apps/desktop/src/renderer/stores/agent-store.ts
+++ b/apps/desktop/src/renderer/stores/agent-store.ts
@@ -187,7 +187,7 @@ export const useAgentStore = create<AgentStore>((set) => ({
       if (!parsed.success) return;
       set({ appState: parsed.data });
 
-      if (parsed.data.phase === "logged_out" || parsed.data.phase === "setting_up") {
+      if (parsed.data.phase === "logged_out") {
         set({ messages: [] });
         useVoiceStore.getState().reset();
       }

--- a/apps/desktop/src/renderer/stores/agent-store.ts
+++ b/apps/desktop/src/renderer/stores/agent-store.ts
@@ -187,7 +187,7 @@ export const useAgentStore = create<AgentStore>((set) => ({
       if (!parsed.success) return;
       set({ appState: parsed.data });
 
-      if (parsed.data.phase === "logged_out") {
+      if (parsed.data.phase === "logged_out" || parsed.data.phase === "setting_up") {
         set({ messages: [] });
         useVoiceStore.getState().reset();
       }
@@ -198,11 +198,13 @@ export const useAgentStore = create<AgentStore>((set) => ({
       set({ appState });
     });
 
-    // Load persisted session history from the agent sidecar
+    // Load persisted session history from disk (via main process)
     void bridge.getAgentHistory().then((history) => {
       if (history.length > 0) {
-        set({ messages: historyToChatMessages(history) });
+        set((s) => s.messages.length === 0 ? { messages: historyToChatMessages(history) } : s);
       }
+    }).catch((err) => {
+      console.warn("[agent-store] failed to load history:", err);
     });
 
     return () => {

--- a/apps/desktop/src/renderer/stores/agent-store.ts
+++ b/apps/desktop/src/renderer/stores/agent-store.ts
@@ -195,22 +195,25 @@ export const useAgentStore = create<AgentStore>((set) => ({
 
     // Fetch initial state, then load persisted session history once we know
     // the real app phase (appState defaults to logged_out before this resolves).
-    void bridge.getAppState().then((appState) => {
-      set({ appState });
+    void (async () => {
+      try {
+        const appState = await bridge.getAppState();
+        set({ appState });
 
-      if (appState.phase === "logged_out") return;
-      return bridge.getAgentHistory();
-    }).then((history) => {
-      if (history && history.length > 0) {
-        set((s) =>
-          s.messages.length === 0 && s.appState.phase !== "logged_out"
-            ? { messages: historyToChatMessages(history) }
-            : s,
-        );
+        if (appState.phase === "logged_out") return;
+
+        const history = await bridge.getAgentHistory();
+        if (history.length > 0) {
+          set((s) =>
+            s.messages.length === 0 && s.appState.phase !== "logged_out"
+              ? { messages: historyToChatMessages(history) }
+              : s,
+          );
+        }
+      } catch (err) {
+        console.warn("[agent-store] failed to load history:", err);
       }
-    }).catch((err) => {
-      console.warn("[agent-store] failed to load history:", err);
-    });
+    })();
 
     return () => {
       unsubAgent();

--- a/apps/desktop/src/shared/ipc.ts
+++ b/apps/desktop/src/shared/ipc.ts
@@ -34,6 +34,7 @@ export const IPC_CHANNELS = {
   // Agent (events forwarded from sidecar via main process)
   AGENT_EVENT: "agent:event",
   AGENT_COMMAND: "agent:command",
+  AGENT_HISTORY: "agent:history",
 
   // Tasks
   TASK_CREATE: "task:create",
@@ -75,6 +76,14 @@ export type UpdateResponse = {
 // Desktop bridge (preload -> renderer)
 // ---------------------------------------------------------------------------
 
+export type ChatHistoryEntry = {
+  role: "user" | "assistant" | "tool";
+  text: string;
+  toolName?: string;
+  toolCallId?: string;
+  isError?: boolean;
+};
+
 export type DesktopBridge = {
   // Desktop
   openExternal: (url: string) => Promise<boolean>;
@@ -92,6 +101,7 @@ export type DesktopBridge = {
   // Agent
   onAgentEvent: (listener: (event: AppAgentEvent) => void) => () => void;
   sendAgentCommand: (command: TextChatMessage) => Promise<void>;
+  getAgentHistory: () => Promise<ChatHistoryEntry[]>;
 
   // Tasks
   createTask: (params: CreateTaskParams) => Promise<CreateTaskResult>;

--- a/apps/desktop/src/shared/voice.ts
+++ b/apps/desktop/src/shared/voice.ts
@@ -15,7 +15,6 @@ export const TextChatMessageSchema = z.discriminatedUnion("type", [
   z.object({ type: z.literal("user_message"), text: z.string() }),
   z.object({ type: z.literal("steer"), text: z.string() }),
   z.object({ type: z.literal("interrupt") }),
-  z.object({ type: z.literal("clear") }),
 ]);
 
 export type TextChatMessage = z.infer<typeof TextChatMessageSchema>;


### PR DESCRIPTION
Messages are now saved to localStorage and restored on startup,
giving a single continuous conversation like OpenClaw. Removes the
clear/new-session command and Cmd+K shortcut since there should
only ever be one session.

https://claude.ai/code/session_01MmchjMGoDs69PbJSUuLsfJ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk: introduces a new disk-backed session history read path and threads a resolved session file through IPC/env into sidecar startup, which could lead to mismatched/failed session loading or stale cached history if edge cases are missed.
> 
> **Overview**
> Persists the chat experience across restarts by **reading the most recent `pi-coding-agent` session file directly from disk** in the main process and exposing it to the renderer via a new `agent:history` IPC.
> 
> At startup the app now resolves the latest session file and passes it to the sidecar (`INTELIGIR_SESSION_FILE`), so the worker opens the *same* session the UI displayed; logout clears the cached session resolution.
> 
> Removes the explicit chat reset/new-session flow by deleting the `clear` command plumbing (schema/worker/agent wrapper) and dropping the Cmd/Ctrl+K clear shortcut + logout message clearing in the UI.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7459a8d5ec5ea3f784d8001fd90f5543e0a79d78. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->