### PR TITLE
Add long-term memory via self-hosted supermemory server

### DIFF
--- a/apps/desktop/resources/agent/AGENTS.md
+++ b/apps/desktop/resources/agent/AGENTS.md
@@ -31,6 +31,7 @@ You have raw system tools (`bash`, `read`, `edit`, `write`) on the user's machin
 - `peekaboo` — native macOS apps.
 - `manage_ui` — installing/placing widgets in the user's UI.
 - `manage_tasks` — scheduled/background work.
+- `memory` — long-term memory across conversations (remember, recall, forget).
 
 Reach for raw bash/read/edit/write only when no curated surface fits: files the user pointed you at, local glue work (unzip, convert, move), or inspecting output another tool produced.
 
@@ -39,6 +40,17 @@ Rules for raw system access:
 - No destructive operations — deleting/overwriting user files, killing processes, anything with `sudo` — without asking first.
 - Keep scratch files and downloads inside your workspace (`~/.inteligir/workspace`); don't scatter temp files around the user's system.
 - Don't install software or change system settings unless the user asked.
+
+## Memory
+
+You have long-term memory across conversations via the `memory` tool. Use it like a good chief of staff uses a notebook — quietly and constantly.
+
+- When the user tells you something durable — a preference, a decision, a project, a person — store it right away with `add`. One concise fact per call. Don't ask permission to remember.
+- Before answering anything that leans on prior context ("what was that place I liked?"), `search` first instead of guessing.
+- Each conversation starts with a distilled profile of what you already know about the user. Trust it for orientation; `search` for specifics.
+- Never store secrets, passwords, API keys, or one-off trivia. Memory is for facts that are still true next week.
+- When the user says "forget that", use `forget` — immediately, no debate.
+- If memory is unavailable (the local server isn't running), carry on without it. Bring up setup only if the user asks about memory.
 
 ## Tool scoping: web vs native apps
 

--- a/apps/desktop/src/__tests__/memory-extension.test.ts
+++ b/apps/desktop/src/__tests__/memory-extension.test.ts
@@ -135,6 +135,18 @@ describe("createProfileCache", () => {
     expect(await cache.get()).toBeNull();
   });
 
+  it("keeps the last good profile through a transient server error", async () => {
+    profile.mockResolvedValue({ static: ["a"], dynamic: [] });
+    const cache = createProfileCache({ profile });
+    expect(await cache.get()).toEqual({ static: ["a"], dynamic: [] });
+
+    // Reachable server, failed request (e.g. HTTP 500) — durable facts
+    // don't expire because one request failed.
+    profile.mockRejectedValue(new Error("supermemory POST /v4/profile failed (500): boom"));
+    await cache.refresh();
+    expect(await cache.get()).toEqual({ static: ["a"], dynamic: [] });
+  });
+
   it("returns null without throwing when the server is down", async () => {
     profile.mockRejectedValue(
       new MemoryUnavailableError("http://localhost:6767", new TypeError("fetch failed")),

--- a/apps/desktop/src/__tests__/memory-extension.test.ts
+++ b/apps/desktop/src/__tests__/memory-extension.test.ts
@@ -128,6 +128,22 @@ describe("createProfileCache", () => {
     const cache = createProfileCache({ profile }, 50);
     expect(await cache.get()).toBeNull();
   });
+
+  it("pays the cold-start wait only until the first attempt settles", async () => {
+    // First attempt fails fast (server down), every later attempt hangs —
+    // worst case for blocking. Reads after the first settled attempt must
+    // return immediately instead of racing firstLoadWaitMs again.
+    profile.mockRejectedValueOnce(
+      new MemoryUnavailableError("http://localhost:6767", new TypeError("fetch failed")),
+    );
+    const cache = createProfileCache({ profile }, 500);
+    expect(await cache.get()).toBeNull();
+
+    profile.mockImplementation(() => new Promise<never>(() => {}));
+    const start = Date.now();
+    expect(await cache.get()).toBeNull();
+    expect(Date.now() - start).toBeLessThan(400);
+  });
 });
 
 describe("resolveMemoryConfig", () => {

--- a/apps/desktop/src/__tests__/memory-extension.test.ts
+++ b/apps/desktop/src/__tests__/memory-extension.test.ts
@@ -1,0 +1,146 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+
+import {
+  buildMemoryTool,
+  createProfileCache,
+  type MemoryToolClient,
+} from "@/agent/memory/extension";
+import { validateToolParametersSchema } from "@/agent/extension";
+import { MemoryUnavailableError, resolveMemoryConfig } from "@/agent/memory/client";
+
+// The tool receives the client as a method surface (MemoryToolClient), so the
+// test injects fakes directly instead of intercepting fetch.
+const add = vi.fn<MemoryToolClient["add"]>();
+const search = vi.fn<MemoryToolClient["search"]>();
+const profile = vi.fn<MemoryToolClient["profile"]>();
+const list = vi.fn<MemoryToolClient["list"]>();
+const forget = vi.fn<MemoryToolClient["forget"]>();
+
+const memoryTool = buildMemoryTool({ add, search, profile, list, forget });
+
+function textOf(result: { content: [{ type: "text"; text: string }] }): string {
+  return result.content[0].text;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("memory parameters schema", () => {
+  it("passes provider root-shape validation (type: object, no root anyOf)", () => {
+    expect(() => validateToolParametersSchema(memoryTool, "memory")).not.toThrow();
+  });
+});
+
+describe("memory tool execute", () => {
+  it("add stores content under the agent source tag", async () => {
+    add.mockResolvedValue({ id: "doc-1", status: "queued" });
+    const result = await memoryTool.execute("t1", { action: "add", content: "User likes tea" });
+    expect(add).toHaveBeenCalledWith("User likes tea", { source: "agent" });
+    expect(textOf(result)).toBe("Stored memory doc-1 (status: queued).");
+  });
+
+  it("add without content is a self-correcting error", async () => {
+    const result = await memoryTool.execute("t1", { action: "add" });
+    expect(add).not.toHaveBeenCalled();
+    expect(textOf(result)).toContain("'content' is required");
+  });
+
+  it("search renders memory and chunk hits with scores", async () => {
+    search.mockResolvedValue({
+      results: [
+        { id: "m1", memory: "User likes tea", similarity: 0.91 },
+        { id: "c1", chunk: "tea > coffee", similarity: 0.5 },
+      ],
+      total: 2,
+    });
+    const result = await memoryTool.execute("t1", { action: "search", query: "drinks" });
+    expect(search).toHaveBeenCalledWith("drinks", 10);
+    expect(textOf(result)).toContain("[0.91] User likes tea (m1)");
+    expect(textOf(result)).toContain("[0.50] tea > coffee (c1)");
+  });
+
+  it("search with no hits says so", async () => {
+    search.mockResolvedValue({ results: [], total: 0 });
+    const result = await memoryTool.execute("t1", { action: "search", query: "nothing" });
+    expect(textOf(result)).toBe('No memories matched "nothing".');
+  });
+
+  it("profile formats static and dynamic sections", async () => {
+    profile.mockResolvedValue({ static: ["Lives in SF"], dynamic: ["Planning a trip"] });
+    const result = await memoryTool.execute("t1", { action: "profile" });
+    expect(textOf(result)).toBe(
+      "Stable facts:\n- Lives in SF\n\nRecent context:\n- Planning a trip",
+    );
+  });
+
+  it("forget requires an id or content description", async () => {
+    const result = await memoryTool.execute("t1", { action: "forget" });
+    expect(forget).not.toHaveBeenCalled();
+    expect(textOf(result)).toContain("'memoryId' or a 'content' description");
+  });
+
+  it("forget passes through id and reason", async () => {
+    forget.mockResolvedValue({ id: "m1", forgotten: true });
+    const result = await memoryTool.execute("t1", {
+      action: "forget",
+      memoryId: "m1",
+      reason: "user asked",
+    });
+    expect(forget).toHaveBeenCalledWith({ id: "m1", reason: "user asked" });
+    expect(textOf(result)).toBe("Forgot memory m1.");
+  });
+
+  it("an unreachable server turns into setup guidance, not a stack trace", async () => {
+    search.mockRejectedValue(
+      new MemoryUnavailableError("http://localhost:6767", new TypeError("fetch failed")),
+    );
+    const result = await memoryTool.execute("t1", { action: "search", query: "x" });
+    expect(textOf(result)).toContain("npx supermemory local");
+    expect(textOf(result)).toContain("Continue without memory");
+  });
+
+  it("other server errors are reported as tool errors", async () => {
+    list.mockRejectedValue(new Error("boom"));
+    const result = await memoryTool.execute("t1", { action: "list" });
+    expect(textOf(result)).toBe("memory error: boom");
+  });
+});
+
+describe("createProfileCache", () => {
+  it("waits for the first load, then serves cached and refreshes in background", async () => {
+    profile.mockResolvedValue({ static: ["a"], dynamic: [] });
+    const cache = createProfileCache({ profile });
+
+    expect(await cache.get()).toEqual({ static: ["a"], dynamic: [] });
+    expect(profile).toHaveBeenCalledTimes(1);
+
+    // Second read returns the cache immediately and schedules a refresh.
+    profile.mockResolvedValue({ static: ["a", "b"], dynamic: [] });
+    expect(await cache.get()).toEqual({ static: ["a"], dynamic: [] });
+    expect(profile).toHaveBeenCalledTimes(2);
+  });
+
+  it("returns null without throwing when the server is down", async () => {
+    profile.mockRejectedValue(
+      new MemoryUnavailableError("http://localhost:6767", new TypeError("fetch failed")),
+    );
+    const cache = createProfileCache({ profile }, 50);
+    expect(await cache.get()).toBeNull();
+  });
+});
+
+describe("resolveMemoryConfig", () => {
+  it("defaults to the local server with no key", () => {
+    expect(resolveMemoryConfig({})).toEqual({ baseUrl: "http://localhost:6767" });
+  });
+
+  it("honors SUPERMEMORY_BASE_URL (trailing slash stripped) and SUPERMEMORY_API_KEY", () => {
+    expect(
+      resolveMemoryConfig({
+        SUPERMEMORY_BASE_URL: "http://10.0.0.5:6767/",
+        SUPERMEMORY_API_KEY: "sm_test",
+      }),
+    ).toEqual({ baseUrl: "http://10.0.0.5:6767", apiKey: "sm_test" });
+  });
+});

--- a/apps/desktop/src/__tests__/memory-extension.test.ts
+++ b/apps/desktop/src/__tests__/memory-extension.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi, beforeEach } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import {
   buildMemoryTool,
@@ -6,7 +6,7 @@ import {
   type MemoryToolClient,
 } from "@/agent/memory/extension";
 import { validateToolParametersSchema } from "@/agent/extension";
-import { MemoryUnavailableError, resolveMemoryConfig } from "@/agent/memory/client";
+import { MemoryClient, MemoryUnavailableError, resolveMemoryConfig } from "@/agent/memory/client";
 
 // The tool receives the client as a method surface (MemoryToolClient), so the
 // test injects fakes directly instead of intercepting fetch.
@@ -169,6 +169,38 @@ describe("createProfileCache", () => {
     const second = Date.now();
     expect(await cache.get()).toBeNull();
     expect(Date.now() - second).toBeLessThan(400);
+  });
+});
+
+describe("MemoryClient error classification", () => {
+  const client = new MemoryClient({ baseUrl: "http://localhost:6767" });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("connection failure becomes MemoryUnavailableError", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(() => Promise.reject(new TypeError("fetch failed"))),
+    );
+    await expect(client.profile()).rejects.toBeInstanceOf(MemoryUnavailableError);
+  });
+
+  it("timeout from a reachable-but-slow server is a plain error, not unavailability", async () => {
+    const timeout = new Error("The operation was aborted due to timeout");
+    timeout.name = "TimeoutError";
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(() => Promise.reject(timeout)),
+    );
+    const err: unknown = await client.profile().then(
+      () => null,
+      (e: unknown) => e,
+    );
+    expect(err).toBeInstanceOf(Error);
+    expect(err).not.toBeInstanceOf(MemoryUnavailableError);
+    if (err instanceof Error) expect(err.message).toMatch(/timed out after/);
   });
 });
 

--- a/apps/desktop/src/__tests__/memory-extension.test.ts
+++ b/apps/desktop/src/__tests__/memory-extension.test.ts
@@ -121,6 +121,20 @@ describe("createProfileCache", () => {
     expect(profile).toHaveBeenCalledTimes(2);
   });
 
+  it("drops the cached profile when the server goes down", async () => {
+    profile.mockResolvedValue({ static: ["a"], dynamic: [] });
+    const cache = createProfileCache({ profile });
+    expect(await cache.get()).toEqual({ static: ["a"], dynamic: [] });
+
+    // Server goes away — the next settled refresh must clear the snapshot
+    // so priming goes silent instead of replaying stale facts.
+    profile.mockRejectedValue(
+      new MemoryUnavailableError("http://localhost:6767", new TypeError("fetch failed")),
+    );
+    await cache.refresh();
+    expect(await cache.get()).toBeNull();
+  });
+
   it("returns null without throwing when the server is down", async () => {
     profile.mockRejectedValue(
       new MemoryUnavailableError("http://localhost:6767", new TypeError("fetch failed")),

--- a/apps/desktop/src/__tests__/memory-extension.test.ts
+++ b/apps/desktop/src/__tests__/memory-extension.test.ts
@@ -129,20 +129,20 @@ describe("createProfileCache", () => {
     expect(await cache.get()).toBeNull();
   });
 
-  it("pays the cold-start wait only until the first attempt settles", async () => {
-    // First attempt fails fast (server down), every later attempt hangs —
-    // worst case for blocking. Reads after the first settled attempt must
-    // return immediately instead of racing firstLoadWaitMs again.
-    profile.mockRejectedValueOnce(
-      new MemoryUnavailableError("http://localhost:6767", new TypeError("fetch failed")),
-    );
-    const cache = createProfileCache({ profile }, 500);
-    expect(await cache.get()).toBeNull();
-
+  it("spends the cold-start wait once, even while the first request hangs", async () => {
+    // Every profile call hangs (slow/unreachable host) — worst case for
+    // blocking. Only the first read may pay firstLoadWaitMs; later reads
+    // must return immediately even though the first request never settled.
     profile.mockImplementation(() => new Promise<never>(() => {}));
-    const start = Date.now();
+    const cache = createProfileCache({ profile }, 500);
+
+    const first = Date.now();
     expect(await cache.get()).toBeNull();
-    expect(Date.now() - start).toBeLessThan(400);
+    expect(Date.now() - first).toBeGreaterThanOrEqual(450);
+
+    const second = Date.now();
+    expect(await cache.get()).toBeNull();
+    expect(Date.now() - second).toBeLessThan(400);
   });
 });
 

--- a/apps/desktop/src/__tests__/memory-extension.test.ts
+++ b/apps/desktop/src/__tests__/memory-extension.test.ts
@@ -60,6 +60,19 @@ describe("memory tool execute", () => {
     expect(textOf(result)).toContain("[0.50] tea > coffee (c1)");
   });
 
+  it("clamps malformed limits before they reach the server", async () => {
+    search.mockResolvedValue({ results: [], total: 0 });
+    await memoryTool.execute("t1", { action: "search", query: "x", limit: 1e9 });
+    expect(search).toHaveBeenLastCalledWith("x", 100);
+    await memoryTool.execute("t1", { action: "search", query: "x", limit: -3 });
+    expect(search).toHaveBeenLastCalledWith("x", 1);
+    await memoryTool.execute("t1", { action: "search", query: "x", limit: 2.9 });
+    expect(search).toHaveBeenLastCalledWith("x", 2);
+    list.mockResolvedValue([]);
+    await memoryTool.execute("t1", { action: "list", limit: Number.NaN });
+    expect(list).toHaveBeenLastCalledWith(20);
+  });
+
   it("search with no hits says so", async () => {
     search.mockResolvedValue({ results: [], total: 0 });
     const result = await memoryTool.execute("t1", { action: "search", query: "nothing" });
@@ -98,6 +111,15 @@ describe("memory tool execute", () => {
     const result = await memoryTool.execute("t1", { action: "search", query: "x" });
     expect(textOf(result)).toContain("npx supermemory local");
     expect(textOf(result)).toContain("Continue without memory");
+  });
+
+  it("a custom-configured server gets check-the-URL guidance, not local setup", async () => {
+    search.mockRejectedValue(
+      new MemoryUnavailableError("http://10.0.0.5:6767", new TypeError("fetch failed")),
+    );
+    const result = await memoryTool.execute("t1", { action: "search", query: "x" });
+    expect(textOf(result)).toContain("SUPERMEMORY_BASE_URL");
+    expect(textOf(result)).not.toContain("npx supermemory local");
   });
 
   it("other server errors are reported as tool errors", async () => {
@@ -177,6 +199,14 @@ describe("MemoryClient error classification", () => {
 
   afterEach(() => {
     vi.unstubAllGlobals();
+  });
+
+  it("add fails loudly when the server confirms no document id", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(() => Promise.resolve(new Response("{}", { status: 200 }))),
+    );
+    await expect(client.add("fact")).rejects.toThrow(/no document id/);
   });
 
   it("connection failure becomes MemoryUnavailableError", async () => {

--- a/apps/desktop/src/agent/memory/client.ts
+++ b/apps/desktop/src/agent/memory/client.ts
@@ -194,9 +194,16 @@ export class MemoryClient {
         signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
       });
     } catch (err) {
-      // fetch rejects with TypeError on connection refusal and DOMException
-      // on timeout — both mean "no usable server", which callers translate
-      // into setup guidance.
+      // Only connection failures (fetch rejects with TypeError) mean "no
+      // usable server" — callers translate those into setup guidance and
+      // cleared recall priming. A timeout from a reachable-but-slow server
+      // is a plain error: the last good profile stays cached and the tool
+      // reports the timeout instead of telling the user to install it.
+      if (err instanceof Error && err.name === "TimeoutError") {
+        throw new Error(`supermemory ${method} ${path} timed out after ${REQUEST_TIMEOUT_MS}ms`, {
+          cause: err,
+        });
+      }
       throw new MemoryUnavailableError(this.config.baseUrl, err);
     }
     if (!response.ok) {

--- a/apps/desktop/src/agent/memory/client.ts
+++ b/apps/desktop/src/agent/memory/client.ts
@@ -1,0 +1,209 @@
+/**
+ * Minimal HTTP client for a self-hosted supermemory server
+ * (https://supermemory.ai/docs/self-hosting/overview). The server runs
+ * locally (`npx supermemory local`, default http://localhost:6767) and
+ * exposes the hosted Memory API; localhost requests are auto-authenticated
+ * so no key exchange is needed for the default setup.
+ *
+ * Deliberately fetch-based instead of the `supermemory` SDK — we use five
+ * endpoints with fixed shapes, and a dependency-free client keeps the
+ * experiment easy to rip out or swap for the hosted platform later.
+ * Responses are narrowed field-by-field (never cast): the server is an
+ * external process and its payloads are untrusted input.
+ */
+
+import { isRecord } from "@/shared/ipc";
+
+const DEFAULT_BASE_URL = "http://localhost:6767";
+const REQUEST_TIMEOUT_MS = 15_000;
+
+/** All inteligir memories live under one container tag so a future hosted
+ *  (multi-tenant) deployment can scope them per user/device. */
+const MEMORY_CONTAINER_TAG = "inteligir";
+
+export type MemoryClientConfig = {
+  baseUrl: string;
+  /** Optional bearer key — unnecessary for localhost (auto-authenticated),
+   *  required when pointing at a remote/hosted instance. */
+  apiKey?: string;
+};
+
+export function resolveMemoryConfig(env: NodeJS.ProcessEnv = process.env): MemoryClientConfig {
+  const apiKey = env["SUPERMEMORY_API_KEY"];
+  return {
+    baseUrl: (env["SUPERMEMORY_BASE_URL"] ?? DEFAULT_BASE_URL).replace(/\/+$/, ""),
+    ...(apiKey !== undefined ? { apiKey } : {}),
+  };
+}
+
+/** The server isn't reachable (not installed / not running). Callers turn
+ *  this into guidance rather than a stack trace. */
+export class MemoryUnavailableError extends Error {
+  constructor(baseUrl: string, cause: unknown) {
+    super(`supermemory server not reachable at ${baseUrl}`, { cause });
+    this.name = "MemoryUnavailableError";
+  }
+}
+
+// Response shapes, pruned to the fields we render. Verified against the
+// supermemory SDK (v4.24) type definitions for /v3/documents, /v4/search,
+// /v4/profile, /v4/memories.
+export type MemoryAddResult = { id: string; status: string };
+
+type MemorySearchHit = {
+  id: string;
+  /** Present for memory results. */
+  memory?: string | undefined;
+  /** Present for chunk results from hybrid/document search. */
+  chunk?: string | undefined;
+  similarity: number;
+};
+
+export type MemorySearchResult = { results: MemorySearchHit[]; total: number };
+
+export type MemoryProfile = { static: string[]; dynamic: string[] };
+
+export type MemoryForgetResult = { id: string; forgotten: boolean };
+
+export type MemoryDocument = {
+  id: string;
+  title?: string | undefined;
+  summary?: string | undefined;
+  status?: string | undefined;
+};
+
+// ---------------------------------------------------------------------------
+// Field narrowing — payloads come from an external process, so every read
+// goes through a typeof check instead of a cast.
+// ---------------------------------------------------------------------------
+
+function asString(value: unknown): string | undefined {
+  return typeof value === "string" ? value : undefined;
+}
+
+function asStringArray(value: unknown): string[] {
+  return Array.isArray(value)
+    ? value.filter((item): item is string => typeof item === "string")
+    : [];
+}
+
+function asRecordArray(value: unknown): Record<string, unknown>[] {
+  return Array.isArray(value) ? value.filter(isRecord) : [];
+}
+
+export class MemoryClient {
+  constructor(private readonly config: MemoryClientConfig) {}
+
+  get baseUrl(): string {
+    return this.config.baseUrl;
+  }
+
+  /** Store one memory. The server extracts/indexes asynchronously. */
+  async add(content: string, metadata?: Record<string, string>): Promise<MemoryAddResult> {
+    const raw = await this.request("POST", "/v3/documents", {
+      content,
+      containerTag: MEMORY_CONTAINER_TAG,
+      ...(metadata ? { metadata } : {}),
+    });
+    return {
+      id: asString(raw["id"]) ?? "(unknown)",
+      status: asString(raw["status"]) ?? "queued",
+    };
+  }
+
+  /** Low-latency conversational memory search. */
+  async search(query: string, limit = 10): Promise<MemorySearchResult> {
+    const raw = await this.request("POST", "/v4/search", {
+      q: query,
+      containerTag: MEMORY_CONTAINER_TAG,
+      limit,
+    });
+    const results = asRecordArray(raw["results"]).map(
+      (hit): MemorySearchHit => ({
+        id: asString(hit["id"]) ?? "(unknown)",
+        memory: asString(hit["memory"]),
+        chunk: asString(hit["chunk"]),
+        similarity: typeof hit["similarity"] === "number" ? hit["similarity"] : 0,
+      }),
+    );
+    return {
+      results,
+      total: typeof raw["total"] === "number" ? raw["total"] : results.length,
+    };
+  }
+
+  /** Static + dynamic user profile distilled from stored memories. */
+  async profile(): Promise<MemoryProfile> {
+    const raw = await this.request("POST", "/v4/profile", {
+      containerTag: MEMORY_CONTAINER_TAG,
+    });
+    const profile = isRecord(raw["profile"]) ? raw["profile"] : {};
+    return {
+      static: asStringArray(profile["static"]),
+      dynamic: asStringArray(profile["dynamic"]),
+    };
+  }
+
+  /** Forget by memory id, or by free-text description of what to forget. */
+  async forget(target: {
+    id?: string;
+    content?: string;
+    reason?: string;
+  }): Promise<MemoryForgetResult> {
+    const raw = await this.request("DELETE", "/v4/memories", {
+      containerTag: MEMORY_CONTAINER_TAG,
+      ...target,
+    });
+    return {
+      id: asString(raw["id"]) ?? "(unknown)",
+      forgotten: raw["forgotten"] === true,
+    };
+  }
+
+  /** Recently stored documents (raw inputs, not extracted memories). */
+  async list(limit = 20): Promise<MemoryDocument[]> {
+    const raw = await this.request("POST", "/v3/documents/list", {
+      containerTags: [MEMORY_CONTAINER_TAG],
+      limit,
+      order: "desc",
+    });
+    return asRecordArray(raw["memories"]).map(
+      (doc): MemoryDocument => ({
+        id: asString(doc["id"]) ?? "(unknown)",
+        title: asString(doc["title"]),
+        summary: asString(doc["summary"]),
+        status: asString(doc["status"]),
+      }),
+    );
+  }
+
+  private async request(
+    method: "POST" | "DELETE",
+    path: string,
+    body: Record<string, unknown>,
+  ): Promise<Record<string, unknown>> {
+    let response: Response;
+    try {
+      response = await fetch(`${this.config.baseUrl}${path}`, {
+        method,
+        headers: {
+          "content-type": "application/json",
+          ...(this.config.apiKey ? { authorization: `Bearer ${this.config.apiKey}` } : {}),
+        },
+        body: JSON.stringify(body),
+        signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
+      });
+    } catch (err) {
+      // fetch rejects with TypeError on connection refusal and DOMException
+      // on timeout — both mean "no usable server", which callers translate
+      // into setup guidance.
+      throw new MemoryUnavailableError(this.config.baseUrl, err);
+    }
+    if (!response.ok) {
+      const detail = (await response.text().catch(() => "")).slice(0, 300);
+      throw new Error(`supermemory ${method} ${path} failed (${response.status}): ${detail}`);
+    }
+    const parsed: unknown = await response.json();
+    return isRecord(parsed) ? parsed : {};
+  }
+}

--- a/apps/desktop/src/agent/memory/client.ts
+++ b/apps/desktop/src/agent/memory/client.ts
@@ -14,7 +14,7 @@
 
 import { isRecord } from "@/shared/ipc";
 
-const DEFAULT_BASE_URL = "http://localhost:6767";
+export const DEFAULT_MEMORY_BASE_URL = "http://localhost:6767";
 const REQUEST_TIMEOUT_MS = 15_000;
 
 /** All inteligir memories live under one container tag so a future hosted
@@ -31,7 +31,7 @@ export type MemoryClientConfig = {
 export function resolveMemoryConfig(env: NodeJS.ProcessEnv = process.env): MemoryClientConfig {
   const apiKey = env["SUPERMEMORY_API_KEY"];
   return {
-    baseUrl: (env["SUPERMEMORY_BASE_URL"] ?? DEFAULT_BASE_URL).replace(/\/+$/, ""),
+    baseUrl: (env["SUPERMEMORY_BASE_URL"] ?? DEFAULT_MEMORY_BASE_URL).replace(/\/+$/, ""),
     ...(apiKey !== undefined ? { apiKey } : {}),
   };
 }
@@ -39,7 +39,10 @@ export function resolveMemoryConfig(env: NodeJS.ProcessEnv = process.env): Memor
 /** The server isn't reachable (not installed / not running). Callers turn
  *  this into guidance rather than a stack trace. */
 export class MemoryUnavailableError extends Error {
-  constructor(baseUrl: string, cause: unknown) {
+  constructor(
+    readonly baseUrl: string,
+    cause: unknown,
+  ) {
     super(`supermemory server not reachable at ${baseUrl}`, { cause });
     this.name = "MemoryUnavailableError";
   }
@@ -105,8 +108,14 @@ export class MemoryClient {
       containerTag: MEMORY_CONTAINER_TAG,
       ...(metadata ? { metadata } : {}),
     });
+    const id = asString(raw["id"]);
+    if (id === undefined) {
+      // A 2xx without a document id means the write can't be confirmed —
+      // fail loudly instead of fabricating a success the agent would relay.
+      throw new Error("supermemory POST /v3/documents returned no document id");
+    }
     return {
-      id: asString(raw["id"]) ?? "(unknown)",
+      id,
       status: asString(raw["status"]) ?? "queued",
     };
   }

--- a/apps/desktop/src/agent/memory/extension.ts
+++ b/apps/desktop/src/agent/memory/extension.ts
@@ -183,10 +183,12 @@ export function createProfileCache(client: Pick<MemoryClient, "profile">, firstL
     inflight ??= (async () => {
       try {
         cached = await client.profile();
-      } catch {
-        // Server down or not set up — drop any previous snapshot so priming
-        // goes silent, consistent with the tool reporting unavailability.
-        cached = null;
+      } catch (err) {
+        // Server gone — drop any previous snapshot so priming goes silent,
+        // consistent with the tool reporting unavailability. A transient
+        // error from a reachable server keeps the last good profile;
+        // durable facts don't expire because one request failed.
+        if (err instanceof MemoryUnavailableError) cached = null;
       } finally {
         inflight = null;
       }

--- a/apps/desktop/src/agent/memory/extension.ts
+++ b/apps/desktop/src/agent/memory/extension.ts
@@ -167,6 +167,12 @@ export function buildMemoryTool(client: MemoryToolClient) {
  * spent exactly once, by the first read — a brand-new session still gets
  * primed when the server is warm, while a down, hung, or slow server costs
  * at most one firstLoadWaitMs ever, never one per turn.
+ *
+ * Deliberate tradeoff: because reads never wait after cold start, the
+ * snapshot can be one turn stale around server state changes (e.g. the
+ * turn where the server just died still primes from the last good
+ * profile). That's fine — the profile holds durable user facts, not
+ * availability state — and the alternative is blocking every turn on HTTP.
  */
 export function createProfileCache(client: Pick<MemoryClient, "profile">, firstLoadWaitMs = 1_500) {
   let cached: MemoryProfile | null = null;

--- a/apps/desktop/src/agent/memory/extension.ts
+++ b/apps/desktop/src/agent/memory/extension.ts
@@ -163,15 +163,14 @@ export function buildMemoryTool(client: MemoryToolClient) {
 /**
  * Cached profile for recall priming. before_agent_start must not stall the
  * turn on a cold HTTP call, so reads come from the last completed refresh
- * and every read schedules the next one. Only the very first read waits
- * briefly (until the first refresh settles) so a brand-new session still
- * gets primed when the server is warm; once that attempt fails — server
- * down or not set up — later reads return immediately rather than paying
- * the wait on every turn.
+ * and every read schedules the next one. The cold-start wait budget is
+ * spent exactly once, by the first read — a brand-new session still gets
+ * primed when the server is warm, while a down, hung, or slow server costs
+ * at most one firstLoadWaitMs ever, never one per turn.
  */
 export function createProfileCache(client: Pick<MemoryClient, "profile">, firstLoadWaitMs = 1_500) {
   let cached: MemoryProfile | null = null;
-  let attempted = false;
+  let coldWaitSpent = false;
   let inflight: Promise<void> | null = null;
 
   const refresh = (): Promise<void> => {
@@ -181,7 +180,6 @@ export function createProfileCache(client: Pick<MemoryClient, "profile">, firstL
       } catch {
         // Server down or not set up — recall priming just stays silent.
       } finally {
-        attempted = true;
         inflight = null;
       }
     })();
@@ -190,11 +188,11 @@ export function createProfileCache(client: Pick<MemoryClient, "profile">, firstL
 
   return {
     refresh,
-    /** Cached profile; waits up to firstLoadWaitMs only before the first
-     *  refresh has settled. */
+    /** Cached profile; only the first read waits (up to firstLoadWaitMs). */
     async get(): Promise<MemoryProfile | null> {
       const pending = refresh();
-      if (!attempted) {
+      if (!coldWaitSpent) {
+        coldWaitSpent = true;
         await Promise.race([pending, new Promise((r) => setTimeout(r, firstLoadWaitMs))]);
       }
       return cached;

--- a/apps/desktop/src/agent/memory/extension.ts
+++ b/apps/desktop/src/agent/memory/extension.ts
@@ -163,11 +163,15 @@ export function buildMemoryTool(client: MemoryToolClient) {
 /**
  * Cached profile for recall priming. before_agent_start must not stall the
  * turn on a cold HTTP call, so reads come from the last completed refresh
- * and every read schedules the next one. First run (empty cache) waits
- * briefly so a brand-new session still gets primed when the server is warm.
+ * and every read schedules the next one. Only the very first read waits
+ * briefly (until the first refresh settles) so a brand-new session still
+ * gets primed when the server is warm; once that attempt fails — server
+ * down or not set up — later reads return immediately rather than paying
+ * the wait on every turn.
  */
 export function createProfileCache(client: Pick<MemoryClient, "profile">, firstLoadWaitMs = 1_500) {
   let cached: MemoryProfile | null = null;
+  let attempted = false;
   let inflight: Promise<void> | null = null;
 
   const refresh = (): Promise<void> => {
@@ -177,6 +181,7 @@ export function createProfileCache(client: Pick<MemoryClient, "profile">, firstL
       } catch {
         // Server down or not set up — recall priming just stays silent.
       } finally {
+        attempted = true;
         inflight = null;
       }
     })();
@@ -185,10 +190,11 @@ export function createProfileCache(client: Pick<MemoryClient, "profile">, firstL
 
   return {
     refresh,
-    /** Cached profile, waiting up to firstLoadWaitMs only when cold. */
+    /** Cached profile; waits up to firstLoadWaitMs only before the first
+     *  refresh has settled. */
     async get(): Promise<MemoryProfile | null> {
       const pending = refresh();
-      if (cached === null) {
+      if (!attempted) {
         await Promise.race([pending, new Promise((r) => setTimeout(r, firstLoadWaitMs))]);
       }
       return cached;

--- a/apps/desktop/src/agent/memory/extension.ts
+++ b/apps/desktop/src/agent/memory/extension.ts
@@ -1,0 +1,222 @@
+/**
+ * Memory extension — long-term memory backed by a self-hosted supermemory
+ * server (https://supermemory.ai/docs/self-hosting/overview).
+ *
+ * Two halves:
+ *  - the `memory` tool: add / search / profile / list / forget against the
+ *    local server (default http://localhost:6767, override with
+ *    SUPERMEMORY_BASE_URL — see agent/memory/client.ts);
+ *  - recall priming: each agent run is primed with the distilled user
+ *    profile (static facts + recent context) as a hidden message, the same
+ *    way the tasks extension primes the active task list.
+ *
+ * The server is opt-in and user-managed for now: `npx supermemory local`
+ * installs and runs it (one LLM provider key in ~/.supermemory/env is
+ * required for memory extraction). Nothing here installs binaries — when
+ * the server isn't reachable the tool answers with setup guidance and the
+ * priming hook stays silent, so the extension is inert until the user
+ * starts the server. Owning the server lifecycle (spawn/health/shutdown)
+ * is the obvious next step if the experiment sticks.
+ */
+
+import { Type, type Static } from "@sinclair/typebox";
+
+import type { PiExtensionBundle } from "@/agent/extension";
+import { textResult } from "@/agent/extension-helpers";
+import { toErrorMessage } from "@/shared/ipc";
+import {
+  MemoryClient,
+  MemoryUnavailableError,
+  resolveMemoryConfig,
+  type MemoryProfile,
+} from "@/agent/memory/client";
+
+const memorySchema = Type.Object({
+  action: Type.Union(
+    [
+      Type.Literal("add"),
+      Type.Literal("search"),
+      Type.Literal("profile"),
+      Type.Literal("list"),
+      Type.Literal("forget"),
+    ],
+    { description: "Action to perform" },
+  ),
+  content: Type.Optional(
+    Type.String({
+      description:
+        "Memory text to store (required for add). One self-contained fact per call, " +
+        "e.g. 'User prefers metric units' — not a transcript dump.",
+    }),
+  ),
+  query: Type.Optional(
+    Type.String({ description: "Natural-language search query (required for search)" }),
+  ),
+  limit: Type.Optional(Type.Number({ description: "Max results for search/list (default 10/20)" })),
+  memoryId: Type.Optional(
+    Type.String({ description: "Memory id to forget (forget needs this or 'content')" }),
+  ),
+  reason: Type.Optional(Type.String({ description: "Optional reason when forgetting" })),
+});
+
+type MemoryParams = Static<typeof memorySchema>;
+
+function unavailableGuidance(err: MemoryUnavailableError): string {
+  return (
+    `${err.message}. Long-term memory is unavailable until the local supermemory ` +
+    "server is running. The user can set it up with `npx supermemory local` " +
+    "(adds an LLM provider key to ~/.supermemory/env on first run) and keep it " +
+    "running in the background. Continue without memory for now."
+  );
+}
+
+function formatProfile(profile: MemoryProfile): string {
+  const lines: string[] = [];
+  if (profile.static.length > 0) {
+    lines.push("Stable facts:", ...profile.static.map((f) => `- ${f}`));
+  }
+  if (profile.dynamic.length > 0) {
+    if (lines.length > 0) lines.push("");
+    lines.push("Recent context:", ...profile.dynamic.map((f) => `- ${f}`));
+  }
+  return lines.join("\n");
+}
+
+/** Method surface the tool needs — lets tests inject a stub client. */
+export type MemoryToolClient = Pick<MemoryClient, "add" | "search" | "profile" | "list" | "forget">;
+
+/** Exported for unit testing — see __tests__/memory-extension.test.ts. */
+export function buildMemoryTool(client: MemoryToolClient) {
+  return {
+    name: "memory",
+    label: "memory",
+    description:
+      "Long-term memory across conversations (local supermemory server). " +
+      "Use 'add' to remember durable facts about the user — preferences, decisions, " +
+      "projects, people — as soon as they come up; one concise fact per call. " +
+      "Use 'search' before answering questions that depend on prior context, " +
+      "'profile' for a distilled summary of the user, 'list' for recently stored " +
+      "entries, and 'forget' (by memoryId or content description) when the user " +
+      "asks you to forget something.",
+    parameters: memorySchema,
+    execute: async (_toolCallId: string, params: MemoryParams) => {
+      try {
+        switch (params.action) {
+          case "add": {
+            if (!params.content)
+              return textResult("Error: 'content' is required for action 'add'.");
+            const added = await client.add(params.content, { source: "agent" });
+            return textResult(`Stored memory ${added.id} (status: ${added.status}).`);
+          }
+          case "search": {
+            if (!params.query) return textResult("Error: 'query' is required for action 'search'.");
+            const found = await client.search(params.query, params.limit ?? 10);
+            if (found.results.length === 0) {
+              return textResult(`No memories matched "${params.query}".`);
+            }
+            const lines = found.results.map((hit) => {
+              const text = hit.memory ?? hit.chunk ?? "(no content)";
+              return `- [${hit.similarity.toFixed(2)}] ${text} (${hit.id})`;
+            });
+            return textResult(`${found.total} result(s):\n${lines.join("\n")}`);
+          }
+          case "profile": {
+            const profile = await client.profile();
+            const text = formatProfile(profile);
+            return textResult(text || "No profile yet — nothing has been remembered.");
+          }
+          case "list": {
+            const listed = await client.list(params.limit ?? 20);
+            if (listed.length === 0) return textResult("No memories stored yet.");
+            const lines = listed.map((doc) => {
+              const label = doc.title ?? doc.summary ?? "(untitled)";
+              return `- ${label} (${doc.id}${doc.status ? `, ${doc.status}` : ""})`;
+            });
+            return textResult(lines.join("\n"));
+          }
+          case "forget": {
+            if (!params.memoryId && !params.content) {
+              return textResult(
+                "Error: 'forget' needs 'memoryId' or a 'content' description of what to forget.",
+              );
+            }
+            const forgotten = await client.forget({
+              ...(params.memoryId !== undefined ? { id: params.memoryId } : {}),
+              ...(params.content !== undefined ? { content: params.content } : {}),
+              ...(params.reason !== undefined ? { reason: params.reason } : {}),
+            });
+            return textResult(
+              forgotten.forgotten
+                ? `Forgot memory ${forgotten.id}.`
+                : `Nothing was forgotten (server declined for ${forgotten.id}).`,
+            );
+          }
+        }
+      } catch (err) {
+        if (err instanceof MemoryUnavailableError) return textResult(unavailableGuidance(err));
+        return textResult(`memory error: ${toErrorMessage(err)}`);
+      }
+    },
+  };
+}
+
+/**
+ * Cached profile for recall priming. before_agent_start must not stall the
+ * turn on a cold HTTP call, so reads come from the last completed refresh
+ * and every read schedules the next one. First run (empty cache) waits
+ * briefly so a brand-new session still gets primed when the server is warm.
+ */
+export function createProfileCache(client: Pick<MemoryClient, "profile">, firstLoadWaitMs = 1_500) {
+  let cached: MemoryProfile | null = null;
+  let inflight: Promise<void> | null = null;
+
+  const refresh = (): Promise<void> => {
+    inflight ??= (async () => {
+      try {
+        cached = await client.profile();
+      } catch {
+        // Server down or not set up — recall priming just stays silent.
+      } finally {
+        inflight = null;
+      }
+    })();
+    return inflight;
+  };
+
+  return {
+    refresh,
+    /** Cached profile, waiting up to firstLoadWaitMs only when cold. */
+    async get(): Promise<MemoryProfile | null> {
+      const pending = refresh();
+      if (cached === null) {
+        await Promise.race([pending, new Promise((r) => setTimeout(r, firstLoadWaitMs))]);
+      }
+      return cached;
+    },
+  };
+}
+
+const memoryExtension: PiExtensionBundle = {
+  name: "memory",
+  register: () => (pi) => {
+    const client = new MemoryClient(resolveMemoryConfig());
+    const profileCache = createProfileCache(client);
+
+    pi.registerTool(buildMemoryTool(client));
+
+    pi.on("before_agent_start", async () => {
+      const profile = await profileCache.get();
+      if (!profile) return;
+      const text = formatProfile(profile);
+      if (!text) return;
+
+      pi.sendMessage({
+        customType: "memory-profile",
+        content: `[What you remember about the user]\n${text}`,
+        display: false,
+      });
+    });
+  },
+};
+
+export default memoryExtension;

--- a/apps/desktop/src/agent/memory/extension.ts
+++ b/apps/desktop/src/agent/memory/extension.ts
@@ -25,6 +25,7 @@ import type { PiExtensionBundle } from "@/agent/extension";
 import { textResult } from "@/agent/extension-helpers";
 import { toErrorMessage } from "@/shared/ipc";
 import {
+  DEFAULT_MEMORY_BASE_URL,
   MemoryClient,
   MemoryUnavailableError,
   resolveMemoryConfig,
@@ -52,7 +53,9 @@ const memorySchema = Type.Object({
   query: Type.Optional(
     Type.String({ description: "Natural-language search query (required for search)" }),
   ),
-  limit: Type.Optional(Type.Number({ description: "Max results for search/list (default 10/20)" })),
+  limit: Type.Optional(
+    Type.Number({ description: "Max results for search/list (default 10/20, clamped to 1-100)" }),
+  ),
   memoryId: Type.Optional(
     Type.String({ description: "Memory id to forget (forget needs this or 'content')" }),
   ),
@@ -61,7 +64,20 @@ const memorySchema = Type.Object({
 
 type MemoryParams = Static<typeof memorySchema>;
 
+/** Providers can hand back any number — clamp to something the server
+ *  accepts instead of forwarding a 4xx-bound or expensive value. */
+function clampLimit(value: number | undefined, fallback: number): number {
+  if (value === undefined || !Number.isFinite(value)) return fallback;
+  return Math.min(100, Math.max(1, Math.trunc(value)));
+}
+
 function unavailableGuidance(err: MemoryUnavailableError): string {
+  if (err.baseUrl !== DEFAULT_MEMORY_BASE_URL) {
+    return (
+      `${err.message}. That server was configured via SUPERMEMORY_BASE_URL — the user ` +
+      "should check that it's running and the URL is right. Continue without memory for now."
+    );
+  }
   return (
     `${err.message}. Long-term memory is unavailable until the local supermemory ` +
     "server is running. The user can set it up with `npx supermemory local` " +
@@ -110,7 +126,7 @@ export function buildMemoryTool(client: MemoryToolClient) {
           }
           case "search": {
             if (!params.query) return textResult("Error: 'query' is required for action 'search'.");
-            const found = await client.search(params.query, params.limit ?? 10);
+            const found = await client.search(params.query, clampLimit(params.limit, 10));
             if (found.results.length === 0) {
               return textResult(`No memories matched "${params.query}".`);
             }
@@ -126,7 +142,7 @@ export function buildMemoryTool(client: MemoryToolClient) {
             return textResult(text || "No profile yet — nothing has been remembered.");
           }
           case "list": {
-            const listed = await client.list(params.limit ?? 20);
+            const listed = await client.list(clampLimit(params.limit, 20));
             if (listed.length === 0) return textResult("No memories stored yet.");
             const lines = listed.map((doc) => {
               const label = doc.title ?? doc.summary ?? "(untitled)";

--- a/apps/desktop/src/agent/memory/extension.ts
+++ b/apps/desktop/src/agent/memory/extension.ts
@@ -178,7 +178,9 @@ export function createProfileCache(client: Pick<MemoryClient, "profile">, firstL
       try {
         cached = await client.profile();
       } catch {
-        // Server down or not set up — recall priming just stays silent.
+        // Server down or not set up — drop any previous snapshot so priming
+        // goes silent, consistent with the tool reporting unavailability.
+        cached = null;
       } finally {
         inflight = null;
       }


### PR DESCRIPTION
## What

Trial integration of [supermemory local](https://supermemory.ai/docs/self-hosting/overview) as the agent's long-term memory. New auto-discovered extension bundle at `apps/desktop/src/agent/memory/`:

- **`memory` tool** with `add` / `search` / `profile` / `list` / `forget` actions against the local server's Memory API (`/v3/documents`, `/v4/search`, `/v4/profile`, `/v4/memories`). All memories live under one `inteligir` container tag.
- **Recall priming**: `before_agent_start` injects the distilled user profile (static facts + recent context) as a hidden message — same pattern as the tasks extension's active-task priming. Served from a cache with background refresh so turns never stall on a cold HTTP call (first load waits ≤1.5s).
- **Dependency-free client** (`client.ts`): plain fetch, field-by-field response narrowing (no casts), endpoints verified against the `supermemory` SDK v4.24 type definitions. `SUPERMEMORY_BASE_URL` / `SUPERMEMORY_API_KEY` override the default `http://localhost:6767` target (localhost requests are auto-authenticated by the server, so no key plumbing needed by default).

## Trying it out

```bash
npx supermemory local   # installs + runs the server; prompts for one LLM
                        # provider key (~/.supermemory/env) used for extraction
```

The extension is **inert until the server is running**: the tool answers with setup guidance and the priming hook stays silent. No binaries are installed by the app.

## Notes from poking at the server (v0.0.2)

- Single binary (~190MB, Bun), data in `$SUPERMEMORY_DATA_DIR` (default `./.supermemory`), local embeddings via `Xenova/bge-base-en-v1.5` (~106MB one-time download from HF).
- Requires one of `OPENAI_API_KEY` / `ANTHROPIC_API_KEY` / `GEMINI_API_KEY` / `GROQ_API_KEY` at boot for memory extraction — worth noting our desktop auth is OpenAI **OAuth** via pi, so there's no API key we can hand it automatically.
- The server hardcodes its listener on `::`; it crashed in this (IPv6-less) CI sandbox, so I could not run a live end-to-end test here — behavior is covered by unit tests against SDK-verified shapes instead. Normal macOS/Linux desktops have IPv6 loopback, so this shouldn't affect real use, but **please verify locally** with the desktop app + a running server.

## Follow-ups if the experiment sticks

- Own the server lifecycle (install via bundle `setup()`, spawn/health-check/shutdown from main) instead of user-managed.
- Settings UI for enabling memory + entering the extraction-model key.
- Feed conversation turns to the server automatically (today the model decides what to `add`).

## Testing

- `pnpm typecheck && pnpm lint && pnpm test && pnpm knip && pnpm format && pnpm build` all green (14 new tests in `memory-extension.test.ts`).

https://claude.ai/code/session_01YQZbY4Wi4DtL5wRMcpBZtr

---
_Generated by [Claude Code](https://claude.ai/code/session_01YQZbY4Wi4DtL5wRMcpBZtr)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New external dependency and user-data persistence path; failures are handled gracefully but stored memories and hidden profile priming affect agent behavior across sessions.
> 
> **Overview**
> Adds **long-term memory** for the desktop agent via an opt-in, user-run **supermemory** server (default `http://localhost:6767`, overridable with `SUPERMEMORY_BASE_URL` / `SUPERMEMORY_API_KEY`).
> 
> A new **`memory` extension** registers a curated **`memory` tool** (`add`, `search`, `profile`, `list`, `forget`) backed by a small fetch HTTP client scoped to the `inteligir` container tag, with defensive response parsing and user-facing setup guidance when the server is unreachable. On each turn, **`before_agent_start`** injects a hidden distilled user profile from a **cached background refresh** (one-time cold wait ≤1.5s) so turns do not block on HTTP.
> 
> **`AGENTS.md`** documents when to remember, search, forget, and how to behave if memory is down. **Unit tests** cover tool behavior, limit clamping, profile-cache edge cases, and client error classification.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f243017e50a45777026849c4d9e0588bde66296c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds self-hosted long-term memory to the desktop agent via a local `supermemory` server. Includes a `memory` tool, recall priming from a cached profile with a one-turn staleness tradeoff, AGENTS.md guidance, and a small fetch client that shows setup help when the server is unreachable.

- **Bug Fixes**
  - Recall priming spends the cold wait once even if the first profile request hangs.
  - Clears the cached profile only when the server is unreachable; treats request timeouts as transient and keeps the last good profile.
  - Clamps `limit` to an integer in 1–100 for `search`/`list` before hitting the server.
  - Unreachable-server guidance is contextual: local default shows `npx supermemory local`; custom `SUPERMEMORY_BASE_URL` advises checking the URL/server.
  - `add` fails loudly if the server returns 2xx without a document id (no false success).

- **Migration**
  - Run `npx supermemory local` and provide one LLM provider key at `~/.supermemory/env`.
  - Optionally set `SUPERMEMORY_BASE_URL` and `SUPERMEMORY_API_KEY` for a remote server.

<sup>Written for commit f243017e50a45777026849c4d9e0588bde66296c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kyh/inteligir/pull/342?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

