### PR TITLE
Redesign chat action bar with tabbed interface and drag-to-dismiss

### DIFF
--- a/apps/desktop/src/renderer/chat/chat-page.tsx
+++ b/apps/desktop/src/renderer/chat/chat-page.tsx
@@ -250,10 +250,8 @@ export function ChatPage() {
     (e: React.PointerEvent) => {
       if (!dragRef.current) return;
       const delta = e.clientY - dragRef.current.startY;
-      if (Math.abs(delta) > 10) {
-        didDragRef.current = true;
-      }
       if (delta > 40) {
+        didDragRef.current = true;
         setDismissed(true);
       }
       dragRef.current = null;
@@ -276,7 +274,8 @@ export function ChatPage() {
     <>
       <div className="flex h-full w-72 flex-col">
         {/* Conversation area — hidden via CSS when dismissed to preserve scroll state */}
-        <Conversation className={cn("flex-1 px-3 pt-10", dismissed && "invisible h-0 min-h-0 flex-none overflow-hidden")}>
+        {!dismissed && (
+          <Conversation className="flex-1 px-3 pt-10">
           <ConversationContent className="space-y-1 pb-2">
             {messages.length === 0 ? (
               <div className="px-1 py-4 text-center text-xs text-muted-foreground/60">
@@ -290,6 +289,7 @@ export function ChatPage() {
           </ConversationContent>
           <ConversationScrollButton />
         </Conversation>
+        )}
 
         {/* Spacer when dismissed to push action bar to bottom */}
         {dismissed && <div className="flex-1" />}

--- a/apps/desktop/src/renderer/chat/chat-page.tsx
+++ b/apps/desktop/src/renderer/chat/chat-page.tsx
@@ -1,28 +1,27 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import type { FormEvent, KeyboardEvent } from "react";
 import {
+  CheckSquareIcon,
+  GripHorizontalIcon,
   ListTodoIcon,
-  MenuIcon,
+  MailIcon,
   MicIcon,
   MicOffIcon,
+  PenLineIcon,
+  PhoneIcon,
+  PlusIcon,
   SendIcon,
   SettingsIcon,
+  SmartphoneIcon,
   SquareIcon,
+  MoreVerticalIcon,
 } from "lucide-react";
 import { cn } from "@repo/ui/utils";
-import { Button } from "@repo/ui/button";
-import { Label } from "@repo/ui/label";
 import {
   Conversation,
   ConversationContent,
   ConversationScrollButton,
 } from "@repo/ui/conversation";
-import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuTrigger,
-} from "@repo/ui/dropdown-menu";
 
 import { getSessionStatus } from "@/shared/agent";
 import type { VoiceSessionState } from "@/shared/voice";
@@ -32,6 +31,14 @@ import { TaskPanel } from "@/renderer/chat/task-panel";
 import { DraggablePanel } from "@/renderer/components/draggable-panel";
 import { useAgentStore } from "@/renderer/stores/agent-store";
 import { useVoiceStore } from "@/renderer/stores/voice-store";
+import { Button } from "@repo/ui/button";
+import { Label } from "@repo/ui/label";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+type ActionTab = "message" | "voice" | "other";
 
 // ---------------------------------------------------------------------------
 // Status indicator
@@ -45,7 +52,7 @@ const statusColors = {
 } as const;
 
 // ---------------------------------------------------------------------------
-// Voice button
+// Voice labels
 // ---------------------------------------------------------------------------
 
 const voiceLabels: Record<VoiceSessionState, string> = {
@@ -55,30 +62,8 @@ const voiceLabels: Record<VoiceSessionState, string> = {
   error: "Error",
 };
 
-function VoiceButton() {
-  const sessionState = useVoiceStore((s) => s.sessionState);
-  const toggleVoice = useVoiceStore((s) => s.toggleVoice);
-  const active = sessionState === "connected" || sessionState === "connecting";
-  const Icon = active ? MicIcon : MicOffIcon;
-
-  return (
-    <button
-      type="button"
-      onClick={toggleVoice}
-      className={cn(
-        "flex shrink-0 items-center gap-1.5 rounded-md px-2 py-1.5 text-xs transition-colors hover:bg-foreground/10",
-        active ? "text-green-400" : "text-muted-foreground",
-        sessionState === "connecting" && "animate-pulse",
-      )}
-      title={voiceLabels[sessionState]}
-    >
-      <Icon className="size-3.5" />
-    </button>
-  );
-}
-
 // ---------------------------------------------------------------------------
-// Settings content
+// Settings content (inline panel)
 // ---------------------------------------------------------------------------
 
 function SettingsContent() {
@@ -120,14 +105,75 @@ function SettingsContent() {
 }
 
 // ---------------------------------------------------------------------------
+// Tab icon button
+// ---------------------------------------------------------------------------
+
+function TabButton({
+  icon: Icon,
+  active,
+  onClick,
+  label,
+}: {
+  icon: React.ComponentType<{ className?: string }>;
+  active?: boolean;
+  onClick: () => void;
+  label: string;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={cn(
+        "flex size-9 items-center justify-center rounded-lg transition-colors",
+        active
+          ? "bg-foreground/15 text-foreground"
+          : "text-muted-foreground hover:bg-foreground/10 hover:text-foreground",
+      )}
+      title={label}
+      aria-label={label}
+    >
+      <Icon className="size-4" />
+    </button>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Grid option button (for "other" tab)
+// ---------------------------------------------------------------------------
+
+function GridOption({
+  icon: Icon,
+  label,
+  onClick,
+}: {
+  icon: React.ComponentType<{ className?: string }>;
+  label: string;
+  onClick: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className="flex flex-col items-center gap-1.5 rounded-lg p-3 text-muted-foreground transition-colors hover:bg-foreground/10 hover:text-foreground"
+    >
+      <Icon className="size-4" />
+      <span className="text-[10px]">{label}</span>
+    </button>
+  );
+}
+
+// ---------------------------------------------------------------------------
 // Chat page
 // ---------------------------------------------------------------------------
 
 export function ChatPage() {
   const [input, setInput] = useState("");
+  const [activeTab, setActiveTab] = useState<ActionTab>("message");
+  const [dismissed, setDismissed] = useState(false);
   const [showTasks, setShowTasks] = useState(false);
   const [showSettings, setShowSettings] = useState(false);
   const inputRef = useRef<HTMLInputElement>(null);
+  const dragRef = useRef<{ startY: number; isDragging: boolean } | null>(null);
 
   const messages = useAgentStore((s) => s.messages);
   const appState = useAgentStore((s) => s.appState);
@@ -141,6 +187,11 @@ export function ChatPage() {
 
   const initVoice = useVoiceStore((s) => s.init);
   useEffect(() => initVoice(), [initVoice]);
+
+  const sessionState = useVoiceStore((s) => s.sessionState);
+  const toggleVoice = useVoiceStore((s) => s.toggleVoice);
+  const voiceActive =
+    sessionState === "connected" || sessionState === "connecting";
 
   const currentTranscript = useVoiceStore((s) => s.currentTranscript);
 
@@ -180,30 +231,63 @@ export function ChatPage() {
   );
 
   useEffect(() => {
-    inputRef.current?.focus();
+    if (!dismissed) {
+      inputRef.current?.focus();
+    }
+  }, [dismissed]);
+
+  // Drag-to-dismiss handlers
+  const handleDragStart = useCallback(
+    (e: React.PointerEvent) => {
+      dragRef.current = { startY: e.clientY, isDragging: true };
+      (e.target as HTMLElement).setPointerCapture(e.pointerId);
+    },
+    [],
+  );
+
+  const handleDragEnd = useCallback(
+    (e: React.PointerEvent) => {
+      if (!dragRef.current) return;
+      const delta = e.clientY - dragRef.current.startY;
+      if (delta > 40) {
+        setDismissed(true);
+      }
+      dragRef.current = null;
+    },
+    [],
+  );
+
+  // Tap to restore when dismissed
+  const handleRestore = useCallback(() => {
+    setDismissed(false);
   }, []);
 
   return (
     <>
       <div className="flex h-full w-72 flex-col">
-        {/* Messages — pt for electron titlebar/traffic lights */}
-        <Conversation className="flex-1 px-3 pt-10">
-          <ConversationContent className="space-y-1 pb-2">
-            {messages.length === 0 ? (
-              <div className="px-1 py-4 text-center text-xs text-muted-foreground/60">
-                No messages yet
-              </div>
-            ) : (
-              messages.map((msg) => (
-                <ChatMessageView key={msg.id} message={msg} />
-              ))
-            )}
-          </ConversationContent>
-          <ConversationScrollButton />
-        </Conversation>
+        {/* Conversation area — hidden when dismissed */}
+        {!dismissed && (
+          <Conversation className="flex-1 px-3 pt-10">
+            <ConversationContent className="space-y-1 pb-2">
+              {messages.length === 0 ? (
+                <div className="px-1 py-4 text-center text-xs text-muted-foreground/60">
+                  No messages yet
+                </div>
+              ) : (
+                messages.map((msg) => (
+                  <ChatMessageView key={msg.id} message={msg} />
+                ))
+              )}
+            </ConversationContent>
+            <ConversationScrollButton />
+          </Conversation>
+        )}
+
+        {/* Spacer when dismissed to push action bar to bottom */}
+        {dismissed && <div className="flex-1" />}
 
         {/* Transcript overlay */}
-        {currentTranscript && (
+        {!dismissed && currentTranscript && (
           <div className="px-3 pb-1">
             <p className="truncate text-xs italic text-muted-foreground">
               &ldquo;{currentTranscript}&hellip;&rdquo;
@@ -211,66 +295,166 @@ export function ChatPage() {
           </div>
         )}
 
-        {/* Input bar */}
-        <form onSubmit={send} className="flex items-center gap-1 border-t border-border/40 px-2 py-2">
-          <DropdownMenu>
-            <DropdownMenuTrigger asChild>
-              <button
-                type="button"
-                className="shrink-0 rounded-md p-1.5 text-muted-foreground transition-colors hover:bg-foreground/10 hover:text-foreground"
-              >
-                <MenuIcon className="size-3.5" />
-              </button>
-            </DropdownMenuTrigger>
-            <DropdownMenuContent align="start" className="w-44">
-              <DropdownMenuItem onClick={() => setShowTasks(!showTasks)}>
-                <ListTodoIcon className="size-3.5" />
-                Tasks
-              </DropdownMenuItem>
-              <DropdownMenuItem onClick={() => setShowSettings(!showSettings)}>
-                <SettingsIcon className="size-3.5" />
-                Settings
-              </DropdownMenuItem>
-            </DropdownMenuContent>
-          </DropdownMenu>
+        {/* Floating action bar */}
+        <div className="mx-2 mb-2 overflow-hidden rounded-2xl">
+          {/* Drag bar to dismiss */}
+          <div
+            className="flex cursor-grab items-center justify-center bg-foreground/5 py-1.5 active:cursor-grabbing"
+            onPointerDown={handleDragStart}
+            onPointerUp={handleDragEnd}
+            onClick={dismissed ? handleRestore : undefined}
+          >
+            <div className="h-1 w-8 rounded-full bg-foreground/20" />
+          </div>
 
-          <span
-            className={cn(
-              "inline-block h-1.5 w-1.5 shrink-0 rounded-full",
-              statusColors[sessionStatus],
-            )}
-          />
+          {/* Input section */}
+          {!dismissed && (
+            <div className="bg-foreground/8 px-3 py-2">
+              {activeTab === "message" && (
+                <form onSubmit={send} className="flex items-center gap-2">
+                  <span
+                    className={cn(
+                      "inline-block h-1.5 w-1.5 shrink-0 rounded-full",
+                      statusColors[sessionStatus],
+                    )}
+                  />
+                  <input
+                    ref={inputRef}
+                    value={input}
+                    onChange={(e) => setInput(e.target.value)}
+                    onKeyDown={handleKeyDown}
+                    placeholder={busy ? "Redirect..." : "Message..."}
+                    className="min-w-0 flex-1 bg-transparent text-xs text-foreground placeholder:text-muted-foreground/60 focus:outline-none"
+                  />
+                  {busy && !input.trim() ? (
+                    <button
+                      type="button"
+                      onClick={interrupt}
+                      className="shrink-0 rounded-md p-1 text-muted-foreground transition-colors hover:text-foreground"
+                      aria-label="Stop"
+                    >
+                      <SquareIcon className="size-3.5" />
+                    </button>
+                  ) : (
+                    <button
+                      type="submit"
+                      className="shrink-0 rounded-md p-1 text-muted-foreground transition-colors hover:text-foreground"
+                      aria-label="Send"
+                    >
+                      <SendIcon className="size-3.5" />
+                    </button>
+                  )}
+                </form>
+              )}
 
-          <input
-            ref={inputRef}
-            value={input}
-            onChange={(e) => setInput(e.target.value)}
-            onKeyDown={handleKeyDown}
-            placeholder={busy ? "Redirect..." : "Message..."}
-            className="min-w-0 flex-1 bg-transparent text-xs text-foreground placeholder:text-muted-foreground/60 focus:outline-none"
-          />
+              {activeTab === "voice" && (
+                <div className="flex items-center justify-between">
+                  <div className="flex items-center gap-2">
+                    <span
+                      className={cn(
+                        "inline-block h-1.5 w-1.5 shrink-0 rounded-full",
+                        voiceActive ? "bg-green-400 animate-pulse" : statusColors[sessionStatus],
+                      )}
+                    />
+                    <span className="text-xs text-muted-foreground">
+                      {voiceLabels[sessionState]}
+                    </span>
+                  </div>
+                  <div className="flex items-center gap-1">
+                    <button
+                      type="button"
+                      onClick={toggleVoice}
+                      className={cn(
+                        "rounded-full p-2 transition-colors",
+                        voiceActive
+                          ? "bg-red-500/80 text-foreground hover:bg-red-500"
+                          : "bg-foreground/15 text-foreground hover:bg-foreground/25",
+                      )}
+                      title={voiceActive ? "End call" : "Start call"}
+                    >
+                      {voiceActive ? (
+                        <PhoneIcon className="size-3.5 rotate-[135deg]" />
+                      ) : (
+                        <MicIcon className="size-3.5" />
+                      )}
+                    </button>
+                  </div>
+                </div>
+              )}
 
-          <VoiceButton />
-
-          {busy && !input.trim() ? (
-            <button
-              type="button"
-              onClick={interrupt}
-              className="shrink-0 rounded-md p-1.5 text-muted-foreground transition-colors hover:bg-foreground/10 hover:text-foreground"
-              aria-label="Stop"
-            >
-              <SquareIcon className="size-3.5" />
-            </button>
-          ) : (
-            <button
-              type="submit"
-              className="shrink-0 rounded-md p-1.5 text-muted-foreground transition-colors hover:bg-foreground/10 hover:text-foreground"
-              aria-label="Send"
-            >
-              <SendIcon className="size-3.5" />
-            </button>
+              {activeTab === "other" && (
+                <div className="grid grid-cols-4 gap-1">
+                  <GridOption
+                    icon={ListTodoIcon}
+                    label="Tasks"
+                    onClick={() => setShowTasks(!showTasks)}
+                  />
+                  <GridOption
+                    icon={SettingsIcon}
+                    label="Settings"
+                    onClick={() => setShowSettings(!showSettings)}
+                  />
+                  <GridOption
+                    icon={CheckSquareIcon}
+                    label="Todos"
+                    onClick={() => {}}
+                  />
+                  <GridOption
+                    icon={PenLineIcon}
+                    label="Notes"
+                    onClick={() => {}}
+                  />
+                </div>
+              )}
+            </div>
           )}
-        </form>
+
+          {/* Tabs section */}
+          <div className="flex items-center justify-between bg-foreground/12 px-2 py-1.5">
+            <div className="flex items-center gap-0.5">
+              <TabButton
+                icon={MailIcon}
+                active={activeTab === "message"}
+                onClick={() => { setActiveTab("message"); setDismissed(false); }}
+                label="Message"
+              />
+              <TabButton
+                icon={PhoneIcon}
+                active={activeTab === "voice"}
+                onClick={() => { setActiveTab("voice"); setDismissed(false); }}
+                label="Voice"
+              />
+              <TabButton
+                icon={SmartphoneIcon}
+                active={activeTab === "other" && !dismissed}
+                onClick={() => { setActiveTab("other"); setDismissed(false); }}
+                label="More"
+              />
+            </div>
+            <div className="flex items-center gap-0.5">
+              <TabButton
+                icon={CheckSquareIcon}
+                onClick={() => { setShowTasks(!showTasks); }}
+                label="Tasks"
+              />
+              <TabButton
+                icon={PenLineIcon}
+                onClick={() => {}}
+                label="Notes"
+              />
+              <TabButton
+                icon={PlusIcon}
+                onClick={() => { setActiveTab("other"); setDismissed(false); }}
+                label="Add"
+              />
+              <TabButton
+                icon={MoreVerticalIcon}
+                onClick={() => { setShowSettings(!showSettings); }}
+                label="More options"
+              />
+            </div>
+          </div>
+        </div>
       </div>
 
       {/* Draggable panels */}

--- a/apps/desktop/src/renderer/chat/chat-page.tsx
+++ b/apps/desktop/src/renderer/chat/chat-page.tsx
@@ -2,15 +2,14 @@ import { useCallback, useEffect, useRef, useState } from "react";
 import type { FormEvent, KeyboardEvent } from "react";
 import {
   CheckSquareIcon,
+  GridIcon,
   ListTodoIcon,
-  MailIcon,
+  MessageSquareIcon,
   MicIcon,
   PenLineIcon,
   PhoneIcon,
-  PlusIcon,
   SendIcon,
   SettingsIcon,
-  SmartphoneIcon,
   SquareIcon,
   MoreVerticalIcon,
 } from "lucide-react";
@@ -160,6 +159,8 @@ function GridOption({
       type="button"
       onClick={onClick}
       disabled={disabled}
+      title={label}
+      aria-label={label}
       className={cn(
         "flex flex-col items-center gap-1.5 rounded-lg p-3 transition-colors",
         disabled
@@ -272,16 +273,18 @@ export function ChatPage() {
     [],
   );
 
+  const handleDragCancel = useCallback(() => {
+    dragRef.current = null;
+  }, []);
+
   // Tap to restore when dismissed (suppressed if a drag just occurred)
   const handleBarClick = useCallback(() => {
     if (didDragRef.current) {
       didDragRef.current = false;
       return;
     }
-    if (dismissed) {
-      setDismissed(false);
-    }
-  }, [dismissed]);
+    setDismissed(false);
+  }, []);
 
   return (
     <>
@@ -307,8 +310,8 @@ export function ChatPage() {
         {/* Spacer when dismissed to push action bar to bottom */}
         {dismissed && <div className="flex-1" />}
 
-        {/* Transcript overlay */}
-        {!dismissed && currentTranscript && (
+        {/* Transcript overlay — visible during active voice even when dismissed */}
+        {(voiceActive || !dismissed) && currentTranscript && (
           <div className="px-3 pb-1">
             <p className="truncate text-xs italic text-muted-foreground">
               &ldquo;{currentTranscript}&hellip;&rdquo;
@@ -323,7 +326,7 @@ export function ChatPage() {
             className="flex cursor-grab items-center justify-center bg-foreground/5 py-1.5 active:cursor-grabbing"
             onPointerDown={handleDragStart}
             onPointerUp={handleDragEnd}
-            onPointerCancel={() => { dragRef.current = null; }}
+            onPointerCancel={handleDragCancel}
             onClick={handleBarClick}
           >
             <div className="h-1 w-8 rounded-full bg-foreground/20" />
@@ -375,7 +378,7 @@ export function ChatPage() {
                     <span
                       className={cn(
                         "inline-block h-1.5 w-1.5 shrink-0 rounded-full",
-                        voiceActive ? "bg-green-400 animate-pulse" : statusColors[sessionStatus],
+                        voiceActive ? "bg-green-400 animate-pulse" : "bg-muted-foreground/40",
                       )}
                     />
                     <span className="text-xs text-muted-foreground">
@@ -437,7 +440,7 @@ export function ChatPage() {
           <div className="flex items-center justify-between bg-foreground/12 px-2 py-1.5">
             <div className="flex items-center gap-0.5">
               <TabButton
-                icon={MailIcon}
+                icon={MessageSquareIcon}
                 active={activeTab === "message" && !dismissed}
                 onClick={() => { setActiveTab("message"); setDismissed(false); }}
                 label="Message"
@@ -449,7 +452,7 @@ export function ChatPage() {
                 label="Voice"
               />
               <TabButton
-                icon={SmartphoneIcon}
+                icon={GridIcon}
                 active={activeTab === "other" && !dismissed}
                 onClick={() => { setActiveTab("other"); setDismissed(false); }}
                 label="More"
@@ -466,11 +469,6 @@ export function ChatPage() {
                 onClick={() => {}}
                 label="Notes"
                 disabled
-              />
-              <TabButton
-                icon={PlusIcon}
-                onClick={() => { setActiveTab("other"); setDismissed(false); }}
-                label="Add"
               />
               <TabButton
                 icon={MoreVerticalIcon}

--- a/apps/desktop/src/renderer/chat/chat-page.tsx
+++ b/apps/desktop/src/renderer/chat/chat-page.tsx
@@ -111,21 +111,26 @@ function TabButton({
   active,
   onClick,
   label,
+  disabled,
 }: {
   icon: React.ComponentType<{ className?: string }>;
   active?: boolean;
   onClick: () => void;
   label: string;
+  disabled?: boolean;
 }) {
   return (
     <button
       type="button"
       onClick={onClick}
+      disabled={disabled}
       className={cn(
         "flex size-9 items-center justify-center rounded-lg transition-colors",
-        active
-          ? "bg-foreground/15 text-foreground"
-          : "text-muted-foreground hover:bg-foreground/10 hover:text-foreground",
+        disabled
+          ? "cursor-not-allowed text-muted-foreground/40"
+          : active
+            ? "bg-foreground/15 text-foreground"
+            : "text-muted-foreground hover:bg-foreground/10 hover:text-foreground",
       )}
       title={label}
       aria-label={label}
@@ -143,16 +148,24 @@ function GridOption({
   icon: Icon,
   label,
   onClick,
+  disabled,
 }: {
   icon: React.ComponentType<{ className?: string }>;
   label: string;
   onClick: () => void;
+  disabled?: boolean;
 }) {
   return (
     <button
       type="button"
       onClick={onClick}
-      className="flex flex-col items-center gap-1.5 rounded-lg p-3 text-muted-foreground transition-colors hover:bg-foreground/10 hover:text-foreground"
+      disabled={disabled}
+      className={cn(
+        "flex flex-col items-center gap-1.5 rounded-lg p-3 transition-colors",
+        disabled
+          ? "cursor-not-allowed text-muted-foreground/40"
+          : "text-muted-foreground hover:bg-foreground/10 hover:text-foreground",
+      )}
     >
       <Icon className="size-4" />
       <span className="text-[10px]">{label}</span>
@@ -310,6 +323,7 @@ export function ChatPage() {
             className="flex cursor-grab items-center justify-center bg-foreground/5 py-1.5 active:cursor-grabbing"
             onPointerDown={handleDragStart}
             onPointerUp={handleDragEnd}
+            onPointerCancel={() => { dragRef.current = null; }}
             onClick={handleBarClick}
           >
             <div className="h-1 w-8 rounded-full bg-foreground/20" />
@@ -406,11 +420,13 @@ export function ChatPage() {
                     icon={CheckSquareIcon}
                     label="Todos"
                     onClick={() => {}}
+                    disabled
                   />
                   <GridOption
                     icon={PenLineIcon}
                     label="Notes"
                     onClick={() => {}}
+                    disabled
                   />
                 </div>
               )}
@@ -449,6 +465,7 @@ export function ChatPage() {
                 icon={PenLineIcon}
                 onClick={() => {}}
                 label="Notes"
+                disabled
               />
               <TabButton
                 icon={PlusIcon}

--- a/apps/desktop/src/renderer/chat/chat-page.tsx
+++ b/apps/desktop/src/renderer/chat/chat-page.tsx
@@ -237,9 +237,12 @@ export function ChatPage() {
   }, [dismissed]);
 
   // Drag-to-dismiss handlers
+  const didDragRef = useRef(false);
+
   const handleDragStart = useCallback(
     (e: React.PointerEvent) => {
       dragRef.current = { startY: e.clientY, isDragging: true };
+      didDragRef.current = false;
       (e.target as HTMLElement).setPointerCapture(e.pointerId);
     },
     [],
@@ -249,6 +252,9 @@ export function ChatPage() {
     (e: React.PointerEvent) => {
       if (!dragRef.current) return;
       const delta = e.clientY - dragRef.current.startY;
+      if (Math.abs(delta) > 10) {
+        didDragRef.current = true;
+      }
       if (delta > 40) {
         setDismissed(true);
       }
@@ -257,10 +263,16 @@ export function ChatPage() {
     [],
   );
 
-  // Tap to restore when dismissed
-  const handleRestore = useCallback(() => {
-    setDismissed(false);
-  }, []);
+  // Tap to restore when dismissed (suppressed if a drag just occurred)
+  const handleBarClick = useCallback(() => {
+    if (didDragRef.current) {
+      didDragRef.current = false;
+      return;
+    }
+    if (dismissed) {
+      setDismissed(false);
+    }
+  }, [dismissed]);
 
   return (
     <>
@@ -302,7 +314,7 @@ export function ChatPage() {
             className="flex cursor-grab items-center justify-center bg-foreground/5 py-1.5 active:cursor-grabbing"
             onPointerDown={handleDragStart}
             onPointerUp={handleDragEnd}
-            onClick={dismissed ? handleRestore : undefined}
+            onClick={handleBarClick}
           >
             <div className="h-1 w-8 rounded-full bg-foreground/20" />
           </div>

--- a/apps/desktop/src/renderer/chat/chat-page.tsx
+++ b/apps/desktop/src/renderer/chat/chat-page.tsx
@@ -460,7 +460,7 @@ export function ChatPage() {
             </div>
             <div className="flex items-center gap-0.5">
               <TabButton
-                icon={CheckSquareIcon}
+                icon={ListTodoIcon}
                 onClick={() => { setShowTasks(!showTasks); }}
                 label="Tasks"
               />

--- a/apps/desktop/src/renderer/chat/chat-page.tsx
+++ b/apps/desktop/src/renderer/chat/chat-page.tsx
@@ -2,11 +2,9 @@ import { useCallback, useEffect, useRef, useState } from "react";
 import type { FormEvent, KeyboardEvent } from "react";
 import {
   CheckSquareIcon,
-  GripHorizontalIcon,
   ListTodoIcon,
   MailIcon,
   MicIcon,
-  MicOffIcon,
   PenLineIcon,
   PhoneIcon,
   PlusIcon,
@@ -277,23 +275,21 @@ export function ChatPage() {
   return (
     <>
       <div className="flex h-full w-72 flex-col">
-        {/* Conversation area — hidden when dismissed */}
-        {!dismissed && (
-          <Conversation className="flex-1 px-3 pt-10">
-            <ConversationContent className="space-y-1 pb-2">
-              {messages.length === 0 ? (
-                <div className="px-1 py-4 text-center text-xs text-muted-foreground/60">
-                  No messages yet
-                </div>
-              ) : (
-                messages.map((msg) => (
-                  <ChatMessageView key={msg.id} message={msg} />
-                ))
-              )}
-            </ConversationContent>
-            <ConversationScrollButton />
-          </Conversation>
-        )}
+        {/* Conversation area — hidden via CSS when dismissed to preserve scroll state */}
+        <Conversation className={cn("flex-1 px-3 pt-10", dismissed && "invisible h-0 min-h-0 flex-none overflow-hidden")}>
+          <ConversationContent className="space-y-1 pb-2">
+            {messages.length === 0 ? (
+              <div className="px-1 py-4 text-center text-xs text-muted-foreground/60">
+                No messages yet
+              </div>
+            ) : (
+              messages.map((msg) => (
+                <ChatMessageView key={msg.id} message={msg} />
+              ))
+            )}
+          </ConversationContent>
+          <ConversationScrollButton />
+        </Conversation>
 
         {/* Spacer when dismissed to push action bar to bottom */}
         {dismissed && <div className="flex-1" />}

--- a/apps/desktop/src/renderer/chat/chat-page.tsx
+++ b/apps/desktop/src/renderer/chat/chat-page.tsx
@@ -273,7 +273,7 @@ export function ChatPage() {
   return (
     <>
       <div className="flex h-full w-72 flex-col">
-        {/* Conversation area — hidden via CSS when dismissed to preserve scroll state */}
+        {/* Conversation area — unmounted when dismissed */}
         {!dismissed && (
           <Conversation className="flex-1 px-3 pt-10">
           <ConversationContent className="space-y-1 pb-2">

--- a/apps/desktop/src/renderer/chat/chat-page.tsx
+++ b/apps/desktop/src/renderer/chat/chat-page.tsx
@@ -173,7 +173,7 @@ export function ChatPage() {
   const [showTasks, setShowTasks] = useState(false);
   const [showSettings, setShowSettings] = useState(false);
   const inputRef = useRef<HTMLInputElement>(null);
-  const dragRef = useRef<{ startY: number; isDragging: boolean } | null>(null);
+  const dragRef = useRef<{ startY: number } | null>(null);
 
   const messages = useAgentStore((s) => s.messages);
   const appState = useAgentStore((s) => s.appState);
@@ -241,7 +241,7 @@ export function ChatPage() {
 
   const handleDragStart = useCallback(
     (e: React.PointerEvent) => {
-      dragRef.current = { startY: e.clientY, isDragging: true };
+      dragRef.current = { startY: e.clientY };
       didDragRef.current = false;
       (e.target as HTMLElement).setPointerCapture(e.pointerId);
     },

--- a/apps/desktop/src/renderer/chat/chat-page.tsx
+++ b/apps/desktop/src/renderer/chat/chat-page.tsx
@@ -275,6 +275,7 @@ export function ChatPage() {
 
   const handleDragCancel = useCallback(() => {
     dragRef.current = null;
+    didDragRef.current = false;
   }, []);
 
   // Tap to restore when dismissed (suppressed if a drag just occurred)
@@ -283,7 +284,7 @@ export function ChatPage() {
       didDragRef.current = false;
       return;
     }
-    setDismissed(false);
+    setDismissed((prev) => (prev ? false : prev));
   }, []);
 
   return (
@@ -292,19 +293,19 @@ export function ChatPage() {
         {/* Conversation area — unmounted when dismissed */}
         {!dismissed && (
           <Conversation className="flex-1 px-3 pt-10">
-          <ConversationContent className="space-y-1 pb-2">
-            {messages.length === 0 ? (
-              <div className="px-1 py-4 text-center text-xs text-muted-foreground/60">
-                No messages yet
-              </div>
-            ) : (
-              messages.map((msg) => (
-                <ChatMessageView key={msg.id} message={msg} />
-              ))
-            )}
-          </ConversationContent>
-          <ConversationScrollButton />
-        </Conversation>
+            <ConversationContent className="space-y-1 pb-2">
+              {messages.length === 0 ? (
+                <div className="px-1 py-4 text-center text-xs text-muted-foreground/60">
+                  No messages yet
+                </div>
+              ) : (
+                messages.map((msg) => (
+                  <ChatMessageView key={msg.id} message={msg} />
+                ))
+              )}
+            </ConversationContent>
+            <ConversationScrollButton />
+          </Conversation>
         )}
 
         {/* Spacer when dismissed to push action bar to bottom */}
@@ -409,6 +410,9 @@ export function ChatPage() {
 
               {activeTab === "other" && (
                 <div className="grid grid-cols-4 gap-1">
+                  {/* Tasks & Settings intentionally duplicated here and in the
+                      tab bar for discoverability — the grid is the full menu,
+                      the tab bar provides quick access to frequent actions. */}
                   <GridOption
                     icon={ListTodoIcon}
                     label="Tasks"

--- a/apps/desktop/src/renderer/chat/chat-page.tsx
+++ b/apps/desktop/src/renderer/chat/chat-page.tsx
@@ -11,7 +11,6 @@ import {
   SendIcon,
   SettingsIcon,
   SquareIcon,
-  MoreVerticalIcon,
 } from "lucide-react";
 import { cn } from "@repo/ui/utils";
 import {
@@ -284,8 +283,8 @@ export function ChatPage() {
       didDragRef.current = false;
       return;
     }
-    setDismissed((prev) => (prev ? false : prev));
-  }, []);
+    if (dismissed) setDismissed(false);
+  }, [dismissed]);
 
   return (
     <>
@@ -465,6 +464,7 @@ export function ChatPage() {
             <div className="flex items-center gap-0.5">
               <TabButton
                 icon={ListTodoIcon}
+                active={showTasks}
                 onClick={() => { setShowTasks(!showTasks); }}
                 label="Tasks"
               />
@@ -475,9 +475,10 @@ export function ChatPage() {
                 disabled
               />
               <TabButton
-                icon={MoreVerticalIcon}
+                icon={SettingsIcon}
+                active={showSettings}
                 onClick={() => { setShowSettings(!showSettings); }}
-                label="More options"
+                label="Settings"
               />
             </div>
           </div>

--- a/apps/desktop/src/renderer/chat/chat-page.tsx
+++ b/apps/desktop/src/renderer/chat/chat-page.tsx
@@ -414,13 +414,13 @@ export function ChatPage() {
             <div className="flex items-center gap-0.5">
               <TabButton
                 icon={MailIcon}
-                active={activeTab === "message"}
+                active={activeTab === "message" && !dismissed}
                 onClick={() => { setActiveTab("message"); setDismissed(false); }}
                 label="Message"
               />
               <TabButton
                 icon={PhoneIcon}
-                active={activeTab === "voice"}
+                active={activeTab === "voice" && !dismissed}
                 onClick={() => { setActiveTab("voice"); setDismissed(false); }}
                 label="Voice"
               />


### PR DESCRIPTION
## Summary
Redesigned the chat page's action bar from a simple dropdown menu to a modern tabbed interface with multiple action modes and a drag-to-dismiss gesture. The new design provides better organization of messaging, voice, and utility features.

## Key Changes
- **Tabbed interface**: Replaced dropdown menu with three main tabs (Message, Voice, Other) that switch between different input modes
- **Drag-to-dismiss**: Added pointer-based drag gesture to collapse the action bar, with tap-to-restore functionality
- **Voice controls**: Moved voice functionality into dedicated Voice tab with improved visual feedback and status display
- **Grid layout for utilities**: "Other" tab displays Tasks, Settings, Todos, and Notes in a 4-column grid
- **Enhanced action buttons**: Added dedicated quick-access buttons for Tasks, Notes, Add, and More options in the tab bar
- **Improved visual hierarchy**: Reorganized imports, added type definitions, and created reusable component utilities (`TabButton`, `GridOption`)
- **State management**: Added `activeTab` and `dismissed` state to track UI mode and visibility

## Implementation Details
- Removed `VoiceButton` component and integrated voice controls directly into the Voice tab
- Created `TabButton` component for consistent icon button styling across tabs
- Created `GridOption` component for the utility grid in the "Other" tab
- Implemented drag handlers using pointer events with capture for smooth gesture detection
- Conversation area conditionally renders based on `dismissed` state with spacer to maintain layout
- Voice status indicator now shows animated pulse when active and displays current session state
- Cleaned up imports and organized code sections with clear comment boundaries

https://claude.ai/code/session_01BbJ1YE5CNZRnm5cY5siqPi

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate UI/UX refactor in the core chat input area (new tab state, voice controls, and pointer gesture handling) that could impact message/voice interaction and focus behavior, but does not change backend/data logic.
> 
> **Overview**
> Refactors `ChatPage`’s bottom input into a **floating, tabbed action bar** (Message / Voice / More), replacing the old dropdown-based menu and inlining reusable UI pieces (`TabButton`, `GridOption`).
> 
> Adds **drag-to-dismiss** for the action bar, including tap-to-restore, conditional focus, and conditional unmounting of the conversation area; the transcript overlay now remains visible during active voice even when dismissed. Voice controls move into a dedicated tab with clearer state/controls, and the “More” tab presents utilities in a small grid (with some options currently disabled).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fa492be5b5920d121ad2e8f8b1e1c72ebabf4ff8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->