### PR TITLE
fix: add standalone output to resolve zod module not found in deployment

### DIFF
--- a/apps/desktop/electron.vite.config.ts
+++ b/apps/desktop/electron.vite.config.ts
@@ -32,6 +32,7 @@ export default defineConfig(({ mode }) => ({
       alias: { "@": resolve(__dirname, "src") },
     },
     build: {
+      externalizeDeps: false,
       outDir: ".output/app/main",
       rollupOptions: {
         external: [...nativeExternals, "electron"],

--- a/apps/web/next.config.js
+++ b/apps/web/next.config.js
@@ -42,7 +42,6 @@ const transpilePackages = ["@repo/api", "@repo/db", "@repo/ui"];
 
 /** @type {import("next").NextConfig} */
 const config = {
-  output: "standalone",
   cacheComponents: true,
   pageExtensions: ["js", "jsx", "md", "mdx", "ts", "tsx"],
   transpilePackages,

--- a/apps/web/next.config.js
+++ b/apps/web/next.config.js
@@ -42,6 +42,7 @@ const transpilePackages = ["@repo/api", "@repo/db", "@repo/ui"];
 
 /** @type {import("next").NextConfig} */
 const config = {
+  output: "standalone",
   cacheComponents: true,
   pageExtensions: ["js", "jsx", "md", "mdx", "ts", "tsx"],
   transpilePackages,


### PR DESCRIPTION
pnpm's strict module isolation means zod is only available via symlinks
in each workspace's node_modules, which aren't preserved in deployed
environments. standalone output bundles all dependencies into the build.

https://claude.ai/code/session_0182hRj9Yz2LiuiF3XHVCp1T

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit e856431b6c7dce9e96d6c98b61e06a34e496f1da. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bundle dependencies in the desktop main build to fix `zod` module-not-found errors in deployment. Disable `electron-vite` externalization (`externalizeDeps: false`) so non-native deps (like `zod`) are bundled, while native modules stay external via `rollupOptions.external`, avoiding `pnpm` workspace symlink issues with `electron-builder`.

<sup>Written for commit e856431b6c7dce9e96d6c98b61e06a34e496f1da. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

