### PR TITLE
docs: add READMEs to all packages and apps

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,24 +8,35 @@ Turborepo monorepo. Desktop app (Electron + pi-coding-agent) plus a static marke
 
 ```
 apps/
-  desktop/         Electron app — the product. See apps/desktop/README.md
+  desktop/         Electron app — the product
   mobile/          Expo app — remote surface, pairs to the desktop
   server/          Cloudflare Worker (partyserver) — WS relay + external chat gateway
   web/             Next.js static marketing site (landing page only)
 packages/
-  agent-runtime/   Filesystem + install primitives for the agent — see packages/agent-runtime/README.md
-  dispatch/        Shared mobile↔desktop wire protocol — see packages/dispatch/PROTOCOL.md
+  agent-runtime/   Filesystem + install primitives for the agent
+  dispatch/        Shared mobile↔desktop wire protocol
   pi-driver/       Wrapper around pi-coding-agent — stable surface for app code
   ui/              Shared UI components (shadcn/ui base)
 ```
 
-Architecture-level docs live next to the code:
+Every app and package has its own `README.md`:
+
+| Workspace | README |
+| --- | --- |
+| `apps/desktop` | [process boundary, IPC, lifecycle, voice](./apps/desktop/README.md) |
+| `apps/mobile` | [Expo remote — pairing flow, screens](./apps/mobile/README.md) |
+| `apps/server` | [relay Worker — WS relay + chat gateway, auth](./apps/server/README.md) |
+| `apps/web` | [static marketing site](./apps/web/README.md) |
+| `packages/agent-runtime` | [install / seed / run-cli primitives](./packages/agent-runtime/README.md) |
+| `packages/dispatch` | [protocol code map](./packages/dispatch/README.md) · [spec](./packages/dispatch/PROTOCOL.md) |
+| `packages/pi-driver` | [pi-coding-agent wrapper](./packages/pi-driver/README.md) |
+| `packages/ui` | [shared design system](./packages/ui/README.md) |
+
+Deeper architecture docs live next to the code:
 
 - [`docs/chat-interfaces.md`](./docs/chat-interfaces.md) — chat with the agent from Slack/Telegram/WhatsApp/Discord (Chat SDK gateway + relay bridge on `@repo/server`)
-- [`apps/desktop/README.md`](./apps/desktop/README.md) — process boundary, IPC, lifecycle, "where do I add X?"
 - [`apps/desktop/src/main/README.md`](./apps/desktop/src/main/README.md) — state machine triad (reducer/effects/machine)
 - [`apps/desktop/src/agent/README.md`](./apps/desktop/src/agent/README.md) — pi extension bundle pattern
-- [`packages/agent-runtime/README.md`](./packages/agent-runtime/README.md) — install/seed primitives, what goes here vs. in `apps/desktop/`
 - [`packages/dispatch/PROTOCOL.md`](./packages/dispatch/PROTOCOL.md) — dispatch protocol v1: pairing, message catalog, trust boundaries
 
 `AGENTS.md` (root) is read by Claude Code / agents working in the repo — quality gates, dev-loop tools, conventions.

--- a/README.md
+++ b/README.md
@@ -21,16 +21,16 @@ packages/
 
 Every app and package has its own `README.md`:
 
-| Workspace | README |
-| --- | --- |
-| `apps/desktop` | [process boundary, IPC, lifecycle, voice](./apps/desktop/README.md) |
-| `apps/mobile` | [Expo remote — pairing flow, screens](./apps/mobile/README.md) |
-| `apps/server` | [relay Worker — WS relay + chat gateway, auth](./apps/server/README.md) |
-| `apps/web` | [static marketing site](./apps/web/README.md) |
-| `packages/agent-runtime` | [install / seed / run-cli primitives](./packages/agent-runtime/README.md) |
-| `packages/dispatch` | [protocol code map](./packages/dispatch/README.md) · [spec](./packages/dispatch/PROTOCOL.md) |
-| `packages/pi-driver` | [pi-coding-agent wrapper](./packages/pi-driver/README.md) |
-| `packages/ui` | [shared design system](./packages/ui/README.md) |
+| Workspace                | README                                                                                       |
+| ------------------------ | -------------------------------------------------------------------------------------------- |
+| `apps/desktop`           | [process boundary, IPC, lifecycle, voice](./apps/desktop/README.md)                          |
+| `apps/mobile`            | [Expo remote — pairing flow, screens](./apps/mobile/README.md)                               |
+| `apps/server`            | [relay Worker — WS relay + chat gateway, auth](./apps/server/README.md)                      |
+| `apps/web`               | [static marketing site](./apps/web/README.md)                                                |
+| `packages/agent-runtime` | [install / seed / run-cli primitives](./packages/agent-runtime/README.md)                    |
+| `packages/dispatch`      | [protocol code map](./packages/dispatch/README.md) · [spec](./packages/dispatch/PROTOCOL.md) |
+| `packages/pi-driver`     | [pi-coding-agent wrapper](./packages/pi-driver/README.md)                                    |
+| `packages/ui`            | [shared design system](./packages/ui/README.md)                                              |
 
 Deeper architecture docs live next to the code:
 

--- a/apps/mobile/README.md
+++ b/apps/mobile/README.md
@@ -1,0 +1,61 @@
+# `@repo/mobile` — Inteligir mobile remote
+
+Expo / React Native app. A **remote surface** for the desktop product, not a
+standalone agent: it pairs to a running desktop over the dispatch relay and
+mirrors the agent transcript. There is no agent on the phone.
+
+## How it works
+
+The desktop shows a pairing string (`roomId.token`). The phone scans/enters it,
+then connects to the relay Worker (`apps/server`) as the `mobile` peer. While an
+authenticated `desktop` peer is present in the same room, the desktop streams
+its agent events down; the phone renders them and can send messages back. The
+wire contract is dispatch protocol v1 — see
+[`packages/dispatch/PROTOCOL.md`](../../packages/dispatch/PROTOCOL.md).
+
+```
+phone (mobile peer) ── partysocket/WSS ──▶ relay Worker ◀── WSS ── desktop peer
+            └── PairingCredential (roomId + token), parsed locally ──┘
+```
+
+## Layout
+
+```
+src/
+  app/                 expo-router screens
+    index.tsx          Entry — restores a saved session or routes to pairing
+    pair.tsx           Enter / scan a pairing credential
+    dispatch.tsx       Connected view — agent transcript + input
+    _layout.tsx        Router layout
+  hooks/
+    use-dispatch-connection.ts   Socket lifecycle, presence, reconnect, fatal states
+  utils/
+    session-store.ts   Persists the pairing credential (expo-secure-store)
+    base-url.ts        Resolves the relay host (dev vs. EXPO_PUBLIC_SERVER_HOST)
+  styles.css           NativeWind / Tailwind
+app.config.ts          Expo config (bundle ids, scheme, splash)
+```
+
+Styling is NativeWind (Tailwind for RN). The pairing credential lives in
+`expo-secure-store`; only `parsePairingString` (pure) runs on-device — the phone
+never touches WebCrypto.
+
+## Dev
+
+```bash
+pnpm --filter @repo/mobile dev          # expo start
+pnpm --filter @repo/mobile dev-ios      # expo start --ios
+pnpm --filter @repo/mobile dev-android  # expo start --android
+```
+
+Point the app at a local relay with `EXPO_PUBLIC_SERVER_HOST` (defaults to the
+deployed `inteligir-server` in packaged builds, `localhost:8787` in dev).
+
+## Native builds
+
+```bash
+pnpm --filter @repo/mobile ios       # expo run:ios
+pnpm --filter @repo/mobile android   # expo run:android
+```
+
+OTA updates are intentionally disabled (`expo-updates` is not installed).

--- a/apps/server/README.md
+++ b/apps/server/README.md
@@ -1,0 +1,60 @@
+# `@repo/server` — Inteligir relay Worker
+
+Cloudflare Worker (partyserver) that does two jobs:
+
+1. **WebSocket relay** — pairs the mobile app to the desktop. The two peers meet
+   in a Durable Object "room"; the Worker authenticates each socket and shuttles
+   dispatch-protocol frames between them. It stores no agent data and only ever
+   sees the token's SHA-256 hash.
+2. **External chat gateway** (optional) — a Chat SDK gateway hosted alongside the
+   relay so Slack / Telegram / WhatsApp / Discord webhooks can reach the desktop
+   agent through the same room. Single-tenant in v1 (one desktop per Worker).
+
+Deployed to Cloudflare as `inteligir-server` via
+[`.github/workflows/deploy.yml`](../../.github/workflows/deploy.yml).
+
+## Layout
+
+```
+src/
+  server.ts          DispatchServer Durable Object — connect-time auth, room
+                     presence, frame relay, gateway POST handler
+  bot.ts             Chat SDK gateway — adapters (Slack/Telegram/WhatsApp/Discord)
+  housekeeping.ts    Room claims, dedupe, idle-TTL sweep
+  token-bucket.ts    Per-connection rate limiting
+  env.ts             Env var schema + hasValidEnvVars guard
+  *.test.ts          Vitest suites (housekeeping, token-bucket)
+wrangler.jsonc       Worker config (DO bindings, routes)
+.dev.vars.example    Local secrets template — copy to .dev.vars
+```
+
+## Auth & trust
+
+Clients authenticate at connect time: `role` + raw pairing token travel as query
+params on the WSS URL (`parseConnectionAuth` in `onConnect`). A missing role,
+missing token, or token-hash mismatch is refused before the socket enters the
+room. Per-connection state (`role`) is only written after auth succeeds, so
+`state?.role` doubles as the "is authenticated" check. See
+[`packages/dispatch/PROTOCOL.md`](../../packages/dispatch/PROTOCOL.md) for the
+full trust model.
+
+The relay itself needs **no** configuration — rooms are claimed by the desktop's
+pairing credential. Everything in `.dev.vars.example` powers the optional chat
+gateway, which fails closed: unset `CHAT_RELAY_SECRET` ⇒ the DO refuses every
+gateway POST ⇒ inbound chat is disabled.
+
+## Dev
+
+```bash
+pnpm dev:server      # wrangler dev (localhost:8787)
+```
+
+Copy `.dev.vars.example` → `.dev.vars` and fill in chat secrets only if you're
+working on the gateway. In production set each with `wrangler secret put <NAME>`.
+
+## Test & deploy
+
+```bash
+pnpm --filter @repo/server test      # vitest run
+pnpm --filter @repo/server deploy    # wrangler deploy (usually via CI)
+```

--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -1,0 +1,43 @@
+# `@repo/web` — Inteligir marketing site
+
+Static Next.js 15 landing page. No backend, no database, no auth — just the
+public-facing pitch for the product. Built with the App Router + Turbopack and
+styled with Tailwind 4 via `@repo/ui`.
+
+## Layout
+
+```
+src/
+  app/
+    page.tsx       Landing page
+    layout.tsx     Root layout — fonts, theme provider, metadata
+    error.tsx      Error boundary
+    robots.ts      Generated robots.txt
+  components/
+    site-header.tsx
+    hero-orb.tsx       Three.js orb (via @repo/ui)
+    theme-provider.tsx next-themes wrapper
+  lib/
+    site-config.ts     Title, description, links — single source for metadata
+public/                Static assets
+```
+
+Shared components and styles come from `@repo/ui` (`@repo/ui/globals.css`,
+`@repo/ui/components/*`). Keep page-specific bits here; promote anything reused
+across apps into `packages/ui`.
+
+## Dev
+
+```bash
+pnpm dev:web      # next dev --turbopack
+```
+
+## Build
+
+```bash
+pnpm --filter @repo/web build   # next build --turbopack
+pnpm --filter @repo/web start   # serve the production build
+```
+
+The site is fully static — the desktop app (`apps/desktop`) is the actual
+product; this is the landing page only.

--- a/packages/agent-runtime/README.md
+++ b/packages/agent-runtime/README.md
@@ -8,6 +8,7 @@ Filesystem + install primitives for the Inteligir desktop agent. Pure Node, **ze
 src/
   seed.ts     seedDirectory, seedFile (atomic via COPYFILE_EXCL), prependPath
   install.ts  installCliFromGithubRelease — fetch + verify + atomic rename
+  run-cli.ts  runCli — spawn an installed binary with our pi-extension conventions
 ```
 
 No `index.ts` barrel. Consumers import directly:
@@ -15,6 +16,7 @@ No `index.ts` barrel. Consumers import directly:
 ```ts
 import { prependPath, seedDirectory, seedFile } from "@repo/agent-runtime/seed";
 import { installCliFromGithubRelease } from "@repo/agent-runtime/install";
+import { runCli } from "@repo/agent-runtime/run-cli";
 ```
 
 ## `installCliFromGithubRelease`
@@ -72,6 +74,30 @@ Why `artifactName` is caller-supplied: every upstream uses a different filename 
 - `sha256-sidecar` mode: only guards download corruption — same origin as the artifact, no protection against compromised upstream.
 - `version-check` mode: weaker, but the only option when upstream doesn't publish checksums. Probes the staged binary before rename so a wrong-arch download doesn't get installed.
 - Swallows failures with a `console.error`. Onboarding must succeed offline; the calling tool surfaces "binary not installed" later.
+
+## `runCli`
+
+Spawns an installed binary (`execFile`, no shell) and captures
+`{ stdout, stderr, code }`, applying the conventions every pi-extension tool
+wrapper relies on:
+
+- **ENOENT → a tool-named error.** A missing binary rejects with
+  `notFoundMessage` (e.g. `"peekaboo binary not installed"`) instead of leaking
+  the raw spawn error, so the tool can surface an actionable string.
+- **Bounded.** `timeoutMs` (SIGTERM on overrun) and `maxBuffer` (cap on captured
+  output) are required — a runaway CLI can't hang or OOM the agent.
+- **Optional `stdin`** is piped to the child and the stream closed.
+
+```ts
+const { stdout, code } = await runCli(binPath, ["--json", "see"], {
+  timeoutMs: 30_000,
+  maxBuffer: 8 * 1024 * 1024,
+  notFoundMessage: "peekaboo binary not installed",
+});
+```
+
+Pairs with `installCliFromGithubRelease`: install puts the binary on disk and on
+PATH, `runCli` invokes it.
 
 ## When to add to this package
 

--- a/packages/dispatch/README.md
+++ b/packages/dispatch/README.md
@@ -1,0 +1,57 @@
+# `@repo/dispatch` — mobile↔desktop wire protocol
+
+The shared contract that lets the mobile app, the desktop app, and the relay
+Worker talk to each other. Pure TypeScript + TypeBox, **zero** runtime deps on
+Electron / React Native / partysocket — every consumer imports the same source.
+
+> **Read [`PROTOCOL.md`](./PROTOCOL.md) first.** It is the spec: the full message
+> catalog, routing, pairing flow, and trust boundaries. This README is the map of
+> the code that implements it.
+
+## Modules
+
+```
+src/
+  protocol.ts     Wire protocol v1 — TypeBox envelopes, parseMessage /
+                  serializeMessage, PROTOCOL_VERSION, MAX_MESSAGE_BYTES
+  pairing.ts      Pairing credentials — generate / parse / hashToken
+  room.ts         Room addressing + connect-time auth (parseConnectionAuth,
+                  buildConnectionConfig, PARTY_NAME, server host resolution)
+  connection.ts   Connection-attempt registry (cancel stale reconnects)
+  *.test.ts       Vitest suites for each
+```
+
+No barrel — import by file:
+
+```ts
+import { parseMessage, serializeMessage, PROTOCOL_VERSION } from "@repo/dispatch/protocol";
+import { parsePairingString, hashToken } from "@repo/dispatch/pairing";
+import { buildConnectionConfig, parseConnectionAuth } from "@repo/dispatch/room";
+```
+
+## The shape of the contract
+
+- **Every frame** is a flat discriminated union on `type`, each carrying `v: 1`.
+  No `Record<string, unknown>` payloads. Senders build a literal `DispatchMessage`
+  and `serializeMessage`; receivers `parseMessage` at the trust boundary and
+  switch on the typed result.
+- **Versioning is checked first.** The three peers ship independently, so a
+  `version_mismatch` is rejected loudly rather than misread.
+- **Pairing credential** = `roomId.token` shown as one copyable string. `roomId`
+  is 80 bits CSPRNG (and doubles as the relay room name); `token` is the 128-bit
+  bearer secret. The Worker stores only `hashToken(token)`. Runtime requirements
+  are isolated per function so each consumer's environment only pulls what it can
+  run (mobile only calls the pure `parsePairingString`).
+
+## Test / typecheck
+
+```bash
+pnpm --filter @repo/dispatch test
+pnpm --filter @repo/dispatch typecheck
+```
+
+## Changing the protocol
+
+Bump `PROTOCOL_VERSION` on any breaking message-shape change, update the catalog
+in `PROTOCOL.md`, and add/adjust the TypeBox schema + tests. All three peers
+(`apps/desktop`, `apps/mobile`, `apps/server`) must ship the new version together.

--- a/packages/pi-driver/README.md
+++ b/packages/pi-driver/README.md
@@ -1,0 +1,45 @@
+# `@repo/pi-driver` — pi-coding-agent wrapper
+
+A thin, stable surface over [`@mariozechner/pi-coding-agent`](https://www.npmjs.com/package/@mariozechner/pi-coding-agent)
+and `@mariozechner/pi-ai`. App code (mainly `apps/desktop`) talks to this package
+instead of pi's internals, so when pi moves an export or changes a signature, the
+blast radius is one file here — not the whole desktop app.
+
+## Modules
+
+```
+src/
+  agent.ts      The Agent class — wraps createAgentSession; lifecycle, events,
+                tool/message plumbing. PiAgentConfig is the injection surface
+                (cwd, agentDir, authStorage, model, sessionManager, extensions).
+  auth.ts       createAuthStorage(authPath) — pi's OAuth credential store
+  model.ts      resolveModel(provider, modelId) from pi-ai's static registry
+  skills.ts     loadSkills + PiAgentSkill projection (serializable over IPC)
+  complete.ts   One-shot complete() helper, with a cached ModelRegistry per AuthStorage
+  pi-types.ts   Curated re-exports of pi types the desktop reaches for
+```
+
+No barrel — import by file:
+
+```ts
+import { Agent } from "@repo/pi-driver/agent";
+import { createAuthStorage } from "@repo/pi-driver/auth";
+import { resolveModel } from "@repo/pi-driver/model";
+```
+
+## Design rule
+
+Everything that crosses the IPC boundary is projected to a **plain, serializable**
+shape here (`PiAgentTool`, `PiAgentSkill`, …) rather than leaking pi's classes.
+`pi-types.ts` is the single chokepoint for type re-exports: if pi swaps an export
+location, only that file changes.
+
+This package has no Electron dependency — it's the pi adapter, not the app. The
+glue that wires it into the desktop (ports, lifecycle, IPC) lives in
+`apps/desktop/src/main/`.
+
+## Typecheck
+
+```bash
+pnpm --filter @repo/pi-driver typecheck
+```

--- a/packages/ui/README.md
+++ b/packages/ui/README.md
@@ -1,0 +1,68 @@
+# `@repo/ui` — shared UI components
+
+The design system shared by the web app and the desktop renderer. shadcn/ui
+built on **Base UI** (`@base-ui/react`), styled with Tailwind 4, plus a few
+heavier shared pieces (charts, a Three.js orb, markdown streaming, motion
+helpers).
+
+## Layout
+
+```
+src/
+  components/        shadcn-style primitives — button, dialog, drawer, select,
+                     table, tabs, chart/data-chart, sonner, geometric-orb, …
+  hooks/             use-proximity-hover, use-merge-refs
+  lib/
+    utils.ts         cn() and friends
+    surface-context.tsx  Elevation ladder (1–8) for nested surfaces
+    surface-classes.ts / css-vars.ts / shape.ts / springs.ts / motion-bridge.ts
+  styles/
+    globals.css      Tailwind entry — theme tokens, dark variant, @source globs
+postcss.config.mjs   Shared PostCSS config (re-exported)
+components.json      shadcn config — style "base-vega", base color zinc
+```
+
+## Usage
+
+Exports are path-based (see `package.json` `exports`):
+
+```ts
+import { Button } from "@repo/ui/components/button";
+import { cn } from "@repo/ui/lib/utils";
+import { useSurface } from "@repo/ui/lib/surface-context";
+```
+
+```css
+/* in the consuming app's CSS entry */
+@import "@repo/ui/globals.css";
+```
+
+```js
+// postcss.config.mjs
+export { default } from "@repo/ui/postcss.config";
+```
+
+`globals.css` uses `@source` globs to scan both this package and `apps/**` for
+class usage, so consuming apps don't re-declare content paths.
+
+## Surfaces
+
+`surface-context` tracks an elevation level (1–8). Nested surfaces — dropdowns,
+dialogs, floating layers — read the current level via `useSurface()` and pick a
+background one or more steps above their substrate, so depth composes
+automatically instead of being hand-tuned per component.
+
+## Adding a component
+
+```bash
+cd packages/ui && pnpm dlx shadcn@latest add <component>
+```
+
+Components land in `src/components/`; adjust to the Base UI primitives and the
+surface system as needed.
+
+## Typecheck
+
+```bash
+pnpm --filter @repo/ui typecheck
+```


### PR DESCRIPTION
## What

Adds a README to every workspace that was missing one, so each package/app is self-documenting at its root. `apps/desktop` and `packages/agent-runtime` already had thorough READMEs and were left untouched.

New READMEs:

| Workspace | Covers |
| --- | --- |
| `apps/web` | Static Next.js marketing site — layout, dev/build, that it's landing-page-only |
| `apps/mobile` | Expo remote surface — pairing flow, screens, dispatch connection, native builds |
| `apps/server` | Cloudflare relay Worker — WS relay + chat gateway, connect-time auth/trust, dev/deploy |
| `packages/dispatch` | Wire protocol code map (points at `PROTOCOL.md` as the spec), modules, versioning rules |
| `packages/pi-driver` | pi-coding-agent wrapper — module map, the "stable surface" design rule |
| `packages/ui` | Shared design system — Base UI/shadcn, path exports, surface elevation system |

Each README is written from the actual source (package.json, entry files, config) and cross-links the existing architecture docs rather than duplicating them.

## Notes

Docs only — no code changes.

https://claude.ai/code/session_01SuxWpsbNP6bzAUf7pARA28

---
_Generated by [Claude Code](https://claude.ai/code/session_01SuxWpsbNP6bzAUf7pARA28)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Markdown-only changes with no runtime, auth, or data-path impact.
> 
> **Overview**
> Adds **per-workspace READMEs** for `apps/web`, `apps/mobile`, `apps/server`, and `packages/dispatch`, `pi-driver`, and `ui`, each describing purpose, layout, dev commands, and links to deeper specs (e.g. `PROTOCOL.md`).
> 
> The **root `README.md`** now indexes every workspace in a table and trims duplicated inline README pointers from the layout tree while keeping links to architecture docs.
> 
> **`packages/agent-runtime/README.md`** documents **`runCli`** / `run-cli.ts` (spawn conventions, timeouts, import path) alongside the existing install/seed docs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2ecf9a2f693378f8d24478607abbba63d8e8c9ae. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add READMEs to missing workspaces so each app and package is self-documented and easier to onboard.
New docs for `apps/web`, `apps/mobile`, `apps/server`, `packages/dispatch`, `packages/pi-driver`, and `packages/ui`; the root `README.md` now links to each workspace, `packages/agent-runtime` adds `run-cli` docs, and the workspace table is aligned for readability.

<sup>Written for commit 2ecf9a2f693378f8d24478607abbba63d8e8c9ae. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kyh/inteligir/pull/343?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

