### PR TITLE
Remove logo from UI library page

### DIFF
--- a/apps/web/src/app/ui/page.tsx
+++ b/apps/web/src/app/ui/page.tsx
@@ -82,7 +82,6 @@ import {
 import { InputField, InputGroup } from "@repo/ui/components/input-group-fields";
 import { InputMessage } from "@repo/ui/components/input-message";
 import { Label } from "@repo/ui/components/label";
-import { Logo } from "@repo/ui/components/logo";
 import { NavItem } from "@repo/ui/components/nav-item";
 import { NavMenu } from "@repo/ui/components/nav-menu";
 import { Popover, PopoverContent, PopoverTrigger } from "@repo/ui/components/popover";
@@ -165,7 +164,6 @@ export default function UiPage() {
   return (
     <main className="mx-auto max-w-3xl px-6 pt-24 pb-32">
       <header className="flex items-center gap-3">
-        <Logo className="size-8" />
         <div className="flex flex-col">
           <h1 className="text-2xl font-semibold">UI library</h1>
           <p className="text-sm text-muted-foreground">


### PR DESCRIPTION
Removes the `<Logo />` from the header of the `/ui` UI library page (`apps/web/src/app/ui/page.tsx`) and drops the now-unused `Logo` import. The shared `Logo` component itself is untouched.

https://claude.ai/code/session_01KwpZrHb6j8BhciwGK8EyQi

---
_Generated by [Claude Code](https://claude.ai/code/session_01KwpZrHb6j8BhciwGK8EyQi)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Cosmetic change to a dev-only UI showcase page with no auth, data, or shared component logic affected.
> 
> **Overview**
> Removes the **`Logo`** from the `/ui` showcase page header so the title block is text-only, and deletes the unused **`Logo`** import from `apps/web/src/app/ui/page.tsx`. The shared **`@repo/ui`** `Logo` component is unchanged and still used elsewhere (e.g. auth layout).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a392cb91923a58fd48b01d30859312ada475c0d9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the `Logo` from the `/ui` page header and deleted the unused `Logo` import in `apps/web/src/app/ui/page.tsx`. This keeps the header simple and avoids duplicate branding.

<sup>Written for commit a392cb91923a58fd48b01d30859312ada475c0d9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kyh/inteligir/pull/327?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

