### PR TITLE
Confine orb to initial/onboarding pages

### DIFF
--- a/apps/desktop/src/renderer/app.tsx
+++ b/apps/desktop/src/renderer/app.tsx
@@ -1,27 +1,10 @@
 import { useEffect } from "react";
 import { Navigate, Outlet, useLocation } from "react-router";
-import { motion } from "motion/react";
 
-import { GeometricOrb, type DisplayStatus } from "@repo/ui/components/geometric-orb";
 import { Toaster } from "@repo/ui/components/sonner";
-import { cn } from "@repo/ui/lib/utils";
-import { useTheme } from "@/renderer/lib/use-theme";
 import { ReauthDialog } from "@/renderer/shell/reauth-dialog";
 import { useAgentStore } from "@/renderer/stores/agent-store";
 import { useUiStateStore } from "@/renderer/stores/ui-state-store";
-import { useVoiceStore } from "@/renderer/stores/voice-store";
-
-function phaseToOrbStatus(phase: string, listening: boolean): DisplayStatus {
-  if (listening) return "listening";
-  switch (phase) {
-    case "ready":
-      return "idle";
-    case "error":
-      return "error";
-    default:
-      return "starting";
-  }
-}
 
 function phaseToPath(phase: string): "/" | "/login" | "/onboarding" {
   switch (phase) {
@@ -42,20 +25,8 @@ export function AppLayout() {
   const initUiState = useUiStateStore((s) => s.init);
   const { pathname } = useLocation();
 
-  const { resolved } = useTheme();
-
   useEffect(() => init(), [init]);
   useEffect(() => void initUiState(), [initUiState]);
-
-  // Voice store is initialized by ShellPage's useEffect(init). Before that,
-  // state.kind defaults to "idle" — orb falls back to the agent-only status.
-  const listening = useVoiceStore((s) => s.state.kind === "listening");
-  const orbStatus = phaseToOrbStatus(appState.phase, listening);
-
-  // Once the agent is ready the orb retires to the top-left corner and lives
-  // there as the app's logo (matching where a logo sits on a regular site).
-  // During login/onboarding it stays centered and large.
-  const docked = appState.phase === "ready";
 
   // Redirect during render (not in useEffect) so we never flash the wrong
   // route while the navigation effect runs after first paint.
@@ -65,17 +36,6 @@ export function AppLayout() {
 
   return (
     <div className="relative h-full w-full font-mono">
-      <motion.div
-        layout
-        transition={{ type: "spring", stiffness: 130, damping: 22 }}
-        className={cn(
-          "pointer-events-none fixed z-30",
-          docked ? "top-2.5 left-[76px] h-8 w-8" : "inset-0 m-auto h-44 w-44",
-        )}
-      >
-        <GeometricOrb status={orbStatus} baseColor={resolved === "dark" ? "#eeeeee" : "#0a0a0a"} />
-      </motion.div>
-
       <div className="flex h-full flex-col">
         {needsRedirect ? <Navigate to={target} replace /> : <Outlet />}
       </div>

--- a/apps/desktop/src/renderer/components/initial-orb.tsx
+++ b/apps/desktop/src/renderer/components/initial-orb.tsx
@@ -1,0 +1,25 @@
+import { GeometricOrb, type DisplayStatus } from "@repo/ui/components/geometric-orb";
+
+import { useTheme } from "@/renderer/lib/use-theme";
+import { useAgentStore } from "@/renderer/stores/agent-store";
+
+function phaseToOrbStatus(phase: string): DisplayStatus {
+  return phase === "error" ? "error" : "starting";
+}
+
+// Centered orb shown on the initial surfaces (login + onboarding). Once the
+// agent is ready the shell takes over and the orb is gone — it only lives on
+// these pre-app pages, so there's no docking/animation to manage anymore.
+export function InitialOrb() {
+  const phase = useAgentStore((s) => s.appState.phase);
+  const { resolved } = useTheme();
+
+  return (
+    <div className="pointer-events-none fixed inset-0 z-30 m-auto h-44 w-44">
+      <GeometricOrb
+        status={phaseToOrbStatus(phase)}
+        baseColor={resolved === "dark" ? "#eeeeee" : "#0a0a0a"}
+      />
+    </div>
+  );
+}

--- a/apps/desktop/src/renderer/login/login-page.tsx
+++ b/apps/desktop/src/renderer/login/login-page.tsx
@@ -2,6 +2,7 @@ import { useCallback } from "react";
 
 import { Button } from "@repo/ui/components/button";
 
+import { InitialOrb } from "@/renderer/components/initial-orb";
 import { getBridge } from "@/renderer/lib/bridge";
 import { useAgentStore } from "@/renderer/stores/agent-store";
 
@@ -22,6 +23,7 @@ export function LoginPage() {
 
   return (
     <div className="flex flex-1 flex-col items-center justify-end px-6 pb-16">
+      <InitialOrb />
       <div className="flex w-full max-w-xs flex-col gap-3">
         <Button
           onClick={loginError ? handleRetry : handleLogin}

--- a/apps/desktop/src/renderer/onboarding/onboarding-page.tsx
+++ b/apps/desktop/src/renderer/onboarding/onboarding-page.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useRef, useState } from "react";
 
 import { Button } from "@repo/ui/components/button";
 
+import { InitialOrb } from "@/renderer/components/initial-orb";
 import { getBridge } from "@/renderer/lib/bridge";
 import { useAgentStore } from "@/renderer/stores/agent-store";
 import type { VoiceModelStateEvent } from "@/shared/ipc";
@@ -70,6 +71,7 @@ export function OnboardingPage() {
 
   return (
     <div className="flex flex-1 flex-col items-center justify-end px-6 pb-16">
+      <InitialOrb />
       <div className="flex w-full max-w-xs flex-col gap-3 text-center">
         {setupError ? (
           <>

--- a/apps/desktop/src/renderer/shell/shell-page.tsx
+++ b/apps/desktop/src/renderer/shell/shell-page.tsx
@@ -36,8 +36,9 @@ export function ShellPage() {
       {/* Draggable title strip — the native title bar is hidden. */}
       <div className="app-drag fixed inset-x-0 top-0 z-10 h-12" />
 
-      {/* Greeting — top left. */}
-      <div className="fixed top-3 left-4 z-20">
+      {/* Greeting — top left, clearing the macOS traffic lights
+          (hiddenInset title bar, controls at x: 16). */}
+      <div className="fixed top-3 left-20 z-20">
         <h1 className="text-sm font-medium text-foreground">{timeOfDayGreeting()}</h1>
       </div>
 

--- a/apps/desktop/src/renderer/shell/shell-page.tsx
+++ b/apps/desktop/src/renderer/shell/shell-page.tsx
@@ -36,8 +36,8 @@ export function ShellPage() {
       {/* Draggable title strip — the native title bar is hidden. */}
       <div className="app-drag fixed inset-x-0 top-0 z-10 h-12" />
 
-      {/* Greeting — sits to the right of the docked logo orb. */}
-      <div className="fixed top-3 left-[118px] z-20">
+      {/* Greeting — top left. */}
+      <div className="fixed top-3 left-4 z-20">
         <h1 className="text-sm font-medium text-foreground">{timeOfDayGreeting()}</h1>
       </div>
 


### PR DESCRIPTION
## What

The orb used to live in `AppLayout` and animate from a large centered position to a small docked logo in the top-left corner once the agent reached the `ready` phase. The running app no longer needs the orb, so this drops the docking animation entirely and renders the orb only on the **login** and **onboarding** surfaces.

## Changes

- **New** `renderer/components/initial-orb.tsx` — a small shared component that renders the centered orb with a phase-derived status (`error` → error, otherwise `starting`). Used by both pre-app pages.
- **`renderer/app.tsx`** — removed the `motion.div` docking wrapper, the `docked`/`orbStatus` state, and the now-unused imports (`motion`, `GeometricOrb`, `useTheme`, `useVoiceStore`, `cn`). `AppLayout` is now just routing + chrome.
- **`renderer/login/login-page.tsx`** / **`renderer/onboarding/onboarding-page.tsx`** — render `<InitialOrb />`. Visually identical to before for these pages (the orb was already fixed-centered).
- **`renderer/shell/shell-page.tsx`** — repositioned the greeting (`left-[118px]` → `left-4`) now that the docked logo no longer occupies the top-left.

## Verification

`pnpm --filter @repo/desktop typecheck`, `pnpm lint`, and `pnpm --filter @repo/desktop build` all pass.

https://claude.ai/code/session_01E8meYvt1KgCzF29ciJC8s2

---
_Generated by [Claude Code](https://claude.ai/code/session_01E8meYvt1KgCzF29ciJC8s2)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Desktop renderer layout and branding only; no auth, data, or agent lifecycle logic changes.
> 
> **Overview**
> The **geometric orb** is no longer a global, animated element in `AppLayout`. The spring **dock-to-top-left logo** behavior and **voice-driven** orb status on the main app are removed; layout chrome is now routing, reauth, and toasts only.
> 
> A new **`InitialOrb`** renders a fixed, centered orb on **login** and **onboarding** only, with status derived from agent phase (`error` vs `starting`) and theme-based colors—matching those pre-ready surfaces without affecting the shell.
> 
> On **`ShellPage`**, the greeting shifts from beside the old docked orb to **`left-20`** so it clears macOS window controls now that the top-left logo is gone.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4b43f23b92b142605072815b42c8e02bc0271d75. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Confines the orb to login and onboarding and removes the dock-to-logo animation. Simplifies `AppLayout` and updates the shell greeting to clear macOS window controls.

- **Refactors**
  - Added `InitialOrb` (centered; status from phase: `error` or `starting`) and render it on login and onboarding.
  - Removed docking animation and related state from `AppLayout`; dropped `motion/react` and unused theme/voice wiring.
  - Moved the shell greeting to `left-20` to clear macOS traffic lights now that the docked logo is gone.

<sup>Written for commit 4b43f23b92b142605072815b42c8e02bc0271d75. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kyh/inteligir/pull/332?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

