### PR TITLE
refactor(desktop): lifecycle registries for startup/shutdown/setup

### DIFF
--- a/apps/desktop/src/__tests__/app-effects.test.ts
+++ b/apps/desktop/src/__tests__/app-effects.test.ts
@@ -1,17 +1,23 @@
-import { describe, it, expect, vi } from "vitest";
+import { beforeEach, describe, it, expect, vi } from "vitest";
 import { runEffect, type EffectDeps } from "@/main/app-effects";
+import { registerSetup, resetSetup } from "@/main/lifecycle";
+
+vi.mock("@/main/session-history", () => ({
+  clearResolvedSessionFile: vi.fn(),
+}));
 
 function makeDeps(overrides?: Partial<EffectDeps>): EffectDeps {
   return {
     login: vi.fn<() => Promise<void>>().mockResolvedValue(undefined),
-    seedResources: vi.fn(),
-    installGws: vi.fn<() => Promise<void>>().mockResolvedValue(undefined),
-    startAgent: vi.fn<() => Promise<void>>().mockResolvedValue(undefined),
     stopAgent: vi.fn<() => Promise<void>>().mockResolvedValue(undefined),
     teardownResources: vi.fn(),
     ...overrides,
   };
 }
+
+beforeEach(() => {
+  resetSetup();
+});
 
 describe("runEffect", () => {
   // ---- LOGIN ----------------------------------------------------------------
@@ -33,29 +39,32 @@ describe("runEffect", () => {
 
   // ---- SETUP ----------------------------------------------------------------
 
-  it("SETUP calls deps.seedResources and deps.installGws, returns SETUP_OK", async () => {
-    const deps = makeDeps();
-    const result = await runEffect("SETUP", deps);
-    expect(deps.seedResources).toHaveBeenCalledOnce();
-    expect(deps.installGws).toHaveBeenCalledOnce();
+  it("SETUP runs all registered setup steps and returns SETUP_OK", async () => {
+    const step1 = vi.fn();
+    const step2 = vi.fn<() => Promise<void>>().mockResolvedValue(undefined);
+    registerSetup({ name: "step-1", run: step1 });
+    registerSetup({ name: "step-2", run: step2 });
+
+    const result = await runEffect("SETUP", makeDeps());
+    expect(step1).toHaveBeenCalledOnce();
+    expect(step2).toHaveBeenCalledOnce();
     expect(result).toEqual({ type: "SETUP_OK" });
   });
 
-  it("SETUP returns SETUP_FAIL when seedResources throws", async () => {
-    const deps = makeDeps({
-      seedResources: vi.fn().mockImplementation(() => {
-        throw new Error("seed broke");
-      }),
-    });
-    const result = await runEffect("SETUP", deps);
-    expect(result).toEqual({ type: "SETUP_FAIL", message: "seed broke" });
+  it("SETUP returns SETUP_FAIL with step name when a step throws", async () => {
+    registerSetup({ name: "ok", run: vi.fn() });
+    registerSetup({ name: "broken", run: () => { throw new Error("seed broke"); } });
+
+    const result = await runEffect("SETUP", makeDeps());
+    expect(result).toEqual({ type: "SETUP_FAIL", message: "broken: seed broke" });
   });
 
   // ---- LOGOUT ---------------------------------------------------------------
 
-  it("LOGOUT calls deps.teardownResources and returns LOGOUT_OK", async () => {
+  it("LOGOUT calls stopAgent + teardownResources and returns LOGOUT_OK", async () => {
     const deps = makeDeps();
     const result = await runEffect("LOGOUT", deps);
+    expect(deps.stopAgent).toHaveBeenCalledOnce();
     expect(deps.teardownResources).toHaveBeenCalledOnce();
     expect(result).toEqual({ type: "LOGOUT_OK" });
   });

--- a/apps/desktop/src/__tests__/app-machine.test.ts
+++ b/apps/desktop/src/__tests__/app-machine.test.ts
@@ -1,6 +1,7 @@
-import { describe, it, expect, vi } from "vitest";
+import { beforeEach, describe, it, expect, vi } from "vitest";
 import { AppMachine } from "@/main/app-machine";
 import type { EffectDeps } from "@/main/app-effects";
+import { registerSetup, resetSetup } from "@/main/lifecycle";
 import type { AppState } from "@/shared/app-state";
 
 vi.mock("electron", () => ({
@@ -12,22 +13,25 @@ vi.mock("@/agent/setup", () => ({
   isLoggedIn: vi.fn().mockReturnValue(false),
   isSetupComplete: vi.fn().mockReturnValue(false),
   login: vi.fn().mockResolvedValue(undefined),
-  seedResources: vi.fn(),
-  installGws: vi.fn().mockResolvedValue(undefined),
   teardownResources: vi.fn(),
+}));
+
+vi.mock("@/main/notifications", () => ({
+  getNotifications: () => ({ notifyAgentIdle: vi.fn() }),
 }));
 
 function fakeDeps(overrides?: Partial<EffectDeps>): EffectDeps {
   return {
-    login: vi.fn().mockResolvedValue(undefined),
-    seedResources: vi.fn(),
-    installGws: vi.fn().mockResolvedValue(undefined),
-    startAgent: vi.fn().mockResolvedValue(undefined),
-    stopAgent: vi.fn().mockResolvedValue(undefined),
+    login: vi.fn<() => Promise<void>>().mockResolvedValue(undefined),
+    stopAgent: vi.fn<() => Promise<void>>().mockResolvedValue(undefined),
     teardownResources: vi.fn(),
     ...overrides,
   };
 }
+
+beforeEach(() => {
+  resetSetup();
+});
 
 describe("AppMachine", () => {
   it("starts in logged_out by default", () => {
@@ -57,7 +61,7 @@ describe("AppMachine", () => {
 
   it("LOGIN failure → error state", async () => {
     const deps = fakeDeps({
-      login: vi.fn().mockRejectedValue(new Error("auth failed")),
+      login: vi.fn<() => Promise<void>>().mockRejectedValue(new Error("auth failed")),
     });
     const machine = new AppMachine(deps, vi.fn());
 
@@ -70,15 +74,31 @@ describe("AppMachine", () => {
     });
   });
 
-  it("SETUP → setting_up → seedResources() + installGws() → ready", async () => {
-    const deps = fakeDeps();
-    const machine = new AppMachine(deps, vi.fn(), { phase: "logged_in" });
+  it("SETUP runs registered steps and transitions to ready", async () => {
+    const seed = vi.fn();
+    const install = vi.fn<() => Promise<void>>().mockResolvedValue(undefined);
+    registerSetup({ name: "seed", run: seed });
+    registerSetup({ name: "install", run: install });
 
+    const machine = new AppMachine(fakeDeps(), vi.fn(), { phase: "logged_in" });
     await machine.send({ type: "SETUP" });
 
-    expect(deps.seedResources).toHaveBeenCalledOnce();
-    expect(deps.installGws).toHaveBeenCalledOnce();
+    expect(seed).toHaveBeenCalledOnce();
+    expect(install).toHaveBeenCalledOnce();
     expect(machine.getState()).toEqual({ phase: "ready", agent: "idle" });
+  });
+
+  it("SETUP step failure → error state carries step name", async () => {
+    registerSetup({ name: "install-gws", run: () => { throw new Error("boom"); } });
+
+    const machine = new AppMachine(fakeDeps(), vi.fn(), { phase: "logged_in" });
+    await machine.send({ type: "SETUP" });
+
+    expect(machine.getState()).toEqual({
+      phase: "error",
+      prev: "setting_up",
+      message: "install-gws: boom",
+    });
   });
 
   it("LOGOUT → logging_out → teardown → logged_out", async () => {
@@ -103,13 +123,13 @@ describe("AppMachine", () => {
 
   it("ignores invalid events", async () => {
     const machine = new AppMachine(fakeDeps(), vi.fn());
-    await machine.send({ type: "SETUP" }); // invalid from logged_out
+    await machine.send({ type: "SETUP" });
     expect(machine.getState()).toEqual({ phase: "logged_out" });
   });
 
   it("serializes concurrent sends", async () => {
     const deps = fakeDeps({
-      login: vi.fn().mockImplementation(
+      login: vi.fn<() => Promise<void>>().mockImplementation(
         () => new Promise((resolve) => setTimeout(resolve, 50)),
       ),
     });

--- a/apps/desktop/src/__tests__/lifecycle.test.ts
+++ b/apps/desktop/src/__tests__/lifecycle.test.ts
@@ -1,0 +1,90 @@
+import { beforeEach, describe, it, expect, vi } from "vitest";
+import {
+  registerSetup,
+  registerShutdown,
+  registerStartup,
+  resetSetup,
+  resetShutdown,
+  resetStartup,
+  runSetup,
+  runShutdown,
+  runStartup,
+} from "@/main/lifecycle";
+
+beforeEach(() => {
+  resetStartup();
+  resetShutdown();
+  resetSetup();
+});
+
+describe("startup registry", () => {
+  it("runs hooks in registration order", async () => {
+    const calls: string[] = [];
+    registerStartup({ name: "a", run: () => { calls.push("a"); } });
+    registerStartup({ name: "b", run: async () => { calls.push("b"); } });
+    registerStartup({ name: "c", run: () => { calls.push("c"); } });
+
+    await runStartup();
+    expect(calls).toEqual(["a", "b", "c"]);
+  });
+
+  it("propagates errors (caller decides fatality)", async () => {
+    registerStartup({ name: "boom", run: () => { throw new Error("nope"); } });
+    await expect(runStartup()).rejects.toThrow("nope");
+  });
+});
+
+describe("shutdown registry", () => {
+  it("runs hooks in reverse registration order (LIFO)", async () => {
+    const calls: string[] = [];
+    registerShutdown({ name: "a", run: () => { calls.push("a"); } });
+    registerShutdown({ name: "b", run: () => { calls.push("b"); } });
+    registerShutdown({ name: "c", run: () => { calls.push("c"); } });
+
+    await runShutdown();
+    expect(calls).toEqual(["c", "b", "a"]);
+  });
+
+  it("continues after a failing hook", async () => {
+    const calls: string[] = [];
+    registerShutdown({ name: "ok-1", run: () => { calls.push("ok-1"); } });
+    registerShutdown({ name: "bad", run: () => { throw new Error("boom"); } });
+    registerShutdown({ name: "ok-2", run: () => { calls.push("ok-2"); } });
+
+    await runShutdown();
+    expect(calls).toEqual(["ok-2", "ok-1"]);
+  });
+
+  it("times out a stuck hook and keeps going", async () => {
+    const calls: string[] = [];
+    registerShutdown({ name: "stuck", run: () => new Promise(() => {}), timeoutMs: 20 });
+    registerShutdown({ name: "after", run: () => { calls.push("after"); } });
+
+    // "after" is registered later → runs first (LIFO)
+    await runShutdown();
+    expect(calls).toEqual(["after"]);
+  });
+});
+
+describe("setup registry", () => {
+  it("runs steps in registration order, returns ok", async () => {
+    const calls: string[] = [];
+    registerSetup({ name: "a", run: () => { calls.push("a"); } });
+    registerSetup({ name: "b", run: async () => { calls.push("b"); } });
+
+    const result = await runSetup();
+    expect(calls).toEqual(["a", "b"]);
+    expect(result).toEqual({ ok: true });
+  });
+
+  it("aborts on first failure and reports step name", async () => {
+    const after = vi.fn();
+    registerSetup({ name: "ok", run: vi.fn() });
+    registerSetup({ name: "install-gws", run: () => { throw new Error("checksum mismatch"); } });
+    registerSetup({ name: "after", run: after });
+
+    const result = await runSetup();
+    expect(result).toEqual({ ok: false, step: "install-gws", message: "checksum mismatch" });
+    expect(after).not.toHaveBeenCalled();
+  });
+});

--- a/apps/desktop/src/main/app-effects.ts
+++ b/apps/desktop/src/main/app-effects.ts
@@ -3,6 +3,7 @@
 // Returns a completion MachineEvent to feed back into the reducer.
 // ---------------------------------------------------------------------------
 
+import { runSetup } from "@/main/lifecycle";
 import { toErrorMessage } from "@/shared/ipc";
 import type { MachineEvent } from "@/shared/app-state";
 import { clearResolvedSessionFile } from "./session-history";
@@ -10,9 +11,6 @@ import type { EffectTag } from "./app-reducer";
 
 export type EffectDeps = {
   login: () => Promise<void>;
-  seedResources: () => void;
-  installGws: () => Promise<void>;
-  startAgent: () => Promise<void>;
   stopAgent: () => Promise<void>;
   teardownResources: () => void;
 };
@@ -29,14 +27,9 @@ export async function runEffect(tag: EffectTag, deps: EffectDeps): Promise<Machi
     }
 
     case "SETUP": {
-      try {
-        deps.seedResources();
-        await deps.installGws();
-        await deps.startAgent();
-        return { type: "SETUP_OK" };
-      } catch (err) {
-        return { type: "SETUP_FAIL", message: toErrorMessage(err) };
-      }
+      const result = await runSetup();
+      if (result.ok) return { type: "SETUP_OK" };
+      return { type: "SETUP_FAIL", message: `${result.step}: ${result.message}` };
     }
 
     case "LOGOUT": {

--- a/apps/desktop/src/main/app-machine.ts
+++ b/apps/desktop/src/main/app-machine.ts
@@ -4,11 +4,9 @@
 
 import {
   Agent,
-  installGws,
   isLoggedIn,
   isSetupComplete,
   login,
-  seedResources,
   teardownResources,
 } from "@/agent/setup";
 import { reduce } from "@/main/app-reducer";
@@ -56,7 +54,7 @@ function handleAgentEvent(event: AppAgentEvent): void {
   broadcastToRenderer(IPC_CHANNELS.AGENT_EVENT, event);
 }
 
-async function startAgent(): Promise<void> {
+export async function startAgent(): Promise<void> {
   if (agent) return;
   const next = new Agent();
   try {
@@ -80,7 +78,7 @@ async function startAgent(): Promise<void> {
   agent = next;
 }
 
-async function stopAgent(): Promise<void> {
+export async function stopAgent(): Promise<void> {
   taskManager.stopScheduler();
   if (agent) {
     await agent.stop();
@@ -164,9 +162,6 @@ function broadcast(state: AppState): void {
 
 const realDeps: EffectDeps = {
   login,
-  seedResources,
-  installGws,
-  startAgent,
   stopAgent,
   teardownResources,
 };

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -17,9 +17,25 @@ try {
   // .env file is optional
 }
 
-import { getAgent, getAppState, initMachine, shutdown, transition } from "@/main/app-machine";
+import { disposeBrowserTool } from "@/agent/browser-tool";
+import { installGws, seedResources } from "@/agent/setup";
+import {
+  getAgent,
+  getAppState,
+  initMachine,
+  shutdown,
+  startAgent,
+  transition,
+} from "@/main/app-machine";
 import { broadcastToRenderer } from "@/main/lib/broadcast";
 import { createIpcHandler, createVoidIpcHandler } from "@/main/lib/ipc-handler";
+import {
+  registerSetup,
+  registerShutdown,
+  registerStartup,
+  runShutdown,
+  runStartup,
+} from "@/main/lifecycle";
 import { getNotifications } from "@/main/notifications";
 import { taskManager } from "@/main/tasks/task-singleton";
 import { readSessionHistory } from "@/main/session-history";
@@ -371,6 +387,33 @@ function createWindow(): BrowserWindow {
 }
 
 // ---------------------------------------------------------------------------
+// Lifecycle wiring — registered once at module load, executed on whenReady().
+// Startup = every launch. Setup = first sign-in. Shutdown = LIFO on quit.
+// ---------------------------------------------------------------------------
+
+registerStartup({ name: "app-identity", run: configureAppIdentity });
+registerStartup({ name: "application-menu", run: configureApplicationMenu });
+registerStartup({ name: "auto-updater", run: configureAutoUpdater });
+registerStartup({ name: "ipc-handlers", run: registerIpcHandlers });
+registerStartup({
+  name: "main-window",
+  run: () => {
+    mainWindow = createWindow();
+    getNotifications().setTargetWindow(mainWindow);
+  },
+});
+// Resolve session file path so Agent opens the same session the UI loaded.
+registerStartup({ name: "session-history", run: () => { readSessionHistory(); } });
+registerStartup({ name: "app-machine", run: initMachine });
+
+registerSetup({ name: "seed-resources", run: seedResources });
+registerSetup({ name: "install-gws", run: installGws });
+registerSetup({ name: "start-agent", run: startAgent });
+
+registerShutdown({ name: "browser-tool", run: disposeBrowserTool });
+registerShutdown({ name: "app-machine", run: shutdown });
+
+// ---------------------------------------------------------------------------
 // App lifecycle
 // ---------------------------------------------------------------------------
 
@@ -378,27 +421,14 @@ app.on("before-quit", (event) => {
   if (isQuitting) return;
   isQuitting = true;
   event.preventDefault();
-  void shutdown().finally(() => {
+  void runShutdown().finally(() => {
     app.quit();
   });
 });
 
 app
   .whenReady()
-  .then(async () => {
-    configureAppIdentity();
-    configureApplicationMenu();
-    configureAutoUpdater();
-    registerIpcHandlers();
-
-    mainWindow = createWindow();
-    getNotifications().setTargetWindow(mainWindow);
-
-    // Resolve session file path before initMachine() starts the agent
-    readSessionHistory();
-
-    initMachine();
-  })
+  .then(() => runStartup())
   .catch((error) => {
     console.error("[desktop] fatal startup error", error);
     dialog.showErrorBox("Inteligir failed to start", toErrorMessage(error));

--- a/apps/desktop/src/main/lifecycle/index.ts
+++ b/apps/desktop/src/main/lifecycle/index.ts
@@ -1,0 +1,8 @@
+export { registerStartup, runStartup, resetStartup } from "./startup";
+export type { StartupHook } from "./startup";
+
+export { registerShutdown, runShutdown, resetShutdown } from "./shutdown";
+export type { ShutdownHook } from "./shutdown";
+
+export { registerSetup, runSetup, resetSetup } from "./setup";
+export type { SetupStep, SetupResult } from "./setup";

--- a/apps/desktop/src/main/lifecycle/setup.ts
+++ b/apps/desktop/src/main/lifecycle/setup.ts
@@ -1,0 +1,37 @@
+// ---------------------------------------------------------------------------
+// Setup registry — first-sign-in steps. FIFO, aborts on first failure. Each
+// step carries a name so the UI can show "Installing gws… failed".
+// ---------------------------------------------------------------------------
+
+export type SetupStep = {
+  name: string;
+  run: () => void | Promise<void>;
+};
+
+export type SetupResult =
+  | { ok: true }
+  | { ok: false; step: string; message: string };
+
+const steps: SetupStep[] = [];
+
+export function registerSetup(step: SetupStep): void {
+  steps.push(step);
+}
+
+export async function runSetup(): Promise<SetupResult> {
+  for (const step of steps) {
+    console.log(`[setup] ${step.name}`);
+    try {
+      await step.run();
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      return { ok: false, step: step.name, message };
+    }
+  }
+  return { ok: true };
+}
+
+/** Test-only — clear between cases. */
+export function resetSetup(): void {
+  steps.length = 0;
+}

--- a/apps/desktop/src/main/lifecycle/shutdown.ts
+++ b/apps/desktop/src/main/lifecycle/shutdown.ts
@@ -1,0 +1,50 @@
+// ---------------------------------------------------------------------------
+// Shutdown registry — LIFO (reverse of registration). Best-effort: a failing
+// hook is logged and the next one still runs, so we always finish teardown.
+// ---------------------------------------------------------------------------
+
+export type ShutdownHook = {
+  name: string;
+  run: () => void | Promise<void>;
+  /** Per-hook timeout in ms. Default 5s. */
+  timeoutMs?: number;
+};
+
+const hooks: ShutdownHook[] = [];
+
+export function registerShutdown(hook: ShutdownHook): void {
+  hooks.push(hook);
+}
+
+export async function runShutdown(): Promise<void> {
+  for (let i = hooks.length - 1; i >= 0; i--) {
+    const hook = hooks[i];
+    if (!hook) continue;
+    const timeoutMs = hook.timeoutMs ?? 5_000;
+    console.log(`[shutdown] ${hook.name}`);
+    try {
+      await withTimeout(hook.run(), timeoutMs, hook.name);
+    } catch (err) {
+      console.error(`[shutdown] ${hook.name} failed:`, err);
+    }
+  }
+}
+
+/** Test-only — clear between cases. */
+export function resetShutdown(): void {
+  hooks.length = 0;
+}
+
+function withTimeout<T>(
+  value: T | Promise<T>,
+  timeoutMs: number,
+  name: string,
+): Promise<T> {
+  return new Promise<T>((resolve, reject) => {
+    const timer = setTimeout(() => reject(new Error(`${name} timed out after ${timeoutMs}ms`)), timeoutMs);
+    Promise.resolve(value).then(
+      (v) => { clearTimeout(timer); resolve(v); },
+      (e) => { clearTimeout(timer); reject(e); },
+    );
+  });
+}

--- a/apps/desktop/src/main/lifecycle/startup.ts
+++ b/apps/desktop/src/main/lifecycle/startup.ts
@@ -1,0 +1,27 @@
+// ---------------------------------------------------------------------------
+// Startup registry — hooks run every launch, in registration order.
+// Errors propagate: the caller decides whether to show a fatal dialog + quit.
+// ---------------------------------------------------------------------------
+
+export type StartupHook = {
+  name: string;
+  run: () => void | Promise<void>;
+};
+
+const hooks: StartupHook[] = [];
+
+export function registerStartup(hook: StartupHook): void {
+  hooks.push(hook);
+}
+
+export async function runStartup(): Promise<void> {
+  for (const hook of hooks) {
+    console.log(`[startup] ${hook.name}`);
+    await hook.run();
+  }
+}
+
+/** Test-only — clear between cases. */
+export function resetStartup(): void {
+  hooks.length = 0;
+}


### PR DESCRIPTION
## Summary

Rebased onto post-#314 `main`. Dropped the `agent/` folder split (superseded by #314's `@repo/pi-driver` / `@repo/agent-runtime` package extraction) and the `waitForIdle` TDZ fix (already in #314). What remains is just the lifecycle work — three small registries plus their wiring.

## Lifecycle registries (`src/main/lifecycle/`)

| Registry | Order | Error policy | Used for |
|----------|-------|--------------|----------|
| `startup`  | FIFO | Propagates → fatal dialog + quit | identity, menu, auto-updater, IPC, window + notification target, session history, machine init |
| `setup`    | FIFO | Aborts on first failure, returns `{ step, message }` | first-sign-in: seed resources, install gws, start agent |
| `shutdown` | LIFO | Best-effort with per-hook timeout | browser-tool dispose, machine shutdown |

`main/index.ts`'s `whenReady` is now `runStartup()`; `before-quit` is `runShutdown()`. `app-effects.ts` SETUP calls `runSetup()` and formats `SETUP_FAIL` as `"<step>: <message>"`. `EffectDeps` trims to `login` / `stopAgent` / `teardownResources` — `seedResources` / `installGws` / `startAgent` are now setup-registry hooks instead of being threaded through deps.

## Diff size

10 files, +327 / −68. Four new lifecycle modules, one new test, five wiring tweaks. Compare to the pre-rebase scope (21 files, +972 / −748).

## Test plan

- [x] `pnpm -F @repo/desktop typecheck` — clean
- [x] `pnpm -F @repo/desktop test` — 126/126 pass, including new `lifecycle.test.ts` covering FIFO/LIFO ordering, shutdown timeout, continue-after-failure, and setup step-name reporting
- [x] `pnpm -F @repo/desktop build` — succeeds
- [ ] Manual smoke in dev: fresh install (each setup step name appears in logs in order), re-launch (machine init startup hook runs), logout + retry, quit (shutdown order visible in logs in reverse-of-registration)

https://claude.ai/code/session_011rQtfBiaypxxDfhdzofh8A