### PR TITLE
Align component styling with fluid-functionalism

### DIFF
--- a/packages/ui/src/components/alert-dialog.tsx
+++ b/packages/ui/src/components/alert-dialog.tsx
@@ -23,7 +23,7 @@ function AlertDialogOverlay({ className, ...props }: AlertDialogPrimitive.Backdr
     <AlertDialogPrimitive.Backdrop
       data-slot="alert-dialog-overlay"
       className={cn(
-        "fixed inset-0 isolate z-50 bg-black/10 duration-100 supports-backdrop-filter:backdrop-blur-xs data-open:animate-in data-open:fade-in-0 data-closed:animate-out data-closed:fade-out-0",
+        "fixed inset-0 isolate z-50 bg-black/40 duration-100 dark:bg-black/80 data-open:animate-in data-open:fade-in-0 data-closed:animate-out data-closed:fade-out-0",
         className,
       )}
       {...props}

--- a/packages/ui/src/components/dialog.tsx
+++ b/packages/ui/src/components/dialog.tsx
@@ -90,6 +90,7 @@ function DialogContent({
   children,
   showCloseButton = true,
   size = "sm",
+  style,
   ...props
 }: DialogPrimitive.Popup.Props & {
   showCloseButton?: boolean;
@@ -108,21 +109,23 @@ function DialogContent({
       <DialogOverlay />
       <DialogPrimitive.Popup
         data-slot="dialog-content"
+        // Behavioral Popup props (focus management, etc.) and any HTML
+        // attributes/handlers stay on the primitive, so Base UI applies the
+        // behavioral ones and merges the forwardable ones into `popupProps` for
+        // the rendered element. className/style are pulled out and handled in
+        // the render callback to preserve tailwind-merge / motion semantics.
+        {...props}
         render={(popupProps, state) => {
           const exiting = state.transitionStatus === "ending";
           const { style: baseStyle, rest } = stripMotionConflicts(
             popupProps as React.HTMLAttributes<HTMLDivElement>,
           );
-          const { style: consumerStyle, ...consumerRest } = props as StrippedProps & {
-            style?: React.CSSProperties;
-          };
           return (
             <motion.div
-              // Base UI's props first (data attrs, refs, role, etc.)…
+              // Base UI's resolved props (data attrs, refs, role, plus the
+              // consumer's merged HTML attributes/handlers) land on the
+              // visible motion.div.
               {...rest}
-              // …then the consumer's `<DialogContent>` props (className, event
-              // handlers, data-*, etc.) land on the visible motion.div.
-              {...consumerRest}
               // Centering lives in Tailwind's `translate` utilities (a
               // standalone CSS property in v4), not in the motion transform, so
               // consumers can still override placement via className — e.g. the
@@ -138,7 +141,7 @@ function DialogContent({
                 shape.container,
                 className,
               )}
-              style={{ ...baseStyle, ...consumerStyle }}
+              style={{ ...baseStyle, ...(style as React.CSSProperties | undefined) }}
               initial={{ opacity: 0, scale: 0.97 }}
               animate={{
                 opacity: exiting ? 0 : 1,

--- a/packages/ui/src/components/dialog.tsx
+++ b/packages/ui/src/components/dialog.tsx
@@ -2,10 +2,47 @@
 
 import * as React from "react";
 import { Dialog as DialogPrimitive } from "@base-ui/react/dialog";
+import { motion } from "motion/react";
+import { XIcon } from "lucide-react";
 
 import { cn } from "@repo/ui/lib/utils";
 import { Button } from "@repo/ui/components/button";
-import { XIcon } from "lucide-react";
+import { springs } from "@repo/ui/lib/springs";
+import { getShape } from "@repo/ui/lib/shape";
+import { surfaceClasses } from "@repo/ui/lib/surface-classes";
+import { SurfaceProvider, useSurface } from "@repo/ui/lib/surface-context";
+
+// A dialog floats four elevation steps above whatever surface it opens over.
+const DIALOG_OFFSET = 4;
+
+// framer-motion needs these stripped from Base UI's render-prop props so its
+// own (incompatible) drag/animation handler signatures win on the motion.div.
+type StrippedProps = Omit<
+  React.HTMLAttributes<HTMLDivElement>,
+  | "onDrag"
+  | "onDragStart"
+  | "onDragEnd"
+  | "onAnimationStart"
+  | "onAnimationEnd"
+  | "onAnimationIteration"
+>;
+
+function stripMotionConflicts(props: React.HTMLAttributes<HTMLDivElement>): {
+  style?: React.CSSProperties;
+  rest: StrippedProps;
+} {
+  const {
+    style,
+    onDrag: _onDrag,
+    onDragStart: _onDragStart,
+    onDragEnd: _onDragEnd,
+    onAnimationStart: _onAnimationStart,
+    onAnimationEnd: _onAnimationEnd,
+    onAnimationIteration: _onAnimationIteration,
+    ...rest
+  } = props;
+  return { style: style as React.CSSProperties | undefined, rest };
+}
 
 function Dialog({ ...props }: DialogPrimitive.Root.Props) {
   return <DialogPrimitive.Root data-slot="dialog" {...props} />;
@@ -23,15 +60,27 @@ function DialogClose({ ...props }: DialogPrimitive.Close.Props) {
   return <DialogPrimitive.Close data-slot="dialog-close" {...props} />;
 }
 
-function DialogOverlay({ className, ...props }: DialogPrimitive.Backdrop.Props) {
+// Spring-animated scrim. Motion is information — the backdrop eases in on the
+// slow spring and out on the moderate one, matching the popup's tempo.
+function DialogOverlay({ className }: { className?: string }) {
   return (
     <DialogPrimitive.Backdrop
       data-slot="dialog-overlay"
-      className={cn(
-        "fixed inset-0 isolate z-50 bg-black/10 duration-100 supports-backdrop-filter:backdrop-blur-xs data-open:animate-in data-open:fade-in-0 data-closed:animate-out data-closed:fade-out-0",
-        className,
-      )}
-      {...props}
+      render={(backdropProps, state) => {
+        const exiting = state.transitionStatus === "ending";
+        const { rest } = stripMotionConflicts(
+          backdropProps as React.HTMLAttributes<HTMLDivElement>,
+        );
+        return (
+          <motion.div
+            {...rest}
+            className={cn("fixed inset-0 z-50 bg-black/40 dark:bg-black/80", className)}
+            initial={{ opacity: 0 }}
+            animate={{ opacity: exiting ? 0 : 1 }}
+            transition={exiting ? springs.moderate : springs.slow}
+          />
+        );
+      }}
     />
   );
 }
@@ -40,39 +89,88 @@ function DialogContent({
   className,
   children,
   showCloseButton = true,
+  size = "sm",
   ...props
 }: DialogPrimitive.Popup.Props & {
   showCloseButton?: boolean;
+  size?: "sm" | "lg";
 }) {
+  const shape = getShape();
+  const substrate = useSurface();
+  const dialogLevel = Math.min(substrate + DIALOG_OFFSET, 8);
+
+  // No `if (!open) return null` here — Base UI's `<DialogPrimitive.Popup>`
+  // handles mount/unmount itself, and waits for the motion opacity/scale tween
+  // below to finish (via `element.getAnimations()`) before unmounting.
+  // Returning null early would short-circuit the closing animation.
   return (
     <DialogPortal>
       <DialogOverlay />
       <DialogPrimitive.Popup
         data-slot="dialog-content"
-        className={cn(
-          "fixed top-1/2 left-1/2 z-50 grid w-full max-w-[calc(100%-2rem)] -translate-x-1/2 -translate-y-1/2 gap-6 rounded-3xl bg-surface-5 p-6 text-sm text-popover-foreground shadow-surface-5 duration-100 outline-none sm:max-w-md data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95",
-          className,
-        )}
-        {...props}
-      >
-        {children}
-        {showCloseButton && (
-          <DialogPrimitive.Close
-            data-slot="dialog-close"
-            render={<Button variant="ghost" className="absolute top-4 right-4" size="icon-sm" />}
-          >
-            <XIcon />
-            <span className="sr-only">Close</span>
-          </DialogPrimitive.Close>
-        )}
-      </DialogPrimitive.Popup>
+        render={(popupProps, state) => {
+          const exiting = state.transitionStatus === "ending";
+          const { style: baseStyle, rest } = stripMotionConflicts(
+            popupProps as React.HTMLAttributes<HTMLDivElement>,
+          );
+          const { style: consumerStyle, ...consumerRest } = props as StrippedProps & {
+            style?: React.CSSProperties;
+          };
+          return (
+            <motion.div
+              // Base UI's props first (data attrs, refs, role, etc.)…
+              {...rest}
+              // …then the consumer's `<DialogContent>` props (className, event
+              // handlers, data-*, etc.) land on the visible motion.div.
+              {...consumerRest}
+              className={cn(
+                "fixed top-1/2 left-1/2 z-50 w-[calc(100%-2rem)]",
+                surfaceClasses(dialogLevel),
+                "p-6 text-sm text-popover-foreground outline-none",
+                size === "sm" && "max-w-[400px]",
+                size === "lg" && "max-w-[540px]",
+                shape.container,
+                className,
+              )}
+              style={{ ...baseStyle, ...consumerStyle }}
+              initial={{ opacity: 0, scale: 0.97, x: "-50%", y: "-50%" }}
+              animate={{
+                opacity: exiting ? 0 : 1,
+                scale: exiting ? 0.97 : 1,
+                x: "-50%",
+                y: "-50%",
+              }}
+              transition={exiting ? springs.moderate : springs.slow}
+            >
+              <SurfaceProvider value={dialogLevel}>
+                {children}
+                {showCloseButton && (
+                  <DialogPrimitive.Close
+                    data-slot="dialog-close"
+                    render={
+                      <Button variant="ghost" size="icon-sm" className="absolute top-3 right-3" />
+                    }
+                  >
+                    <XIcon />
+                    <span className="sr-only">Close</span>
+                  </DialogPrimitive.Close>
+                )}
+              </SurfaceProvider>
+            </motion.div>
+          );
+        }}
+      />
     </DialogPortal>
   );
 }
 
 function DialogHeader({ className, ...props }: React.ComponentProps<"div">) {
   return (
-    <div data-slot="dialog-header" className={cn("flex flex-col gap-2", className)} {...props} />
+    <div
+      data-slot="dialog-header"
+      className={cn("flex flex-col gap-1.5 mb-4", className)}
+      {...props}
+    />
   );
 }
 
@@ -87,7 +185,7 @@ function DialogFooter({
   return (
     <div
       data-slot="dialog-footer"
-      className={cn("flex flex-col-reverse gap-2 sm:flex-row sm:justify-end", className)}
+      className={cn("flex justify-end gap-2 mt-6", className)}
       {...props}
     >
       {children}
@@ -102,7 +200,8 @@ function DialogTitle({ className, ...props }: DialogPrimitive.Title.Props) {
   return (
     <DialogPrimitive.Title
       data-slot="dialog-title"
-      className={cn("font-heading text-base leading-none font-medium", className)}
+      className={cn("text-[16px] text-foreground leading-tight", className)}
+      style={{ fontVariationSettings: "'wght' 700" }}
       {...props}
     />
   );
@@ -113,7 +212,7 @@ function DialogDescription({ className, ...props }: DialogPrimitive.Description.
     <DialogPrimitive.Description
       data-slot="dialog-description"
       className={cn(
-        "text-sm text-muted-foreground *:[a]:underline *:[a]:underline-offset-3 *:[a]:hover:text-foreground",
+        "text-[13px] text-muted-foreground *:[a]:underline *:[a]:underline-offset-3 *:[a]:hover:text-foreground",
         className,
       )}
       {...props}

--- a/packages/ui/src/components/dialog.tsx
+++ b/packages/ui/src/components/dialog.tsx
@@ -123,8 +123,14 @@ function DialogContent({
               // …then the consumer's `<DialogContent>` props (className, event
               // handlers, data-*, etc.) land on the visible motion.div.
               {...consumerRest}
+              // Centering lives in Tailwind's `translate` utilities (a
+              // standalone CSS property in v4), not in the motion transform, so
+              // consumers can still override placement via className — e.g. the
+              // command palette's `top-1/3 translate-y-0`. Motion only animates
+              // opacity + scale (the `transform` property), which composes with
+              // `translate` rather than clobbering it.
               className={cn(
-                "fixed top-1/2 left-1/2 z-50 w-[calc(100%-2rem)]",
+                "fixed top-1/2 left-1/2 z-50 w-[calc(100%-2rem)] -translate-x-1/2 -translate-y-1/2",
                 surfaceClasses(dialogLevel),
                 "p-6 text-sm text-popover-foreground outline-none",
                 size === "sm" && "max-w-[400px]",
@@ -133,12 +139,10 @@ function DialogContent({
                 className,
               )}
               style={{ ...baseStyle, ...consumerStyle }}
-              initial={{ opacity: 0, scale: 0.97, x: "-50%", y: "-50%" }}
+              initial={{ opacity: 0, scale: 0.97 }}
               animate={{
                 opacity: exiting ? 0 : 1,
                 scale: exiting ? 0.97 : 1,
-                x: "-50%",
-                y: "-50%",
               }}
               transition={exiting ? springs.moderate : springs.slow}
             >

--- a/packages/ui/src/styles/globals.css
+++ b/packages/ui/src/styles/globals.css
@@ -28,6 +28,7 @@
   --color-input: var(--input);
   --color-border: var(--border);
   --color-destructive: var(--destructive);
+  --color-destructive-light: var(--destructive-light);
   --color-accent-foreground: var(--accent-foreground);
   --color-accent: var(--accent);
   --color-muted-foreground: var(--muted-foreground);
@@ -76,24 +77,43 @@
 }
 
 :root {
-  --background: oklch(1 0 0);
-  --foreground: oklch(0.141 0.005 285.823);
-  --card: oklch(1 0 0);
-  --card-foreground: oklch(0.141 0.005 285.823);
-  --popover: oklch(1 0 0);
-  --popover-foreground: oklch(0.141 0.005 285.823);
-  --primary: oklch(0.21 0.006 285.885);
-  --primary-foreground: oklch(0.985 0 0);
-  --secondary: oklch(0.967 0.001 286.375);
-  --secondary-foreground: oklch(0.21 0.006 285.885);
-  --muted: oklch(0.967 0.001 286.375);
-  --muted-foreground: oklch(0.552 0.016 285.938);
-  --accent: oklch(0.967 0.001 286.375);
-  --accent-foreground: oklch(0.21 0.006 285.885);
-  --destructive: oklch(0.577 0.245 27.325);
-  --border: oklch(0.92 0.004 286.32);
-  --input: oklch(0.92 0.004 286.32);
-  --ring: oklch(0.705 0.015 286.067);
+  /* Core palette — derived from the Fluid Functionalism neutral hex scale and
+     the surface ladder, so idiomatic shadcn tokens and surface utilities share
+     one coherent set of colors. */
+  --background: var(--surface-1);
+  --foreground: #171717;
+  --card: var(--surface-3);
+  --card-foreground: #171717;
+  --popover: var(--surface-3);
+  --popover-foreground: #171717;
+  --primary: #171717;
+  --primary-foreground: #fafafa;
+  --secondary: #e5e5e5;
+  --secondary-foreground: #171717;
+  --muted: var(--surface-2);
+  --muted-foreground: #737373;
+  --accent: #e5e5e5;
+  --accent-foreground: #171717;
+  --destructive: #ef4444;
+  --destructive-light: #fef2f2;
+  --border: color-mix(in oklab, var(--foreground) 12%, transparent);
+  --input: #e5e5e5;
+  --ring: #e5e5e5;
+
+  /* Neutral scale (for opacity variants that can't reference tokens directly). */
+  --neutral-100: #f5f5f5;
+  --neutral-200: #e5e5e5;
+  --neutral-300: #d4d4d4;
+  --neutral-400: #a3a3a3;
+  --neutral-500: #737373;
+  --neutral-600: #525252;
+  --neutral-700: #404040;
+  --neutral-800: #262626;
+  --neutral-900: #171717;
+
+  /* Color-picker transparency checkerboard. */
+  --checker-a: #bbbbbb;
+  --checker-b: #ffffff;
   --chart-1: oklch(0.871 0.006 286.286);
   --chart-2: oklch(0.552 0.016 285.938);
   --chart-3: oklch(0.442 0.017 285.786);
@@ -126,12 +146,30 @@
   --shadow-color: rgb(0 0 0 / 0.06);
   --shadow-1: 0 0 0 1px var(--shadow-color);
   --shadow-2: 0 0 0 1px var(--shadow-color), 0 1px 1px -0.5px var(--shadow-color);
-  --shadow-3: 0 0 0 1px var(--shadow-color), 0 1px 1px -0.5px var(--shadow-color), 0 3px 3px -1.5px var(--shadow-color);
-  --shadow-4: 0 0 0 1px var(--shadow-color), 0 1px 1px -0.5px var(--shadow-color), 0 3px 3px -1.5px var(--shadow-color), 0 6px 6px -3px var(--shadow-color);
-  --shadow-5: 0 0 0 1px var(--shadow-color), 0 1px 1px -0.5px var(--shadow-color), 0 3px 3px -1.5px var(--shadow-color), 0 6px 6px -3px var(--shadow-color), 0 12px 12px -6px var(--shadow-color);
-  --shadow-6: 0 0 0 1px var(--shadow-color), 0 1px 1px -0.5px var(--shadow-color), 0 3px 3px -1.5px var(--shadow-color), 0 6px 6px -3px var(--shadow-color), 0 12px 12px -6px var(--shadow-color), 0 24px 24px -12px var(--shadow-color);
-  --shadow-7: 0 0 0 1px var(--shadow-color), 0 1px 1px -0.5px var(--shadow-color), 0 3px 3px -1.5px var(--shadow-color), 0 6px 6px -3px var(--shadow-color), 0 12px 12px -6px var(--shadow-color), 0 24px 24px -12px var(--shadow-color), 0 48px 48px -24px var(--shadow-color);
-  --shadow-8: 0 0 0 1px var(--shadow-color), 0 1px 1px -0.5px var(--shadow-color), 0 3px 3px -1.5px var(--shadow-color), 0 6px 6px -3px var(--shadow-color), 0 12px 12px -6px var(--shadow-color), 0 24px 24px -12px var(--shadow-color), 0 48px 48px -24px var(--shadow-color), 0 96px 96px -48px var(--shadow-color);
+  --shadow-3:
+    0 0 0 1px var(--shadow-color), 0 1px 1px -0.5px var(--shadow-color),
+    0 3px 3px -1.5px var(--shadow-color);
+  --shadow-4:
+    0 0 0 1px var(--shadow-color), 0 1px 1px -0.5px var(--shadow-color),
+    0 3px 3px -1.5px var(--shadow-color), 0 6px 6px -3px var(--shadow-color);
+  --shadow-5:
+    0 0 0 1px var(--shadow-color), 0 1px 1px -0.5px var(--shadow-color),
+    0 3px 3px -1.5px var(--shadow-color), 0 6px 6px -3px var(--shadow-color),
+    0 12px 12px -6px var(--shadow-color);
+  --shadow-6:
+    0 0 0 1px var(--shadow-color), 0 1px 1px -0.5px var(--shadow-color),
+    0 3px 3px -1.5px var(--shadow-color), 0 6px 6px -3px var(--shadow-color),
+    0 12px 12px -6px var(--shadow-color), 0 24px 24px -12px var(--shadow-color);
+  --shadow-7:
+    0 0 0 1px var(--shadow-color), 0 1px 1px -0.5px var(--shadow-color),
+    0 3px 3px -1.5px var(--shadow-color), 0 6px 6px -3px var(--shadow-color),
+    0 12px 12px -6px var(--shadow-color), 0 24px 24px -12px var(--shadow-color),
+    0 48px 48px -24px var(--shadow-color);
+  --shadow-8:
+    0 0 0 1px var(--shadow-color), 0 1px 1px -0.5px var(--shadow-color),
+    0 3px 3px -1.5px var(--shadow-color), 0 6px 6px -3px var(--shadow-color),
+    0 12px 12px -6px var(--shadow-color), 0 24px 24px -12px var(--shadow-color),
+    0 48px 48px -24px var(--shadow-color), 0 96px 96px -48px var(--shadow-color);
 
   /* Surface-relative interactive overlays. --overlay is the tint direction
      (black on light surfaces, white on dark) so hover/active read correctly at
@@ -139,29 +177,45 @@
   --overlay: 0 0 0;
   --hover: rgb(var(--overlay) / 0.06);
   --active: rgb(var(--overlay) / 0.1);
-  --selected: oklch(0.871 0.006 286.286);
+  --selected: #d4d4d4;
   --focus-ring: #6b97ff;
 }
 
 .dark {
-  --background: oklch(0.141 0.005 285.823);
-  --foreground: oklch(0.985 0 0);
-  --card: oklch(0.21 0.006 285.885);
-  --card-foreground: oklch(0.985 0 0);
-  --popover: oklch(0.21 0.006 285.885);
-  --popover-foreground: oklch(0.985 0 0);
-  --primary: oklch(0.92 0.004 286.32);
-  --primary-foreground: oklch(0.21 0.006 285.885);
-  --secondary: oklch(0.274 0.006 286.033);
-  --secondary-foreground: oklch(0.985 0 0);
-  --muted: oklch(0.274 0.006 286.033);
-  --muted-foreground: oklch(0.705 0.015 286.067);
-  --accent: oklch(0.274 0.006 286.033);
-  --accent-foreground: oklch(0.985 0 0);
-  --destructive: oklch(0.704 0.191 22.216);
-  --border: oklch(1 0 0 / 10%);
-  --input: oklch(1 0 0 / 15%);
-  --ring: oklch(0.552 0.016 285.938);
+  /* Core palette — additive dark neutral scale over the #171717 surface floor.
+     --border is left to inherit the :root foreground-mix so it stays
+     theme-aware (light translucent edge on dark surfaces). */
+  --background: var(--surface-1);
+  --foreground: #f5f5f5;
+  --card: var(--surface-3);
+  --card-foreground: #f5f5f5;
+  --popover: var(--surface-3);
+  --popover-foreground: #f5f5f5;
+  --primary: #f5f5f5;
+  --primary-foreground: #171717;
+  --secondary: #525252;
+  --secondary-foreground: #f5f5f5;
+  --muted: var(--surface-2);
+  --muted-foreground: #a3a3a3;
+  --accent: #525252;
+  --accent-foreground: #f5f5f5;
+  --destructive: #f87171;
+  --destructive-light: #450a0a;
+  --input: #404040;
+  --ring: #404040;
+
+  --neutral-100: #f5f5f5;
+  --neutral-200: #e5e5e5;
+  --neutral-300: #d4d4d4;
+  --neutral-400: #a3a3a3;
+  --neutral-500: #737373;
+  --neutral-600: #525252;
+  --neutral-700: #404040;
+  --neutral-800: #262626;
+  --neutral-900: #171717;
+
+  --checker-a: #1f1f1f;
+  --checker-b: #2a2a2a;
   --chart-1: oklch(0.871 0.006 286.286);
   --chart-2: oklch(0.552 0.016 285.938);
   --chart-3: oklch(0.442 0.017 285.786);
@@ -196,18 +250,40 @@
   --dm-ring-high: rgba(255, 255, 255, 0.06);
   --dm-drop: rgba(0, 0, 0, 0.18);
   --shadow-1: inset 0 0 0 1px var(--dm-ring-base);
-  --shadow-2: inset 0 1px 0 0 var(--dm-hi-base), inset 0 0 0 1px var(--dm-ring-base), 0 1px 1px -0.5px var(--dm-drop);
-  --shadow-3: inset 0 1px 0 0 var(--dm-hi-mid), inset 0 0 0 1px var(--dm-ring-base), 0 0 0 1px rgba(0, 0, 0, 0.12), 0 1px 1px -0.5px var(--dm-drop), 0 3px 3px -1.5px var(--dm-drop);
-  --shadow-4: inset 0 1px 0 0 var(--dm-hi-mid), inset 0 0 0 1px var(--dm-ring-mid), 0 0 0 1px rgba(0, 0, 0, 0.14), 0 1px 1px -0.5px var(--dm-drop), 0 3px 3px -1.5px var(--dm-drop), 0 6px 6px -3px var(--dm-drop);
-  --shadow-5: inset 0 1px 0 0 var(--dm-hi-high), inset 0 0 0 1px var(--dm-ring-mid), 0 0 0 1px rgba(0, 0, 0, 0.16), 0 1px 1px -0.5px var(--dm-drop), 0 3px 3px -1.5px var(--dm-drop), 0 6px 6px -3px var(--dm-drop), 0 12px 12px -6px var(--dm-drop);
-  --shadow-6: inset 0 1px 0 0 var(--dm-hi-high), inset 0 0 0 1px var(--dm-ring-high), 0 0 0 1px rgba(0, 0, 0, 0.18), 0 1px 1px -0.5px var(--dm-drop), 0 3px 3px -1.5px var(--dm-drop), 0 6px 6px -3px var(--dm-drop), 0 12px 12px -6px var(--dm-drop), 0 24px 24px -12px var(--dm-drop);
-  --shadow-7: inset 0 1px 0 0 var(--dm-hi-peak), inset 0 0 0 1px var(--dm-ring-high), 0 0 0 1px rgba(0, 0, 0, 0.2), 0 1px 1px -0.5px var(--dm-drop), 0 3px 3px -1.5px var(--dm-drop), 0 6px 6px -3px var(--dm-drop), 0 12px 12px -6px var(--dm-drop), 0 24px 24px -12px var(--dm-drop), 0 48px 48px -24px var(--dm-drop);
-  --shadow-8: inset 0 1px 0 0 var(--dm-hi-peak), inset 0 0 0 1px var(--dm-ring-high), 0 0 0 1px rgba(0, 0, 0, 0.22), 0 1px 1px -0.5px var(--dm-drop), 0 3px 3px -1.5px var(--dm-drop), 0 6px 6px -3px var(--dm-drop), 0 12px 12px -6px var(--dm-drop), 0 24px 24px -12px var(--dm-drop), 0 48px 48px -24px var(--dm-drop), 0 96px 96px -48px var(--dm-drop);
+  --shadow-2:
+    inset 0 1px 0 0 var(--dm-hi-base), inset 0 0 0 1px var(--dm-ring-base),
+    0 1px 1px -0.5px var(--dm-drop);
+  --shadow-3:
+    inset 0 1px 0 0 var(--dm-hi-mid), inset 0 0 0 1px var(--dm-ring-base),
+    0 0 0 1px rgba(0, 0, 0, 0.12), 0 1px 1px -0.5px var(--dm-drop), 0 3px 3px -1.5px var(--dm-drop);
+  --shadow-4:
+    inset 0 1px 0 0 var(--dm-hi-mid), inset 0 0 0 1px var(--dm-ring-mid),
+    0 0 0 1px rgba(0, 0, 0, 0.14), 0 1px 1px -0.5px var(--dm-drop), 0 3px 3px -1.5px var(--dm-drop),
+    0 6px 6px -3px var(--dm-drop);
+  --shadow-5:
+    inset 0 1px 0 0 var(--dm-hi-high), inset 0 0 0 1px var(--dm-ring-mid),
+    0 0 0 1px rgba(0, 0, 0, 0.16), 0 1px 1px -0.5px var(--dm-drop), 0 3px 3px -1.5px var(--dm-drop),
+    0 6px 6px -3px var(--dm-drop), 0 12px 12px -6px var(--dm-drop);
+  --shadow-6:
+    inset 0 1px 0 0 var(--dm-hi-high), inset 0 0 0 1px var(--dm-ring-high),
+    0 0 0 1px rgba(0, 0, 0, 0.18), 0 1px 1px -0.5px var(--dm-drop), 0 3px 3px -1.5px var(--dm-drop),
+    0 6px 6px -3px var(--dm-drop), 0 12px 12px -6px var(--dm-drop), 0 24px 24px -12px var(--dm-drop);
+  --shadow-7:
+    inset 0 1px 0 0 var(--dm-hi-peak), inset 0 0 0 1px var(--dm-ring-high),
+    0 0 0 1px rgba(0, 0, 0, 0.2), 0 1px 1px -0.5px var(--dm-drop), 0 3px 3px -1.5px var(--dm-drop),
+    0 6px 6px -3px var(--dm-drop), 0 12px 12px -6px var(--dm-drop),
+    0 24px 24px -12px var(--dm-drop), 0 48px 48px -24px var(--dm-drop);
+  --shadow-8:
+    inset 0 1px 0 0 var(--dm-hi-peak), inset 0 0 0 1px var(--dm-ring-high),
+    0 0 0 1px rgba(0, 0, 0, 0.22), 0 1px 1px -0.5px var(--dm-drop), 0 3px 3px -1.5px var(--dm-drop),
+    0 6px 6px -3px var(--dm-drop), 0 12px 12px -6px var(--dm-drop),
+    0 24px 24px -12px var(--dm-drop), 0 48px 48px -24px var(--dm-drop),
+    0 96px 96px -48px var(--dm-drop);
 
   --overlay: 255 255 255;
   --hover: rgb(var(--overlay) / 0.06);
   --active: rgb(var(--overlay) / 0.1);
-  --selected: oklch(0.442 0.017 285.786);
+  --selected: #525252;
   --focus-ring: #6b97ff;
 }
 


### PR DESCRIPTION
## Why

`@repo/ui` vendors the [fluid-functionalism](https://github.com/mickadesign/fluid-functionalism) design system, but some components looked different from the upstream reference (https://www.fluidfunctionalism.com/). Investigating the two flagged examples (accordion + modals) showed the drift lives in **two distinct layers**:

### 1. Theme tokens (`packages/ui/src/styles/globals.css`) — the root cause for most "looks different" cases

The accordion's component code is **byte-identical** to upstream, yet it rendered differently because the core palette was still the **stock shadcn neutral oklch** scale, not fluid-functionalism's **hex** palette. Fixed by:

- Retuning the core palette to the fluid neutral hex scale (`--foreground: #171717`, `--accent: #e5e5e5`, `--muted-foreground: #737373`, `--destructive: #ef4444`, …)
- Deriving `--background`/`--card`/`--muted`/`--popover` from the existing surface ladder
- Adding the missing `--destructive-light`, `--neutral-*`, and `--checker-*` tokens (+ the `--color-destructive-light` utility mapping)
- Leaving app-specific `sidebar`/`chart` tokens untouched

This alone corrects the many components whose code already matched upstream (accordion, switch, tabs, slider, checkbox-group, select, dropdown-menu, popover, button, badge, …).

### 2. Dialog — a genuine implementation divergence (the "modals look different" example)

The modal was a generic shadcn implementation (CSS keyframe open/close, flat `bg-surface-5`) instead of fluid-functionalism's signature **spring-motion** modal. Ported:

- framer-motion spring animation (opacity + scale on `springs.slow` / `springs.moderate`)
- surface-level-aware background via `surfaceClasses(min(substrate + 4, 8))`
- weight-700 title via `fontVariationSettings`
- scrim → `bg-black/40 dark:bg-black/80`

…while **preserving the idiomatic shadcn API** (`Dialog`/`DialogContent` with `showCloseButton`, `DialogOverlay`/`DialogPortal` exports, header/footer/title/description) and adding an optional `size` prop. The `alert-dialog` scrim was aligned to match for modal consistency.

## Scope note

Per the agreed direction, **public component APIs are kept idiomatic-shadcn — only the styling is updated**. Components that are standard shadcn primitives (e.g. `radio-group`, `table`, `input-group`, `checkbox`) are left structurally as-is; upstream's bespoke proximity-hover variants of those use a non-compound API that would break the shadcn surface, so they pick up the corrected colors from the theme instead.

## Verification

- `pnpm typecheck` ✅ (12/12)
- `pnpm lint` ✅
- `pnpm --filter @repo/web build` ✅

No browser tooling is available in this environment, so visual parity hasn't been confirmed in a running app — worth a quick look at `/ui` (and the desktop shell) before merging.

https://claude.ai/code/session_01JPBavmGvG1sQmMs5McA6YY

---
_Generated by [Claude Code](https://claude.ai/code/session_01JPBavmGvG1sQmMs5McA6YY)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Wide-ranging theme token changes affect every shadcn-styled surface app-wide; Dialog’s motion/render refactor is the main behavioral regression surface beyond color drift.
> 
> **Overview**
> **Theme tokens** in `globals.css` move the shadcn core palette from stock oklch neutrals to the fluid-functionalism hex scale, wiring `--background` / `--card` / `--muted` / `--popover` to the surface ladder and adding `--destructive-light`, `--neutral-*`, and `--checker-*` (plus Tailwind `--color-destructive-light`). `--selected` and borders/destructive colors are retuned in light and dark; shadow variable definitions are reformatted only.
> 
> **Dialog** drops CSS enter/exit keyframes for `motion/react` spring fades on the scrim and panel (opacity + scale, exit driven by Base UI `transitionStatus`), uses `surfaceClasses(substrate + 4)` with `SurfaceProvider`, shape tokens, optional `size` (`sm`/`lg`), and updated header/footer/title typography. Scrim is **`bg-black/40` / `dark:bg-black/80`** (no light-mode backdrop blur). **Alert dialog** overlay is aligned to the same scrim; its content still uses the older CSS zoom animation.
> 
> This is a broad visual pass across `@repo/ui` consumers; worth a quick UI smoke check before merge.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eb445fc65a4a88ef29c16ee5b7e18139c02867eb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aligns `@repo/ui` with the fluid-functionalism design system by retuning theme tokens and rebuilding the `Dialog` with spring motion and surface-aware styling. Restores upstream parity and preserves the shadcn API; also fixes `DialogContent` prop forwarding so Base UI focus/behavior works again.

- **New Features**
  - Spring-animated `Dialog` using `motion/react` and `@repo/ui/lib/springs`, with surface-aware background, weight-700 title, and a consistent black scrim; respects placement overrides via `className` (centering moved to translate utilities; motion animates opacity+scale only); adds optional `size` prop (`sm`/`lg`) while keeping shadcn exports; forwards `DialogContent` props to the Popup primitive to restore Base UI behaviors.
  - `AlertDialog` scrim matches the modal.

- **Refactors**
  - Retuned `globals.css` to the fluid hex palette; derived `--background`/`--card`/`--muted`/`--popover` from the surface ladder; added `--destructive-light`, `--neutral-*`, `--checker-*`, `--color-destructive-light`, and hex `--selected` in light/dark. Existing components now render with upstream colors (accordion, switch, tabs, slider, select, dropdown-menu, button, badge).

<sup>Written for commit eb445fc65a4a88ef29c16ee5b7e18139c02867eb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kyh/inteligir/pull/329?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

