### PR TITLE
Redesign shell docks: vertical left dock + chat/voice bottom dock

### DIFF
--- a/apps/desktop/src/renderer/shell/bottom-dock.tsx
+++ b/apps/desktop/src/renderer/shell/bottom-dock.tsx
@@ -1,60 +1,18 @@
-import { useMemo } from "react";
 import { MicIcon, PhoneIcon } from "lucide-react";
 
 import { cn } from "@repo/ui/lib/utils";
-import { toast } from "@repo/ui/components/sonner";
-import { BUILTIN_WIDGET_UI } from "@/renderer/shell/builtin-widgets";
-import { getBridge } from "@/renderer/lib/bridge";
-import { useShellStore } from "@/renderer/stores/shell-store";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@repo/ui/components/tooltip";
+import { Composer } from "@/renderer/shell/chat/composer";
 import { useVoiceStore } from "@/renderer/stores/voice-store";
-import { BUILTIN_DEFS, CHAT_WIDGET_ID } from "@/shared/shell";
 
-// The dock is the launcher for built-in widgets only. Custom (JSON-UI) widgets
-// live in the Widgets panel — keeping the dock fixed-size avoids growing every
-// time the agent installs something.
-const CHAT_DEF = BUILTIN_DEFS.find((d) => d.id === CHAT_WIDGET_ID);
-const SECONDARY_BUILTINS = BUILTIN_DEFS.filter((d) => d.id !== CHAT_WIDGET_ID);
-
-type DockButtonProps = {
-  icon: React.ComponentType<{ className?: string }>;
-  label: string;
-  onClick: () => void;
-  active?: boolean;
-  disabled?: boolean;
-};
-
-function DockButton({ icon: Icon, label, onClick, active, disabled }: DockButtonProps) {
-  return (
-    <button
-      type="button"
-      onClick={onClick}
-      disabled={disabled}
-      title={label}
-      aria-label={label}
-      className={cn(
-        "flex size-9 items-center justify-center rounded-xl transition-colors",
-        disabled
-          ? "cursor-not-allowed text-muted-foreground/40"
-          : active
-            ? "bg-foreground/15 text-foreground"
-            : "text-muted-foreground hover:bg-foreground/10 hover:text-foreground",
-      )}
-    >
-      <Icon className="size-4" />
-    </button>
-  );
-}
-
-function launchWidget(widgetId: string): void {
-  // placeWidget rejects when the renderer flush of an existing singleton's
-  // pending state didn't persist — surface that to the user instead of
-  // letting it land as an unhandled promise rejection.
-  getBridge()
-    ?.placeWidget(widgetId)
-    .catch((err) => {
-      toast.error(err instanceof Error ? err.message : "Couldn't open the widget");
-    });
-}
+// The bottom dock is the always-available way to talk to the agent: the chat
+// composer (typed input) on the left, a voice mic toggle on the right. The
+// conversation history and other panels are launched from the LeftDock.
 
 export function BottomDock() {
   const voiceState = useVoiceStore((s) => s.state);
@@ -62,46 +20,37 @@ export function BottomDock() {
   const voiceActive = voiceState.kind === "listening" || voiceState.kind === "connecting";
   const voiceBusy = voiceState.kind === "downloading_model" || voiceState.kind === "connecting";
 
-  const instances = useShellStore((s) => s.instances);
-  const placedWidgetIds = useMemo(() => {
-    const ids = new Set<string>();
-    for (const i of instances) {
-      ids.add(i.widgetId);
-    }
-    return ids;
-  }, [instances]);
+  const MicGlyph = voiceActive ? PhoneIcon : MicIcon;
+  const voiceLabel = voiceActive ? "End call" : "Start call";
 
   return (
-    <div className="pointer-events-auto fixed bottom-4 left-1/2 z-30 -translate-x-1/2">
-      <div className="flex items-center gap-1 rounded-2xl border border-border bg-card/70 px-2 py-1.5 shadow-xl backdrop-blur-md">
-        {CHAT_DEF && (
-          <DockButton
-            icon={BUILTIN_WIDGET_UI[CHAT_DEF.id].icon}
-            label={CHAT_DEF.title}
-            active={placedWidgetIds.has(CHAT_DEF.id)}
-            onClick={() => launchWidget(CHAT_DEF.id)}
-          />
-        )}
-        <DockButton
-          icon={voiceActive ? PhoneIcon : MicIcon}
-          label={voiceActive ? "End call" : "Start call"}
-          onClick={toggleVoice}
-          disabled={voiceBusy}
-          active={voiceActive}
-        />
+    <div className="pointer-events-auto fixed bottom-4 left-1/2 z-30 w-full max-w-xl -translate-x-1/2 px-4">
+      <TooltipProvider>
+        <div className="flex items-end gap-1.5 rounded-2xl border border-border bg-card/70 p-1.5 shadow-xl backdrop-blur-md">
+          <div className="min-w-0 flex-1">
+            <Composer className="bg-transparent px-1 py-0 backdrop-blur-none" />
+          </div>
 
-        <span className="mx-1 h-5 w-px bg-border" />
-
-        {SECONDARY_BUILTINS.map((def) => (
-          <DockButton
-            key={def.id}
-            icon={BUILTIN_WIDGET_UI[def.id].icon}
-            label={def.title}
-            active={placedWidgetIds.has(def.id)}
-            onClick={() => launchWidget(def.id)}
-          />
-        ))}
-      </div>
+          <Tooltip>
+            <TooltipTrigger
+              onClick={toggleVoice}
+              disabled={voiceBusy}
+              aria-label={voiceLabel}
+              className={cn(
+                "mb-0.5 flex size-9 shrink-0 items-center justify-center rounded-xl transition-colors",
+                voiceBusy
+                  ? "cursor-not-allowed text-muted-foreground/40"
+                  : voiceActive
+                    ? "bg-foreground/15 text-foreground"
+                    : "text-muted-foreground hover:bg-foreground/10 hover:text-foreground",
+              )}
+            >
+              <MicGlyph className="size-4" />
+            </TooltipTrigger>
+            <TooltipContent side="top">{voiceLabel}</TooltipContent>
+          </Tooltip>
+        </div>
+      </TooltipProvider>
     </div>
   );
 }

--- a/apps/desktop/src/renderer/shell/builtin-widgets.tsx
+++ b/apps/desktop/src/renderer/shell/builtin-widgets.tsx
@@ -20,7 +20,6 @@ import {
 } from "@repo/ui/components/ai-elements/conversation";
 
 import { ChatActivityRow, ChatMessageView } from "@/renderer/shell/chat/chat-message";
-import { Composer } from "@/renderer/shell/chat/composer";
 import { ExtensionsPanel } from "@/renderer/shell/builtin/extensions-panel";
 import { SettingsPanel } from "@/renderer/shell/builtin/settings-panel";
 import { TaskPanel } from "@/renderer/shell/builtin/task-panel";
@@ -60,14 +59,12 @@ function ChatWidget() {
       </Conversation>
 
       {currentTranscript && (
-        <div className="px-3 pb-1">
+        <div className="px-3 pb-2">
           <p className="truncate text-xs italic text-muted-foreground">
             &ldquo;{currentTranscript}&hellip;&rdquo;
           </p>
         </div>
       )}
-
-      <Composer />
     </>
   );
 }

--- a/apps/desktop/src/renderer/shell/chat/composer.tsx
+++ b/apps/desktop/src/renderer/shell/chat/composer.tsx
@@ -79,7 +79,7 @@ function keyedMessages(prefix: string, messages: string[]): QueuedMessage[] {
   });
 }
 
-export function Composer() {
+export function Composer({ className }: { className?: string }) {
   const [hasInput, setHasInput] = useState(false);
   // UI-local signal that the user clicked the Zap button. Consumed once on
   // the next submit; cleared on agent_end so an unsubmitted Zap doesn't
@@ -168,7 +168,7 @@ export function Composer() {
   }, []);
 
   return (
-    <div ref={wrapperRef} className="bg-foreground/8 px-3 py-2 backdrop-blur-sm">
+    <div ref={wrapperRef} className={cn("bg-foreground/8 px-3 py-2 backdrop-blur-sm", className)}>
       {queueCount > 0 && (
         <Queue className="mb-2 rounded-md bg-foreground/5 px-1.5 pb-1 pt-1 shadow-none">
           <QueueList className="-mb-1 mt-0">

--- a/apps/desktop/src/renderer/shell/left-dock.tsx
+++ b/apps/desktop/src/renderer/shell/left-dock.tsx
@@ -1,0 +1,131 @@
+import { useMemo } from "react";
+
+import { cn } from "@repo/ui/lib/utils";
+import { toast } from "@repo/ui/components/sonner";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@repo/ui/components/tooltip";
+import { BUILTIN_WIDGET_UI } from "@/renderer/shell/builtin-widgets";
+import { getBridge } from "@/renderer/lib/bridge";
+import { useAgentStore } from "@/renderer/stores/agent-store";
+import { useShellStore } from "@/renderer/stores/shell-store";
+import { getSessionStatus, type SessionStatus } from "@/shared/agent";
+import { BUILTIN_DEFS } from "@/shared/shell";
+
+// The left dock is the vertical launcher for built-in widget panels. Chat
+// input and voice now live in the BottomDock; custom (JSON-UI) widgets live in
+// the Widgets panel — so this stays fixed-size no matter what's installed.
+
+// The orb is the first item: a status-only indicator (not a launcher). Its
+// gradient + label reflect the agent's current session status.
+const ORB_GRADIENT: Record<SessionStatus, string> = {
+  idle: "from-sky-300 to-blue-600",
+  busy: "from-amber-300 to-orange-500 animate-pulse",
+  error: "from-red-400 to-rose-600",
+  starting: "from-sky-200 to-blue-500 animate-pulse",
+};
+const ORB_LABEL: Record<SessionStatus, string> = {
+  idle: "Ready",
+  busy: "Working…",
+  error: "Needs attention",
+  starting: "Starting…",
+};
+
+function StatusOrb() {
+  const appState = useAgentStore((s) => s.appState);
+  const status = getSessionStatus(appState);
+  return (
+    <Tooltip>
+      <TooltipTrigger
+        // Status only — not interactive. Rendered as a div so it never reads
+        // as a button to the user or to assistive tech.
+        render={<div />}
+        aria-label={`Status: ${ORB_LABEL[status]}`}
+        className="flex size-9 items-center justify-center"
+      >
+        <span
+          className={cn(
+            "size-6 rounded-full bg-gradient-to-br shadow-inner",
+            "shadow-white/40 ring-1 ring-white/30",
+            ORB_GRADIENT[status],
+          )}
+        />
+      </TooltipTrigger>
+      <TooltipContent side="right">{ORB_LABEL[status]}</TooltipContent>
+    </Tooltip>
+  );
+}
+
+type DockButtonProps = {
+  icon: React.ComponentType<{ className?: string }>;
+  label: string;
+  onClick: () => void;
+  active?: boolean;
+};
+
+function DockButton({ icon: Icon, label, onClick, active }: DockButtonProps) {
+  return (
+    <Tooltip>
+      <TooltipTrigger
+        onClick={onClick}
+        aria-label={label}
+        className={cn(
+          "flex size-9 items-center justify-center rounded-xl transition-colors",
+          active
+            ? "bg-foreground/15 text-foreground"
+            : "text-muted-foreground hover:bg-foreground/10 hover:text-foreground",
+        )}
+      >
+        <Icon className="size-4" />
+      </TooltipTrigger>
+      <TooltipContent side="right">{label}</TooltipContent>
+    </Tooltip>
+  );
+}
+
+function launchWidget(widgetId: string): void {
+  // placeWidget rejects when the renderer flush of an existing singleton's
+  // pending state didn't persist — surface that to the user instead of
+  // letting it land as an unhandled promise rejection.
+  getBridge()
+    ?.placeWidget(widgetId)
+    .catch((err) => {
+      toast.error(err instanceof Error ? err.message : "Couldn't open the widget");
+    });
+}
+
+export function LeftDock() {
+  const instances = useShellStore((s) => s.instances);
+  const placedWidgetIds = useMemo(() => {
+    const ids = new Set<string>();
+    for (const i of instances) {
+      ids.add(i.widgetId);
+    }
+    return ids;
+  }, [instances]);
+
+  return (
+    <div className="pointer-events-auto fixed top-1/2 left-4 z-30 -translate-y-1/2">
+      <TooltipProvider>
+        <div className="flex flex-col items-center gap-1 rounded-2xl border border-border bg-card/70 px-1.5 py-2 shadow-xl backdrop-blur-md">
+          <StatusOrb />
+
+          <span className="my-1 h-px w-5 bg-border" />
+
+          {BUILTIN_DEFS.map((def) => (
+            <DockButton
+              key={def.id}
+              icon={BUILTIN_WIDGET_UI[def.id].icon}
+              label={def.title}
+              active={placedWidgetIds.has(def.id)}
+              onClick={() => launchWidget(def.id)}
+            />
+          ))}
+        </div>
+      </TooltipProvider>
+    </div>
+  );
+}

--- a/apps/desktop/src/renderer/shell/shell-page.tsx
+++ b/apps/desktop/src/renderer/shell/shell-page.tsx
@@ -1,6 +1,7 @@
 import { useEffect } from "react";
 
 import { BottomDock } from "@/renderer/shell/bottom-dock";
+import { LeftDock } from "@/renderer/shell/left-dock";
 import { PanelGrid } from "@/renderer/shell/panel-grid";
 import { useVoiceStore } from "@/renderer/stores/voice-store";
 
@@ -47,11 +48,12 @@ export function ShellPage() {
         <span className="text-xs text-muted-foreground">{todayLabel()}</span>
       </div>
 
-      {/* Widget workspace. */}
-      <div className="absolute inset-0 px-4 pt-14 pb-20">
+      {/* Widget workspace. Left padding clears the vertical LeftDock. */}
+      <div className="absolute inset-0 pt-14 pr-4 pb-24 pl-20">
         <PanelGrid />
       </div>
 
+      <LeftDock />
       <BottomDock />
     </div>
   );

--- a/apps/desktop/src/renderer/styles.css
+++ b/apps/desktop/src/renderer/styles.css
@@ -32,7 +32,8 @@ textarea,
   opacity: 0.1;
   border-radius: var(--radius-xl);
 }
+/* Panels stay resizable from their edges/corner, but we hide the default
+ * diagonal-arrow affordance for a cleaner desktop look. */
 .react-grid-item > .react-resizable-handle::after {
-  border-right-color: color-mix(in oklab, var(--foreground) 40%, transparent);
-  border-bottom-color: color-mix(in oklab, var(--foreground) 40%, transparent);
+  display: none;
 }


### PR DESCRIPTION
## What

Reworks the desktop shell chrome per the requested UI update:

1. **No resize arrows on pinned widgets** — dropped the diagonal arrow affordance on grid panels. Panels stay resizable from their edges/corner; only the visual indicator is gone (`styles.css`).
2. **Dock is now vertical, top-left** — built-in widget launchers moved into a new `LeftDock` (`left-dock.tsx`), anchored vertically on the left.
3. **Chat & voice split into a bottom dock** — `BottomDock` is now the always-available agent input: the chat composer + a voice mic toggle. The composer was removed from the chat panel so there's a single input.
4. **Status orb** — first item in the left dock is a status-only orb whose gradient/label reflect the agent session status (Ready / Working / etc.).
5. **Tooltips** — every left-dock item (and the mic) has a tooltip, shown to the right of the vertical dock.

## Decisions (confirmed with the requester)

- The orb is **status only** (non-interactive). The conversation history is reachable via the chat launcher in the left dock.
- The typed input lives in the **bottom dock only** — the chat panel shows history (no duplicate composer).

## Files

- `shell/left-dock.tsx` *(new)* — vertical launcher: status orb + built-in panels, with tooltips.
- `shell/bottom-dock.tsx` — composer + mic toggle.
- `shell/builtin-widgets.tsx` — chat panel no longer renders its own composer.
- `shell/chat/composer.tsx` — accepts a `className` so it can blend into the bottom dock.
- `shell/shell-page.tsx` — mounts `LeftDock`; workspace padding clears the dock.
- `styles.css` — hides the resize-handle arrow.

## Verification

- `pnpm --filter @repo/desktop typecheck`, `pnpm lint`, and `pnpm --filter @repo/desktop build` all pass.
- Drove the running Electron app (headless via Xvfb + CDP) and confirmed the new layout: vertical left dock with the orb on top, the bottom chat input + mic, the conversation panel with no inner composer, the removed panel resize arrow, and tooltips on hover.

https://claude.ai/code/session_01DZDE8BSR8eZmTy61gvUu6m

---
_Generated by [Claude Code](https://claude.ai/code/session_01DZDE8BSR8eZmTy61gvUu6m)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only shell layout and styling; no auth, data, or agent protocol changes.
> 
> **Overview**
> Reworks the desktop shell so **agent input is always at the bottom** and **built-in panels launch from a vertical strip on the left**.
> 
> **Bottom dock** is no longer a row of widget icons. It is a wide bar with the shared **`Composer`** (typed messages) and a voice mic toggle with tooltips. Widget launch and `placeWidget` logic were removed from here.
> 
> **New `LeftDock`** takes the former bottom-dock launcher behavior: a non-interactive **status orb** (gradient/label from session status) plus tooltips and buttons for all **`BUILTIN_DEFS`**, with active state when a panel is placed.
> 
> The **chat panel** drops its embedded composer so history is view-only; **`Composer`** gains an optional **`className`** for transparent styling in the bottom bar. **`ShellPage`** mounts **`LeftDock`** and adjusts workspace padding for the left rail and taller bottom chrome.
> 
> **`styles.css`** hides the react-grid-layout resize handle’s diagonal arrow while keeping edge/corner resize.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e7c8c57bc0c37c3c9c55f7c63570c5491562e51b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Redesigned the desktop shell: built-in widgets move to a vertical left dock with a status orb, and chat/voice input is unified in a bottom dock. Removed the diagonal resize handle for a cleaner look.

- **New Features**
  - `LeftDock`: vertical, top-left launcher with a non-interactive status orb that reflects session state; tooltips on all items; shows active panels.
  - `BottomDock`: single agent input with the chat `Composer` and a mic toggle; mic shows a phone icon when active and disables while busy; tooltip included.
  - Chat panel now shows history only; its composer was removed to avoid duplicate inputs; transcript hint remains.
  - Layout and polish: workspace padding updated to clear the left dock; diagonal resize affordance hidden; subtle card backdrop and shadow applied.
  - Small API/UX tweaks: `Composer` accepts `className` for embedding; widget launch failures surface via toast.

<sup>Written for commit e7c8c57bc0c37c3c9c55f7c63570c5491562e51b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kyh/inteligir/pull/333?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

