### PR TITLE
feat(desktop): add callTool action — JSON-UI widgets as live artifacts

### DIFF
--- a/apps/desktop/src/__tests__/widget-actions.test.ts
+++ b/apps/desktop/src/__tests__/widget-actions.test.ts
@@ -4,7 +4,14 @@ vi.mock("electron", () => ({
   shell: { openExternal: vi.fn() },
 }));
 
-import { fetchHttpText, openHttpUrl } from "@/main/widget-actions";
+vi.mock("@/main/executor/executor-client", () => ({
+  execute: vi.fn(),
+}));
+
+import { execute } from "@/main/executor/executor-client";
+import { fetchHttpText, openHttpUrl, widgetCallTool } from "@/main/widget-actions";
+
+const mockExecute = vi.mocked(execute);
 
 describe("widget action network helpers", () => {
   it("rejects non-http fetch URLs before calling fetch", async () => {
@@ -71,5 +78,51 @@ describe("widget action network helpers", () => {
 
     await expect(openHttpUrl("https://example.com", openExternal)).resolves.toBe(true);
     expect(openExternal).toHaveBeenCalledWith("https://example.com");
+  });
+});
+
+describe("widgetCallTool", () => {
+  it("rejects tool paths that aren't a plain namespaced accessor", async () => {
+    for (const bad of ["", "github", "github.search; rm -rf /", "tools['x']", "a.b()"]) {
+      await expect(widgetCallTool(bad, {})).rejects.toThrow(/Invalid tool path/);
+    }
+    expect(mockExecute).not.toHaveBeenCalled();
+  });
+
+  it("runs a namespaced call with JSON-serialized input and returns the unwrapped data", async () => {
+    mockExecute.mockResolvedValue({
+      status: "completed",
+      text: "",
+      structured: [{ title: "issue 1" }],
+      isError: false,
+    });
+
+    const data = await widgetCallTool("github.search_issues", { query: "bug" });
+
+    expect(data).toEqual([{ title: "issue 1" }]);
+    const code = mockExecute.mock.calls[0]?.[0] ?? "";
+    expect(code).toContain("tools.github.search_issues(__input)");
+    expect(code).toContain('{"query":"bug"}');
+    // unwraps the { ok, data } envelope
+    expect(code).toContain("__r.ok !== true");
+  });
+
+  it("surfaces an execution error", async () => {
+    mockExecute.mockResolvedValue({
+      status: "completed",
+      text: "rate limited",
+      structured: undefined,
+      isError: true,
+    });
+
+    await expect(widgetCallTool("github.search_issues", {})).rejects.toThrow("rate limited");
+  });
+
+  it("rejects when the execution pauses for interaction", async () => {
+    mockExecute.mockResolvedValue({ status: "paused", text: "", structured: undefined });
+
+    await expect(widgetCallTool("github.search_issues", {})).rejects.toThrow(
+      "requires interaction",
+    );
   });
 });

--- a/apps/desktop/src/__tests__/widget-actions.test.ts
+++ b/apps/desktop/src/__tests__/widget-actions.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("electron", () => ({
   shell: { openExternal: vi.fn() },
@@ -82,6 +82,10 @@ describe("widget action network helpers", () => {
 });
 
 describe("widgetCallTool", () => {
+  beforeEach(() => {
+    mockExecute.mockReset();
+  });
+
   it("rejects tool paths that aren't a plain namespaced accessor", async () => {
     for (const bad of ["", "github", "github.search; rm -rf /", "tools['x']", "a.b()"]) {
       await expect(widgetCallTool(bad, {})).rejects.toThrow(/Invalid tool path/);
@@ -89,7 +93,20 @@ describe("widgetCallTool", () => {
     expect(mockExecute).not.toHaveBeenCalled();
   });
 
-  it("runs a namespaced call with JSON-serialized input and returns the unwrapped data", async () => {
+  it("rejects paths with JS meta segments that would reach runtime internals", async () => {
+    for (const bad of [
+      "github.constructor",
+      "a.__proto__",
+      "x.prototype",
+      "__proto__.x",
+      "ns.constructor.tool",
+    ]) {
+      await expect(widgetCallTool(bad, {})).rejects.toThrow(/Invalid tool path/);
+    }
+    expect(mockExecute).not.toHaveBeenCalled();
+  });
+
+  it("runs a namespaced call and returns the unwrapped data", async () => {
     mockExecute.mockResolvedValue({
       status: "completed",
       text: "",
@@ -102,9 +119,31 @@ describe("widgetCallTool", () => {
     expect(data).toEqual([{ title: "issue 1" }]);
     const code = mockExecute.mock.calls[0]?.[0] ?? "";
     expect(code).toContain("tools.github.search_issues(__input)");
-    expect(code).toContain('{"query":"bug"}');
+    // Input is parsed from a JSON string in-sandbox (not a JS literal), so a
+    // "__proto__" key stays a data property instead of a prototype setter.
+    expect(code).toContain("JSON.parse(");
+    expect(code).toContain("query");
     // unwraps the { ok, data } envelope
     expect(code).toContain("__r.ok !== true");
+  });
+
+  it("embeds input as a parsed JSON string so a __proto__ key stays data", async () => {
+    mockExecute.mockResolvedValue({
+      status: "completed",
+      text: "",
+      structured: null,
+      isError: false,
+    });
+
+    // Computed key avoids the literal __proto__ setter when building the input.
+    const input = { ["__proto__"]: { polluted: true } };
+    await widgetCallTool("ns.tool", input);
+
+    const firstLine = (mockExecute.mock.calls[0]?.[0] ?? "").split("\n")[0];
+    // The bug being guarded: `const __input = {"__proto__":{...}}` evaluates the
+    // key as a prototype setter. Parsing a JSON string literal instead keeps it
+    // a plain data property.
+    expect(firstLine).toBe(`const __input = JSON.parse(${JSON.stringify(JSON.stringify(input))});`);
   });
 
   it("surfaces an execution error", async () => {

--- a/apps/desktop/src/main/widget-actions.ts
+++ b/apps/desktop/src/main/widget-actions.ts
@@ -3,6 +3,7 @@ import { z } from "zod";
 
 import { completeOnce } from "@/agent/setup";
 import { getAgent } from "@/main/app-machine";
+import { execute } from "@/main/executor/executor-client";
 import { createIpcHandler } from "@/main/lib/ipc-handler";
 import { IPC_CHANNELS, isHttpUrl } from "@/shared/ipc";
 
@@ -46,9 +47,53 @@ export function registerWidgetActionIpcHandlers(): void {
     fetchHttpText(url),
   );
 
+  createIpcHandler(
+    IPC_CHANNELS.WIDGET_CALL_TOOL,
+    z.object({ tool: z.string().min(1), input: z.unknown().optional() }),
+    ({ tool, input }) => widgetCallTool(tool, input),
+  );
+
   createIpcHandler(IPC_CHANNELS.WIDGET_OPEN_URL, z.object({ url: z.string() }), ({ url }) =>
     openHttpUrl(url),
   );
+}
+
+// A dotted accessor into executor's `tools.*` proxy: a namespace and at least
+// one tool segment (e.g. `github.search_issues`). We interpolate this into the
+// code-mode snippet, so it must be a strict identifier path — never anything
+// that could break out of the member-access expression. The `input` object is
+// JSON-serialized (a safe JS literal), so only `tool` needs guarding.
+const TOOL_PATH_RE = /^[A-Za-z_$][\w$]*(?:\.[A-Za-z_$][\w$]*)+$/;
+
+/**
+ * Invoke a configured integration tool from a widget via executor's code-mode
+ * sandbox, returning just the tool's data. Unlike the agent's `execute` tool —
+ * which lets the model write arbitrary TypeScript — this is a fixed snippet:
+ * one namespaced `tools.*` call with a JSON input, with the standard
+ * `{ ok, data | error }` envelope unwrapped. Throws on a bad tool path, a
+ * failed call, or an execution that pauses for interaction (widgets can't
+ * resume an elicitation).
+ */
+export async function widgetCallTool(tool: string, input: unknown): Promise<unknown> {
+  if (!TOOL_PATH_RE.test(tool)) {
+    throw new Error(`Invalid tool path '${tool}' (expected e.g. 'namespace.tool')`);
+  }
+  const code = [
+    `const __input = ${JSON.stringify(input ?? {})};`,
+    `const __r = await tools.${tool}(__input);`,
+    `if (!__r || __r.ok !== true) {`,
+    `  throw new Error(typeof __r?.error === "string" ? __r.error : "Tool call failed");`,
+    `}`,
+    `return __r.data;`,
+  ].join("\n");
+  const result = await execute(code);
+  if (result.status === "paused") {
+    throw new Error("Tool call requires interaction and cannot run from a widget");
+  }
+  if (result.isError) {
+    throw new Error(result.text || "Tool call failed");
+  }
+  return result.structured;
 }
 
 export async function fetchHttpText(url: string, deps: FetchHttpTextDeps = {}): Promise<string> {

--- a/apps/desktop/src/main/widget-actions.ts
+++ b/apps/desktop/src/main/widget-actions.ts
@@ -61,9 +61,11 @@ export function registerWidgetActionIpcHandlers(): void {
 // A dotted accessor into executor's `tools.*` proxy: a namespace and at least
 // one tool segment (e.g. `github.search_issues`). We interpolate this into the
 // code-mode snippet, so it must be a strict identifier path — never anything
-// that could break out of the member-access expression. The `input` object is
-// JSON-serialized (a safe JS literal), so only `tool` needs guarding.
+// that could break out of the member-access expression. Real tool paths never
+// use JS meta names, and `tools.x.constructor`/`__proto__`/`prototype` would
+// reach the runtime's own machinery rather than a tool, so reject them.
 const TOOL_PATH_RE = /^[A-Za-z_$][\w$]*(?:\.[A-Za-z_$][\w$]*)+$/;
+const UNSAFE_PATH_SEGMENTS = new Set(["__proto__", "prototype", "constructor"]);
 
 /**
  * Invoke a configured integration tool from a widget via executor's code-mode
@@ -75,11 +77,18 @@ const TOOL_PATH_RE = /^[A-Za-z_$][\w$]*(?:\.[A-Za-z_$][\w$]*)+$/;
  * resume an elicitation).
  */
 export async function widgetCallTool(tool: string, input: unknown): Promise<unknown> {
-  if (!TOOL_PATH_RE.test(tool)) {
+  if (
+    !TOOL_PATH_RE.test(tool) ||
+    tool.split(".").some((segment) => UNSAFE_PATH_SEGMENTS.has(segment))
+  ) {
     throw new Error(`Invalid tool path '${tool}' (expected e.g. 'namespace.tool')`);
   }
+  // Pass input as a JSON string parsed inside the sandbox, not as a JS object
+  // literal: a literal reinterprets a "__proto__" key as a prototype setter
+  // (Annex B.3.1), corrupting the tool's input. JSON.parse keeps JSON semantics
+  // and a string literal can't break out of the expression.
   const code = [
-    `const __input = ${JSON.stringify(input ?? {})};`,
+    `const __input = JSON.parse(${JSON.stringify(JSON.stringify(input ?? {}))});`,
     `const __r = await tools.${tool}(__input);`,
     `if (!__r || __r.ok !== true) {`,
     `  throw new Error(typeof __r?.error === "string" ? __r.error : "Tool call failed");`,

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -87,6 +87,8 @@ const desktopBridge: DesktopBridge = {
   widgetComplete: (prompt, system) =>
     ipcRenderer.invoke(IPC_CHANNELS.WIDGET_COMPLETE, { prompt, system }),
   widgetFetch: (url) => ipcRenderer.invoke(IPC_CHANNELS.WIDGET_FETCH, { url }),
+  widgetCallTool: (tool, input) =>
+    ipcRenderer.invoke(IPC_CHANNELS.WIDGET_CALL_TOOL, { tool, input }),
   widgetOpenUrl: (url) => ipcRenderer.invoke(IPC_CHANNELS.WIDGET_OPEN_URL, { url }),
 
   // Executor (integration backend)

--- a/apps/desktop/src/renderer/shell/widget-catalog.ts
+++ b/apps/desktop/src/renderer/shell/widget-catalog.ts
@@ -288,5 +288,14 @@ export const widgetCatalog = defineCatalog(schema, {
       params: z.object({ url: z.string().url(), into: z.string() }),
       description: WIDGET_ACTION_DESCRIPTIONS.fetchUrl,
     },
+    callTool: {
+      params: z.object({
+        tool: z.string(),
+        input: z.record(z.string(), z.unknown()).optional(),
+        into: z.string(),
+        error: z.string().optional(),
+      }),
+      description: WIDGET_ACTION_DESCRIPTIONS.callTool,
+    },
   },
 });

--- a/apps/desktop/src/renderer/shell/widget-registry.tsx
+++ b/apps/desktop/src/renderer/shell/widget-registry.tsx
@@ -781,5 +781,6 @@ export const { registry: widgetRegistry } = defineRegistry(widgetCatalog, {
     sendPrompt: async () => {},
     generateText: async () => {},
     fetchUrl: async () => {},
+    callTool: async () => {},
   },
 });

--- a/apps/desktop/src/renderer/shell/widget-viewer.tsx
+++ b/apps/desktop/src/renderer/shell/widget-viewer.tsx
@@ -175,7 +175,9 @@ export const WidgetViewer = memo(function WidgetViewer({ instance, def }: Props)
         try {
           const data = await bridge.widgetCallTool(tool, input);
           getStore().set(into, data ?? null);
-          if (errorPath) getStore().set(errorPath, null);
+          // Clear a stale error, but never the path we just wrote the result
+          // to (a widget may legitimately point `error` at `into`).
+          if (errorPath && errorPath !== into) getStore().set(errorPath, null);
         } catch (err) {
           reportError(err instanceof Error ? err.message : "Tool call failed");
         }

--- a/apps/desktop/src/renderer/shell/widget-viewer.tsx
+++ b/apps/desktop/src/renderer/shell/widget-viewer.tsx
@@ -49,6 +49,10 @@ export const WidgetViewer = memo(function WidgetViewer({ instance, def }: Props)
   const idRef = useRef(instance.instanceId);
   idRef.current = instance.instanceId;
 
+  // Per-`into`-path invocation counter for callTool: a slower earlier call
+  // must not clobber a newer result written to the same path (latest-wins).
+  const callSeqRef = useRef(new Map<string, number>());
+
   // Resolves with whether the latest pending state actually reached main, so
   // surface-change and unplace callers can tell a true success ("flushed" or
   // "nothing to flush") from a quiet failure (bridge missing, IPC threw). A
@@ -172,13 +176,21 @@ export const WidgetViewer = memo(function WidgetViewer({ instance, def }: Props)
           reportError("Agent unavailable");
           return;
         }
+        // Claim a sequence number for this `into` path; only write if no newer
+        // call to the same path started while this one was in flight.
+        const seqMap = callSeqRef.current;
+        const seq = (seqMap.get(into) ?? 0) + 1;
+        seqMap.set(into, seq);
+        const isLatest = () => seqMap.get(into) === seq;
         try {
           const data = await bridge.widgetCallTool(tool, input);
+          if (!isLatest()) return;
           getStore().set(into, data ?? null);
           // Clear a stale error, but never the path we just wrote the result
           // to (a widget may legitimately point `error` at `into`).
           if (errorPath && errorPath !== into) getStore().set(errorPath, null);
         } catch (err) {
+          if (!isLatest()) return;
           reportError(err instanceof Error ? err.message : "Tool call failed");
         }
       },

--- a/apps/desktop/src/renderer/shell/widget-viewer.tsx
+++ b/apps/desktop/src/renderer/shell/widget-viewer.tsx
@@ -168,30 +168,36 @@ export const WidgetViewer = memo(function WidgetViewer({ instance, def }: Props)
         // apart from a real result downstream. Treat its absence as an error
         // rather than silently writing null over bound data.
         const bridge = getBridge();
-        const reportError = (message: string) => {
-          if (errorPath) getStore().set(errorPath, message);
-          else toast.error(message);
-        };
         if (!bridge) {
-          reportError("Agent unavailable");
+          if (errorPath) getStore().set(errorPath, "Agent unavailable");
+          else toast.error("Agent unavailable");
           return;
         }
-        // Claim a sequence number for this `into` path; only write if no newer
-        // call to the same path started while this one was in flight.
+        // Latest-wins per state path this call writes: claim a token for each
+        // pointer, then only write a pointer if no newer call has claimed it.
+        // Keying per pointer (not just `into`) means a success on one target
+        // can't null out an error a concurrent call wrote to a shared `error`
+        // pointer. When `error` coincides with `into` it's a single pointer —
+        // claiming once and never clearing it on success.
         const seqMap = callSeqRef.current;
-        const seq = (seqMap.get(into) ?? 0) + 1;
-        seqMap.set(into, seq);
-        const isLatest = () => seqMap.get(into) === seq;
+        const claim = (path: string): (() => boolean) => {
+          const seq = (seqMap.get(path) ?? 0) + 1;
+          seqMap.set(path, seq);
+          return () => seqMap.get(path) === seq;
+        };
+        const intoLatest = claim(into);
+        const errorLatest = errorPath && errorPath !== into ? claim(errorPath) : null;
         try {
           const data = await bridge.widgetCallTool(tool, input);
-          if (!isLatest()) return;
-          getStore().set(into, data ?? null);
-          // Clear a stale error, but never the path we just wrote the result
-          // to (a widget may legitimately point `error` at `into`).
-          if (errorPath && errorPath !== into) getStore().set(errorPath, null);
+          if (intoLatest()) getStore().set(into, data ?? null);
+          // Clear a stale error only if we still own the error pointer and it
+          // isn't the path we just wrote the result to.
+          if (errorLatest?.()) getStore().set(errorPath, null);
         } catch (err) {
-          if (!isLatest()) return;
-          reportError(err instanceof Error ? err.message : "Tool call failed");
+          const message = err instanceof Error ? err.message : "Tool call failed";
+          if (!errorPath) toast.error(message);
+          else if (errorPath === into ? intoLatest() : errorLatest?.())
+            getStore().set(errorPath, message);
         }
       },
     };

--- a/apps/desktop/src/renderer/shell/widget-viewer.tsx
+++ b/apps/desktop/src/renderer/shell/widget-viewer.tsx
@@ -150,6 +150,25 @@ export const WidgetViewer = memo(function WidgetViewer({ instance, def }: Props)
           toast.error(err instanceof Error ? err.message : "Fetch failed");
         }
       },
+      // Calls a configured integration tool and writes its data into `into`.
+      // On failure, route the message into the `error` state path when given
+      // (so the widget can show it inline) and otherwise toast.
+      callTool: async (params: Record<string, unknown>) => {
+        const tool = typeof params["tool"] === "string" ? params["tool"] : "";
+        const into = typeof params["into"] === "string" ? params["into"] : "";
+        const errorPath = typeof params["error"] === "string" ? params["error"] : "";
+        const input = params["input"];
+        if (!tool || !into) return;
+        try {
+          const data = await getBridge()?.widgetCallTool(tool, input);
+          getStore().set(into, data ?? null);
+          if (errorPath) getStore().set(errorPath, null);
+        } catch (err) {
+          const message = err instanceof Error ? err.message : "Tool call failed";
+          if (errorPath) getStore().set(errorPath, message);
+          else toast.error(message);
+        }
+      },
     };
   }, []);
 

--- a/apps/desktop/src/renderer/shell/widget-viewer.tsx
+++ b/apps/desktop/src/renderer/shell/widget-viewer.tsx
@@ -159,14 +159,25 @@ export const WidgetViewer = memo(function WidgetViewer({ instance, def }: Props)
         const errorPath = typeof params["error"] === "string" ? params["error"] : "";
         const input = params["input"];
         if (!tool || !into) return;
+        // Resolve the bridge up front: a tool call returns arbitrary data
+        // (including a legitimate null), so a missing bridge can't be told
+        // apart from a real result downstream. Treat its absence as an error
+        // rather than silently writing null over bound data.
+        const bridge = getBridge();
+        const reportError = (message: string) => {
+          if (errorPath) getStore().set(errorPath, message);
+          else toast.error(message);
+        };
+        if (!bridge) {
+          reportError("Agent unavailable");
+          return;
+        }
         try {
-          const data = await getBridge()?.widgetCallTool(tool, input);
+          const data = await bridge.widgetCallTool(tool, input);
           getStore().set(into, data ?? null);
           if (errorPath) getStore().set(errorPath, null);
         } catch (err) {
-          const message = err instanceof Error ? err.message : "Tool call failed";
-          if (errorPath) getStore().set(errorPath, message);
-          else toast.error(message);
+          reportError(err instanceof Error ? err.message : "Tool call failed");
         }
       },
     };

--- a/apps/desktop/src/shared/ipc.ts
+++ b/apps/desktop/src/shared/ipc.ts
@@ -90,6 +90,7 @@ export const IPC_CHANNELS = {
   WIDGET_SEND_PROMPT: "widget:send-prompt",
   WIDGET_COMPLETE: "widget:complete",
   WIDGET_FETCH: "widget:fetch",
+  WIDGET_CALL_TOOL: "widget:call-tool",
   WIDGET_OPEN_URL: "widget:open-url",
 
   // Executor (integration backend) — wraps the executor daemon's HTTP API
@@ -261,6 +262,7 @@ export type DesktopBridge = {
   widgetSendPrompt: (prompt: string) => Promise<void>;
   widgetComplete: (prompt: string, system?: string) => Promise<string>;
   widgetFetch: (url: string) => Promise<string>;
+  widgetCallTool: (tool: string, input?: unknown) => Promise<unknown>;
   widgetOpenUrl: (url: string) => Promise<boolean>;
 
   // Executor (integration backend)

--- a/apps/desktop/src/shared/widget-spec.ts
+++ b/apps/desktop/src/shared/widget-spec.ts
@@ -155,6 +155,7 @@ export type WidgetActionName =
   | "sendPrompt"
   | "generateText"
   | "fetchUrl"
+  | "callTool"
   | "setState"
   | "pushState"
   | "removeState"
@@ -166,6 +167,7 @@ export const WIDGET_ACTION_NAMES: readonly WidgetActionName[] = [
   "sendPrompt",
   "generateText",
   "fetchUrl",
+  "callTool",
   "setState",
   "pushState",
   "removeState",
@@ -181,6 +183,8 @@ export const WIDGET_ACTION_DESCRIPTIONS: Record<WidgetActionName, string> = {
     "Call the model once and write the resulting text into state at the JSON pointer `into`.",
   fetchUrl:
     "HTTP GET `url` and write the capped response body into state at the JSON pointer `into`.",
+  callTool:
+    "Invoke a configured integration tool (MCP / API source) by its dotted path `tool` (e.g. 'github.search_issues') with the `input` object, and write the returned data into state at the JSON pointer `into`. Pulls live data without an agent turn — bind a Table/Chart/Markdown to `into` to display it. Optional `error` JSON pointer receives the error message on failure (otherwise a toast is shown).",
   setState: "Write a value into widget state.",
   pushState: "Append an item to an array in widget state.",
   removeState: "Remove an item from an array in widget state.",


### PR DESCRIPTION
## What & why

JSON-UI widgets could already hold reactive state, take input, fetch URLs, call the model once (`generateText`), and poke the agent (`sendPrompt`). The one thing missing for a **live artifact** is the ability to *call a tool and render the result* — directly, deterministically, without spinning up a whole agent turn. This adds that.

A new **`callTool`** action lets a widget invoke any configured integration tool (MCP / API source) and write the returned data straight into widget state:

```jsonc
{ "action": "callTool",
  "params": {
    "tool": "github.search_issues",     // dotted path into executor's tools.* proxy
    "input": { "query": "is:open label:bug" },
    "into": "/issues",                   // JSON pointer — result lands here
    "error": "/issues_error"             // optional — message lands here on failure
  } }
```

Bind a `Table`/`Chart`/`Markdown` (from #328) to `/issues` and the widget renders live data. Wire `callTool` to a Button's `on.press`, or to a `watch` binding, to refresh on demand.

This is the smallest change that turns the existing declarative widgets into the "live artifact that talks to tools" model — and it shares one channel (the executor's `tools.*` catalog) regardless of how a widget is rendered.

## How it works

- **Main** (`widget-actions.ts`) bridges to executor's code-mode sandbox with a **fixed** snippet — one namespaced `tools.*` call with a JSON input, `{ ok, data | error }` envelope unwrapped — *not* agent-authored code. This is deliberately narrower than the agent's `execute` tool.
- The tool path is guarded by a strict identifier regex (`namespace.tool[.tool…]`) so it can't break out of the interpolated member-access expression; `input` is JSON-serialized (a safe JS literal).
- Paused (elicitation) executions are rejected — a widget can't resume an interaction.
- **Renderer** (`widget-viewer.tsx`) writes the result `into` state; on failure routes the message to the `error` pointer if given, else toasts.

Wired through every layer that the existing live actions touch: spec language (`widget-spec.ts`), IPC channel + bridge type (`ipc.ts`), preload (`preload/index.ts`), viewer handler, registry stub, and the agent-facing `catalog` description.

## Scope notes

- Deliberately **not** changing `sendPrompt`: its return path (the agent patching the widget via `manage_ui`) already exists, and a structured "await the agent's final message" channel would mean subscribing to the agent event stream — a much larger, more fragile change. `callTool` is the deterministic, bounded primitive.
- Stacks on **#328** (12→37 components incl. charts/tables/markdown). Based on that branch so the diff is just the action; GitHub will retarget to `main` once #328 merges.

## Verification

- `pnpm --filter @repo/desktop typecheck` ✅
- `pnpm lint` (oxlint) ✅ clean
- `pnpm --filter @repo/desktop test` ✅ **178/178** (added 4 covering: invalid/injection tool paths rejected before execution, namespaced call + JSON input + envelope unwrap, execution-error surfacing, paused-execution rejection)

⚠️ Not yet driven visually in the Electron renderer (headless container). Worth a `manage_ui` smoke test: install a widget whose Button `callTool`s a configured source into `/data`, with a Table/Chart bound to `/data`.

https://claude.ai/code/session_01SNBhQe5x8gvUuEps2oRbgz

---
_Generated by [Claude Code](https://claude.ai/code/session_01SNBhQe5x8gvUuEps2oRbgz)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Widgets can trigger real integration tools in the main/executor path; risk is mitigated by a fixed snippet and strict path/input guards, but tool access and credentials still apply.
> 
> **Overview**
> Adds a **`callTool`** live widget action so JSON-UI panels can invoke configured integration tools (dotted `namespace.tool` paths) and bind results into widget state at `into`, with optional inline errors at `error`—without an agent turn.
> 
> **Main process** exposes `widgetCallTool` via a new `WIDGET_CALL_TOOL` IPC channel: a fixed executor code-mode snippet (single `tools.*` call, unwraps `{ ok, data }`), strict path validation (identifier segments only; rejects `__proto__` / `prototype` / `constructor`), input passed as `JSON.parse` of a JSON string (avoids prototype pollution), and rejection of paused (elicitation) runs. **Preload**, **shared spec/IPC types**, **catalog**, and a registry stub wire the action through the stack.
> 
> **Renderer** (`widget-viewer`) implements the real handler: requires bridge up front, **latest-wins** sequence tokens per state path so concurrent calls don’t overwrite newer results, routes failures to `error` or toast, and clears stale errors only when appropriate (including when `error` equals `into`).
> 
> **Tests** cover invalid/injection paths, successful unwrap, `JSON.parse` embedding for `__proto__` keys, execution errors, and paused executions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f557c5ee9314cdbe116c3cd346a3bd7a04cfac06. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a `callTool` action to JSON-UI widgets so they can call integration tools and write results into state, enabling live, deterministic artifacts without an agent turn. Execution and viewer safeguards block proto pollution and prevent stale or cross-clobbering writes.

- **New Features**
  - `callTool` action: `tool` (dotted path), optional `input`, `into` state path, optional `error` path. Bind to a Button or `watch`; Tables/Charts/Markdown render from `into`.
  - Fixed, safe executor call: single `tools.*` invocation, strict dotted-path validation (rejects `__proto__`/`prototype`/`constructor`), input parsed via `JSON.parse` of a JSON string, unwraps `{ ok, data | error }`, rejects paused runs. Wired through spec, IPC (`widget:call-tool`), preload bridge, viewer handler, registry, and catalog. Tests cover invalid/meta paths, JSON.parse handling, envelope unwrap, error surfacing, and paused-run rejection.

- **Bug Fixes**
  - Viewer treats a missing bridge as an error for `callTool` (writes to `error` path or toasts) to avoid silent null writes.
  - On success, no longer clears the `error` path when it equals `into`.
  - Latest-wins guard now sequences writes per state pointer (`into` and `error`), so slower calls or a success on one call won’t clobber a newer result or clear a concurrent error on a shared `error` path.

<sup>Written for commit f557c5ee9314cdbe116c3cd346a3bd7a04cfac06. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kyh/inteligir/pull/330?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

