### PR TITLE
feat: add heartbeat as a system task that runs every 30 minutes

### DIFF
--- a/apps/desktop/src/__tests__/task-manager.test.ts
+++ b/apps/desktop/src/__tests__/task-manager.test.ts
@@ -82,6 +82,45 @@ describe("TaskManager CRUD", () => {
   });
 });
 
+describe("Heartbeat (system task)", () => {
+  it("ensureHeartbeat creates the heartbeat task", () => {
+    const mgr = createManager();
+    mgr.ensureHeartbeat();
+
+    const tasks = mgr.getTasks();
+    expect(tasks).toHaveLength(1);
+    expect(tasks[0]!.label).toBe("Heartbeat");
+    expect(tasks[0]!.system).toBe(true);
+    expect(tasks[0]!.schedule).toEqual({ type: "interval", intervalMs: 30 * 60 * 1000 });
+  });
+
+  it("ensureHeartbeat is idempotent", () => {
+    const mgr = createManager();
+    mgr.ensureHeartbeat();
+    mgr.ensureHeartbeat();
+
+    expect(mgr.getTasks()).toHaveLength(1);
+  });
+
+  it("cannot delete a system task", () => {
+    const mgr = createManager();
+    mgr.ensureHeartbeat();
+    const heartbeat = mgr.getTasks()[0]!;
+
+    expect(() => mgr.deleteTask(heartbeat.id)).toThrow("Cannot delete a system task");
+    expect(mgr.getTasks()).toHaveLength(1);
+  });
+
+  it("can toggle a system task", () => {
+    const mgr = createManager();
+    mgr.ensureHeartbeat();
+    const heartbeat = mgr.getTasks()[0]!;
+
+    const toggled = mgr.toggleTask(heartbeat.id);
+    expect(toggled.enabled).toBe(false);
+  });
+});
+
 describe("shouldFire", () => {
   const base: Task = {
     id: "t1",

--- a/apps/desktop/src/agent/setup.ts
+++ b/apps/desktop/src/agent/setup.ts
@@ -181,8 +181,12 @@ function registerTasksExtension(pi: ExtensionAPI): void {
         }
         case "delete": {
           if (!p.taskId) return text("Error: taskId is required for delete");
-          taskManager.deleteTask(p.taskId);
-          return text(`Deleted task ${p.taskId}`);
+          try {
+            taskManager.deleteTask(p.taskId);
+            return text(`Deleted task ${p.taskId}`);
+          } catch (err) {
+            return text(`Error: ${toErrorMessage(err)}`);
+          }
         }
       }
     },

--- a/apps/desktop/src/agent/worker.ts
+++ b/apps/desktop/src/agent/worker.ts
@@ -198,6 +198,7 @@ async function main(): Promise<void> {
   // 1. Init agent immediately — text chat is ready
   const agent = await ensureAgent();
   agent.subscribe(forwardToMain);
+  taskManager.ensureHeartbeat();
   taskManager.startScheduler(() => piAgent);
 
   // 2. Preload VAD in background for when voice is needed

--- a/apps/desktop/src/agent/worker.ts
+++ b/apps/desktop/src/agent/worker.ts
@@ -198,7 +198,6 @@ async function main(): Promise<void> {
   // 1. Init agent immediately — text chat is ready
   const agent = await ensureAgent();
   agent.subscribe(forwardToMain);
-  taskManager.ensureHeartbeat();
   taskManager.startScheduler(() => piAgent);
 
   // 2. Preload VAD in background for when voice is needed

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -188,6 +188,8 @@ function registerIpcHandlers(): void {
 
   // ---- Tasks ----------------------------------------------------------------
 
+  taskManager.ensureHeartbeat();
+
   createIpcHandler(IPC_CHANNELS.TASK_CREATE, CreateTaskParamsSchema, (params) => {
     return { task: taskManager.createTask(params) };
   });

--- a/apps/desktop/src/main/tasks/task-manager.ts
+++ b/apps/desktop/src/main/tasks/task-manager.ts
@@ -26,6 +26,12 @@ const POLL_INTERVAL_MS = 15_000;
 const TASK_TIMEOUT_MS = 5 * 60 * 1000;
 const MAX_RUNS = 500;
 
+// Heartbeat defaults
+const HEARTBEAT_ID = "system:heartbeat";
+const HEARTBEAT_INTERVAL_MS = 30 * 60 * 1000; // 30 minutes
+const HEARTBEAT_PROMPT =
+  "Review recent activity and context. If anything needs the user's attention, surface it concisely. Otherwise, stay completely silent — do not respond.";
+
 // ---------------------------------------------------------------------------
 // Store schemas
 // ---------------------------------------------------------------------------
@@ -90,7 +96,33 @@ export class TaskManager {
   }
 
   deleteTask(id: string): void {
+    const task = this.tasks.read().find((t) => t.id === id);
+    if (task?.system) throw new Error("Cannot delete a system task");
     this.tasks.update((tasks) => tasks.filter((t) => t.id !== id));
+  }
+
+  // ---- Heartbeat ------------------------------------------------------------
+
+  /**
+   * Ensure the system heartbeat task exists. Called once at startup.
+   * If the heartbeat was previously created it is left as-is (preserving
+   * the user's enabled/disabled toggle).
+   */
+  ensureHeartbeat(): void {
+    const existing = this.tasks.read().find((t) => t.id === HEARTBEAT_ID);
+    if (existing) return;
+
+    const heartbeat: Task = {
+      id: HEARTBEAT_ID,
+      label: "Heartbeat",
+      prompt: HEARTBEAT_PROMPT,
+      schedule: { type: "interval", intervalMs: HEARTBEAT_INTERVAL_MS },
+      enabled: true,
+      lastRunAt: null,
+      createdAt: Date.now(),
+      system: true,
+    };
+    this.tasks.update((tasks) => [...tasks, heartbeat]);
   }
 
   toggleTask(id: string): Task {

--- a/apps/desktop/src/renderer/chat/task-panel.tsx
+++ b/apps/desktop/src/renderer/chat/task-panel.tsx
@@ -186,14 +186,16 @@ export function TaskPanel() {
                   {formatSchedule(task.schedule)}
                 </span>
               </div>
-              <button
-                type="button"
-                className="shrink-0 text-[10px] text-muted-foreground/50 transition-colors hover:text-destructive-foreground"
-                onClick={() => deleteTask(task.id)}
-                title="Delete"
-              >
-                ×
-              </button>
+              {!task.system && (
+                <button
+                  type="button"
+                  className="shrink-0 text-[10px] text-muted-foreground/50 transition-colors hover:text-destructive-foreground"
+                  onClick={() => deleteTask(task.id)}
+                  title="Delete"
+                >
+                  ×
+                </button>
+              )}
             </div>
           ))}
         </div>

--- a/apps/desktop/src/shared/task.ts
+++ b/apps/desktop/src/shared/task.ts
@@ -39,6 +39,8 @@ export const TaskSchema = z.object({
   enabled: z.boolean(),
   lastRunAt: z.number().nullable(),
   createdAt: z.number(),
+  /** System tasks (e.g. heartbeat) cannot be deleted by the user. */
+  system: z.boolean().optional(),
 });
 
 export type Task = z.infer<typeof TaskSchema>;


### PR DESCRIPTION
Adds a `system` flag to tasks that prevents deletion. The heartbeat is
a preconfigured interval task seeded on startup that periodically checks
if anything needs the user's attention and stays silent otherwise.

https://claude.ai/code/session_01J6514D5Lcdc1XJusmmnGvc

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes task lifecycle semantics (startup seeding and delete behavior) and adds a new periodically running scheduled task that could affect agent load/behavior if it fires unexpectedly.
> 
> **Overview**
> Adds a built-in **Heartbeat** scheduled task (`system:heartbeat`) that is automatically created on app startup via `taskManager.ensureHeartbeat()` and runs every 30 minutes with a silent-unless-needed prompt.
> 
> Introduces an optional `Task.system` flag; `TaskManager.deleteTask` now rejects deletion of system tasks, the task panel hides the delete affordance for them, and the agent `manage_tasks` tool now returns a user-friendly error when deletions fail. Tests were extended to cover heartbeat creation/idempotency plus system-task delete protection and toggling.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d69bfcddd0ae602dd1a237cd872636ea63f34a41. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a built-in Heartbeat system task that runs every 30 minutes to quietly check if anything needs the user's attention. Moves heartbeat seeding to the main process to ensure persistence and prevent cache overwrite.

- **New Features**
  - Added `system` flag to `Task`; deletion of system tasks is blocked with a clear error.
  - Seeded `Heartbeat` (`system:heartbeat`) on startup via `taskManager.ensureHeartbeat()`; 30‑min interval; silent‑unless‑needed prompt; idempotent; preserves user enable/disable state.
  - Task panel hides the delete button for system tasks.
  - Tests cover heartbeat creation, idempotency, delete protection, and toggling.

- **Bug Fixes**
  - Moved `ensureHeartbeat()` to the main process before task IPC registration so the main store owns it, preventing overwrites from the worker’s separate cache.

<sup>Written for commit d69bfcddd0ae602dd1a237cd872636ea63f34a41. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

