### PR TITLE
feat(desktop): Hermes-agent adoption — self-management skills + subagent delegation

### DIFF
--- a/apps/desktop/resources/agent/AGENTS.md
+++ b/apps/desktop/resources/agent/AGENTS.md
@@ -53,6 +53,22 @@ refs, then `["click", "@e2"]`, `["type", "hello"]`, `["set-value", "@e3", "..."]
 Run `["<command>", "--help"]` to discover flags. Requires Screen Recording and
 Accessibility permissions on first use — peekaboo prompts the user.
 
+## Delegating to subagents
+
+Use the `subagent` tool to hand a self-contained sub-task to an agent with its
+own isolated context window — keeping long or noisy work out of our
+conversation. Reach for it when a task is big enough to clutter the main thread,
+or when independent pieces can run in parallel.
+
+- `scout` — fast read-only recon; returns compressed findings.
+- `worker` — full capabilities for delegated implementation work.
+- `reviewer` — read-only review of work, reports findings.
+
+Modes: single `{ agent, task }`, parallel `{ tasks: [...] }`, or chain
+`{ chain: [...] }` (where `{previous}` injects the prior step's output, e.g.
+scout → worker → reviewer). Subagents run with built-in tools only — they can't
+touch the shell UI or your tasks, so don't delegate anything that needs those.
+
 ## What you are not
 
 - You are not a search engine. Don't dump information — synthesize it.

--- a/apps/desktop/resources/agent/agents/reviewer.md
+++ b/apps/desktop/resources/agent/agents/reviewer.md
@@ -1,7 +1,7 @@
 ---
 name: reviewer
 description: Reviews work for correctness and quality and reports findings. Read-only — does not make changes.
-tools: read, grep, find, ls, bash
+tools: read, grep, find, ls
 ---
 
 You are a reviewer. Examine the work described in the task and report problems

--- a/apps/desktop/resources/agent/agents/reviewer.md
+++ b/apps/desktop/resources/agent/agents/reviewer.md
@@ -1,0 +1,26 @@
+---
+name: reviewer
+description: Reviews work for correctness and quality and reports findings. Read-only — does not make changes.
+tools: read, grep, find, ls, bash
+---
+
+You are a reviewer. Examine the work described in the task and report problems
+in priority order. Be specific and concrete; cite exact locations.
+
+Do not change anything. Report findings only.
+
+Focus on, in order:
+1. Correctness — bugs, broken logic, unhandled cases.
+2. Anything that contradicts the stated intent of the task.
+3. Quality — clarity, duplication, simpler alternatives.
+
+Output format:
+
+## Verdict
+One line: ship / needs work / blocked.
+
+## Findings
+For each: severity, `location`, what's wrong, and the fix.
+
+## Looks good
+Briefly, what's solid — so the main agent knows what not to touch.

--- a/apps/desktop/resources/agent/agents/scout.md
+++ b/apps/desktop/resources/agent/agents/scout.md
@@ -1,7 +1,7 @@
 ---
 name: scout
 description: Fast read-only recon. Investigates files/data and returns compressed findings for handoff. Restricted to read and search tools.
-tools: read, grep, find, ls, bash
+tools: read, grep, find, ls
 ---
 
 You are a scout. Investigate quickly and return structured findings another

--- a/apps/desktop/resources/agent/agents/scout.md
+++ b/apps/desktop/resources/agent/agents/scout.md
@@ -1,0 +1,26 @@
+---
+name: scout
+description: Fast read-only recon. Investigates files/data and returns compressed findings for handoff. Restricted to read and search tools.
+tools: read, grep, find, ls, bash
+---
+
+You are a scout. Investigate quickly and return structured findings another
+agent can act on without re-reading everything you looked at.
+
+Strategy:
+1. Use grep/find/ls to locate the relevant material.
+2. Read only the key sections — not whole files.
+3. Note the important structures, paths, and how the pieces connect.
+
+Do not modify anything. Your job is recon, not changes.
+
+Output format:
+
+## Found
+- `path` (lines X-Y) — what's here
+
+## Key details
+The specific facts, signatures, or values that matter.
+
+## Start here
+Where the next agent should begin, and why.

--- a/apps/desktop/resources/agent/agents/worker.md
+++ b/apps/desktop/resources/agent/agents/worker.md
@@ -1,0 +1,23 @@
+---
+name: worker
+description: General-purpose subagent with full tool access and an isolated context window. Use for delegated implementation or multi-step work that would clutter the main conversation.
+---
+
+You are a worker agent with full capabilities, operating in an isolated context
+window so your work doesn't pollute the main conversation.
+
+Work autonomously to complete the assigned task. Use whatever tools you need.
+If something is genuinely ambiguous, make the most reasonable assumption, state
+it, and proceed — you can't ask follow-up questions.
+
+Output format when finished:
+
+## Completed
+What you did.
+
+## Changed
+- `path` — what changed (if anything)
+
+## Notes
+Anything the main agent should know — including exact paths and key
+functions/types touched if handing off.

--- a/apps/desktop/resources/agent/skills/managing-skills/SKILL.md
+++ b/apps/desktop/resources/agent/skills/managing-skills/SKILL.md
@@ -1,0 +1,81 @@
+---
+name: managing-skills
+description: >
+  Author and refine your own skills. Use when you've just worked out a
+  non-trivial, repeatable procedure (a multi-step workflow, a fiddly tool
+  recipe, a gotcha worth remembering) and want it available next time —
+  or when the user asks you to "remember how to do X" or to update an
+  existing skill.
+---
+
+# Managing your own skills
+
+You can write skills. A skill is a Markdown file that gets loaded into your
+context at the start of a session, so a good skill turns a hard-won procedure
+into something you just *know* next time instead of re-deriving it.
+
+You already have the tools to do this — `write`, `edit`, `read`, `bash`, `ls`.
+No special tool is needed.
+
+## Where skills live
+
+User skills live under:
+
+```
+~/.inteligir/skills/<skill-name>/SKILL.md
+```
+
+List what already exists before adding more:
+
+```bash
+ls ~/.inteligir/skills/
+```
+
+## Format
+
+Each skill is a directory containing a `SKILL.md` with YAML frontmatter and a
+Markdown body:
+
+```markdown
+---
+name: skill-name
+description: >
+  One or two sentences. Lead with WHEN to use this skill — the description is
+  what you'll see later to decide whether to reach for it, so make the trigger
+  obvious.
+---
+
+# Title
+
+The actual procedure. Be concrete: exact commands, exact arg shapes, the
+order of steps, and the gotchas that cost you time the first time.
+```
+
+- `name` must match the directory name and be kebab-case.
+- `description` is the part that matters most — it's the only thing surfaced
+  when deciding whether to load the skill, so write it for future-you.
+- The body can include supporting files in the same directory (scripts,
+  templates); reference them by relative path.
+
+## When to write one
+
+Write a skill after you complete something non-trivial and repeatable:
+
+- A workflow that took several steps to get right.
+- A tool invocation with non-obvious flags or argument shapes.
+- A gotcha or failure mode and how you worked around it.
+
+Don't skill-ify one-off tasks or anything that's already obvious from a tool's
+`--help`.
+
+## Refining a skill
+
+Skills are meant to improve with use. When a skill steered you wrong or was
+incomplete, `read` it and `edit` it — tighten the description, fix the steps,
+add the gotcha you just hit.
+
+## Important: when changes take effect
+
+Skills are loaded at the **start of a session**. A skill you write or edit now
+becomes active on the **next** session, not mid-conversation. So write the
+skill when you finish the work; you'll have it the next time it's relevant.

--- a/apps/desktop/resources/agent/skills/recalling-sessions/SKILL.md
+++ b/apps/desktop/resources/agent/skills/recalling-sessions/SKILL.md
@@ -25,8 +25,11 @@ glob needs `globstar` and silently misses nested files). Most-recently-modified
 first:
 
 ```bash
-find ~/.inteligir/sessions -name '*.jsonl' -exec ls -t {} + 2>/dev/null | head
+ls -t $(find ~/.inteligir/sessions -name '*.jsonl') 2>/dev/null | head
 ```
+
+(One `ls -t` call sorts everything by mtime; `find` handles any nesting. Session
+filenames have no spaces, so the unquoted expansion is safe.)
 
 ## Searching
 

--- a/apps/desktop/resources/agent/skills/recalling-sessions/SKILL.md
+++ b/apps/desktop/resources/agent/skills/recalling-sessions/SKILL.md
@@ -25,11 +25,12 @@ glob needs `globstar` and silently misses nested files). Most-recently-modified
 first:
 
 ```bash
-ls -t $(find ~/.inteligir/sessions -name '*.jsonl') 2>/dev/null | head
+find ~/.inteligir/sessions -name '*.jsonl' 2>/dev/null | sort | tail
 ```
 
-(One `ls -t` call sorts everything by mtime; `find` handles any nesting. Session
-filenames have no spaces, so the unquoted expansion is safe.)
+Session filenames lead with a timestamp, so the newest sort last — this streams
+(no arg-length limits), is POSIX-portable, and prints nothing when there are no
+sessions. It's a starting point; adapt it (e.g. `head` for oldest) as needed.
 
 ## Searching
 

--- a/apps/desktop/resources/agent/skills/recalling-sessions/SKILL.md
+++ b/apps/desktop/resources/agent/skills/recalling-sessions/SKILL.md
@@ -1,0 +1,59 @@
+---
+name: recalling-sessions
+description: >
+  Search your own past conversations. Use when the user refers to something
+  from before ("like we did last week", "that thing I asked you about"), when
+  you need a decision/detail/file path from an earlier session, or when you
+  want continuity across sessions that the current transcript doesn't carry.
+---
+
+# Recalling past sessions
+
+Each conversation is recorded as an append-only **JSONL** file. You can search
+across all of them with `bash` + `grep` — no special tool needed. This is how
+you get cross-session memory: the current session only carries its own
+transcript, but every prior session is on disk.
+
+## Where sessions live
+
+```
+~/.inteligir/sessions/<path>/<timestamp>_<id>.jsonl
+```
+
+Files are named with a leading timestamp, so newest sorts last. List recent
+sessions first:
+
+```bash
+ls -t ~/.inteligir/sessions/**/*.jsonl 2>/dev/null | head
+```
+
+## Searching
+
+Each line is one JSON entry (a message, tool call, or tool result). Plain
+text search across everything:
+
+```bash
+grep -ril "keyword" ~/.inteligir/sessions/        # which sessions mention it
+grep -rin "keyword" ~/.inteligir/sessions/ | head  # the matching lines
+```
+
+Once you've found the right file, read around the hit for context. The file is
+chronological, so a few lines before/after a match usually tell the story:
+
+```bash
+grep -n "keyword" <file>          # find line numbers
+sed -n '40,70p' <file>            # read that span
+```
+
+For a readable digest of a session rather than raw JSON, just `read` the file
+and summarize it yourself — you parse the JSON fine.
+
+## Tips
+
+- Search a few candidate keywords; conversations rarely use the exact phrasing
+  you remember.
+- Prefer the most recent matching session unless the user points further back.
+- Don't dump raw JSONL at the user — extract the answer and synthesize it.
+- If you find a durable fact worth keeping (a preference, a decision, a path),
+  consider capturing it as a skill (see the managing-skills skill) so you don't
+  have to re-discover it.

--- a/apps/desktop/resources/agent/skills/recalling-sessions/SKILL.md
+++ b/apps/desktop/resources/agent/skills/recalling-sessions/SKILL.md
@@ -25,8 +25,7 @@ glob needs `globstar` and silently misses nested files). Most-recently-modified
 first:
 
 ```bash
-find ~/.inteligir/sessions -name '*.jsonl' -printf '%T@ %p\n' 2>/dev/null \
-  | sort -rn | cut -d' ' -f2- | head
+find ~/.inteligir/sessions -name '*.jsonl' -exec ls -t {} + 2>/dev/null | head
 ```
 
 ## Searching

--- a/apps/desktop/resources/agent/skills/recalling-sessions/SKILL.md
+++ b/apps/desktop/resources/agent/skills/recalling-sessions/SKILL.md
@@ -20,11 +20,13 @@ transcript, but every prior session is on disk.
 ~/.inteligir/sessions/<path>/<timestamp>_<id>.jsonl
 ```
 
-Files are named with a leading timestamp, so newest sorts last. List recent
-sessions first:
+Sessions are nested one directory deep, so list them with `find` (a bare `**`
+glob needs `globstar` and silently misses nested files). Most-recently-modified
+first:
 
 ```bash
-ls -t ~/.inteligir/sessions/**/*.jsonl 2>/dev/null | head
+find ~/.inteligir/sessions -name '*.jsonl' -printf '%T@ %p\n' 2>/dev/null \
+  | sort -rn | cut -d' ' -f2- | head
 ```
 
 ## Searching

--- a/apps/desktop/src/agent/setup.ts
+++ b/apps/desktop/src/agent/setup.ts
@@ -141,8 +141,12 @@ function syncBundledResources(bundledDir: string): void {
     return;
   }
 
-  // Up to date (or a bundled source was missing) — only seed what's absent,
-  // never overwrite the user's files.
+  // Up to date (or a bundled source was missing). Recreate a resource only when
+  // the user removed it wholesale (seedDirectory/seedFile no-op when dest
+  // exists), never overwriting their files. Updates to existing bundled
+  // resources are intentionally NOT pushed here — that's the version-bump
+  // syncDirectory path above; between versions we respect the user's deletions
+  // and edits within skills/agents.
   seedDirectory(skillsSrc, skillsDest);
   seedFile(agentsMdSrc, agentsMdDest);
   seedDirectory(agentsSrc, agentsDest);

--- a/apps/desktop/src/agent/setup.ts
+++ b/apps/desktop/src/agent/setup.ts
@@ -14,7 +14,7 @@ import {
   resolveModel,
   SessionManager,
 } from "@repo/pi-driver";
-import { prependPath, seedDirectory, seedFile } from "@repo/agent-runtime/seed";
+import { prependPath, seedDirectory, seedFile, syncDirectory, syncFile } from "@repo/agent-runtime/seed";
 import { readCliVersion } from "@repo/agent-runtime/install";
 import open from "open";
 
@@ -36,6 +36,15 @@ import {
 
 const AUTH_PROVIDER = "openai-codex";
 const MODEL_ID = "gpt-5.5";
+
+/**
+ * Bump when bundled resources (skills, AGENTS.md, agent defs) change and should
+ * be pushed to already-installed users. On a bump, seedResources overwrites the
+ * bundled-named files in ~/.inteligir (user-added files are left intact). This
+ * does overwrite user edits to those bundled files — the accepted trade-off for
+ * delivering updated prompts/skills on upgrade.
+ */
+const RESOURCE_VERSION = 1;
 
 /** ~/.inteligir — used as pi's agentDir so all discovery looks here */
 const AGENT_DIR = inteligirPath();
@@ -87,6 +96,50 @@ function buildRegisterContext(): ExtensionRegisterContext {
   return { binDir: BIN_DIR };
 }
 
+const RESOURCE_VERSION_PATH = inteligirPath(".resources-version");
+
+function readResourceVersion(): number {
+  try {
+    return Number.parseInt(fs.readFileSync(RESOURCE_VERSION_PATH, "utf8").trim(), 10) || 0;
+  } catch {
+    return 0;
+  }
+}
+
+/**
+ * Copy bundled skills / AGENTS.md / agent defs into ~/.inteligir. Fresh installs
+ * and version bumps overwrite the bundled-named files (so upgraded users get new
+ * skills and updated prompts); when the on-disk version is already current we
+ * fall back to seed-once, which only fills in anything missing without
+ * clobbering user edits.
+ */
+function syncBundledResources(bundledDir: string): void {
+  const skillsSrc = path.join(bundledDir, "skills");
+  const agentsMdSrc = path.join(bundledDir, "AGENTS.md");
+  const agentsSrc = path.join(bundledDir, "agents");
+  const skillsDest = path.join(AGENT_DIR, "skills");
+  const agentsMdDest = path.join(AGENT_DIR, "AGENTS.md");
+  const agentsDest = path.join(AGENT_DIR, "agents");
+
+  if (readResourceVersion() < RESOURCE_VERSION) {
+    syncDirectory(skillsSrc, skillsDest);
+    syncFile(agentsMdSrc, agentsMdDest);
+    syncDirectory(agentsSrc, agentsDest);
+    try {
+      fs.writeFileSync(RESOURCE_VERSION_PATH, String(RESOURCE_VERSION));
+    } catch (err) {
+      console.warn("[agent] failed to record resource version:", err);
+    }
+    return;
+  }
+
+  // Up to date — only seed what's missing (e.g. a dir a user deleted), never
+  // overwrite their edits.
+  seedDirectory(skillsSrc, skillsDest);
+  seedFile(agentsMdSrc, agentsMdDest);
+  seedDirectory(agentsSrc, agentsDest);
+}
+
 /**
  * Seed bundled skills + AGENTS.md into ~/.inteligir/ on first run, ensure the
  * bundled CLI bin dir is on PATH so agent tools can find it, and run each
@@ -109,8 +162,7 @@ export async function seedResources(onProgress: (p: SetupProgress) => void): Pro
     return;
   }
 
-  seedDirectory(path.join(ctx.bundledResourcesDir, "skills"), path.join(AGENT_DIR, "skills"));
-  seedFile(path.join(ctx.bundledResourcesDir, "AGENTS.md"), path.join(AGENT_DIR, "AGENTS.md"));
+  syncBundledResources(ctx.bundledResourcesDir);
 
   await runBundleSetups(EXTENSION_BUNDLES, ctx);
 }

--- a/apps/desktop/src/agent/setup.ts
+++ b/apps/desktop/src/agent/setup.ts
@@ -121,29 +121,28 @@ function syncBundledResources(bundledDir: string): void {
   const agentsMdDest = path.join(AGENT_DIR, "AGENTS.md");
   const agentsDest = path.join(AGENT_DIR, "agents");
 
-  if (readResourceVersion() < RESOURCE_VERSION) {
-    const copied = [
-      syncDirectory(skillsSrc, skillsDest),
-      syncFile(agentsMdSrc, agentsMdDest),
-      syncDirectory(agentsSrc, agentsDest),
-    ];
-    // Only record the version once every source actually copied — otherwise a
-    // missing bundled source would mark the install current and never retry the
-    // overwrite on a later launch.
-    if (copied.every(Boolean)) {
-      try {
-        fs.writeFileSync(RESOURCE_VERSION_PATH, String(RESOURCE_VERSION));
-      } catch (err) {
-        console.warn("[agent] failed to record resource version:", err);
-      }
-    } else {
-      console.warn("[agent] bundled resources incomplete; deferring version bump");
+  // Only enter the overwrite path when ALL bundled sources are present, so a
+  // broken/partial bundle never repeatedly clobbers user edits and never marks
+  // the version current without a real sync. Gating on existence up front keeps
+  // sync-and-record atomic: either every source is overwritten and the version
+  // is recorded once, or we fall through to the non-destructive seed-once below.
+  const allSourcesPresent =
+    fs.existsSync(skillsSrc) && fs.existsSync(agentsMdSrc) && fs.existsSync(agentsSrc);
+
+  if (readResourceVersion() < RESOURCE_VERSION && allSourcesPresent) {
+    syncDirectory(skillsSrc, skillsDest);
+    syncFile(agentsMdSrc, agentsMdDest);
+    syncDirectory(agentsSrc, agentsDest);
+    try {
+      fs.writeFileSync(RESOURCE_VERSION_PATH, String(RESOURCE_VERSION));
+    } catch (err) {
+      console.warn("[agent] failed to record resource version:", err);
     }
     return;
   }
 
-  // Up to date — only seed what's missing (e.g. a dir a user deleted), never
-  // overwrite their edits.
+  // Up to date (or a bundled source was missing) — only seed what's absent,
+  // never overwrite the user's files.
   seedDirectory(skillsSrc, skillsDest);
   seedFile(agentsMdSrc, agentsMdDest);
   seedDirectory(agentsSrc, agentsDest);

--- a/apps/desktop/src/agent/setup.ts
+++ b/apps/desktop/src/agent/setup.ts
@@ -122,13 +122,22 @@ function syncBundledResources(bundledDir: string): void {
   const agentsDest = path.join(AGENT_DIR, "agents");
 
   if (readResourceVersion() < RESOURCE_VERSION) {
-    syncDirectory(skillsSrc, skillsDest);
-    syncFile(agentsMdSrc, agentsMdDest);
-    syncDirectory(agentsSrc, agentsDest);
-    try {
-      fs.writeFileSync(RESOURCE_VERSION_PATH, String(RESOURCE_VERSION));
-    } catch (err) {
-      console.warn("[agent] failed to record resource version:", err);
+    const copied = [
+      syncDirectory(skillsSrc, skillsDest),
+      syncFile(agentsMdSrc, agentsMdDest),
+      syncDirectory(agentsSrc, agentsDest),
+    ];
+    // Only record the version once every source actually copied — otherwise a
+    // missing bundled source would mark the install current and never retry the
+    // overwrite on a later launch.
+    if (copied.every(Boolean)) {
+      try {
+        fs.writeFileSync(RESOURCE_VERSION_PATH, String(RESOURCE_VERSION));
+      } catch (err) {
+        console.warn("[agent] failed to record resource version:", err);
+      }
+    } else {
+      console.warn("[agent] bundled resources incomplete; deferring version bump");
     }
     return;
   }

--- a/apps/desktop/src/agent/subagent/agents.ts
+++ b/apps/desktop/src/agent/subagent/agents.ts
@@ -1,0 +1,123 @@
+/**
+ * Subagent definition discovery.
+ *
+ * A subagent is a Markdown file with YAML frontmatter (name, description,
+ * optional tools/model) and a body that becomes the subagent's system prompt.
+ * Definitions live alongside everything else pi discovers:
+ *   - user scope:    <agentDir>/agents/*.md      (~/.inteligir/agents)
+ *   - project scope: <cwd>/.pi/agents/*.md       (nearest ancestor)
+ * Project defs override user defs on name collision.
+ *
+ * Kept self-contained (no pi internals) so it works regardless of agent
+ * lifecycle state, mirroring how skills.ts in @repo/pi-driver reads from disk.
+ */
+
+import fs from "node:fs";
+import path from "node:path";
+
+export type AgentSource = "user" | "project";
+
+export type AgentConfig = {
+  name: string;
+  description: string;
+  /** Restrict the subagent to this comma-allowlist of built-in tools. */
+  tools?: string[];
+  /** Override the model; omitted defs inherit the host default. */
+  model?: string;
+  /** Markdown body — appended to the subagent's system prompt. */
+  systemPrompt: string;
+  source: AgentSource;
+  filePath: string;
+};
+
+/**
+ * Minimal frontmatter split. Definitions use simple single-line `key: value`
+ * scalars; anything else in the block is ignored. Returns an empty frontmatter
+ * when the file has no leading `---` fence.
+ */
+function parseFrontmatter(content: string): {
+  frontmatter: Record<string, string>;
+  body: string;
+} {
+  const match = /^---\r?\n([\s\S]*?)\r?\n---\r?\n?([\s\S]*)$/.exec(content);
+  if (!match) return { frontmatter: {}, body: content };
+
+  const frontmatter: Record<string, string> = {};
+  for (const line of match[1].split(/\r?\n/)) {
+    const sep = line.indexOf(":");
+    if (sep === -1) continue;
+    const key = line.slice(0, sep).trim();
+    const value = line.slice(sep + 1).trim();
+    if (key) frontmatter[key] = value;
+  }
+  return { frontmatter, body: match[2] ?? "" };
+}
+
+function loadAgentsFromDir(dir: string, source: AgentSource): AgentConfig[] {
+  let entries: fs.Dirent[];
+  try {
+    entries = fs.readdirSync(dir, { withFileTypes: true });
+  } catch {
+    return [];
+  }
+
+  const agents: AgentConfig[] = [];
+  for (const entry of entries) {
+    if (!entry.name.endsWith(".md")) continue;
+    if (!entry.isFile() && !entry.isSymbolicLink()) continue;
+
+    const filePath = path.join(dir, entry.name);
+    let content: string;
+    try {
+      content = fs.readFileSync(filePath, "utf-8");
+    } catch {
+      continue;
+    }
+
+    const { frontmatter, body } = parseFrontmatter(content);
+    if (!frontmatter.name || !frontmatter.description) continue;
+
+    const tools = frontmatter.tools
+      ?.split(",")
+      .map((t) => t.trim())
+      .filter(Boolean);
+
+    agents.push({
+      name: frontmatter.name,
+      description: frontmatter.description,
+      tools: tools && tools.length > 0 ? tools : undefined,
+      model: frontmatter.model || undefined,
+      systemPrompt: body,
+      source,
+      filePath,
+    });
+  }
+  return agents;
+}
+
+function findNearestProjectAgentsDir(cwd: string): string | null {
+  let current = cwd;
+  for (;;) {
+    const candidate = path.join(current, ".pi", "agents");
+    try {
+      if (fs.statSync(candidate).isDirectory()) return candidate;
+    } catch {
+      /* not here, keep walking up */
+    }
+    const parent = path.dirname(current);
+    if (parent === current) return null;
+    current = parent;
+  }
+}
+
+/** Discover subagent definitions across user and project scope. */
+export function discoverAgents(agentDir: string, cwd: string): AgentConfig[] {
+  const userAgents = loadAgentsFromDir(path.join(agentDir, "agents"), "user");
+  const projectDir = findNearestProjectAgentsDir(cwd);
+  const projectAgents = projectDir ? loadAgentsFromDir(projectDir, "project") : [];
+
+  const byName = new Map<string, AgentConfig>();
+  for (const agent of userAgents) byName.set(agent.name, agent);
+  for (const agent of projectAgents) byName.set(agent.name, agent);
+  return [...byName.values()];
+}

--- a/apps/desktop/src/agent/subagent/extension.ts
+++ b/apps/desktop/src/agent/subagent/extension.ts
@@ -235,11 +235,13 @@ async function runSubagent(
         result.stderr += data.toString();
       });
 
-      // SIGTERM, then SIGKILL if the child ignores it — never wait forever.
+      // SIGTERM, then SIGKILL if the child hasn't exited. Checks our own
+      // `settled` flag, not `proc.killed` — Node sets `killed` as soon as a
+      // signal is *sent*, so it can't tell us whether the process actually died.
       const killWithEscalation = () => {
         proc.kill("SIGTERM");
         setTimeout(() => {
-          if (!proc.killed) proc.kill("SIGKILL");
+          if (!settled) proc.kill("SIGKILL");
         }, 5000);
       };
 

--- a/apps/desktop/src/agent/subagent/extension.ts
+++ b/apps/desktop/src/agent/subagent/extension.ts
@@ -27,7 +27,6 @@ import os from "node:os";
 import path from "node:path";
 
 import { Type, type Static } from "@sinclair/typebox";
-import { seedDirectory } from "@repo/agent-runtime/seed";
 
 import { inteligirPath } from "@/main/lib/json-store";
 import type { PiExtensionBundle } from "@/agent/extension";
@@ -411,12 +410,8 @@ function buildDescription(agents: AgentConfig[]): string {
 const subagentExtension: PiExtensionBundle = {
   name: "subagent",
 
-  // Seed the bundled agent definitions into ~/.inteligir/agents on first run,
-  // the same way skills/AGENTS.md are seeded in setup.ts.
-  setup: async ({ bundledResourcesDir }) => {
-    seedDirectory(path.join(bundledResourcesDir, "agents"), path.join(AGENT_DIR, "agents"));
-  },
-
+  // Agent definitions are seeded centrally with the other bundled resources
+  // (skills, AGENTS.md) in setup.ts, so the bundle has no setup() of its own.
   register: () => (pi) => {
     const agents = discoverAgents(AGENT_DIR, WORKSPACE_DIR);
 
@@ -432,7 +427,9 @@ const subagentExtension: PiExtensionBundle = {
         // Enforce the documented "exactly one mode" contract up front so an
         // ambiguous payload (e.g. both chain and tasks) is rejected rather than
         // silently running whichever mode is checked first.
-        const hasSingle = Boolean(params.agent || params.task);
+        // Single mode needs BOTH fields; using `||` would flag a stray leftover
+        // `agent`/`task` next to a tasks/chain payload as ambiguous and reject it.
+        const hasSingle = Boolean(params.agent && params.task);
         const hasParallel = Boolean(params.tasks && params.tasks.length > 0);
         const hasChain = Boolean(params.chain && params.chain.length > 0);
         if (Number(hasSingle) + Number(hasParallel) + Number(hasChain) > 1) {
@@ -464,7 +461,10 @@ const subagentExtension: PiExtensionBundle = {
             const result = await runSubagent(findAgent(live, step.agent)!, task, signal);
             results.push(result);
             previous = result.output;
-            const failedStop = result.stopReason === "error" || result.stopReason === "aborted";
+            // In a chain the output feeds {previous}, so any non-normal stop
+            // (error/aborted, or truncation like max_tokens/length) means the
+            // handoff is incomplete — halt rather than pass partial work on.
+            const failedStop = Boolean(result.stopReason && result.stopReason !== "stop");
             if (result.exitCode !== 0 || result.errorMessage || failedStop) {
               halted = `Skipped: prior step "${step.agent}" did not complete successfully`;
             }

--- a/apps/desktop/src/agent/subagent/extension.ts
+++ b/apps/desktop/src/agent/subagent/extension.ts
@@ -79,6 +79,8 @@ type SubagentResult = {
   usage: SubagentUsage;
   model?: string;
   errorMessage?: string;
+  /** Last assistant turn's stop reason (e.g. "stop", "max_tokens", "error"). */
+  stopReason?: string;
 };
 
 // Loose shapes for the JSONL events pi emits in --mode json.
@@ -88,6 +90,7 @@ type PiMessage = {
   content?: string | PiBlock[];
   model?: string;
   errorMessage?: string;
+  stopReason?: string;
   usage?: {
     input?: number;
     output?: number;
@@ -218,10 +221,11 @@ async function runSubagent(
             result.usage.contextTokens = usage.totalTokens ?? result.usage.contextTokens;
           }
           if (message.model) result.model = message.model;
-          // Reflect only the latest turn — clear a prior turn's error when a
-          // later turn succeeds, so a recovered multi-turn run (exit 0) isn't
+          // Reflect only the latest turn — clear a prior turn's error/stop when
+          // a later turn succeeds, so a recovered multi-turn run (exit 0) isn't
           // left flagged as failed and wrongly halting a chain.
           result.errorMessage = message.errorMessage || undefined;
+          result.stopReason = message.stopReason || undefined;
         }
       };
 
@@ -297,6 +301,11 @@ function formatResult(result: SubagentResult): string {
   const footer = formatUsage(result.usage, result.model);
   const lines = [header, body];
   if (result.errorMessage) lines.push(`\n[error] ${result.errorMessage}`);
+  // Surface a non-normal stop (e.g. truncation) so the caller knows the reply
+  // may be incomplete even when the process exited cleanly.
+  if (result.stopReason && result.stopReason !== "stop") {
+    lines.push(`[stopped: ${result.stopReason}]`);
+  }
   if (result.exitCode !== 0) lines.push(`[exit ${result.exitCode}]`);
   if (result.stderr.trim()) lines.push(`[stderr]\n${result.stderr.trim()}`);
   if (footer) lines.push(`_(${footer})_`);
@@ -455,7 +464,8 @@ const subagentExtension: PiExtensionBundle = {
             const result = await runSubagent(findAgent(live, step.agent)!, task, signal);
             results.push(result);
             previous = result.output;
-            if (result.exitCode !== 0 || result.errorMessage) {
+            const failedStop = result.stopReason === "error" || result.stopReason === "aborted";
+            if (result.exitCode !== 0 || result.errorMessage || failedStop) {
               halted = `Skipped: prior step "${step.agent}" did not complete successfully`;
             }
           }

--- a/apps/desktop/src/agent/subagent/extension.ts
+++ b/apps/desktop/src/agent/subagent/extension.ts
@@ -132,6 +132,14 @@ async function runSubagent(
     model: agent.model ?? DEFAULT_MODEL,
   };
 
+  // Don't spawn at all if we're already aborted — keeps a host interrupt from
+  // launching the next chain step or the rest of the parallel queue.
+  if (signal?.aborted) {
+    result.exitCode = 125;
+    result.errorMessage = "Aborted before start";
+    return result;
+  }
+
   const args = [
     "--mode",
     "json",
@@ -390,6 +398,7 @@ const subagentExtension: PiExtensionBundle = {
           const results: SubagentResult[] = [];
           let previous = "";
           for (const step of params.chain) {
+            if (signal?.aborted) break;
             const agent = findAgent(live, step.agent);
             if (!agent) return unknownAgentResult(live, step.agent);
             const task = step.task.replaceAll("{previous}", previous);

--- a/apps/desktop/src/agent/subagent/extension.ts
+++ b/apps/desktop/src/agent/subagent/extension.ts
@@ -235,17 +235,22 @@ async function runSubagent(
         result.stderr += data.toString();
       });
 
-      const timer = setTimeout(() => {
-        aborted = true;
-        proc.kill("SIGTERM");
-      }, SUBAGENT_TIMEOUT_MS);
-
-      const onAbort = () => {
-        aborted = true;
+      // SIGTERM, then SIGKILL if the child ignores it — never wait forever.
+      const killWithEscalation = () => {
         proc.kill("SIGTERM");
         setTimeout(() => {
           if (!proc.killed) proc.kill("SIGKILL");
         }, 5000);
+      };
+
+      const timer = setTimeout(() => {
+        aborted = true;
+        killWithEscalation();
+      }, SUBAGENT_TIMEOUT_MS);
+
+      const onAbort = () => {
+        aborted = true;
+        killWithEscalation();
       };
       if (signal) {
         if (signal.aborted) onAbort();
@@ -412,6 +417,18 @@ const subagentExtension: PiExtensionBundle = {
       execute: async (_toolCallId, params: SubagentParams, signal?: AbortSignal) => {
         // Re-discover per call so defs added mid-session are picked up.
         const live = discoverAgents(AGENT_DIR, WORKSPACE_DIR);
+
+        // Enforce the documented "exactly one mode" contract up front so an
+        // ambiguous payload (e.g. both chain and tasks) is rejected rather than
+        // silently running whichever mode is checked first.
+        const hasSingle = Boolean(params.agent || params.task);
+        const hasParallel = Boolean(params.tasks && params.tasks.length > 0);
+        const hasChain = Boolean(params.chain && params.chain.length > 0);
+        if (Number(hasSingle) + Number(hasParallel) + Number(hasChain) > 1) {
+          return textResult(
+            "Provide exactly one mode: { agent, task } | { tasks: [...] } | { chain: [...] }.",
+          );
+        }
 
         // chain — sequential, threading {previous} through. Validate every
         // agent up front (like parallel) so a bad name on a later step doesn't

--- a/apps/desktop/src/agent/subagent/extension.ts
+++ b/apps/desktop/src/agent/subagent/extension.ts
@@ -393,16 +393,19 @@ const subagentExtension: PiExtensionBundle = {
         // Re-discover per call so defs added mid-session are picked up.
         const live = discoverAgents(AGENT_DIR, WORKSPACE_DIR);
 
-        // chain — sequential, threading {previous} through.
+        // chain — sequential, threading {previous} through. Validate every
+        // agent up front (like parallel) so a bad name on a later step doesn't
+        // discard the completed, already-paid-for output of earlier ones.
         if (params.chain && params.chain.length > 0) {
+          const missing = params.chain.find((s) => !findAgent(live, s.agent));
+          if (missing) return unknownAgentResult(live, missing.agent);
+
           const results: SubagentResult[] = [];
           let previous = "";
           for (const step of params.chain) {
             if (signal?.aborted) break;
-            const agent = findAgent(live, step.agent);
-            if (!agent) return unknownAgentResult(live, step.agent);
             const task = step.task.replaceAll("{previous}", previous);
-            const result = await runSubagent(agent, task, signal);
+            const result = await runSubagent(findAgent(live, step.agent)!, task, signal);
             results.push(result);
             previous = result.output;
           }

--- a/apps/desktop/src/agent/subagent/extension.ts
+++ b/apps/desktop/src/agent/subagent/extension.ts
@@ -1,0 +1,437 @@
+/**
+ * Subagent extension — delegate work to isolated agents with their own context
+ * windows.
+ *
+ * Each invocation spawns a separate one-shot `pi` process in JSON mode
+ * (`--mode json -p --no-session`), so the subagent's context never pollutes the
+ * main conversation. The child inherits PI_CODING_AGENT_DIR, so it shares the
+ * host's auth and model registry, but runs with `--no-context-files` and
+ * `--no-extensions` — it gets pi's built-in tools (read/bash/grep/edit/…) and
+ * its own system prompt, NOT the Chief-of-Staff persona or the privileged
+ * in-process tools (manage_ui, manage_tasks). That isolation is the point:
+ * subagents are sandboxed workers, not shell operators.
+ *
+ * The host stays on the in-process SDK (createAgentSession); only subagents run
+ * out-of-process. See agents.ts for definition discovery.
+ *
+ * Modes:
+ *   - single:   { agent, task }
+ *   - parallel: { tasks: [{ agent, task }, …] }   (bounded concurrency)
+ *   - chain:    { chain: [{ agent, task }, …] }    ({previous} interpolated)
+ */
+
+import { spawn } from "node:child_process";
+import fs from "node:fs";
+import { createRequire } from "node:module";
+import os from "node:os";
+import path from "node:path";
+
+import { Type, type Static } from "@sinclair/typebox";
+import { seedDirectory } from "@repo/agent-runtime/seed";
+
+import { inteligirPath } from "@/main/lib/json-store";
+import type { PiExtensionBundle } from "@/agent/extension";
+import { textResult, type ToolTextResult } from "@/agent/extension-helpers";
+import { discoverAgents, type AgentConfig } from "@/agent/subagent/agents";
+
+// Mirror setup.ts — openai-codex is the only configured provider, so subagents
+// authenticate the same way. Definitions may override the model via frontmatter.
+const AUTH_PROVIDER = "openai-codex";
+const DEFAULT_MODEL = "gpt-5.5";
+
+const MAX_PARALLEL_TASKS = 8;
+const MAX_CONCURRENCY = 4;
+const SUBAGENT_TIMEOUT_MS = 600_000;
+
+const AGENT_DIR = inteligirPath();
+const WORKSPACE_DIR = inteligirPath("workspace");
+
+// ---------------------------------------------------------------------------
+// pi process invocation
+// ---------------------------------------------------------------------------
+
+let cachedPiCli: string | null = null;
+
+/** Path to pi's CLI entry, resolved from the same node_modules the host uses. */
+function resolvePiCli(): string {
+  if (!cachedPiCli) {
+    cachedPiCli = createRequire(import.meta.url).resolve(
+      "@mariozechner/pi-coding-agent/dist/cli.js",
+    );
+  }
+  return cachedPiCli;
+}
+
+type SubagentUsage = {
+  turns: number;
+  input: number;
+  output: number;
+  cost: number;
+  contextTokens: number;
+};
+
+type SubagentResult = {
+  agent: string;
+  task: string;
+  output: string;
+  exitCode: number;
+  stderr: string;
+  usage: SubagentUsage;
+  model?: string;
+  errorMessage?: string;
+};
+
+// Loose shapes for the JSONL events pi emits in --mode json.
+type PiBlock = { type: string; text?: string };
+type PiMessage = {
+  role?: string;
+  content?: string | PiBlock[];
+  model?: string;
+  errorMessage?: string;
+  usage?: {
+    input?: number;
+    output?: number;
+    cost?: { total?: number };
+    totalTokens?: number;
+  };
+};
+type PiEvent = { type?: string; message?: PiMessage };
+
+function emptyUsage(): SubagentUsage {
+  return { turns: 0, input: 0, output: 0, cost: 0, contextTokens: 0 };
+}
+
+function messageText(message: PiMessage): string {
+  if (typeof message.content === "string") return message.content;
+  if (!Array.isArray(message.content)) return "";
+  return message.content
+    .filter((block) => block.type === "text" && typeof block.text === "string")
+    .map((block) => block.text)
+    .join("");
+}
+
+/** Write the system prompt to a private temp file; pi reads it via a flag. */
+async function writePromptFile(agentName: string): Promise<{ dir: string; filePath: string }> {
+  const dir = await fs.promises.mkdtemp(path.join(os.tmpdir(), "inteligir-subagent-"));
+  const safeName = agentName.replace(/[^\w.-]+/g, "_");
+  return { dir, filePath: path.join(dir, `prompt-${safeName}.md`) };
+}
+
+async function runSubagent(
+  agent: AgentConfig,
+  task: string,
+  signal: AbortSignal | undefined,
+): Promise<SubagentResult> {
+  const result: SubagentResult = {
+    agent: agent.name,
+    task,
+    output: "",
+    exitCode: 0,
+    stderr: "",
+    usage: emptyUsage(),
+    model: agent.model ?? DEFAULT_MODEL,
+  };
+
+  const args = [
+    "--mode",
+    "json",
+    "-p",
+    "--no-session",
+    "--no-context-files",
+    "--no-extensions",
+    "--provider",
+    AUTH_PROVIDER,
+    "--model",
+    result.model as string,
+  ];
+  if (agent.tools && agent.tools.length > 0) args.push("--tools", agent.tools.join(","));
+
+  let tmpDir: string | null = null;
+  let tmpPromptPath: string | null = null;
+  try {
+    if (agent.systemPrompt.trim()) {
+      const tmp = await writePromptFile(agent.name);
+      tmpDir = tmp.dir;
+      tmpPromptPath = tmp.filePath;
+      await fs.promises.writeFile(tmpPromptPath, agent.systemPrompt, { encoding: "utf-8", mode: 0o600 });
+      args.push("--append-system-prompt", tmpPromptPath);
+    }
+    args.push(`Task: ${task}`);
+
+    result.exitCode = await new Promise<number>((resolve) => {
+      const proc = spawn(process.execPath, [resolvePiCli(), ...args], {
+        cwd: WORKSPACE_DIR,
+        shell: false,
+        stdio: ["ignore", "pipe", "pipe"],
+        env: {
+          ...process.env,
+          ELECTRON_RUN_AS_NODE: "1",
+          PI_CODING_AGENT_DIR: AGENT_DIR,
+        },
+      });
+
+      let aborted = false;
+      let settled = false;
+      let buffer = "";
+
+      // Single resolve site — `error` may precede `close`, and either can fire
+      // after a timeout/abort kill.
+      const finish = (code: number) => {
+        if (settled) return;
+        settled = true;
+        clearTimeout(timer);
+        signal?.removeEventListener("abort", onAbort);
+        // The `settled` guard above makes this single-resolve; the linter's
+        // flow analysis can't see it across the two event handlers.
+        // oxlint-disable-next-line promise/no-multiple-resolved
+        resolve(code);
+      };
+
+      const processLine = (line: string) => {
+        if (!line.trim()) return;
+        let event: PiEvent;
+        try {
+          event = JSON.parse(line) as PiEvent;
+        } catch {
+          return;
+        }
+        const message = event.message;
+        if (!message) return;
+
+        if (event.type === "message_end" && message.role === "assistant") {
+          const text = messageText(message);
+          if (text.trim()) result.output = text;
+          result.usage.turns += 1;
+          const usage = message.usage;
+          if (usage) {
+            result.usage.input += usage.input ?? 0;
+            result.usage.output += usage.output ?? 0;
+            result.usage.cost += usage.cost?.total ?? 0;
+            result.usage.contextTokens = usage.totalTokens ?? result.usage.contextTokens;
+          }
+          if (message.model) result.model = message.model;
+          if (message.errorMessage) result.errorMessage = message.errorMessage;
+        }
+      };
+
+      proc.stdout.on("data", (data: Buffer) => {
+        buffer += data.toString();
+        const lines = buffer.split("\n");
+        buffer = lines.pop() ?? "";
+        for (const line of lines) processLine(line);
+      });
+      proc.stderr.on("data", (data: Buffer) => {
+        result.stderr += data.toString();
+      });
+
+      const timer = setTimeout(() => {
+        aborted = true;
+        proc.kill("SIGTERM");
+      }, SUBAGENT_TIMEOUT_MS);
+
+      const onAbort = () => {
+        aborted = true;
+        proc.kill("SIGTERM");
+        setTimeout(() => {
+          if (!proc.killed) proc.kill("SIGKILL");
+        }, 5000);
+      };
+      if (signal) {
+        if (signal.aborted) onAbort();
+        else signal.addEventListener("abort", onAbort, { once: true });
+      }
+
+      proc.on("close", (code) => {
+        if (buffer.trim()) processLine(buffer);
+        if (aborted && !result.errorMessage) result.errorMessage = "Subagent timed out or was aborted";
+        finish(code ?? (aborted ? 124 : 0));
+      });
+      proc.on("error", (err) => {
+        result.stderr += `\n${err instanceof Error ? err.message : String(err)}`;
+        finish(1);
+      });
+    });
+
+    return result;
+  } finally {
+    if (tmpPromptPath) await fs.promises.rm(tmpPromptPath, { force: true }).catch(() => {});
+    if (tmpDir) await fs.promises.rm(tmpDir, { recursive: true, force: true }).catch(() => {});
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Result formatting
+// ---------------------------------------------------------------------------
+
+function formatUsage(usage: SubagentUsage, model?: string): string {
+  const parts: string[] = [];
+  if (usage.turns) parts.push(`${usage.turns} turn${usage.turns === 1 ? "" : "s"}`);
+  if (usage.input) parts.push(`↑${usage.input}`);
+  if (usage.output) parts.push(`↓${usage.output}`);
+  if (usage.cost) parts.push(`$${usage.cost.toFixed(4)}`);
+  if (model) parts.push(model);
+  return parts.join(" ");
+}
+
+function formatResult(result: SubagentResult): string {
+  const header = `### ${result.agent}`;
+  const body = result.output.trim() || "(no output)";
+  const footer = formatUsage(result.usage, result.model);
+  const lines = [header, body];
+  if (result.errorMessage) lines.push(`\n[error] ${result.errorMessage}`);
+  if (result.exitCode !== 0) lines.push(`[exit ${result.exitCode}]`);
+  if (result.stderr.trim()) lines.push(`[stderr]\n${result.stderr.trim()}`);
+  if (footer) lines.push(`_(${footer})_`);
+  return lines.join("\n");
+}
+
+// ---------------------------------------------------------------------------
+// Concurrency
+// ---------------------------------------------------------------------------
+
+async function mapWithConcurrency<TIn, TOut>(
+  items: TIn[],
+  concurrency: number,
+  fn: (item: TIn, index: number) => Promise<TOut>,
+): Promise<TOut[]> {
+  if (items.length === 0) return [];
+  const limit = Math.max(1, Math.min(concurrency, items.length));
+  const results = Array.from<TOut>({ length: items.length });
+  let next = 0;
+  await Promise.all(
+    Array.from({ length: limit }, async () => {
+      for (;;) {
+        const current = next++;
+        if (current >= items.length) return;
+        results[current] = await fn(items[current]!, current);
+      }
+    }),
+  );
+  return results;
+}
+
+// ---------------------------------------------------------------------------
+// Tool schema + registration
+// ---------------------------------------------------------------------------
+
+const TaskItem = Type.Object({
+  agent: Type.String({ description: "Name of the subagent to invoke." }),
+  task: Type.String({ description: "Task to delegate to the subagent." }),
+});
+
+const SubagentSchema = Type.Object({
+  agent: Type.Optional(Type.String({ description: "Subagent name (single mode)." })),
+  task: Type.Optional(Type.String({ description: "Task to delegate (single mode)." })),
+  tasks: Type.Optional(
+    Type.Array(TaskItem, {
+      description: "Run these {agent, task} pairs in parallel (isolated contexts).",
+    }),
+  ),
+  chain: Type.Optional(
+    Type.Array(TaskItem, {
+      description:
+        "Run these {agent, task} pairs sequentially. Use the placeholder {previous} " +
+        "in a task to inject the prior step's output.",
+    }),
+  ),
+});
+
+type SubagentParams = Static<typeof SubagentSchema>;
+
+function findAgent(agents: AgentConfig[], name: string): AgentConfig | undefined {
+  return agents.find((a) => a.name === name);
+}
+
+function unknownAgentResult(agents: AgentConfig[], name: string): ToolTextResult {
+  const available = agents.map((a) => `"${a.name}"`).join(", ") || "none";
+  return textResult(`Unknown subagent "${name}". Available: ${available}.`);
+}
+
+function buildDescription(agents: AgentConfig[]): string {
+  const list =
+    agents.length > 0
+      ? agents.map((a) => `- ${a.name}: ${a.description}`).join("\n")
+      : "- (no subagents defined yet — add Markdown defs under ~/.inteligir/agents/)";
+  return (
+    "Delegate work to a subagent that runs in its own isolated context window, " +
+    "then return its result. Use this to keep a long or noisy sub-task out of the " +
+    "main conversation, or to fan out independent work.\n\n" +
+    "Modes (provide exactly one):\n" +
+    "- single: { agent, task }\n" +
+    "- parallel: { tasks: [{ agent, task }, …] }\n" +
+    "- chain: { chain: [{ agent, task }, …] } — {previous} is replaced with the prior step's output.\n\n" +
+    `Available subagents:\n${list}`
+  );
+}
+
+const subagentExtension: PiExtensionBundle = {
+  name: "subagent",
+
+  // Seed the bundled agent definitions into ~/.inteligir/agents on first run,
+  // the same way skills/AGENTS.md are seeded in setup.ts.
+  setup: async ({ bundledResourcesDir }) => {
+    seedDirectory(path.join(bundledResourcesDir, "agents"), path.join(AGENT_DIR, "agents"));
+  },
+
+  register: () => (pi) => {
+    const agents = discoverAgents(AGENT_DIR, WORKSPACE_DIR);
+
+    pi.registerTool({
+      name: "subagent",
+      label: "subagent",
+      description: buildDescription(agents),
+      parameters: SubagentSchema,
+      execute: async (_toolCallId, params: SubagentParams, signal?: AbortSignal) => {
+        // Re-discover per call so defs added mid-session are picked up.
+        const live = discoverAgents(AGENT_DIR, WORKSPACE_DIR);
+
+        // chain — sequential, threading {previous} through.
+        if (params.chain && params.chain.length > 0) {
+          const results: SubagentResult[] = [];
+          let previous = "";
+          for (const step of params.chain) {
+            const agent = findAgent(live, step.agent);
+            if (!agent) return unknownAgentResult(live, step.agent);
+            const task = step.task.replaceAll("{previous}", previous);
+            const result = await runSubagent(agent, task, signal);
+            results.push(result);
+            previous = result.output;
+          }
+          return textResult(results.map(formatResult).join("\n\n---\n\n"));
+        }
+
+        // parallel — bounded concurrency over independent tasks.
+        if (params.tasks && params.tasks.length > 0) {
+          if (params.tasks.length > MAX_PARALLEL_TASKS) {
+            return textResult(
+              `Too many parallel tasks (${params.tasks.length}). Max is ${MAX_PARALLEL_TASKS}.`,
+            );
+          }
+          const missing = params.tasks.find((t) => !findAgent(live, t.agent));
+          if (missing) return unknownAgentResult(live, missing.agent);
+
+          const results = await mapWithConcurrency(params.tasks, MAX_CONCURRENCY, (t) =>
+            runSubagent(findAgent(live, t.agent)!, t.task, signal),
+          );
+          return textResult(results.map(formatResult).join("\n\n---\n\n"));
+        }
+
+        // single
+        if (params.agent && params.task) {
+          const agent = findAgent(live, params.agent);
+          if (!agent) return unknownAgentResult(live, params.agent);
+          const result = await runSubagent(agent, params.task, signal);
+          return textResult(formatResult(result));
+        }
+
+        const available = live.map((a) => `"${a.name}"`).join(", ") || "none";
+        return textResult(
+          `Provide exactly one mode: { agent, task } | { tasks: [...] } | { chain: [...] }. ` +
+            `Available subagents: ${available}.`,
+        );
+      },
+    });
+  },
+};
+
+export default subagentExtension;

--- a/apps/desktop/src/agent/subagent/extension.ts
+++ b/apps/desktop/src/agent/subagent/extension.ts
@@ -218,7 +218,10 @@ async function runSubagent(
             result.usage.contextTokens = usage.totalTokens ?? result.usage.contextTokens;
           }
           if (message.model) result.model = message.model;
-          if (message.errorMessage) result.errorMessage = message.errorMessage;
+          // Reflect only the latest turn — clear a prior turn's error when a
+          // later turn succeeds, so a recovered multi-turn run (exit 0) isn't
+          // left flagged as failed and wrongly halting a chain.
+          result.errorMessage = message.errorMessage || undefined;
         }
       };
 

--- a/apps/desktop/src/agent/subagent/extension.ts
+++ b/apps/desktop/src/agent/subagent/extension.ts
@@ -355,6 +355,20 @@ function unknownAgentResult(agents: AgentConfig[], name: string): ToolTextResult
   return textResult(`Unknown subagent "${name}". Available: ${available}.`);
 }
 
+/** A chain step we deliberately did not run (abort, or a prior step failed), so
+ *  a truncated chain can't be mistaken for a complete, successful pipeline. */
+function skippedResult(agentName: string, task: string, reason: string): SubagentResult {
+  return {
+    agent: agentName,
+    task,
+    output: "",
+    exitCode: 125,
+    stderr: "",
+    usage: emptyUsage(),
+    errorMessage: reason,
+  };
+}
+
 function buildDescription(agents: AgentConfig[]): string {
   const list =
     agents.length > 0
@@ -368,7 +382,10 @@ function buildDescription(agents: AgentConfig[]): string {
     "- single: { agent, task }\n" +
     "- parallel: { tasks: [{ agent, task }, …] }\n" +
     "- chain: { chain: [{ agent, task }, …] } — {previous} is replaced with the prior step's output.\n\n" +
-    `Available subagents:\n${list}`
+    // This list is fixed when the tool is registered (session start). Defs added
+    // to ~/.inteligir/agents/ mid-session still work — invocation re-discovers
+    // them — but only appear here next session.
+    `Subagents available this session:\n${list}`
   );
 }
 
@@ -402,12 +419,23 @@ const subagentExtension: PiExtensionBundle = {
 
           const results: SubagentResult[] = [];
           let previous = "";
+          // Once set, later steps are recorded as skipped rather than run — so a
+          // downstream agent is never handed an empty {previous}, and the result
+          // shows every step instead of silently truncating.
+          let halted: string | null = null;
           for (const step of params.chain) {
-            if (signal?.aborted) break;
+            const reason = signal?.aborted ? "Aborted before start" : halted;
+            if (reason) {
+              results.push(skippedResult(step.agent, step.task, reason));
+              continue;
+            }
             const task = step.task.replaceAll("{previous}", previous);
             const result = await runSubagent(findAgent(live, step.agent)!, task, signal);
             results.push(result);
             previous = result.output;
+            if (result.exitCode !== 0 || result.errorMessage) {
+              halted = `Skipped: prior step "${step.agent}" did not complete successfully`;
+            }
           }
           return textResult(results.map(formatResult).join("\n\n---\n\n"));
         }

--- a/packages/agent-runtime/src/seed.ts
+++ b/packages/agent-runtime/src/seed.ts
@@ -38,6 +38,31 @@ export function seedFile(src: string, dest: string): boolean {
 }
 
 /**
+ * Recursively copy `src` over `dest`, overwriting bundled files but leaving
+ * unrelated user-added files in `dest` untouched. Unlike `seedDirectory` this
+ * runs even when `dest` exists — used to push updated bundled resources to
+ * already-installed users on a version bump. Returns true if `src` exists.
+ */
+export function syncDirectory(src: string, dest: string): boolean {
+  if (!fs.existsSync(src)) return false;
+  fs.cpSync(src, dest, { recursive: true, force: true });
+  return true;
+}
+
+/**
+ * Copy a single file from `src` to `dest`, overwriting any existing file.
+ * Creates the parent directory if needed. The overwriting counterpart to
+ * `seedFile` — do NOT use for sensitive seed-once files (OAuth secrets/tokens).
+ * Returns true if the copy happened, false if `src` is missing.
+ */
+export function syncFile(src: string, dest: string): boolean {
+  if (!fs.existsSync(src)) return false;
+  fs.mkdirSync(path.dirname(dest), { recursive: true });
+  fs.copyFileSync(src, dest);
+  return true;
+}
+
+/**
  * Prepend `entry` to the calling process's PATH if it is not already on it.
  * Idempotent. Used so subprocesses spawned by the agent's bash tool can find
  * binaries we install under `~/.inteligir/bin`.


### PR DESCRIPTION
## What

Adopts the most valuable ideas from the [Hermes agent](https://github.com/NousResearch/hermes-agent) — but using inteligir's **existing** primitives instead of building new subsystems.

This first PR lands the two lowest-risk, highest-leverage pieces: **closed-loop skills** and **cross-session memory**, both as plain skill files.

### Added skills

- **`managing-skills`** — teaches the agent it can author and refine its own skills. No new tool: pi already ships built-in `write`/`edit`/`bash`, and skills are just `SKILL.md` files under `~/.inteligir/skills/`. The skill documents the convention and the one gotcha (new skills load on the *next* session, since skills are read at session start).
- **`recalling-sessions`** — teaches the agent to `grep` across past session JSONL (`~/.inteligir/sessions/<path>/<ts>_<id>.jsonl`) for cross-session recall. No FTS5/embeddings infra needed; the agent already has `bash`/`grep`/`read`.

Both rely entirely on pi's built-in tools, and their `description` frontmatter is surfaced to the model so it knows the capability exists.

## Why this shape

Investigation of the pinned `@mariozechner/pi-coding-agent@0.73.1` showed inteligir already has most of what Hermes is built on:

| Hermes feature | Verdict |
|---|---|
| Autonomous skill creation | ✅ this PR (skill file, no new tool) |
| Cross-session memory | ✅ this PR (skill file, no new tool) |
| Context compaction (`/compress`) | Already handled by pi (`shouldCompact` + branch summarization) — nothing to build |
| Runtime model switching | Dropped (not wanted) |
| Multi-platform gateway / serverless backends | Out of scope (we're a desktop OS shell, not a chat-bot-everywhere) |
| Subagent delegation | Follow-up (design pending) |

## Not included yet — subagents

pi ships an idiomatic `subagent` reference (agent defs as `.md`, spawns isolated `pi --mode rpc` processes). Porting it has one architectural decision still open: inteligir runs pi **in-process** via `createAgentSession` and ships no `pi` binary, and our privileged tools (`manage_ui`, `manage_tasks`) are coupled to the Electron main process — so we can't replace the SDK with RPC wholesale. The plan is to keep the SDK as host and spawn subagents either in-process or via an installed `pi` RPC binary. Tracking separately.

https://claude.ai/code/session_01Vq9LkW73azJPhWKRzHwkt3

---
_Generated by [Claude Code](https://claude.ai/code/session_01Vq9LkW73azJPhWKRzHwkt3)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Spawns out-of-process pi workers with shared auth and can run parallel chains (cost/time); version bumps intentionally overwrite user edits to bundled prompts/skills/agents.
> 
> **Overview**
> Adds **Hermes-style self-management** as bundled skills (`managing-skills`, `recalling-sessions`) and documents **subagent delegation** in `AGENTS.md`, plus default **scout / worker / reviewer** markdown defs under bundled `agents/`.
> 
> Introduces a **`subagent` extension** that discovers defs from `~/.inteligir/agents` and project `.pi/agents`, then runs isolated one-shot `pi` JSON-mode child processes (no extensions, no `manage_ui`/`manage_tasks`) with **single, parallel, and chain** modes (`{previous}` threading), abort/timeout handling, and strict mode validation.
> 
> **Setup** replaces one-time skill/`AGENTS.md` seeding with **`RESOURCE_VERSION`-gated sync**: on bump, overwrite bundled skills, `AGENTS.md`, and agent defs when all sources exist, record `.resources-version`; otherwise keep seed-once behavior. **`syncDirectory` / `syncFile`** in `@repo/agent-runtime/seed` support that overwrite path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 559e25742f1d696b531a4985f3f7db334aa7aed0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds two self-management skills and a sandboxed `subagent` tool for delegating long or parallel work in isolated contexts. Introduces versioned resource sync that overwrites bundled skills/docs/agent defs on upgrade only when all sources are present, with clear seed-once vs version-bump behavior.

- New Features
  - `managing-skills`: Author/refine skills via `write`/`edit`/`bash`; skills under `~/.inteligir/skills/`; load next session.
  - `recalling-sessions`: Search past session JSONL with `grep`; sessions under `~/.inteligir/sessions/`; list via streamed `find | sort | tail` for portable, correct ordering.
  - `subagent` delegation: Single/parallel/chain modes; runs out-of-process `pi` in JSON mode with built-in tools only (no `manage_ui`/`manage_tasks`); seeds `scout`, `worker`, `reviewer` under `~/.inteligir/agents/`; re-discovers agents per call.
  - Versioned resource sync: On upgrade, overwrite bundled skills/`AGENTS.md`/agent defs in `~/.inteligir/` when all sources exist; record `.resources-version` only after a full sync; otherwise fall back to seed-once. Seed-once only recreates removed resources and does not restore edits; updates to existing bundled files come via version bumps.

- Bug Fixes
  - Abort/timeout: don’t spawn after cancel; propagate abort; escalate SIGTERM→SIGKILL and ensure SIGKILL fires when SIGTERM is ignored.
  - Mode validation: require exactly one of single/parallel/chain; single requires both `agent` and `task`; reject ambiguous payloads.
  - Chains: validate all agent names up front; halt on failure/abort or any non-normal stop (e.g. truncation); record skipped steps; clear stale early-turn errors on later success; surface non-normal `stopReason` in results.
  - Read-only guarantees: drop `bash` from `scout`/`reviewer` allowlists to match the read-only contract.

<sup>Written for commit 559e25742f1d696b531a4985f3f7db334aa7aed0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kyh/inteligir/pull/331?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

