### PR TITLE
docs: add product context, fix stale root README

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,8 +8,6 @@ Turborepo monorepo with Next.js marketing site + shared packages.
 
 ## Product Context
 
-The name **inteligir** is Spanish for "to understand" (in-tel-ee-HEER).
-
 **What it is:** A consumer desktop AI operating system. The product is the
 Electron desktop app (`@repo/desktop`); the web app is just a marketing landing
 page. Pre-launch.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,6 +6,46 @@
 
 Turborepo monorepo with Next.js marketing site + shared packages.
 
+## Product Context
+
+The name **inteligir** is Spanish for "to understand" (in-tel-ee-HEER).
+
+**What it is:** A consumer desktop AI operating system. The product is the
+Electron desktop app (`@repo/desktop`); the web app is just a marketing landing
+page. Pre-launch.
+
+**Who it's for:** General consumers — not developers. The agent does real work
+on the user's own machine, so the UX has to hide the engineering.
+
+**What people do with it (flagship use cases):**
+
+- **Personal admin / inbox** — email, calendar, and docs via connected Google
+  Workspace; the agent reads, drafts, and schedules on the user's behalf.
+- **Voice assistant / Q&A** — voice-driven conversation as a primary loop, not
+  a bolt-on.
+- **Generative UI / widgets** — the agent builds custom widgets and dashboards
+  on the fly (see the JSON-UI widget system below).
+- **Computer automation** — touches the real filesystem/shell to organize files
+  and run tasks on the actual machine.
+
+**Core, deliberate value props** (these are positioning, not implementation
+accidents — preserve them when making changes):
+
+- **Local-first / privacy** — the agent and voice run on-device. No server, no
+  database, no audio or user data leaves the machine. (`@repo/server` is only a
+  thin WebSocket relay for mobile↔desktop pairing; it stores nothing.)
+- **Voice-first** — streaming local STT (NVIDIA Parakeet) + TTS (ElevenLabs).
+- **Mobile↔desktop remote** — pair a phone to drive the desktop agent remotely.
+- **Agentic OS shell** — the agent can build and arrange its own UI; the shell
+  is an OS over installed/placed widgets, not a fixed chat window.
+
+**Business model:** Bring-your-own OpenAI auth (handled on-device by pi); the app
+itself is free. We run no inference and carry no per-user model cost.
+
+**Provider note:** OpenAI is the *starting* provider, not a permanent
+commitment — multi-provider support is anticipated. Don't hard-code
+OpenAI-only assumptions into new abstractions where it's cheap to stay generic.
+
 ## Tech Stack
 
 - **Monorepo**: Turborepo + pnpm workspaces

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,9 +31,12 @@ on the user's own machine, so the UX has to hide the engineering.
 **Core, deliberate value props** (these are positioning, not implementation
 accidents — preserve them when making changes):
 
-- **Local-first / privacy** — the agent and voice run on-device. No server, no
-  database, no audio or user data leaves the machine. (`@repo/server` is only a
-  thin WebSocket relay for mobile↔desktop pairing; it stores nothing.)
+- **Local-first / privacy** — *today* the agent and voice run on-device. No
+  server, no database, no audio or user data leaves the machine. (`@repo/server`
+  is only a thin WebSocket relay for mobile↔desktop pairing; it stores nothing.)
+  Remote cloud execution is anticipated *later* as an option — local-first is
+  the current default and a positioning pillar, not a permanent constraint, so
+  don't hard-code "on-device only, forever" assumptions into new abstractions.
 - **Voice-first** — streaming local STT (NVIDIA Parakeet) + TTS (ElevenLabs).
 - **Mobile↔desktop remote** — pair a phone to drive the desktop agent remotely.
 - **Agentic OS shell** — the agent can build and arrange its own UI; the shell

--- a/README.md
+++ b/README.md
@@ -1,22 +1,34 @@
 # Inteligir
 
-> An artificially intelligent operating system.
+> An artificially intelligent operating system. (_inteligir_ — Spanish, "to understand")
 
-Turborepo monorepo. Desktop app (Electron + pi-coding-agent) plus a marketing/docs site.
+A consumer desktop AI OS. The **product is the Electron desktop app**: a
+local-first, voice-first agent that does real work on your machine — personal
+admin over connected apps (Google Workspace), Q&A, on-the-fly generative
+widgets, and filesystem/shell automation. The agent and voice run on-device;
+nothing leaves the machine. Bring your own OpenAI auth; the app is free.
+Pre-launch.
+
+Turborepo monorepo. Desktop app (Electron + pi-coding-agent) is the product;
+the web app is a marketing landing page.
 
 ## Layout
 
 ```
 apps/
-  desktop/         Electron app — see apps/desktop/README.md
-  web/             Next.js marketing + docs site
+  desktop/         Electron app — the product — see apps/desktop/README.md
+  web/             Next.js marketing landing page (static, no backend)
+  mobile/          Expo app — remote surface, pairs to desktop
+  server/          partyserver Worker — WS relay for mobile↔desktop (Cloudflare)
 packages/
   agent-runtime/   Filesystem + install primitives for the agent — see packages/agent-runtime/README.md
   pi-driver/       Wrapper around pi-coding-agent — stable surface for app code
-  api/             tRPC routers + auth (web)
-  db/              Drizzle schema + Supabase (web)
+  dispatch/        Shared mobile↔desktop message types
   ui/              Shared UI components (shadcn/ui base)
 ```
+
+There is **no server-side API or database** — auth is provider OAuth (OpenAI),
+handled on-device by pi.
 
 Architecture-level docs live next to the code:
 
@@ -33,14 +45,12 @@ Architecture-level docs live next to the code:
 pnpm dev              # All workspaces
 pnpm dev:web          # Web only
 pnpm dev:desktop      # Desktop only
+pnpm dev:server       # WS relay only
 pnpm build
 pnpm typecheck
 pnpm lint             # oxlint
 pnpm format           # oxfmt
 pnpm test
-
-# Database (web)
-pnpm db:start | db:stop | db:push | db:push-remote | db:reset
 ```
 
 ## Quality gates

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Inteligir
 
-> An artificially intelligent operating system. (_inteligir_ — Spanish, "to understand")
+> An artificially intelligent operating system.
 
 A consumer desktop AI OS. The **product is the Electron desktop app**: a
 local-first, voice-first agent that does real work on your machine — personal


### PR DESCRIPTION
## Why

Reviewed whether the repo docs carry enough **business/product context** (not just architecture) for an agent to know what Inteligir is. Finding: the docs are strong on the *how* (architecture, IPC, state machine, widget kernel) but had **zero product/market context**, and the root README had drifted out of sync with the actual repo.

## What changed

**`CLAUDE.md` — new Product Context section.** Captures answers gathered from the owner:
- Name meaning (Spanish, "to understand")
- Audience: general consumers (not developers); pre-launch
- Flagship use cases: personal admin/inbox, voice Q&A, generative UI/widgets, computer automation
- Core value props: local-first/privacy, voice-first, mobile↔desktop remote, agentic OS shell
- Business model: BYO OpenAI auth, app is free, no inference cost to us
- Provider stance: OpenAI is the *starting* provider, not a permanent lock-in

**`README.md` — corrected stale/contradictory content:**
- Removed `packages/api/` (tRPC) and `packages/db/` (Drizzle + Supabase) — **neither exists** in the repo
- Added the real `mobile` (Expo) and `server` (partyserver/Cloudflare) apps and the `dispatch` package
- Fixed web description: "marketing + docs site" → static marketing landing page (no backend)
- Removed stale `db:*` commands (no such scripts), added `dev:server`
- Added a short product blurb + the "no server-side API or database" clarification, aligning the README with CLAUDE.md/AGENTS.md

## Notes

Docs-only; no code touched. The README's package list previously contradicted CLAUDE.md's "no backend, no server-side API or database" statement — this resolves that contradiction in favor of the actual repo state.

https://claude.ai/code/session_01ScMXsBRx9UqArMtBMV7KNW

---
_Generated by [Claude Code](https://claude.ai/code/session_01ScMXsBRx9UqArMtBMV7KNW)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes with no runtime or security impact.
> 
> **Overview**
> Adds **product and market context** to `CLAUDE.md` so agents know what Inteligir is: consumer desktop OS (Electron is the product), flagship use cases, local-first/voice-first value props, BYO OpenAI business model, and guidance not to hard-code permanent on-device-only or OpenAI-only assumptions.
> 
> **Aligns the root `README.md` with the real repo:** replaces stale references to nonexistent `packages/api` / `packages/db` and web “docs + backend” with `mobile`, `server`, `dispatch`, a static marketing web app, and explicit “no server-side API or database.” Updates the monorepo blurb and commands (`pnpm dev:server`, removes `db:*` scripts).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit de142d8845291520c8468ab4cda4a33dc8a38fb1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds product/market context to `CLAUDE.md` and updates the root `README.md` to match the local‑first architecture and current monorepo layout. Clarifies local‑first is the default while planning optional remote/cloud execution later; restores the original plain tagline.

- **Refactors**
  - `CLAUDE.md`: Added Product Context (audience, flagship use cases, value props, BYO OpenAI, provider stance). Noted local‑first default with optional remote/cloud later; avoid hard‑coding on‑device‑only or OpenAI‑only assumptions. Removed the name‑meaning line per review.
  - `README.md`: Reverted tagline; aligned layout with reality (added `apps/mobile`, `apps/server`, `packages/dispatch`; removed `packages/api` and `packages/db`). Clarified web is a static marketing page and there’s no server‑side API or database; added `pnpm dev:server`; removed stale `db:*` scripts.

<sup>Written for commit de142d8845291520c8468ab4cda4a33dc8a38fb1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kyh/inteligir/pull/340?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

