### PR TITLE
chore: format + desktop cdp

### DIFF
--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -1,6 +1,3 @@
 [mcp_servers.next-devtools]
-args = [
-    "-y",
-    "next-devtools-mcp@latest",
-]
+args = ["-y", "next-devtools-mcp@latest"]
 command = "npx"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -48,6 +48,19 @@ pnpm db:push-remote   # Push schema to prod
 pnpm db:reset         # Reset local DB
 ```
 
+## Desktop Debugging
+
+Desktop dev opens Electron with CDP on port 9222 by default.
+
+```bash
+pnpm dev:desktop
+agent-browser --session inteligir-desktop connect 9222
+agent-browser --session inteligir-desktop snapshot -i
+agent-browser --session inteligir-desktop screenshot /tmp/inteligir-desktop.png
+```
+
+Use `agent-browser` for desktop UI validation. Inspect the actual Electron app.
+
 ## Quality Gates
 
 Before committing:

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -12,7 +12,7 @@
     "release:publish": "pnpm verify:release && GH_TOKEN=$(gh auth token) pnpm with-env electron-vite build && GH_TOKEN=$(gh auth token) pnpm with-env electron-builder --mac dmg --publish always && pnpm verify:packaged",
     "with-env": "dotenv -e .env --",
     "clean": "rm -rf .cache .output",
-    "dev": "electron-vite dev",
+    "dev": "electron-vite dev --remoteDebuggingPort 9222",
     "start": "electron-vite preview",
     "test": "vitest run",
     "typecheck": "tsc --noEmit",

--- a/apps/desktop/resources/agent/skills/google-workspace/SKILL.md
+++ b/apps/desktop/resources/agent/skills/google-workspace/SKILL.md
@@ -36,12 +36,14 @@ gws <service> <resource> <method> [flags]
 ```
 
 Common flags:
+
 - `--params '{...}'` — query/path parameters as JSON
 - `--json '{...}'` — request body as JSON
 - `--page-all` — auto-paginate and stream all results as NDJSON
 - `--dry-run` — preview the request without executing
 
 Discover available services and commands:
+
 ```bash
 gws <service> --help
 ```
@@ -51,6 +53,7 @@ gws <service> --help
 Prefixed with `+`, these are high-level workflows:
 
 ### Gmail
+
 ```bash
 gws gmail +triage                                    # inbox summary
 gws gmail +send --to a@b.com --subject "Hi" --body "Hello"
@@ -62,6 +65,7 @@ gws gmail messages get --params '{"id":"<id>","userId":"me"}'
 ```
 
 ### Calendar
+
 ```bash
 gws calendar +agenda                                 # upcoming events
 gws calendar +agenda --timezone America/New_York
@@ -70,6 +74,7 @@ gws calendar events list --params '{"calendarId":"primary","maxResults":10}'
 ```
 
 ### Drive
+
 ```bash
 gws drive +upload ./file.pdf --name "Report"
 gws drive files list --params '{"pageSize":10}'
@@ -77,12 +82,14 @@ gws drive files get --params '{"fileId":"<id>"}'
 ```
 
 ### Docs
+
 ```bash
 gws docs +write --title "Meeting Notes" --body "# Notes\n\nContent here"
 gws docs documents get --params '{"documentId":"<id>"}'
 ```
 
 ### Sheets
+
 ```bash
 gws sheets +read --spreadsheet-id <id> --range "Sheet1!A1:C10"
 gws sheets +append --spreadsheet-id <id> --range "Sheet1" --values '[["a","b"],["c","d"]]'
@@ -90,12 +97,14 @@ gws sheets spreadsheets create --json '{"properties":{"title":"Budget"}}'
 ```
 
 ### Slides
+
 ```bash
 gws slides presentations create --json '{"title":"Deck"}'
 gws slides presentations get --params '{"presentationId":"<id>"}'
 ```
 
 ### Tasks
+
 ```bash
 gws tasks tasklists list
 gws tasks tasks list --params '{"tasklist":"<id>"}'
@@ -103,22 +112,26 @@ gws tasks tasks insert --params '{"tasklist":"<id>"}' --json '{"title":"Do thing
 ```
 
 ### Contacts (People API)
+
 ```bash
 gws people people.connections list --params '{"resourceName":"people/me","personFields":"names,emailAddresses"}'
 ```
 
 ### Chat
+
 ```bash
 gws chat spaces list
 gws chat spaces.messages create --params '{"parent":"spaces/<id>"}' --json '{"text":"Hello"}'
 ```
 
 ### Meet
+
 ```bash
 gws meet conferenceRecords list
 ```
 
 ### Admin
+
 ```bash
 gws admin users list --params '{"domain":"example.com"}'
 ```

--- a/apps/desktop/scripts/verify-packaged-runtime-deps.mjs
+++ b/apps/desktop/scripts/verify-packaged-runtime-deps.mjs
@@ -21,10 +21,7 @@ import { fileURLToPath } from "node:url";
 const APP_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "..");
 const BIN_DIR = join(APP_ROOT, ".output/bin");
 const PACKAGE_JSON = join(APP_ROOT, "package.json");
-const REQUIRED_RUNTIME_DEPS = [
-  "@mariozechner/pi-coding-agent",
-  "@mariozechner/pi-ai",
-];
+const REQUIRED_RUNTIME_DEPS = ["@mariozechner/pi-coding-agent", "@mariozechner/pi-ai"];
 
 // `electron-builder --mac dmg` produces a .app inside .output/bin/mac{,-arm64}/
 function findAppBundle() {

--- a/apps/desktop/scripts/verify-runtime-model-registry.mjs
+++ b/apps/desktop/scripts/verify-runtime-model-registry.mjs
@@ -10,9 +10,7 @@ const MODEL_ID = "gpt-5.5";
 const model = getModel(PROVIDER, MODEL_ID);
 
 if (!model) {
-  console.error(
-    `[verify] Model "${PROVIDER}/${MODEL_ID}" not found in pi-ai model registry.`,
-  );
+  console.error(`[verify] Model "${PROVIDER}/${MODEL_ID}" not found in pi-ai model registry.`);
   console.error(
     `[verify] Either bump pi-ai to a version that ships this model, or update apps/desktop/src/agent/setup.ts to a model that exists.`,
   );

--- a/apps/desktop/src/__tests__/action-dispatcher.test.ts
+++ b/apps/desktop/src/__tests__/action-dispatcher.test.ts
@@ -100,8 +100,7 @@ describe("action-dispatcher", () => {
     it("navigates for valid http URL", async () => {
       // Mock awaitNavigation — Page.loadEventFired fires immediately
       vi.mocked(mockCDP.on).mockImplementation((event, handler) => {
-        if (event === "Page.loadEventFired")
-          setTimeout(() => (handler as () => void)(), 0);
+        if (event === "Page.loadEventFired") setTimeout(() => (handler as () => void)(), 0);
       });
       const result = await dispatchAction({ action: "open", url: "https://example.com" }, ctx);
       expect(textContent(result)).toContain("Navigated to");
@@ -119,7 +118,12 @@ describe("action-dispatcher", () => {
       ctx = { session };
 
       const actions: BrowserAction["action"][] = [
-        "click", "fill", "snapshot", "get_url", "scroll", "screenshot",
+        "click",
+        "fill",
+        "snapshot",
+        "get_url",
+        "scroll",
+        "screenshot",
       ];
       for (const action of actions) {
         const result = await dispatchAction({ action } as BrowserAction, ctx);
@@ -164,10 +168,7 @@ describe("action-dispatcher", () => {
     });
 
     it("scrolls up with negative delta", async () => {
-      const result = await dispatchAction(
-        { action: "scroll", direction: "up", amount: 300 },
-        ctx,
-      );
+      const result = await dispatchAction({ action: "scroll", direction: "up", amount: 300 }, ctx);
       expect(textContent(result)).toBe("Scrolled up 300px");
       expect(evaluate).toHaveBeenCalledWith(mockCDP, "window.scrollBy(0, -300)");
     });

--- a/apps/desktop/src/__tests__/app-machine.test.ts
+++ b/apps/desktop/src/__tests__/app-machine.test.ts
@@ -50,10 +50,7 @@ describe("AppMachine", () => {
 
     expect(deps.login).toHaveBeenCalledOnce();
     expect(machine.getState()).toEqual({ phase: "logged_in" });
-    expect(broadcasts).toEqual([
-      { phase: "logging_in" },
-      { phase: "logged_in" },
-    ]);
+    expect(broadcasts).toEqual([{ phase: "logging_in" }, { phase: "logged_in" }]);
   });
 
   it("LOGIN failure → error state", async () => {
@@ -110,9 +107,7 @@ describe("AppMachine", () => {
 
   it("serializes concurrent sends", async () => {
     const deps = fakeDeps({
-      login: vi.fn().mockImplementation(
-        () => new Promise((resolve) => setTimeout(resolve, 50)),
-      ),
+      login: vi.fn().mockImplementation(() => new Promise((resolve) => setTimeout(resolve, 50))),
     });
     const machine = new AppMachine(deps, vi.fn());
 

--- a/apps/desktop/src/__tests__/app-reducer.test.ts
+++ b/apps/desktop/src/__tests__/app-reducer.test.ts
@@ -68,10 +68,7 @@ describe("reduce", () => {
   });
 
   it("LOGOUT from error → logging_out + LOGOUT effect", () => {
-    const result = reduce(
-      { phase: "error", prev: "ready", message: "oops" },
-      { type: "LOGOUT" },
-    );
+    const result = reduce({ phase: "error", prev: "ready", message: "oops" }, { type: "LOGOUT" });
     expect(result).toEqual({ next: { phase: "logging_out" }, effect: "LOGOUT" });
   });
 
@@ -105,10 +102,7 @@ describe("reduce", () => {
   });
 
   it("RETRY from error(ready) → setting_up + SETUP", () => {
-    const result = reduce(
-      { phase: "error", prev: "ready", message: "fail" },
-      { type: "RETRY" },
-    );
+    const result = reduce({ phase: "error", prev: "ready", message: "fail" }, { type: "RETRY" });
     expect(result).toEqual({ next: { phase: "setting_up" }, effect: "SETUP" });
   });
 
@@ -135,6 +129,8 @@ describe("reduce", () => {
   // ---- Unknown events -------------------------------------------------------
 
   it("unknown event type → null", () => {
-    expect(reduce({ phase: "logged_out" }, { type: "UNKNOWN" } as unknown as MachineEvent)).toBeNull();
+    expect(
+      reduce({ phase: "logged_out" }, { type: "UNKNOWN" } as unknown as MachineEvent),
+    ).toBeNull();
   });
 });

--- a/apps/desktop/src/__tests__/cdp-adapter.test.ts
+++ b/apps/desktop/src/__tests__/cdp-adapter.test.ts
@@ -1,5 +1,11 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { getElementCenter, cdpClick, cdpType, cdpPress, cdpHover } from "@/agent/browser/cdp-adapter";
+import {
+  getElementCenter,
+  cdpClick,
+  cdpType,
+  cdpPress,
+  cdpHover,
+} from "@/agent/browser/cdp-adapter";
 import type { CDPClient } from "@/agent/browser/cdp-client";
 
 function createMockCDP() {
@@ -28,9 +34,12 @@ describe("cdp-adapter", () => {
       mockEvaluateResult(cdp, { x: 100, y: 200 });
       const result = await getElementCenter(cdp, "#btn");
       expect(result).toEqual({ x: 100, y: 200 });
-      expect(cdp.send).toHaveBeenCalledWith("Runtime.evaluate", expect.objectContaining({
-        returnByValue: true,
-      }));
+      expect(cdp.send).toHaveBeenCalledWith(
+        "Runtime.evaluate",
+        expect.objectContaining({
+          returnByValue: true,
+        }),
+      );
     });
 
     it("throws when element not found (null result)", async () => {

--- a/apps/desktop/src/__tests__/json-store.test.ts
+++ b/apps/desktop/src/__tests__/json-store.test.ts
@@ -7,7 +7,9 @@ function memoryFs(): FsAdapter & { files: Map<string, string> } {
   return {
     files,
     read: (path) => files.get(path) ?? null,
-    write: (path, content) => { files.set(path, content); },
+    write: (path, content) => {
+      files.set(path, content);
+    },
   };
 }
 

--- a/apps/desktop/src/__tests__/task-manager.test.ts
+++ b/apps/desktop/src/__tests__/task-manager.test.ts
@@ -7,7 +7,9 @@ function memoryFs(): FsAdapter {
   const files = new Map<string, string>();
   return {
     read: (path) => files.get(path) ?? null,
-    write: (path, content) => { files.set(path, content); },
+    write: (path, content) => {
+      files.set(path, content);
+    },
   };
 }
 

--- a/apps/desktop/src/agent/browser-tool.ts
+++ b/apps/desktop/src/agent/browser-tool.ts
@@ -37,9 +37,7 @@ export function registerBrowserExtension(pi: ExtensionAPI): void {
       try {
         return await dispatchAction(params, { session: currentSession });
       } catch (err) {
-        return text(
-          `Browser error: ${err instanceof Error ? err.message : String(err)}`,
-        );
+        return text(`Browser error: ${err instanceof Error ? err.message : String(err)}`);
       }
     },
   });

--- a/apps/desktop/src/agent/browser/action-dispatcher.ts
+++ b/apps/desktop/src/agent/browser/action-dispatcher.ts
@@ -34,7 +34,9 @@ function validateUrl(url: string): ToolResult | null {
   try {
     const parsed = new URL(url);
     if (!ALLOWED_SCHEMES.has(parsed.protocol)) {
-      return text(`Error: URL scheme "${parsed.protocol}" is not allowed. Use http: or https: URLs only.`);
+      return text(
+        `Error: URL scheme "${parsed.protocol}" is not allowed. Use http: or https: URLs only.`,
+      );
     }
     return null;
   } catch {
@@ -169,7 +171,9 @@ export async function dispatchAction(
       if (!action.selector) return text("Error: selector is required for fill");
       if (action.text === undefined) return text("Error: text is required for fill");
       const sel = session.resolveSelector(action.selector);
-      const cleared = await evaluate(cdp, `
+      const cleared = await evaluate(
+        cdp,
+        `
         (function() {
           const el = document.querySelector(${JSON.stringify(sel)});
           if (!el) return false;
@@ -185,7 +189,8 @@ export async function dispatchAction(
           el.dispatchEvent(new Event("change", { bubbles: true }));
           return true;
         })()
-      `);
+      `,
+      );
       if (!cleared) return text(`Error: Element not found: ${sel}`);
       await cdpType(cdp, action.text);
       return text(`Filled ${action.selector} with "${action.text}"`);
@@ -218,7 +223,9 @@ export async function dispatchAction(
       if (!action.selector) return text("Error: selector is required for select");
       if (!action.text) return text("Error: text (option value) is required for select");
       const sel = session.resolveSelector(action.selector);
-      const selectResult = await evaluate(cdp, `
+      const selectResult = (await evaluate(
+        cdp,
+        `
         (function() {
           const el = document.querySelector(${JSON.stringify(sel)});
           if (!el) return "not_found";
@@ -231,7 +238,8 @@ export async function dispatchAction(
           el.dispatchEvent(new Event("change", { bubbles: true }));
           return "ok";
         })()
-      `) as string;
+      `,
+      )) as string;
       if (selectResult === "not_found") return text(`Error: Element not found: ${sel}`);
       if (selectResult === "invalid_option") {
         return text(`Error: No <option> with value "${action.text}" found in ${action.selector}`);
@@ -243,7 +251,9 @@ export async function dispatchAction(
       if (!action.selector) return text("Error: selector is required for check");
       const sel = session.resolveSelector(action.selector);
       const desired = action.checked !== false;
-      const checkResult = await evaluate(cdp, `
+      const checkResult = (await evaluate(
+        cdp,
+        `
         (function() {
           const el = document.querySelector(${JSON.stringify(sel)});
           if (!el) return "not_found";
@@ -256,9 +266,11 @@ export async function dispatchAction(
           el.dispatchEvent(new Event("change", { bubbles: true }));
           return "toggled";
         })()
-      `) as string;
+      `,
+      )) as string;
       if (checkResult === "not_found") return text(`Error: Element not found: ${sel}`);
-      if (checkResult === "already") return text(`Checkbox ${action.selector} already ${desired ? "checked" : "unchecked"}`);
+      if (checkResult === "already")
+        return text(`Checkbox ${action.selector} already ${desired ? "checked" : "unchecked"}`);
       return text(`${desired ? "Checked" : "Unchecked"} ${action.selector}`);
     }
 
@@ -271,9 +283,12 @@ export async function dispatchAction(
       if (action.fullPage) {
         const MAX_WIDTH = 1280;
         const MAX_HEIGHT = 16384;
-        const size = (await evaluate(cdp, `
+        const size = (await evaluate(
+          cdp,
+          `
           ({ width: document.documentElement.scrollWidth, height: document.documentElement.scrollHeight })
-        `)) as { width: number; height: number };
+        `,
+        )) as { width: number; height: number };
         const captureWidth = Math.min(size.width, MAX_WIDTH);
         const captureHeight = Math.min(size.height, MAX_HEIGHT);
         const devicePixelRatio = (await evaluate(cdp, "window.devicePixelRatio || 1")) as number;
@@ -307,8 +322,9 @@ export async function dispatchAction(
       // for other domains in the user's session.
       const result = await cdp.send("Storage.getCookies");
       const cookies = (result["cookies"] as Array<Record<string, unknown>>) ?? [];
-      const lines = cookies.map((c) =>
-        `${String(c["name"])}=${String(c["value"])}\tdomain=${String(c["domain"])}\tpath=${String(c["path"])}`,
+      const lines = cookies.map(
+        (c) =>
+          `${String(c["name"])}=${String(c["value"])}\tdomain=${String(c["domain"])}\tpath=${String(c["path"])}`,
       );
       return text(lines.length === 0 ? "(no cookies)" : lines.join("\n"));
     }
@@ -335,10 +351,15 @@ export async function dispatchAction(
 
     case "storage_get": {
       if (action.name) {
-        const value = (await evaluate(cdp, `localStorage.getItem(${JSON.stringify(action.name)})`)) as string | null;
+        const value = (await evaluate(
+          cdp,
+          `localStorage.getItem(${JSON.stringify(action.name)})`,
+        )) as string | null;
         return text(value === null ? `(${action.name} not set)` : value);
       }
-      const all = (await evaluate(cdp, `
+      const all = (await evaluate(
+        cdp,
+        `
         (function() {
           const out = {};
           for (let i = 0; i < localStorage.length; i++) {
@@ -347,7 +368,8 @@ export async function dispatchAction(
           }
           return out;
         })()
-      `)) as Record<string, string>;
+      `,
+      )) as Record<string, string>;
       const keys = Object.keys(all);
       if (keys.length === 0) return text("(localStorage is empty)");
       return text(keys.map((k) => `${k}=${all[k]}`).join("\n"));
@@ -356,7 +378,10 @@ export async function dispatchAction(
     case "storage_set": {
       if (!action.name) return text("Error: name is required for storage_set");
       if (action.value === undefined) return text("Error: value is required for storage_set");
-      await evaluate(cdp, `localStorage.setItem(${JSON.stringify(action.name)}, ${JSON.stringify(action.value)})`);
+      await evaluate(
+        cdp,
+        `localStorage.setItem(${JSON.stringify(action.name)}, ${JSON.stringify(action.value)})`,
+      );
       return text(`Set localStorage ${action.name}`);
     }
 
@@ -369,9 +394,12 @@ export async function dispatchAction(
       let result: string;
       if (action.selector) {
         const sel = session.resolveSelector(action.selector);
-        result = (await evaluate(cdp, `
+        result = (await evaluate(
+          cdp,
+          `
           document.querySelector(${JSON.stringify(sel)})?.textContent ?? "(element not found)"
-        `)) as string;
+        `,
+        )) as string;
       } else {
         result = (await evaluate(cdp, "document.body.innerText")) as string;
       }
@@ -405,9 +433,12 @@ export async function dispatchAction(
         });
         return text(`Error: evaluate timed out after ${timeout}ms`);
       }
-      const output = result === undefined ? "undefined"
-        : typeof result === "string" ? result
-        : JSON.stringify(result, null, 2);
+      const output =
+        result === undefined
+          ? "undefined"
+          : typeof result === "string"
+            ? result
+            : JSON.stringify(result, null, 2);
       return text(output);
     }
 
@@ -415,7 +446,9 @@ export async function dispatchAction(
       const ms = action.timeout ?? 5000;
       if (action.selector) {
         const sel = session.resolveSelector(action.selector);
-        const waitPromise = evaluate(cdp, `
+        const waitPromise = evaluate(
+          cdp,
+          `
           new Promise((resolve) => {
             const el = document.querySelector(${JSON.stringify(sel)});
             if (el) return resolve(true);
@@ -428,7 +461,8 @@ export async function dispatchAction(
             observer.observe(document.documentElement, { childList: true, subtree: true });
             setTimeout(() => { observer.disconnect(); resolve(false); }, ${ms});
           })
-        `);
+        `,
+        );
         const found = await Promise.race([
           waitPromise,
           new Promise<false>((resolve) => setTimeout(() => resolve(false), ms + 1000)),

--- a/apps/desktop/src/agent/browser/browser-session.ts
+++ b/apps/desktop/src/agent/browser/browser-session.ts
@@ -6,12 +6,7 @@
  * management actions (tab_new, tab_switch, ...) manipulate the set.
  */
 
-import {
-  CDPClient,
-  closeTab,
-  discoverChromeEndpoint,
-  openNewTab,
-} from "./cdp-client";
+import { CDPClient, closeTab, discoverChromeEndpoint, openNewTab } from "./cdp-client";
 
 // ---------------------------------------------------------------------------
 // Public interface
@@ -119,7 +114,9 @@ export function createBrowserSession(): BrowserSession {
       if (tab) return Promise.resolve(tab.cdp);
     }
     if (connectPromise) return connectPromise.then((t) => t.cdp);
-    connectPromise = connect().finally(() => { connectPromise = null; });
+    connectPromise = connect().finally(() => {
+      connectPromise = null;
+    });
     return connectPromise.then((t) => t.cdp);
   }
 

--- a/apps/desktop/src/agent/browser/cdp-adapter.ts
+++ b/apps/desktop/src/agent/browser/cdp-adapter.ts
@@ -31,14 +31,17 @@ export async function getElementCenter(
   cdp: CDPClient,
   selector: string,
 ): Promise<{ x: number; y: number }> {
-  const rect = await evaluate(cdp, `
+  const rect = await evaluate(
+    cdp,
+    `
     (function() {
       const el = document.querySelector(${JSON.stringify(selector)});
       if (!el) return null;
       const r = el.getBoundingClientRect();
       return { x: r.x + r.width / 2, y: r.y + r.height / 2 };
     })()
-  `);
+  `,
+  );
   if (!rect) throw new Error(`Element not found: ${selector}`);
   return rect as { x: number; y: number };
 }

--- a/apps/desktop/src/agent/browser/cdp-client.ts
+++ b/apps/desktop/src/agent/browser/cdp-client.ts
@@ -48,7 +48,9 @@ export class CDPClient {
       this.ws = ws;
 
       ws.addEventListener("open", () => resolve(), { once: true });
-      ws.addEventListener("error", (e) => reject(new Error(`CDP WebSocket error: ${String(e)}`)), { once: true });
+      ws.addEventListener("error", (e) => reject(new Error(`CDP WebSocket error: ${String(e)}`)), {
+        once: true,
+      });
 
       ws.addEventListener("message", (event) => {
         const data = JSON.parse(String(event.data)) as Record<string, unknown>;
@@ -74,7 +76,11 @@ export class CDPClient {
           const handlers = this.listeners.get(method);
           if (handlers) {
             for (const handler of handlers) {
-              try { handler(params); } catch { /* listener error */ }
+              try {
+                handler(params);
+              } catch {
+                /* listener error */
+              }
             }
           }
         }
@@ -214,19 +220,25 @@ export async function launchChrome(port = DEFAULT_CDP_PORT): Promise<void> {
 
   console.log(`[browser] launching Chrome: ${binary} (port ${port}, profile: ${profileDir})`);
 
-  chromeProcess = spawn(binary, [
-    `--remote-debugging-port=${port}`,
-    `--user-data-dir=${profileDir}`,
-    "--no-first-run",
-    "--no-default-browser-check",
-    "about:blank",
-  ], {
-    stdio: "ignore",
-    detached: true,
-  });
+  chromeProcess = spawn(
+    binary,
+    [
+      `--remote-debugging-port=${port}`,
+      `--user-data-dir=${profileDir}`,
+      "--no-first-run",
+      "--no-default-browser-check",
+      "about:blank",
+    ],
+    {
+      stdio: "ignore",
+      detached: true,
+    },
+  );
 
   chromeProcess.unref();
-  chromeProcess.on("exit", () => { chromeProcess = null; });
+  chromeProcess.on("exit", () => {
+    chromeProcess = null;
+  });
 
   // Wait for CDP endpoint to become available
   const maxAttempts = 30;
@@ -270,10 +282,7 @@ export async function discoverChromeEndpoint(port = DEFAULT_CDP_PORT): Promise<s
 }
 
 /** Open a new tab and return its WebSocket URL. */
-export async function openNewTab(
-  httpEndpoint: string,
-  url = "about:blank",
-): Promise<TabInfo> {
+export async function openNewTab(httpEndpoint: string, url = "about:blank"): Promise<TabInfo> {
   const resp = await fetch(`${httpEndpoint}/json/new?${encodeURIComponent(url)}`);
   if (!resp.ok) throw new Error(`Failed to open new tab: ${resp.status} ${resp.statusText}`);
   const tab = (await resp.json()) as Record<string, string>;

--- a/apps/desktop/src/agent/browser/schema.ts
+++ b/apps/desktop/src/agent/browser/schema.ts
@@ -14,38 +14,97 @@ import { Type, type Static } from "@sinclair/typebox";
 export const BrowserActionSchema = Type.Object({
   action: Type.Union(
     [
-      Type.Literal("open", { description: "Navigate the current tab to a URL (http/https only). Use tab_new instead to open a separate tab." }),
-      Type.Literal("click", { description: "Click an element. selector: @eN from a snapshot, or a CSS selector." }),
-      Type.Literal("fill", { description: "Clear an input/textarea then type. Required: selector, text." }),
-      Type.Literal("type", { description: "Type text into the focused element. If selector is given, click it first. Required: text." }),
-      Type.Literal("press", { description: "Press a keyboard key (e.g. Enter, Tab, Escape, ArrowDown). Required: text (the key name)." }),
+      Type.Literal("open", {
+        description:
+          "Navigate the current tab to a URL (http/https only). Use tab_new instead to open a separate tab.",
+      }),
+      Type.Literal("click", {
+        description: "Click an element. selector: @eN from a snapshot, or a CSS selector.",
+      }),
+      Type.Literal("fill", {
+        description: "Clear an input/textarea then type. Required: selector, text.",
+      }),
+      Type.Literal("type", {
+        description:
+          "Type text into the focused element. If selector is given, click it first. Required: text.",
+      }),
+      Type.Literal("press", {
+        description:
+          "Press a keyboard key (e.g. Enter, Tab, Escape, ArrowDown). Required: text (the key name).",
+      }),
       Type.Literal("hover", { description: "Move the mouse over an element. Required: selector." }),
-      Type.Literal("select", { description: "Pick a <select>'s <option> by its value attribute (not visible label). Required: selector, text." }),
-      Type.Literal("check", { description: "Toggle a checkbox. Required: selector. Optional: checked (default true)." }),
-      Type.Literal("snapshot", { description: "Return the page's accessibility tree with @eN refs for interactive elements. Always run after navigation or DOM change." }),
-      Type.Literal("screenshot", { description: "PNG screenshot. Optional: fullPage (default false). Full-page is capped at 1280x16384." }),
-      Type.Literal("get_text", { description: "Return text content. With selector, returns that element's textContent; otherwise document.body.innerText." }),
+      Type.Literal("select", {
+        description:
+          "Pick a <select>'s <option> by its value attribute (not visible label). Required: selector, text.",
+      }),
+      Type.Literal("check", {
+        description: "Toggle a checkbox. Required: selector. Optional: checked (default true).",
+      }),
+      Type.Literal("snapshot", {
+        description:
+          "Return the page's accessibility tree with @eN refs for interactive elements. Always run after navigation or DOM change.",
+      }),
+      Type.Literal("screenshot", {
+        description:
+          "PNG screenshot. Optional: fullPage (default false). Full-page is capped at 1280x16384.",
+      }),
+      Type.Literal("get_text", {
+        description:
+          "Return text content. With selector, returns that element's textContent; otherwise document.body.innerText.",
+      }),
       Type.Literal("get_url", { description: "Return the current page URL." }),
       Type.Literal("get_title", { description: "Return the current document title." }),
-      Type.Literal("evaluate", { description: "Run JS in the page (returnByValue, awaitPromise). Required: script. Optional: timeout (default 30000ms)." }),
-      Type.Literal("wait", { description: "Wait for selector to appear, or for a fixed timeout (ms, default 5000)." }),
-      Type.Literal("scroll", { description: "Scroll the page. Optional: direction (up/down, default down), amount (px, default 500)." }),
+      Type.Literal("evaluate", {
+        description:
+          "Run JS in the page (returnByValue, awaitPromise). Required: script. Optional: timeout (default 30000ms).",
+      }),
+      Type.Literal("wait", {
+        description: "Wait for selector to appear, or for a fixed timeout (ms, default 5000).",
+      }),
+      Type.Literal("scroll", {
+        description:
+          "Scroll the page. Optional: direction (up/down, default down), amount (px, default 500).",
+      }),
       Type.Literal("back", { description: "Go back in history." }),
       Type.Literal("forward", { description: "Go forward in history." }),
       Type.Literal("reload", { description: "Reload the current page." }),
-      Type.Literal("close", { description: "Close the entire browser session and dispose all tabs." }),
-      Type.Literal("cookies_get", { description: "List all cookies for the current browser session." }),
-      Type.Literal("cookies_set", { description: "Set a cookie on the current page's URL. Required: name, value. Optional: domain." }),
+      Type.Literal("close", {
+        description: "Close the entire browser session and dispose all tabs.",
+      }),
+      Type.Literal("cookies_get", {
+        description: "List all cookies for the current browser session.",
+      }),
+      Type.Literal("cookies_set", {
+        description:
+          "Set a cookie on the current page's URL. Required: name, value. Optional: domain.",
+      }),
       Type.Literal("cookies_clear", { description: "Delete every cookie." }),
-      Type.Literal("storage_get", { description: "Read localStorage. With name returns that key; without name returns all keys for the current origin." }),
-      Type.Literal("storage_set", { description: "Write a localStorage key for the current origin. Required: name, value." }),
+      Type.Literal("storage_get", {
+        description:
+          "Read localStorage. With name returns that key; without name returns all keys for the current origin.",
+      }),
+      Type.Literal("storage_set", {
+        description: "Write a localStorage key for the current origin. Required: name, value.",
+      }),
       Type.Literal("storage_clear", { description: "Clear localStorage for the current origin." }),
-      Type.Literal("tab_list", { description: "List open tabs (ids t1, t2, ...). The current tab is marked with *." }),
-      Type.Literal("tab_new", { description: "Open a new tab and switch to it. Optional: url (also navigates), label." }),
-      Type.Literal("tab_switch", { description: "Switch to a tab by id (e.g. t2). Required: tabId. Refs from the previous tab are cleared." }),
-      Type.Literal("tab_close", { description: "Close a tab. Defaults to the current tab. Optional: tabId." }),
+      Type.Literal("tab_list", {
+        description: "List open tabs (ids t1, t2, ...). The current tab is marked with *.",
+      }),
+      Type.Literal("tab_new", {
+        description: "Open a new tab and switch to it. Optional: url (also navigates), label.",
+      }),
+      Type.Literal("tab_switch", {
+        description:
+          "Switch to a tab by id (e.g. t2). Required: tabId. Refs from the previous tab are cleared.",
+      }),
+      Type.Literal("tab_close", {
+        description: "Close a tab. Defaults to the current tab. Optional: tabId.",
+      }),
     ],
-    { description: "The browser action to perform. See each variant's description for required fields." },
+    {
+      description:
+        "The browser action to perform. See each variant's description for required fields.",
+    },
   ),
   url: Type.Optional(Type.String({ description: "URL (for open action)" })),
   selector: Type.Optional(
@@ -67,33 +126,21 @@ export const BrowserActionSchema = Type.Object({
       description: "Scroll direction (default: down)",
     }),
   ),
-  amount: Type.Optional(
-    Type.Number({ description: "Scroll amount in pixels (default: 500)" }),
-  ),
-  fullPage: Type.Optional(
-    Type.Boolean({ description: "Full page screenshot (default: false)" }),
-  ),
+  amount: Type.Optional(Type.Number({ description: "Scroll amount in pixels (default: 500)" })),
+  fullPage: Type.Optional(Type.Boolean({ description: "Full page screenshot (default: false)" })),
   timeout: Type.Optional(
     Type.Number({ description: "Timeout in ms for wait action (default: 5000)" }),
   ),
   checked: Type.Optional(
     Type.Boolean({ description: "Desired checked state for check action (default: true)" }),
   ),
-  name: Type.Optional(
-    Type.String({ description: "Cookie or storage key name" }),
-  ),
-  value: Type.Optional(
-    Type.String({ description: "Cookie or storage value" }),
-  ),
+  name: Type.Optional(Type.String({ description: "Cookie or storage key name" })),
+  value: Type.Optional(Type.String({ description: "Cookie or storage value" })),
   domain: Type.Optional(
     Type.String({ description: "Cookie domain (defaults to current page host)" }),
   ),
-  tabId: Type.Optional(
-    Type.String({ description: "Tab id (e.g. t1) for tab_switch / tab_close" }),
-  ),
-  label: Type.Optional(
-    Type.String({ description: "Optional human-readable label for tab_new" }),
-  ),
+  tabId: Type.Optional(Type.String({ description: "Tab id (e.g. t1) for tab_switch / tab_close" })),
+  label: Type.Optional(Type.String({ description: "Optional human-readable label for tab_new" })),
 });
 
 export type BrowserAction = Static<typeof BrowserActionSchema>;
@@ -103,10 +150,7 @@ export type BrowserAction = Static<typeof BrowserActionSchema>;
 // ---------------------------------------------------------------------------
 
 export type ToolResult = {
-  content: (
-    | { type: "text"; text: string }
-    | { type: "image"; data: string; mimeType: string }
-  )[];
+  content: ({ type: "text"; text: string } | { type: "image"; data: string; mimeType: string })[];
   details: Record<string, unknown>;
 };
 

--- a/apps/desktop/src/agent/browser/snapshot-builder.ts
+++ b/apps/desktop/src/agent/browser/snapshot-builder.ts
@@ -35,7 +35,9 @@ export async function buildSnapshot(
   const maxDepth = opts?.maxDepth ?? DEFAULT_MAX_DEPTH;
   const maxNodes = opts?.maxNodes ?? DEFAULT_MAX_NODES;
 
-  const result = await evaluate(cdp, `
+  const result = await evaluate(
+    cdp,
+    `
     (function() {
       const interactiveRoles = new Set([
         "link", "button", "textbox", "checkbox", "radio", "combobox",
@@ -121,7 +123,8 @@ export async function buildSnapshot(
       const tree = walk(document.body, 0);
       return JSON.stringify({ tree: tree, refs: refs });
     })()
-  `);
+  `,
+  );
 
   const parsed = JSON.parse(result as string) as {
     tree: string;

--- a/apps/desktop/src/agent/gws-tool.ts
+++ b/apps/desktop/src/agent/gws-tool.ts
@@ -24,9 +24,7 @@ const GwsRunSchema = Type.Object({
     description:
       "Arguments to pass to gws, e.g. ['drive', 'files', 'list', '--params', '{\"pageSize\":10}']. Run with ['--help'] or [<service>, '--help'] to discover commands.",
   }),
-  stdin: Type.Optional(
-    Type.String({ description: "Optional stdin to pipe to gws." }),
-  ),
+  stdin: Type.Optional(Type.String({ description: "Optional stdin to pipe to gws." })),
 });
 
 export function registerGwsExtension(pi: ExtensionAPI): void {
@@ -53,9 +51,7 @@ export function registerGwsExtension(pi: ExtensionAPI): void {
         if (code !== 0) parts.push(`[exit ${code}]`);
         return text(parts.join("\n\n") || "(no output)");
       } catch (err) {
-        return text(
-          `gws error: ${err instanceof Error ? err.message : String(err)}`,
-        );
+        return text(`gws error: ${err instanceof Error ? err.message : String(err)}`);
       }
     },
   });
@@ -75,9 +71,7 @@ function runGws(
           reject(new Error("gws binary not installed"));
           return;
         }
-        const code =
-          (err as { code?: number } | null)?.code ??
-          (err ? 1 : 0);
+        const code = (err as { code?: number } | null)?.code ?? (err ? 1 : 0);
         resolve({ stdout: String(stdout), stderr: String(stderr), code });
       },
     );

--- a/apps/desktop/src/agent/setup.ts
+++ b/apps/desktop/src/agent/setup.ts
@@ -58,12 +58,7 @@ declare const __PROJECT_ROOT__: string;
 
 function getBundledResourcesDir(): string {
   if (app.isPackaged) {
-    return path.join(
-      process.resourcesPath,
-      "app.asar.unpacked",
-      "resources",
-      "agent",
-    );
+    return path.join(process.resourcesPath, "app.asar.unpacked", "resources", "agent");
   }
   return path.join(__PROJECT_ROOT__, "resources", "agent");
 }
@@ -123,17 +118,25 @@ async function getExtensionFactories(): Promise<ExtensionFactory[]> {
 
 function registerTasksExtension(pi: ExtensionAPI): void {
   const manageTasksSchema = Type.Object({
-    action: Type.Union([
-      Type.Literal("create"),
-      Type.Literal("list"),
-      Type.Literal("toggle"),
-      Type.Literal("delete"),
-    ], { description: "Action to perform" }),
+    action: Type.Union(
+      [
+        Type.Literal("create"),
+        Type.Literal("list"),
+        Type.Literal("toggle"),
+        Type.Literal("delete"),
+      ],
+      { description: "Action to perform" },
+    ),
     label: Type.Optional(Type.String({ description: "Task label (required for create)" })),
-    prompt: Type.Optional(Type.String({ description: "Prompt to run when task fires (required for create)" })),
-    schedule: Type.Optional(Type.Unsafe<TaskSchedule>({
-      description: "Schedule: {type:'cron',cron:string} | {type:'interval',intervalMs:number} | {type:'once',runAt:number}",
-    })),
+    prompt: Type.Optional(
+      Type.String({ description: "Prompt to run when task fires (required for create)" }),
+    ),
+    schedule: Type.Optional(
+      Type.Unsafe<TaskSchedule>({
+        description:
+          "Schedule: {type:'cron',cron:string} | {type:'interval',intervalMs:number} | {type:'once',runAt:number}",
+      }),
+    ),
     taskId: Type.Optional(Type.String({ description: "Task ID (required for toggle/delete)" })),
   });
 
@@ -189,7 +192,10 @@ function registerTasksExtension(pi: ExtensionAPI): void {
     if (tasks.length === 0) return;
 
     const summary = tasks
-      .map((t) => `- ${t.label}: ${t.prompt.slice(0, 80)}${t.prompt.length > 80 ? "..." : ""} (${t.schedule.type})`)
+      .map(
+        (t) =>
+          `- ${t.label}: ${t.prompt.slice(0, 80)}${t.prompt.length > 80 ? "..." : ""} (${t.schedule.type})`,
+      )
       .join("\n");
 
     pi.sendMessage({
@@ -255,10 +261,7 @@ function resolveSessionManager(): SessionManager {
     try {
       return SessionManager.open(sessionFile, SESSION_DIR);
     } catch (err) {
-      console.warn(
-        "[agent] failed to open session file, falling back to continueRecent:",
-        err,
-      );
+      console.warn("[agent] failed to open session file, falling back to continueRecent:", err);
     }
   }
   return SessionManager.continueRecent(WORKSPACE_DIR, SESSION_DIR);
@@ -303,26 +306,17 @@ export class Agent {
     return this.pi?.waitForIdle(timeoutMs) ?? Promise.resolve(true);
   }
 
-  async sendMessage(
-    message: string,
-    images?: ImageContent[],
-  ): Promise<SendMessageResult> {
+  async sendMessage(message: string, images?: ImageContent[]): Promise<SendMessageResult> {
     await this.ensurePi().sendMessage(message, images);
     return { accepted: true };
   }
 
-  async steer(
-    message: string,
-    images?: ImageContent[],
-  ): Promise<SteerResult> {
+  async steer(message: string, images?: ImageContent[]): Promise<SteerResult> {
     await this.ensurePi().steer(message, images);
     return { accepted: true };
   }
 
-  async followUp(
-    message: string,
-    images?: ImageContent[],
-  ): Promise<SendMessageResult> {
+  async followUp(message: string, images?: ImageContent[]): Promise<SendMessageResult> {
     await this.ensurePi().followUp(message, images);
     return { accepted: true };
   }

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -76,8 +76,6 @@ function configureAppIdentity(): void {
   });
 }
 
-
-
 function configureApplicationMenu(): void {
   const template: MenuItemConstructorOptions[] = [
     {
@@ -100,9 +98,7 @@ function configureApplicationMenu(): void {
     },
     {
       label: "File",
-      submenu: [
-        { role: "close" },
-      ],
+      submenu: [{ role: "close" }],
     },
     { role: "editMenu" },
     { role: "viewMenu" },

--- a/apps/desktop/src/main/lib/ipc-handler.ts
+++ b/apps/desktop/src/main/lib/ipc-handler.ts
@@ -18,9 +18,6 @@ export function createIpcHandler<T>(
 }
 
 /** Register an IPC handler that takes no input. */
-export function createVoidIpcHandler(
-  channel: string,
-  fn: () => unknown,
-): void {
+export function createVoidIpcHandler(channel: string, fn: () => unknown): void {
   ipcMain.handle(channel, () => fn());
 }

--- a/apps/desktop/src/main/notifications.ts
+++ b/apps/desktop/src/main/notifications.ts
@@ -103,9 +103,7 @@ export class NotificationsManager {
     // "the app is in the foreground" from the user's POV.
     const target = this.targetWindow;
     if (target && !target.isDestroyed() && target.isFocused()) return true;
-    return BrowserWindow.getAllWindows().some(
-      (w) => !w.isDestroyed() && w.isFocused(),
-    );
+    return BrowserWindow.getAllWindows().some((w) => !w.isDestroyed() && w.isFocused());
   }
 }
 

--- a/apps/desktop/src/main/session-history.ts
+++ b/apps/desktop/src/main/session-history.ts
@@ -74,7 +74,10 @@ function isToolResult(msg: unknown): msg is ToolResultMessage {
 function extractTextFromContent(content: Message["content"]): string {
   if (typeof content === "string") return content;
   if (!Array.isArray(content)) return "";
-  return content.filter(isTextContent).map((b) => b.text).join("");
+  return content
+    .filter(isTextContent)
+    .map((b) => b.text)
+    .join("");
 }
 
 // ---------------------------------------------------------------------------

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -2,10 +2,7 @@ import { contextBridge, ipcRenderer } from "electron";
 
 import { IPC_CHANNELS } from "@/shared/ipc";
 
-function forwardEvent(
-  channel: string,
-  listener: (data: unknown) => void,
-): () => void {
+function forwardEvent(channel: string, listener: (data: unknown) => void): () => void {
   const wrapped = (_event: Electron.IpcRendererEvent, data: unknown) => {
     listener(data);
   };

--- a/apps/desktop/src/renderer/app.tsx
+++ b/apps/desktop/src/renderer/app.tsx
@@ -41,9 +41,8 @@ export function AppLayout() {
   useEffect(() => init(), [init]);
 
   useEffect(() => {
-    const target = appState.phase === "error"
-      ? phaseToPath(appState.prev)
-      : phaseToPath(appState.phase);
+    const target =
+      appState.phase === "error" ? phaseToPath(appState.prev) : phaseToPath(appState.phase);
 
     if (pathnameRef.current !== target) {
       void navigate(target);

--- a/apps/desktop/src/renderer/chat/chat-message.tsx
+++ b/apps/desktop/src/renderer/chat/chat-message.tsx
@@ -44,11 +44,7 @@ export function ChatMessageView({ message }: { message: ChatMessage }) {
     case "user":
     case "steer":
       return (
-        <BubbleMessage
-          variant={message.kind}
-          text={message.text}
-          imageCount={message.imageCount}
-        />
+        <BubbleMessage variant={message.kind} text={message.text} imageCount={message.imageCount} />
       );
 
     case "assistant":

--- a/apps/desktop/src/renderer/chat/chat-page.tsx
+++ b/apps/desktop/src/renderer/chat/chat-page.tsx
@@ -132,8 +132,7 @@ export function ChatPage() {
 
   const sessionState = useVoiceStore((s) => s.sessionState);
   const toggleVoice = useVoiceStore((s) => s.toggleVoice);
-  const voiceActive =
-    sessionState === "connected" || sessionState === "connecting";
+  const voiceActive = sessionState === "connected" || sessionState === "connecting";
 
   const currentTranscript = useVoiceStore((s) => s.currentTranscript);
 
@@ -176,9 +175,7 @@ export function ChatPage() {
                       voiceActive ? "bg-green-400 animate-pulse" : "bg-muted-foreground/40",
                     )}
                   />
-                  <span className="text-xs text-muted-foreground">
-                    {voiceLabels[sessionState]}
-                  </span>
+                  <span className="text-xs text-muted-foreground">{voiceLabels[sessionState]}</span>
                 </div>
                 <div className="flex items-center gap-1">
                   <button

--- a/apps/desktop/src/renderer/chat/composer.tsx
+++ b/apps/desktop/src/renderer/chat/composer.tsx
@@ -303,11 +303,7 @@ export function Composer() {
             aria-label={busy ? "Queue for next turn" : "Send"}
             title={busy ? "Queue for next turn" : "Send"}
           >
-            {busy ? (
-              <ListPlusIcon className="size-3.5" />
-            ) : (
-              <SendIcon className="size-3.5" />
-            )}
+            {busy ? <ListPlusIcon className="size-3.5" /> : <SendIcon className="size-3.5" />}
           </button>
         )}
       </form>

--- a/apps/desktop/src/renderer/chat/extensions-panel.tsx
+++ b/apps/desktop/src/renderer/chat/extensions-panel.tsx
@@ -6,9 +6,7 @@ import { getBridge } from "@/renderer/lib/bridge";
 import { useAgentStore } from "@/renderer/stores/agent-store";
 import type { ExtensionToolInfo } from "@/shared/ipc";
 
-function groupBySource(
-  tools: ExtensionToolInfo[],
-): Map<string, ExtensionToolInfo[]> {
+function groupBySource(tools: ExtensionToolInfo[]): Map<string, ExtensionToolInfo[]> {
   const groups = new Map<string, ExtensionToolInfo[]>();
   for (const tool of tools) {
     const list = groups.get(tool.source) ?? [];
@@ -56,9 +54,7 @@ export function ExtensionsPanel() {
 
       // Optimistic update: compute next state synchronously from the ref so
       // rapid back-to-back toggles compose against the latest snapshot.
-      const next = previous.map((t) =>
-        t.name === name ? { ...t, active: nextActive } : t,
-      );
+      const next = previous.map((t) => (t.name === name ? { ...t, active: nextActive } : t));
       applyTools(next);
 
       const nextActiveNames = next.filter((t) => t.active).map((t) => t.name);
@@ -77,10 +73,7 @@ export function ExtensionsPanel() {
     [applyTools, refresh],
   );
 
-  const groups = useMemo(
-    () => (tools ? groupBySource(tools) : null),
-    [tools],
-  );
+  const groups = useMemo(() => (tools ? groupBySource(tools) : null), [tools]);
 
   if (appState.phase !== "ready") {
     return (
@@ -95,20 +88,14 @@ export function ExtensionsPanel() {
   }
 
   if (tools.length === 0) {
-    return (
-      <div className="p-3 text-xs text-muted-foreground">
-        No tools registered.
-      </div>
-    );
+    return <div className="p-3 text-xs text-muted-foreground">No tools registered.</div>;
   }
 
   return (
     <div className="flex flex-col gap-3 p-3">
       {[...groups.entries()].map(([source, items]) => (
         <div key={source} className="flex flex-col gap-1.5">
-          <Label className="text-xs font-medium text-muted-foreground">
-            {source}
-          </Label>
+          <Label className="text-xs font-medium text-muted-foreground">{source}</Label>
           {items.map((tool) => (
             <label
               key={tool.name}
@@ -123,9 +110,7 @@ export function ExtensionsPanel() {
                 className="mt-0.5"
               />
               <div className="flex min-w-0 flex-col">
-                <span className="truncate text-xs text-foreground">
-                  {tool.name}
-                </span>
+                <span className="truncate text-xs text-foreground">{tool.name}</span>
                 {tool.description && (
                   <span className="line-clamp-2 text-[10px] text-muted-foreground">
                     {tool.description}

--- a/apps/desktop/src/renderer/chat/settings-panel.tsx
+++ b/apps/desktop/src/renderer/chat/settings-panel.tsx
@@ -13,9 +13,7 @@ export function SettingsPanel() {
   const isReady = appState.phase === "ready";
   const canStartNewSession = isReady && appState.agent === "idle";
 
-  const [notifications, setNotifications] = useState<NotificationSettings | null>(
-    null,
-  );
+  const [notifications, setNotifications] = useState<NotificationSettings | null>(null);
 
   useEffect(() => {
     const promise = getBridge()?.getNotificationSettings();
@@ -41,9 +39,7 @@ export function SettingsPanel() {
   return (
     <div className="flex flex-col gap-4 p-3">
       <div className="flex flex-col gap-2">
-        <Label className="text-xs font-medium text-muted-foreground">
-          OpenAI Account
-        </Label>
+        <Label className="text-xs font-medium text-muted-foreground">OpenAI Account</Label>
         {isReady ? (
           <div className="flex items-center justify-between rounded-md border border-border px-3 py-2">
             <span className="text-xs text-foreground">Connected</span>
@@ -64,9 +60,7 @@ export function SettingsPanel() {
       </div>
 
       <div className="flex flex-col gap-2">
-        <Label className="text-xs font-medium text-muted-foreground">
-          Session
-        </Label>
+        <Label className="text-xs font-medium text-muted-foreground">Session</Label>
         <div className="flex items-center justify-between rounded-md border border-border px-3 py-2">
           <span className="flex flex-col">
             <span className="text-xs text-foreground">Start new session</span>
@@ -87,15 +81,13 @@ export function SettingsPanel() {
       </div>
 
       <div className="flex flex-col gap-2">
-        <Label className="text-xs font-medium text-muted-foreground">
-          Notifications
-        </Label>
+        <Label className="text-xs font-medium text-muted-foreground">Notifications</Label>
         <label className="flex cursor-pointer items-center justify-between rounded-md border border-border px-3 py-2">
           <span className="flex flex-col">
             <span className="text-xs text-foreground">Notify when idle</span>
             <span className="text-[10px] text-muted-foreground">
-              Show an OS notification when the agent finishes a turn while
-              Inteligir is in the background.
+              Show an OS notification when the agent finishes a turn while Inteligir is in the
+              background.
             </span>
           </span>
           <Checkbox

--- a/apps/desktop/src/renderer/chat/task-panel.tsx
+++ b/apps/desktop/src/renderer/chat/task-panel.tsx
@@ -158,9 +158,7 @@ export function TaskPanel() {
       </div>
 
       {tasks.length === 0 && !creating && (
-        <div className="py-4 text-center text-[10px] text-muted-foreground">
-          No scheduled tasks
-        </div>
+        <div className="py-4 text-center text-[10px] text-muted-foreground">No scheduled tasks</div>
       )}
 
       {tasks.length > 0 && (

--- a/apps/desktop/src/renderer/components/draggable-panel.tsx
+++ b/apps/desktop/src/renderer/components/draggable-panel.tsx
@@ -120,8 +120,14 @@ export function DraggablePanel({
 
         newWidth = Math.min(newWidth, window.innerWidth - newLeft);
         newHeight = Math.min(newHeight, window.innerHeight - newTop);
-        if (newLeft < 0) { newWidth += newLeft; newLeft = 0; }
-        if (newTop < 0) { newHeight += newTop; newTop = 0; }
+        if (newLeft < 0) {
+          newWidth += newLeft;
+          newLeft = 0;
+        }
+        if (newTop < 0) {
+          newHeight += newTop;
+          newTop = 0;
+        }
 
         setPanelState({
           position: { x: newLeft, y: newTop },

--- a/apps/desktop/src/renderer/components/markdown.tsx
+++ b/apps/desktop/src/renderer/components/markdown.tsx
@@ -4,17 +4,10 @@ import { code } from "@streamdown/code";
 
 const plugins = { code };
 
-export const Markdown = memo(function Markdown({
-  content,
-}: {
-  content: string;
-}) {
+export const Markdown = memo(function Markdown({ content }: { content: string }) {
   return (
     <div className="prose prose-sm prose-invert max-w-none break-words [&>*:first-child]:mt-0 [&>*:last-child]:mb-0">
-      <Streamdown
-        plugins={plugins}
-        shikiTheme={["github-dark-dimmed", "github-dark-dimmed"]}
-      >
+      <Streamdown plugins={plugins} shikiTheme={["github-dark-dimmed", "github-dark-dimmed"]}>
         {content}
       </Streamdown>
     </div>

--- a/apps/desktop/src/renderer/components/tool-execution.tsx
+++ b/apps/desktop/src/renderer/components/tool-execution.tsx
@@ -21,11 +21,7 @@ const statusIcon: Record<ToolExecution["status"], string> = {
   error: "✗",
 };
 
-export function ToolExecutionView({
-  execution,
-}: {
-  execution: ToolExecution;
-}) {
+export function ToolExecutionView({ execution }: { execution: ToolExecution }) {
   const [open, setOpen] = useState(false);
   const hasResult = execution.resultText.length > 0;
 

--- a/apps/desktop/src/renderer/lib/use-local-storage.ts
+++ b/apps/desktop/src/renderer/lib/use-local-storage.ts
@@ -24,7 +24,9 @@ export function useLocalStorage<T>(
       } else {
         window.localStorage.removeItem(key);
       }
-    } catch { /* ignore */ }
+    } catch {
+      /* ignore */
+    }
   }, [key, value]);
 
   // Sync across tabs

--- a/apps/desktop/src/renderer/login/login-page.tsx
+++ b/apps/desktop/src/renderer/login/login-page.tsx
@@ -10,9 +10,7 @@ export function LoginPage() {
 
   const loggingIn = appState.phase === "logging_in";
   const loginError =
-    appState.phase === "error" && appState.prev === "logging_in"
-      ? appState.message
-      : null;
+    appState.phase === "error" && appState.prev === "logging_in" ? appState.message : null;
 
   const handleLogin = useCallback(() => {
     getBridge()?.transition({ type: "LOGIN" });

--- a/apps/desktop/src/renderer/onboarding/onboarding-page.tsx
+++ b/apps/desktop/src/renderer/onboarding/onboarding-page.tsx
@@ -10,9 +10,7 @@ export function OnboardingPage() {
   const triggered = useRef(false);
 
   const setupError =
-    appState.phase === "error" && appState.prev === "setting_up"
-      ? appState.message
-      : null;
+    appState.phase === "error" && appState.prev === "setting_up" ? appState.message : null;
 
   // Auto-trigger setup on mount
   useEffect(() => {

--- a/apps/desktop/src/renderer/stores/agent-store.ts
+++ b/apps/desktop/src/renderer/stores/agent-store.ts
@@ -140,9 +140,7 @@ export const useAgentStore = create<AgentStore>((set) => ({
           const delta = event.delta;
           set((s) => ({
             messages: s.messages.map((m) =>
-              m.id === sid && m.kind === "assistant"
-                ? { ...m, text: m.text + delta }
-                : m,
+              m.id === sid && m.kind === "assistant" ? { ...m, text: m.text + delta } : m,
             ),
           }));
           {

--- a/apps/desktop/src/renderer/stores/task-store.ts
+++ b/apps/desktop/src/renderer/stores/task-store.ts
@@ -49,9 +49,7 @@ export const useTaskStore = create<TaskStore>((set) => ({
     if (!bridge) return;
     // Optimistic update
     set((s) => ({
-      tasks: s.tasks.map((t) =>
-        t.id === id ? { ...t, enabled: !t.enabled } : t,
-      ),
+      tasks: s.tasks.map((t) => (t.id === id ? { ...t, enabled: !t.enabled } : t)),
     }));
     void bridge.toggleTask(id).catch(() => {});
   },

--- a/apps/desktop/src/renderer/voice/stt.ts
+++ b/apps/desktop/src/renderer/voice/stt.ts
@@ -34,10 +34,10 @@ export async function startSTT(
     sample_rate: "16000",
   });
 
-  const ws = new WebSocket(
-    `wss://api.deepgram.com/v1/listen?${params.toString()}`,
-    ["token", apiKey],
-  );
+  const ws = new WebSocket(`wss://api.deepgram.com/v1/listen?${params.toString()}`, [
+    "token",
+    apiKey,
+  ]);
 
   let keepAliveInterval: ReturnType<typeof setInterval> | null = null;
   let audioContext: AudioContext | null = null;

--- a/apps/desktop/src/renderer/voice/tts.ts
+++ b/apps/desktop/src/renderer/voice/tts.ts
@@ -13,10 +13,7 @@ export type TTSHandle = {
   close: () => void;
 };
 
-export function createTTS(
-  apiKey: string,
-  voiceId: string = DEFAULT_VOICE_ID,
-): TTSHandle {
+export function createTTS(apiKey: string, voiceId: string = DEFAULT_VOICE_ID): TTSHandle {
   const baseUri =
     `wss://api.elevenlabs.io/v1/text-to-speech/${voiceId}/stream-input` +
     `?model_id=${MODEL_ID}&output_format=pcm_${SAMPLE_RATE}`;
@@ -102,7 +99,11 @@ export function createTTS(
 
   function stopAllSources(): void {
     for (const source of activeSources) {
-      try { source.stop(); } catch { /* already stopped */ }
+      try {
+        source.stop();
+      } catch {
+        /* already stopped */
+      }
     }
     activeSources.clear();
     nextPlayTime = 0;

--- a/apps/desktop/src/renderer/voice/voice-pipeline.ts
+++ b/apps/desktop/src/renderer/voice/voice-pipeline.ts
@@ -29,7 +29,9 @@ export class VoicePipeline {
 
   on(listener: VoicePipelineListener): () => void {
     this.listeners.add(listener);
-    return () => { this.listeners.delete(listener); };
+    return () => {
+      this.listeners.delete(listener);
+    };
   }
 
   getState(): VoiceSessionState {
@@ -42,10 +44,7 @@ export class VoicePipeline {
 
     try {
       // TTS connects lazily on first sendText — just create the handle
-      this.tts = createTTS(
-        this.config.elevenlabsApiKey,
-        this.config.elevenlabsVoiceId,
-      );
+      this.tts = createTTS(this.config.elevenlabsApiKey, this.config.elevenlabsVoiceId);
 
       // STT requests mic permission + opens Deepgram WebSocket
       this.stt = await startSTT(
@@ -99,7 +98,11 @@ export class VoicePipeline {
 
   private emit(event: VoicePipelineEvent): void {
     for (const fn of this.listeners) {
-      try { fn(event); } catch { /* listener error */ }
+      try {
+        fn(event);
+      } catch {
+        /* listener error */
+      }
     }
   }
 }

--- a/apps/desktop/src/shared/ipc.ts
+++ b/apps/desktop/src/shared/ipc.ts
@@ -185,4 +185,3 @@ export function extractText(message: unknown): string {
   }
   return parts.join("");
 }
-

--- a/apps/desktop/src/shared/voice.ts
+++ b/apps/desktop/src/shared/voice.ts
@@ -4,11 +4,7 @@
 
 import { z } from "zod";
 
-export type VoiceSessionState =
-  | "inactive"
-  | "connecting"
-  | "connected"
-  | "error";
+export type VoiceSessionState = "inactive" | "connecting" | "connected" | "error";
 
 // Image attachments — base64 data + mime, matches pi-ai's ImageContent shape.
 const ImageAttachmentSchema = z.object({

--- a/apps/web/src/app/(auth)/_components/auth-form.tsx
+++ b/apps/web/src/app/(auth)/_components/auth-form.tsx
@@ -184,7 +184,9 @@ export const AuthForm = ({ className, type, ...props }: AuthFormProps) => {
             }}
           </form.Field>
         </FieldGroup>
-        <Button type="submit" loading={form.state.isSubmitting}>{type === "login" ? "Login" : "Register"}</Button>
+        <Button type="submit" loading={form.state.isSubmitting}>
+          {type === "login" ? "Login" : "Register"}
+        </Button>
       </form>
     </div>
   );
@@ -273,7 +275,9 @@ export const RequestPasswordResetForm = () => {
           }}
         </form.Field>
       </FieldGroup>
-      <Button type="submit" loading={form.state.isSubmitting}>Request Password Reset</Button>
+      <Button type="submit" loading={form.state.isSubmitting}>
+        Request Password Reset
+      </Button>
     </form>
   );
 };
@@ -408,7 +412,9 @@ export const UpdatePasswordForm = () => {
           }}
         </form.Field>
       </FieldGroup>
-      <Button type="submit" loading={form.state.isSubmitting}>Update Password</Button>
+      <Button type="submit" loading={form.state.isSubmitting}>
+        Update Password
+      </Button>
     </form>
   );
 };

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -7,12 +7,7 @@ const FALLBACK_URL = `https://github.com/${GITHUB_REPO}/releases`;
 
 function MacLogoIcon({ className }: { className?: string }) {
   return (
-    <svg
-      className={className}
-      viewBox="0 0 1024 1024"
-      fill="currentColor"
-      aria-hidden
-    >
+    <svg className={className} viewBox="0 0 1024 1024" fill="currentColor" aria-hidden>
       <path d="M849.124134 704.896288c-1.040702 3.157923-17.300015 59.872622-57.250912 118.190843-34.577516 50.305733-70.331835 101.018741-126.801964 101.909018-55.532781 0.976234-73.303516-33.134655-136.707568-33.134655-63.323211 0-83.23061 32.244378-135.712915 34.110889-54.254671 2.220574-96.003518-54.951543-130.712017-105.011682-70.934562-102.549607-125.552507-290.600541-52.30118-416.625816 36.040844-63.055105 100.821243-103.135962 171.364903-104.230899 53.160757-1.004887 103.739712 36.012192 136.028093 36.012192 33.171494 0 94.357018-44.791136 158.90615-38.089503 27.02654 1.151219 102.622262 11.298324 151.328567 81.891102-3.832282 2.607384-90.452081 53.724599-89.487104 157.76107C739.079832 663.275355 847.952448 704.467523 849.124134 704.896288M633.69669 230.749408c29.107945-35.506678 48.235584-84.314291 43.202964-132.785236-41.560558 1.630127-92.196819 27.600615-122.291231 62.896492-26.609031 30.794353-50.062186 80.362282-43.521213 128.270409C557.264926 291.935955 604.745311 264.949324 633.69669 230.749408" />
     </svg>
   );
@@ -24,10 +19,9 @@ async function getDownloadUrl(): Promise<string> {
   cacheTag("download-url");
 
   try {
-    const res = await fetch(
-      `https://api.github.com/repos/${GITHUB_REPO}/releases/latest`,
-      { headers: { Accept: "application/vnd.github+json" } },
-    );
+    const res = await fetch(`https://api.github.com/repos/${GITHUB_REPO}/releases/latest`, {
+      headers: { Accept: "application/vnd.github+json" },
+    });
     if (!res.ok) return FALLBACK_URL;
 
     const release: {
@@ -59,9 +53,7 @@ export default async function Page() {
           <MacLogoIcon className="size-5 shrink-0" />
           Download for Mac
         </a>
-        <span className="text-xs text-foreground/60">
-          Requires an OpenAI account
-        </span>
+        <span className="text-xs text-foreground/60">Requires an OpenAI account</span>
       </div>
     </main>
   );

--- a/apps/web/src/lib/site-config.ts
+++ b/apps/web/src/lib/site-config.ts
@@ -2,9 +2,6 @@ export const siteConfig = {
   name: "Inteligir",
   shortName: "Inteligir",
   description: "An artificially intelligent operating system.",
-  url:
-    process.env.NODE_ENV === "development"
-      ? "http://localhost:3000"
-      : "https://init.kyh.io",
+  url: process.env.NODE_ENV === "development" ? "http://localhost:3000" : "https://init.kyh.io",
   twitter: "@kaiyuhsu",
 };

--- a/packages/agent-runtime/src/gws.ts
+++ b/packages/agent-runtime/src/gws.ts
@@ -76,9 +76,7 @@ async function installGwsBinary(opts: GwsBootstrapOptions): Promise<void> {
 
   const arch = gwsArchSuffix();
   if (!arch) {
-    console.warn(
-      `[gws] unsupported platform/arch: ${process.platform}/${process.arch}`,
-    );
+    console.warn(`[gws] unsupported platform/arch: ${process.platform}/${process.arch}`);
     return;
   }
 
@@ -122,14 +120,10 @@ async function installGwsBinary(opts: GwsBootstrapOptions): Promise<void> {
       }),
     ]);
     if (!tarResp.ok || !tarResp.body) {
-      throw new Error(
-        `tarball fetch failed: ${tarResp.status} ${tarResp.statusText}`,
-      );
+      throw new Error(`tarball fetch failed: ${tarResp.status} ${tarResp.statusText}`);
     }
     if (!shaResp.ok) {
-      throw new Error(
-        `checksum fetch failed: ${shaResp.status} ${shaResp.statusText}`,
-      );
+      throw new Error(`checksum fetch failed: ${shaResp.status} ${shaResp.statusText}`);
     }
 
     const shaText = await shaResp.text();
@@ -153,22 +147,15 @@ async function installGwsBinary(opts: GwsBootstrapOptions): Promise<void> {
 
     const actualSha = hash.digest("hex");
     if (actualSha !== expectedSha) {
-      throw new Error(
-        `checksum mismatch: expected ${expectedSha}, got ${actualSha}`,
-      );
+      throw new Error(`checksum mismatch: expected ${expectedSha}, got ${actualSha}`);
     }
 
     fs.mkdirSync(stagingDir, { recursive: true });
     await new Promise<void>((resolve, reject) => {
-      execFile(
-        "tar",
-        ["xzf", tarGzPath, "-C", stagingDir, "gws"],
-        { timeout: 30_000 },
-        (err) => {
-          if (err) reject(err);
-          else resolve();
-        },
-      );
+      execFile("tar", ["xzf", tarGzPath, "-C", stagingDir, "gws"], { timeout: 30_000 }, (err) => {
+        if (err) reject(err);
+        else resolve();
+      });
     });
 
     // fs.renameSync is atomic on the same filesystem, so the old binary is
@@ -199,9 +186,7 @@ export function seedGwsClientSecret(bundledResourcesDir: string): void {
   const secretDest = path.join(GWS_CONFIG_DIR, "client_secret.json");
 
   if (!fs.existsSync(secretSrc)) {
-    console.warn(
-      "[gws] client_secret.json not found in bundled resources — OAuth will not work",
-    );
+    console.warn("[gws] client_secret.json not found in bundled resources — OAuth will not work");
     return;
   }
 

--- a/packages/agent-runtime/src/index.ts
+++ b/packages/agent-runtime/src/index.ts
@@ -1,10 +1,2 @@
-export {
-  seedDirectory,
-  seedFile,
-  prependPath,
-} from "./seed";
-export {
-  installGws,
-  seedGwsClientSecret,
-  type GwsBootstrapOptions,
-} from "./gws";
+export { seedDirectory, seedFile, prependPath } from "./seed";
+export { installGws, seedGwsClientSecret, type GwsBootstrapOptions } from "./gws";

--- a/packages/pi-driver/src/agent.ts
+++ b/packages/pi-driver/src/agent.ts
@@ -41,9 +41,7 @@ export type PiAgentConfig = {
    * callers can defer dynamic imports (e.g. extensions that pull in heavy
    * native deps) until `start()` is invoked.
    */
-  extensionFactories:
-    | ExtensionFactory[]
-    | (() => ExtensionFactory[] | Promise<ExtensionFactory[]>);
+  extensionFactories: ExtensionFactory[] | (() => ExtensionFactory[] | Promise<ExtensionFactory[]>);
   /** Optional thinking level. Defaults to "off". */
   thinkingLevel?: "off" | "low" | "medium" | "high" | "xhigh";
 };
@@ -86,10 +84,7 @@ export class PiAgent {
       model: this.config.model,
       thinkingLevel: this.config.thinkingLevel ?? "off",
       sessionManager: this.config.sessionManager,
-      settingsManager: SettingsManager.create(
-        this.config.cwd,
-        this.config.agentDir,
-      ),
+      settingsManager: SettingsManager.create(this.config.cwd, this.config.agentDir),
     });
 
     this.unsubscribe = session.subscribe((event: AgentSessionEvent) => {
@@ -162,13 +157,11 @@ export class PiAgent {
 
     this.status = "busy";
 
-    void session
-      .prompt(message, imgs ? { images: imgs } : undefined)
-      .catch((err: unknown) => {
-        this.status = "error";
-        this.error = err instanceof Error ? err.message : String(err);
-        console.error("[pi-driver] prompt error:", this.error);
-      });
+    void session.prompt(message, imgs ? { images: imgs } : undefined).catch((err: unknown) => {
+      this.status = "error";
+      this.error = err instanceof Error ? err.message : String(err);
+      console.error("[pi-driver] prompt error:", this.error);
+    });
   }
 
   async steer(message: string, images?: ImageContent[]): Promise<void> {

--- a/packages/pi-driver/src/auth.ts
+++ b/packages/pi-driver/src/auth.ts
@@ -32,7 +32,6 @@ export async function loginWithProvider(
 ): Promise<void> {
   await authStorage.login(provider, {
     onAuth: callbacks.onAuth,
-    onPrompt: () =>
-      Promise.reject(new Error("Interactive prompt not supported")),
+    onPrompt: () => Promise.reject(new Error("Interactive prompt not supported")),
   });
 }

--- a/packages/pi-driver/src/index.ts
+++ b/packages/pi-driver/src/index.ts
@@ -1,16 +1,6 @@
 export { PiAgent } from "./agent";
-export type {
-  PiAgentConfig,
-  PiAgentEventListener,
-  PiAgentTool,
-  PiAgentStatus,
-} from "./agent";
-export {
-  createAuthStorage,
-  hasAuth,
-  loginWithProvider,
-  type LoginCallbacks,
-} from "./auth";
+export type { PiAgentConfig, PiAgentEventListener, PiAgentTool, PiAgentStatus } from "./agent";
+export { createAuthStorage, hasAuth, loginWithProvider, type LoginCallbacks } from "./auth";
 export { resolveModel } from "./model";
 
 export { SessionManager } from "@mariozechner/pi-coding-agent";

--- a/packages/pi-driver/src/model.ts
+++ b/packages/pi-driver/src/model.ts
@@ -15,9 +15,7 @@ export function resolveModel<Provider extends Parameters<typeof getModel>[0]>(
 ): Model<Api> {
   const model = getModel(provider, modelId as never);
   if (!model) {
-    throw new Error(
-      `Model "${String(provider)}/${modelId}" not found in pi-ai model registry`,
-    );
+    throw new Error(`Model "${String(provider)}/${modelId}" not found in pi-ai model registry`);
   }
   return model;
 }

--- a/packages/ui/src/components/geometric-orb.tsx
+++ b/packages/ui/src/components/geometric-orb.tsx
@@ -8,13 +8,7 @@ import { Line2 } from "three/examples/jsm/lines/Line2.js";
 import { LineMaterial } from "three/examples/jsm/lines/LineMaterial.js";
 import { LineGeometry } from "three/examples/jsm/lines/LineGeometry.js";
 
-export type DisplayStatus =
-  | "idle"
-  | "busy"
-  | "error"
-  | "starting"
-  | "listening"
-  | "speaking";
+export type DisplayStatus = "idle" | "busy" | "error" | "starting" | "listening" | "speaking";
 
 extend({ Line2, LineMaterial, LineGeometry });
 
@@ -107,7 +101,7 @@ const moods: Record<DisplayStatus, Mood> = {
   },
   speaking: {
     speed: 8,
-    squiggleAmount: 0.10,
+    squiggleAmount: 0.1,
     squiggleFrequency: 7,
     squiggleSpeed: 6,
     morphProgress: 1,
@@ -139,21 +133,15 @@ function referenceEasing(t: number): number {
 }
 
 function easeInOutCubic(t: number): number {
-  return t < 0.5
-    ? 4 * t * t * t
-    : 1 - Math.pow(-2 * t + 2, 3) / 2;
+  return t < 0.5 ? 4 * t * t * t : 1 - Math.pow(-2 * t + 2, 3) / 2;
 }
 
 function lerpMood(current: Mood, target: Mood, alpha: number): void {
   current.speed += (target.speed - current.speed) * alpha;
-  current.squiggleAmount +=
-    (target.squiggleAmount - current.squiggleAmount) * alpha;
-  current.squiggleFrequency +=
-    (target.squiggleFrequency - current.squiggleFrequency) * alpha;
-  current.squiggleSpeed +=
-    (target.squiggleSpeed - current.squiggleSpeed) * alpha;
-  current.morphProgress +=
-    (target.morphProgress - current.morphProgress) * alpha;
+  current.squiggleAmount += (target.squiggleAmount - current.squiggleAmount) * alpha;
+  current.squiggleFrequency += (target.squiggleFrequency - current.squiggleFrequency) * alpha;
+  current.squiggleSpeed += (target.squiggleSpeed - current.squiggleSpeed) * alpha;
+  current.morphProgress += (target.morphProgress - current.morphProgress) * alpha;
   current.helixSpin += (target.helixSpin - current.helixSpin) * alpha;
   current.r += (target.r - current.r) * alpha;
   current.g += (target.g - current.g) * alpha;
@@ -172,8 +160,7 @@ class HelixCurve extends THREE.Curve<THREE.Vector3> {
     const quarter = percent % 0.25;
     const tNorm = quarter / 0.25;
     const segment = Math.floor(percent / 0.25);
-    let t =
-      quarter - (2 * (1 - tNorm) * tNorm * -0.0185 + tNorm * tNorm * 0.25);
+    let t = quarter - (2 * (1 - tNorm) * tNorm * -0.0185 + tNorm * tNorm * 0.25);
     if (segment === 0 || segment === 2) {
       t *= -1;
     }
@@ -183,18 +170,14 @@ class HelixCurve extends THREE.Curve<THREE.Vector3> {
   }
 }
 
-function helixPoint(
-  percent: number,
-  tubeAngle: number,
-): [number, number, number] {
+function helixPoint(percent: number, tubeAngle: number): [number, number, number] {
   const x = HELIX_LENGTH * Math.sin(PI2 * percent);
   const y = HELIX_AMPLITUDE * Math.cos(PI2 * 3 * percent);
 
   const quarter = percent % 0.25;
   const tNorm = quarter / 0.25;
   const segment = Math.floor(percent / 0.25);
-  let t =
-    quarter - (2 * (1 - tNorm) * tNorm * -0.0185 + tNorm * tNorm * 0.25);
+  let t = quarter - (2 * (1 - tNorm) * tNorm * -0.0185 + tNorm * tNorm * 0.25);
   if (segment === 0 || segment === 2) {
     t *= -1;
   }
@@ -215,9 +198,7 @@ function LatitudeLines({ status }: { status: DisplayStatus }) {
   const spinGroupRef = useRef<THREE.Group>(null);
   const camDirRef = useRef(new THREE.Vector3());
   const helixRotationRef = useRef(0);
-  const sphereExpandRef = useRef(
-    moods[status].morphProgress > 0.5 ? 1 : 0,
-  );
+  const sphereExpandRef = useRef(moods[status].morphProgress > 0.5 ? 1 : 0);
   const { size } = useThree();
 
   const moodRef = useRef<Mood>({ ...moods[status] });
@@ -299,10 +280,7 @@ function LatitudeLines({ status }: { status: DisplayStatus }) {
     [],
   );
 
-  const geometries = useMemo(
-    () => Array.from({ length: NUM_LINES }, () => new LineGeometry()),
-    [],
-  );
+  const geometries = useMemo(() => Array.from({ length: NUM_LINES }, () => new LineGeometry()), []);
 
   useEffect(() => {
     return () => {
@@ -320,14 +298,8 @@ function LatitudeLines({ status }: { status: DisplayStatus }) {
   }, [materials, size.width, size.height]);
 
   const vertexCount = POINTS_PER_LINE + 1;
-  const positionBuffer = useMemo(
-    () => new Float32Array(vertexCount * 3),
-    [vertexCount],
-  );
-  const colorBuffer = useMemo(
-    () => new Float32Array(vertexCount * 3),
-    [vertexCount],
-  );
+  const positionBuffer = useMemo(() => new Float32Array(vertexCount * 3), [vertexCount]);
+  const colorBuffer = useMemo(() => new Float32Array(vertexCount * 3), [vertexCount]);
 
   useFrame((state, delta) => {
     const mood = moodRef.current;
@@ -350,14 +322,10 @@ function LatitudeLines({ status }: { status: DisplayStatus }) {
 
       if (spinUp.elapsed <= ACCEL_DURATION) {
         // Acceleration: helix spins + turns to -π/2
-        const normalizedTime = Math.min(
-          spinUp.elapsed / ACCEL_DURATION,
-          1,
-        );
+        const normalizedTime = Math.min(spinUp.elapsed / ACCEL_DURATION, 1);
         const acceleration = referenceEasing(normalizedTime);
 
-        helixRotationRef.current +=
-          (ROTATE_VALUE + acceleration) * delta * 60;
+        helixRotationRef.current += (ROTATE_VALUE + acceleration) * delta * 60;
         mood.morphProgress = 0;
         sphereExpandRef.current = 0;
 
@@ -387,8 +355,7 @@ function LatitudeLines({ status }: { status: DisplayStatus }) {
         const easedMorph = easeInOutCubic(morph);
 
         // Decelerate spin
-        helixRotationRef.current +=
-          (ROTATE_VALUE + 1) * (1 - easedMorph) * delta * 60;
+        helixRotationRef.current += (ROTATE_VALUE + 1) * (1 - easedMorph) * delta * 60;
 
         // morphProgress: helix positions → circle/sphere positions
         mood.morphProgress = easedMorph;
@@ -414,12 +381,9 @@ function LatitudeLines({ status }: { status: DisplayStatus }) {
         const target = moods[spinUp.target];
         const a = easedMorph * 0.1;
         mood.speed += (target.speed - mood.speed) * a;
-        mood.squiggleAmount +=
-          (target.squiggleAmount - mood.squiggleAmount) * a;
-        mood.squiggleFrequency +=
-          (target.squiggleFrequency - mood.squiggleFrequency) * a;
-        mood.squiggleSpeed +=
-          (target.squiggleSpeed - mood.squiggleSpeed) * a;
+        mood.squiggleAmount += (target.squiggleAmount - mood.squiggleAmount) * a;
+        mood.squiggleFrequency += (target.squiggleFrequency - mood.squiggleFrequency) * a;
+        mood.squiggleSpeed += (target.squiggleSpeed - mood.squiggleSpeed) * a;
         mood.r += (target.r - mood.r) * a;
         mood.g += (target.g - mood.g) * a;
         mood.b += (target.b - mood.b) * a;
@@ -443,8 +407,7 @@ function LatitudeLines({ status }: { status: DisplayStatus }) {
 
       // sphereExpand tracks morphProgress in normal mode
       const expandTarget = mood.morphProgress > 0.5 ? 1 : 0;
-      sphereExpandRef.current +=
-        (expandTarget - sphereExpandRef.current) * alpha;
+      sphereExpandRef.current += (expandTarget - sphereExpandRef.current) * alpha;
 
       const morph = mood.morphProgress;
       setTubeVisible(1 - morph);
@@ -459,9 +422,7 @@ function LatitudeLines({ status }: { status: DisplayStatus }) {
 
     // During spin-up: kill spin quickly before group unwind (at morph≈0.2)
     // During normal transitions: spin fades linearly with morph
-    const spinFade = spinUpRef.current
-      ? Math.max(0, 1 - morph * 5)
-      : 1 - morph;
+    const spinFade = spinUpRef.current ? Math.max(0, 1 - morph * 5) : 1 - morph;
     if (spinGroupRef.current) {
       spinGroupRef.current.rotation.x = helixRotationRef.current * spinFade;
     }
@@ -501,28 +462,17 @@ function LatitudeLines({ status }: { status: DisplayStatus }) {
 
         // --- Sphere position (scaled, with squiggle scaled by expand) ---
         const squiggle =
-          Math.sin(
-            angle * mood.squiggleFrequency +
-              time * mood.squiggleSpeed +
-              lineIdx * 0.5,
-          ) *
+          Math.sin(angle * mood.squiggleFrequency + time * mood.squiggleSpeed + lineIdx * 0.5) *
           mood.squiggleAmount *
           expand;
         const radiusSquiggle =
-          Math.cos(
-            angle * mood.squiggleFrequency * 1.3 +
-              time * mood.squiggleSpeed * 0.8,
-          ) *
+          Math.cos(angle * mood.squiggleFrequency * 1.3 + time * mood.squiggleSpeed * 0.8) *
           mood.squiggleAmount *
           0.5 *
           expand;
-        const displacedRadius =
-          circleRadius + (squiggle + radiusSquiggle) * circleRadius;
+        const displacedRadius = circleRadius + (squiggle + radiusSquiggle) * circleRadius;
         const ySquiggle =
-          Math.sin(
-            angle * mood.squiggleFrequency * 0.7 +
-              time * mood.squiggleSpeed * 1.2,
-          ) *
+          Math.sin(angle * mood.squiggleFrequency * 0.7 + time * mood.squiggleSpeed * 1.2) *
           mood.squiggleAmount *
           0.4 *
           expand;
@@ -619,7 +569,13 @@ function OrbLine({
   return (
     <group ref={ref}>
       {/* Line2 from three/examples/jsm — extended via extend() at runtime */}
-      {(React.createElement as (type: string, props: object, ...children: React.ReactNode[]) => React.ReactElement)(
+      {(
+        React.createElement as (
+          type: string,
+          props: object,
+          ...children: React.ReactNode[]
+        ) => React.ReactElement
+      )(
         "line2",
         {},
         React.createElement("primitive", { object: geometry, attach: "geometry" }),

--- a/packages/ui/src/styles/globals.css
+++ b/packages/ui/src/styles/globals.css
@@ -6,88 +6,88 @@
 @source "../**/*.{ts,tsx}";
 
 @theme inline {
-    --font-heading: var(--font-sans);
-    --font-sans: var(--font-sans);
-    --color-sidebar-ring: var(--sidebar-ring);
-    --color-sidebar-border: var(--sidebar-border);
-    --color-sidebar-accent-foreground: var(--sidebar-accent-foreground);
-    --color-sidebar-accent: var(--sidebar-accent);
-    --color-sidebar-primary-foreground: var(--sidebar-primary-foreground);
-    --color-sidebar-primary: var(--sidebar-primary);
-    --color-sidebar-foreground: var(--sidebar-foreground);
-    --color-sidebar: var(--sidebar);
-    --color-chart-5: var(--chart-5);
-    --color-chart-4: var(--chart-4);
-    --color-chart-3: var(--chart-3);
-    --color-chart-2: var(--chart-2);
-    --color-chart-1: var(--chart-1);
-    --color-ring: var(--ring);
-    --color-input: var(--input);
-    --color-border: var(--border);
-    --color-destructive: var(--destructive);
-    --color-accent-foreground: var(--accent-foreground);
-    --color-accent: var(--accent);
-    --color-muted-foreground: var(--muted-foreground);
-    --color-muted: var(--muted);
-    --color-secondary-foreground: var(--secondary-foreground);
-    --color-secondary: var(--secondary);
-    --color-primary-foreground: var(--primary-foreground);
-    --color-primary: var(--primary);
-    --color-popover-foreground: var(--popover-foreground);
-    --color-popover: var(--popover);
-    --color-card-foreground: var(--card-foreground);
-    --color-card: var(--card);
-    --color-foreground: var(--foreground);
-    --color-background: var(--background);
-    --radius-sm: calc(var(--radius) * 0.6);
-    --radius-md: calc(var(--radius) * 0.8);
-    --radius-lg: var(--radius);
-    --radius-xl: calc(var(--radius) * 1.4);
-    --radius-2xl: calc(var(--radius) * 1.8);
-    --radius-3xl: calc(var(--radius) * 2.2);
-    --radius-4xl: calc(var(--radius) * 2.6);
+  --font-heading: var(--font-sans);
+  --font-sans: var(--font-sans);
+  --color-sidebar-ring: var(--sidebar-ring);
+  --color-sidebar-border: var(--sidebar-border);
+  --color-sidebar-accent-foreground: var(--sidebar-accent-foreground);
+  --color-sidebar-accent: var(--sidebar-accent);
+  --color-sidebar-primary-foreground: var(--sidebar-primary-foreground);
+  --color-sidebar-primary: var(--sidebar-primary);
+  --color-sidebar-foreground: var(--sidebar-foreground);
+  --color-sidebar: var(--sidebar);
+  --color-chart-5: var(--chart-5);
+  --color-chart-4: var(--chart-4);
+  --color-chart-3: var(--chart-3);
+  --color-chart-2: var(--chart-2);
+  --color-chart-1: var(--chart-1);
+  --color-ring: var(--ring);
+  --color-input: var(--input);
+  --color-border: var(--border);
+  --color-destructive: var(--destructive);
+  --color-accent-foreground: var(--accent-foreground);
+  --color-accent: var(--accent);
+  --color-muted-foreground: var(--muted-foreground);
+  --color-muted: var(--muted);
+  --color-secondary-foreground: var(--secondary-foreground);
+  --color-secondary: var(--secondary);
+  --color-primary-foreground: var(--primary-foreground);
+  --color-primary: var(--primary);
+  --color-popover-foreground: var(--popover-foreground);
+  --color-popover: var(--popover);
+  --color-card-foreground: var(--card-foreground);
+  --color-card: var(--card);
+  --color-foreground: var(--foreground);
+  --color-background: var(--background);
+  --radius-sm: calc(var(--radius) * 0.6);
+  --radius-md: calc(var(--radius) * 0.8);
+  --radius-lg: var(--radius);
+  --radius-xl: calc(var(--radius) * 1.4);
+  --radius-2xl: calc(var(--radius) * 1.8);
+  --radius-3xl: calc(var(--radius) * 2.2);
+  --radius-4xl: calc(var(--radius) * 2.6);
 }
 
 :root {
-    --background: oklch(0.64 0.14 35.05);
-    --foreground: oklch(0.985 0 0);
-    --card: oklch(0.58 0.14 35.05);
-    --card-foreground: oklch(0.985 0 0);
-    --popover: oklch(0.58 0.14 35.05);
-    --popover-foreground: oklch(0.985 0 0);
-    --primary: oklch(0.985 0 0);
-    --primary-foreground: oklch(0.38 0.125 35.05);
-    --secondary: oklch(0.52 0.115 35.05);
-    --secondary-foreground: oklch(0.985 0 0);
-    --muted: oklch(0.52 0.115 35.05);
-    --muted-foreground: oklch(0.84 0.035 35.05);
-    --accent: oklch(0.52 0.115 35.05);
-    --accent-foreground: oklch(0.985 0 0);
-    --destructive: oklch(0.398 0.161 25);
-    --border: oklch(0.55 0.12 35.05);
-    --input: oklch(0.55 0.12 35.05);
-    --ring: oklch(0.86 0.05 35.05);
-    --chart-1: oklch(0.871 0.006 286.286);
-    --chart-2: oklch(0.552 0.016 285.938);
-    --chart-3: oklch(0.442 0.017 285.786);
-    --chart-4: oklch(0.37 0.013 285.805);
-    --chart-5: oklch(0.274 0.006 286.033);
-    --radius: 0.625rem;
-    --sidebar: oklch(0.985 0 0);
-    --sidebar-foreground: oklch(0.141 0.005 285.823);
-    --sidebar-primary: oklch(0.21 0.006 285.885);
-    --sidebar-primary-foreground: oklch(0.985 0 0);
-    --sidebar-accent: oklch(0.967 0.001 286.375);
-    --sidebar-accent-foreground: oklch(0.21 0.006 285.885);
-    --sidebar-border: oklch(0.92 0.004 286.32);
-    --sidebar-ring: oklch(0.705 0.015 286.067);
+  --background: oklch(0.64 0.14 35.05);
+  --foreground: oklch(0.985 0 0);
+  --card: oklch(0.58 0.14 35.05);
+  --card-foreground: oklch(0.985 0 0);
+  --popover: oklch(0.58 0.14 35.05);
+  --popover-foreground: oklch(0.985 0 0);
+  --primary: oklch(0.985 0 0);
+  --primary-foreground: oklch(0.38 0.125 35.05);
+  --secondary: oklch(0.52 0.115 35.05);
+  --secondary-foreground: oklch(0.985 0 0);
+  --muted: oklch(0.52 0.115 35.05);
+  --muted-foreground: oklch(0.84 0.035 35.05);
+  --accent: oklch(0.52 0.115 35.05);
+  --accent-foreground: oklch(0.985 0 0);
+  --destructive: oklch(0.398 0.161 25);
+  --border: oklch(0.55 0.12 35.05);
+  --input: oklch(0.55 0.12 35.05);
+  --ring: oklch(0.86 0.05 35.05);
+  --chart-1: oklch(0.871 0.006 286.286);
+  --chart-2: oklch(0.552 0.016 285.938);
+  --chart-3: oklch(0.442 0.017 285.786);
+  --chart-4: oklch(0.37 0.013 285.805);
+  --chart-5: oklch(0.274 0.006 286.033);
+  --radius: 0.625rem;
+  --sidebar: oklch(0.985 0 0);
+  --sidebar-foreground: oklch(0.141 0.005 285.823);
+  --sidebar-primary: oklch(0.21 0.006 285.885);
+  --sidebar-primary-foreground: oklch(0.985 0 0);
+  --sidebar-accent: oklch(0.967 0.001 286.375);
+  --sidebar-accent-foreground: oklch(0.21 0.006 285.885);
+  --sidebar-border: oklch(0.92 0.004 286.32);
+  --sidebar-ring: oklch(0.705 0.015 286.067);
 }
 
 @layer base {
-    * {
-        @apply border-border outline-ring/50;
-    }
-    body {
-        @apply bg-background text-foreground;
-    }
+  * {
+    @apply border-border outline-ring/50;
+  }
+  body {
+    @apply bg-background text-foreground;
+  }
 }


### PR DESCRIPTION
## Summary
- format repo
- expose Electron CDP on desktop dev
- document agent-browser desktop validation

## Checks
- pnpm format
- pnpm typecheck && pnpm lint && pnpm build

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mostly formatting-only changes across desktop/web/packages; the only behavior change is enabling Electron remote debugging on port 9222 during desktop dev, which is low risk and limited to local development.
> 
> **Overview**
> **Enables desktop dev CDP debugging** by running Electron with `--remoteDebuggingPort 9222`, and documents how to connect/snapshot/screenshot the live Electron UI via `agent-browser` in `AGENTS.md`.
> 
> Separately, applies broad repo formatting/line-wrapping cleanup (tests, browser tooling, UI components, scripts, exports, and CSS) with no intended runtime behavior changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1bdccf4cb67f103fd10fa5546a9bf22654afd2b3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enable CDP for the desktop app in dev by launching Electron with port 9222, and document how to validate the desktop UI using `agent-browser`. Also formats the repo for consistency.

- **New Features**
  - `apps/desktop`: start with `--remoteDebuggingPort 9222` for CDP access.
  - Docs: added “Desktop Debugging” steps in AGENTS.md with `agent-browser --session inteligir-desktop connect 9222`, `snapshot`, and `screenshot` examples.

- **Refactors**
  - Repo-wide formatting and small cleanups across tests and UI.
  - Browser tool polish: safer element interactions, capped full‑page screenshots, and clearer storage/cookie helpers.

<sup>Written for commit 1bdccf4cb67f103fd10fa5546a9bf22654afd2b3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

