### PR TITLE
Phase 4: packages/server + packages/cli — the product runs in a browser

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@ next-env.d.ts
 # expo
 .expo/
 dist/
+dist-web/
 expo-env.d.ts
 apps/expo/.gitignore
 

--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -3,6 +3,7 @@
   "ignorePatterns": [
     "dist",
     "dist-electron",
+    "dist-web",
     "node_modules",
     "pnpm-lock.yaml",
     "*.tsbuildinfo",
@@ -128,7 +129,7 @@
       // Dependency boundary: the portable app is host-agnostic. It reaches
       // the host only through the injected Bridge (src/lib/bridge.ts) —
       // never electron, node built-ins, or the desktop shell.
-      "files": ["packages/app/src/**", "packages/app/dev/**"],
+      "files": ["packages/app/src/**", "packages/app/dev/**", "packages/app/web/**"],
       "rules": {
         "no-restricted-imports": [
           "error",

--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -106,6 +106,25 @@
       }
     },
     {
+      // Dependency boundary: core is isomorphic — the same modules load in
+      // the browser (bridge-ws-client), the Electron renderer, and node
+      // hosts. No node built-ins, no electron.
+      "files": ["packages/core/src/**"],
+      "rules": {
+        "no-restricted-imports": [
+          "error",
+          {
+            "patterns": [
+              {
+                "group": ["electron", "electron/*", "node:*", "@repo/desktop", "@repo/desktop/*"],
+                "message": "packages/core is isomorphic — no node/electron imports"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
       // Dependency boundary: the portable app is host-agnostic. It reaches
       // the host only through the injected Bridge (src/lib/bridge.ts) —
       // never electron, node built-ins, or the desktop shell.

--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -107,6 +107,31 @@
       }
     },
     {
+      // Dependency boundary: server + cli are headless node shells over
+      // @repo/host — never electron or the desktop shell.
+      "files": ["packages/server/src/**", "packages/cli/src/**", "packages/cli/bin/**"],
+      "rules": {
+        "no-restricted-imports": [
+          "error",
+          {
+            "patterns": [
+              {
+                "group": [
+                  "electron",
+                  "electron/*",
+                  "electron-updater",
+                  "@repo/desktop",
+                  "@repo/desktop/*",
+                  "**/apps/desktop/**"
+                ],
+                "message": "server/cli are headless node — no electron/desktop imports"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
       // Dependency boundary: core is isomorphic — the same modules load in
       // the browser (bridge-ws-client), the Electron renderer, and node
       // hosts. No node built-ins, no electron.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,10 +34,20 @@ apps/
 packages/
   app/           # Portable UI — the whole workspace as a browser React app (@repo/app)
   core/          # Isomorphic contract: Bridge/IPC registry, domain schemas (@repo/core)
+  host/          # Platform-agnostic node backend: vault, pi, delegation, executor, voice (@repo/host)
+  server/        # Loopback HTTP+WS host: folds the registry over WS, serves the app build (@repo/server)
+  cli/           # `inteligir <vault>`: boot host+server, open the browser (@repo/cli)
   ui/            # Shared UI components (@repo/ui)
   agent-runtime/ # CLI install/seed/run helpers for agent extensions (@repo/agent-runtime)
   pi-driver/     # pi-coding-agent wrapper: sessions, auth, models (@repo/pi-driver)
 ```
+
+The product runs two ways over the same `@repo/host` backend + `@repo/app` UI:
+the **Electron desktop** app (`pnpm dev:desktop`) and the **browser** via the
+cli (`pnpm --filter @repo/cli exec tsx src/main.ts <vault> [--port N] [--no-open]`,
+or the `inteligir` bin post-build). The cli boots `@repo/server` (loopback-only
+HTTP+WS; the bind address + Host/Origin allowlists are the auth gate — no
+accounts) and opens `http://127.0.0.1:<port>`.
 
 ## Common Commands
 

--- a/knip.json
+++ b/knip.json
@@ -32,11 +32,11 @@
       "includeEntryExports": true
     },
     "packages/app": {
-      // The portable UI, source-imported by hosts (desktop today, server
-      // later) through its `./*` exports — don't flag them as unused. The dev
-      // harness entry (dev/main.tsx) is picked up via vite.config.ts.
+      // The portable UI, source-imported by hosts (desktop, server). Both
+      // browser entries (dev harness dev/main.tsx, web build web/main.tsx)
+      // are picked up via their vite configs.
       "entry": ["src/__tests__/**/*.test.ts"],
-      "project": ["src/**/*.{ts,tsx,css,js}", "dev/**/*.{ts,tsx}"],
+      "project": ["src/**/*.{ts,tsx,css,js}", "dev/**/*.{ts,tsx}", "web/**/*.{ts,tsx}"],
       "includeEntryExports": false
     },
     "packages/host": {

--- a/knip.json
+++ b/knip.json
@@ -47,9 +47,11 @@
       "includeEntryExports": false
     },
     "packages/core": {
-      // Isomorphic contract + pure-logic library consumed by the desktop app
-      // (and, in later phases, the web server). Its `./*` exports are the
-      // public API across hosts, so don't flag them as unused.
+      // Isomorphic contract + pure-logic library consumed by every host
+      // (desktop shell, web server, browser client). Its `./*` exports are
+      // the public API across hosts, so don't flag them as unused.
+      "entry": ["src/__tests__/**/*.test.ts"],
+      "project": ["src/**/*.ts"],
       "includeEntryExports": false
     },
     "packages/pi-driver": {

--- a/knip.json
+++ b/knip.json
@@ -39,6 +39,22 @@
       "project": ["src/**/*.{ts,tsx,css,js}", "dev/**/*.{ts,tsx}", "web/**/*.{ts,tsx}"],
       "includeEntryExports": false
     },
+    "packages/cli": {
+      // bin/inteligir.js (package.json bin) and src/main.ts (its import +
+      // the dev script) are auto-detected entries.
+      "project": ["src/**/*.ts", "bin/**/*.js"],
+      // @repo/app: never imported — the cli resolves its dist-web assets at
+      // runtime via require.resolve("@repo/app/package.json"), and the
+      // workspace dep is what makes that resolvable (and, at Phase 7, what
+      // ships the build to npm).
+      "ignoreDependencies": ["@repo/app"]
+    },
+    "packages/server": {
+      // Consumed by @repo/cli through its `./*` exports.
+      "entry": ["src/__tests__/**/*.test.ts"],
+      "project": ["src/**/*.ts"],
+      "includeEntryExports": false
+    },
     "packages/host": {
       // The node backend, source-imported by its shells (desktop today,
       // server later) through its `./*` exports — don't flag them as unused.

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -5,7 +5,8 @@
   "description": "Portable Inteligir UI: the whole workspace (editor, sidebar, composer, settings) as a browser React app. Talks to its host exclusively through an injected Bridge — no electron, no node.",
   "type": "module",
   "scripts": {
-    "clean": "git clean -xdf .cache .turbo dist node_modules",
+    "build": "vite build --config vite.web.config.ts",
+    "clean": "git clean -xdf .cache .turbo dist dist-web node_modules",
     "dev": "vite dev",
     "test": "vitest run",
     "typecheck": "tsc --noEmit --emitDeclarationOnly false"

--- a/packages/app/tsconfig.json
+++ b/packages/app/tsconfig.json
@@ -9,7 +9,7 @@
       "@repo/ui/*": ["../ui/src/*"]
     }
   },
-  "include": ["src", "dev", "vite.config.ts", "vitest.config.ts"],
+  "include": ["src", "dev", "web", "vite.config.ts", "vite.web.config.ts", "vitest.config.ts"],
   // The STT worklet runs on the audio rendering thread whose globals
   // (AudioWorkletProcessor, registerProcessor) don't exist in the DOM lib —
   // see the header comment in that file. Note: `exclude` replaces (not

--- a/packages/app/vite.web.config.ts
+++ b/packages/app/vite.web.config.ts
@@ -1,0 +1,21 @@
+import { fileURLToPath } from "node:url";
+import tailwindcss from "@tailwindcss/vite";
+import react from "@vitejs/plugin-react";
+import { defineConfig } from "vite";
+
+// Static web build (`pnpm build` → dist-web/), served by @repo/server. The
+// in-memory dev harness stays in vite.config.ts; this entry installs the
+// WebSocket Bridge instead of a fixture.
+export default defineConfig({
+  root: "web",
+  plugins: [tailwindcss(), react()],
+  resolve: {
+    // Same pinning rationale as vite.config.ts: the package is source-only
+    // with no exports map, so hosts alias `@repo/app` to ./src.
+    alias: { "@repo/app": fileURLToPath(new URL("./src", import.meta.url)) },
+  },
+  build: {
+    outDir: fileURLToPath(new URL("./dist-web", import.meta.url)),
+    emptyOutDir: true,
+  },
+});

--- a/packages/app/web/index.html
+++ b/packages/app/web/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Inteligir</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="./main.tsx"></script>
+  </body>
+</html>

--- a/packages/app/web/main.tsx
+++ b/packages/app/web/main.tsx
@@ -1,0 +1,58 @@
+// ---------------------------------------------------------------------------
+// Browser entry — the WS counterpart of the desktop preload: installs a
+// WebSocket Bridge against the same origin that served this page
+// (@repo/server), then renders the portable App plus a connection-lost
+// overlay fed by the bridge's reconnect state.
+// ---------------------------------------------------------------------------
+
+import { useSyncExternalStore } from "react";
+import { createRoot } from "react-dom/client";
+
+import { App } from "@repo/app/app-root";
+import { installBridge } from "@repo/app/lib/bridge";
+import { createWsBridge, type WsBridgeConnectionState } from "@repo/core/bridge-ws-client";
+
+let connectionState: WsBridgeConnectionState = "connecting";
+const connectionListeners = new Set<() => void>();
+
+function subscribeConnection(listener: () => void): () => void {
+  connectionListeners.add(listener);
+  return () => {
+    connectionListeners.delete(listener);
+  };
+}
+
+const wsProtocol = location.protocol === "https:" ? "wss" : "ws";
+installBridge(
+  createWsBridge(`${wsProtocol}://${location.host}/bridge`, {
+    onConnectionState: (state) => {
+      connectionState = state;
+      for (const listener of connectionListeners) listener();
+    },
+  }),
+);
+
+/** Shown only after the bridge has lost an established connection — the
+ * bridge itself keeps retrying with backoff and resyncs on reopen. */
+function ConnectionOverlay() {
+  const state = useSyncExternalStore(subscribeConnection, () => connectionState);
+  if (state !== "reconnecting") return null;
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/30 backdrop-blur-sm">
+      <div className="flex items-center gap-3 rounded-xl border border-border bg-background px-5 py-3.5 text-sm font-medium text-foreground shadow-lg">
+        <span className="size-2 animate-pulse rounded-full bg-red-500" />
+        Connection lost — reconnecting…
+      </div>
+    </div>
+  );
+}
+
+const root = document.getElementById("root");
+if (root) {
+  createRoot(root).render(
+    <>
+      <App />
+      <ConnectionOverlay />
+    </>,
+  );
+}

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -1,0 +1,40 @@
+# `@repo/cli` — `inteligir`, your vault in a browser
+
+Boots `@repo/host` + `@repo/server` and opens the app in the default browser.
+
+```
+inteligir [vault-path] [--port <n>] [--no-open]
+```
+
+- `vault-path` — folder of markdown notes (default: current dir). Applied at
+  boot through `HostOptions.vaultPath` → the same `VaultManager.setRoot()` the
+  desktop picker uses, so its guards apply (a root inside `~/.inteligir` throws).
+- `--port` — fixed TCP port (default: pick a free one).
+- `--no-open` — don't launch the browser.
+
+The server folds the host over WS on 127.0.0.1 only — the bind address plus the
+Host/Origin allowlists are the auth gate (see `@repo/server`). SIGINT/SIGTERM
+close the server and `host.dispose()` (releases `~/.inteligir/host.lock`, stops
+agents + the executor daemon), with a watchdog so a wedged teardown can't hold
+the process.
+
+## Platform
+
+`src/server-platform.ts` is the headless-node `HostPlatform` — no native dialogs
+(the vault is fixed on the command line), file-key AES-GCM cipher instead of the
+OS keychain, and a per-OS `userDataDir` that mirrors Electron's location so a
+desktop install and the cli share one voice-model download. It is deliberately
+**not** `~/.inteligir` (logout `rm -rf`'s that dir).
+
+## Running
+
+Pre-publish the workspace is source-consumed, so the bin (`bin/inteligir.js`)
+and `dev` script run the TS entry through `tsx`. Flags need the `exec` form so
+they aren't swallowed by pnpm's `--`:
+
+```
+pnpm build   # emits @repo/app dist-web/ that the cli resolves at runtime
+pnpm --filter @repo/cli exec tsx src/main.ts <vault> --port 47990
+```
+
+Phase 7 swaps the tsx hook for a compiled dist import and publishes to npm.

--- a/packages/cli/bin/inteligir.js
+++ b/packages/cli/bin/inteligir.js
@@ -1,0 +1,8 @@
+#!/usr/bin/env node
+// Pre-publish bin: the workspace is source-consumed, so run the TS entry
+// through tsx's module hooks. Phase 7 (npm packaging) replaces this with a
+// compiled dist import.
+import { register } from "tsx/esm/api";
+
+register();
+await import("../src/main.ts");

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "@repo/cli",
+  "version": "0.1.0",
+  "private": true,
+  "description": "inteligir — pick a vault, boot @repo/server against a local @repo/host, open the browser. Pre-publish the bin runs the workspace TS sources through tsx; Phase 7 ships a compiled dist to npm.",
+  "bin": {
+    "inteligir": "./bin/inteligir.js"
+  },
+  "type": "module",
+  "scripts": {
+    "clean": "git clean -xdf .cache .turbo dist node_modules",
+    "dev": "tsx src/main.ts",
+    "typecheck": "tsc --noEmit --emitDeclarationOnly false"
+  },
+  "dependencies": {
+    "@repo/app": "workspace:^",
+    "@repo/host": "workspace:^",
+    "@repo/server": "workspace:^",
+    "open": "^11.0.0",
+    "tsx": "^4.21.1"
+  },
+  "devDependencies": {
+    "@types/node": "catalog:",
+    "typescript": "catalog:"
+  }
+}

--- a/packages/cli/src/main.ts
+++ b/packages/cli/src/main.ts
@@ -1,0 +1,121 @@
+// ---------------------------------------------------------------------------
+// inteligir [vault-path] — boot the local host + server and open the app in
+// the default browser. The vault defaults to the current directory; loopback
+// is the auth gate (see @repo/server/create-server).
+// ---------------------------------------------------------------------------
+
+import fs from "node:fs";
+import { createRequire } from "node:module";
+import path from "node:path";
+import { parseArgs } from "node:util";
+import open from "open";
+
+import { createHost } from "@repo/host/create-host";
+import { createServer } from "@repo/server/create-server";
+
+import { createServerPlatform } from "./server-platform";
+
+const HELP = `inteligir — your vault, in a browser
+
+Usage: inteligir [vault-path] [options]
+
+  vault-path      Folder of markdown notes to open (default: current dir)
+
+Options:
+  --port <n>      Fixed TCP port (default: pick a free one)
+  --no-open       Don't open the browser automatically
+  -h, --help      Show this help
+`;
+
+const SHUTDOWN_TIMEOUT_MS = 5_000;
+
+function fail(message: string): never {
+  console.error(`inteligir: ${message}`);
+  process.exit(1);
+}
+
+async function main(): Promise<void> {
+  const { values, positionals } = parseArgs({
+    allowPositionals: true,
+    options: {
+      port: { type: "string" },
+      "no-open": { type: "boolean", default: false },
+      help: { type: "boolean", short: "h", default: false },
+    },
+  });
+
+  if (values.help) {
+    console.log(HELP);
+    return;
+  }
+  if (positionals.length > 1) fail("expected at most one vault path (see --help)");
+
+  const vaultPath = path.resolve(positionals[0] ?? process.cwd());
+  const existing = fs.statSync(vaultPath, { throwIfNoEntry: false });
+  if (existing && !existing.isDirectory()) fail(`${vaultPath} is not a directory`);
+
+  let port = 0;
+  if (values.port !== undefined) {
+    port = Number.parseInt(values.port, 10);
+    if (!Number.isInteger(port) || port < 0 || port > 65535) fail("--port must be 0–65535");
+  }
+
+  // The web build ships inside @repo/app (dist-web/); in-repo it comes from
+  // `pnpm build`.
+  const appPackageJson = createRequire(import.meta.url).resolve("@repo/app/package.json");
+  const assetsDir = path.join(path.dirname(appPackageJson), "dist-web");
+  if (!fs.existsSync(path.join(assetsDir, "index.html"))) {
+    fail(`app web build missing at ${assetsDir} — run \`pnpm build\` first`);
+  }
+
+  const host = createHost(createServerPlatform(), { vaultPath });
+
+  // Transport fold before host.start() so no early event is dropped.
+  const server = await createServer({ host, assetsDir, port });
+  try {
+    host.start();
+  } catch (err) {
+    await server.close().catch(() => {});
+    throw err;
+  }
+
+  console.log(`\n  inteligir`);
+  console.log(`  vault  ${vaultPath}`);
+  console.log(`  url    ${server.url}\n`);
+
+  let shuttingDown = false;
+  const shutdown = (signal: NodeJS.Signals): void => {
+    if (shuttingDown) return;
+    shuttingDown = true;
+    console.log(`\n[inteligir] ${signal} — shutting down`);
+    // A wedged teardown must not hold the process hostage.
+    const watchdog = setTimeout(() => {
+      console.error(`[inteligir] shutdown timed out after ${SHUTDOWN_TIMEOUT_MS}ms — exiting`);
+      process.exit(1);
+    }, SHUTDOWN_TIMEOUT_MS);
+    void (async () => {
+      await server.close().catch((err: unknown) => {
+        console.error("[inteligir] server close failed:", err);
+      });
+      // dispose() shuts down agents + executor daemon and releases the host lock.
+      await host.dispose().catch((err: unknown) => {
+        console.error("[inteligir] host dispose failed:", err);
+      });
+      clearTimeout(watchdog);
+      process.exit(0);
+    })();
+  };
+  process.on("SIGINT", () => shutdown("SIGINT"));
+  process.on("SIGTERM", () => shutdown("SIGTERM"));
+
+  if (!values["no-open"]) {
+    await open(server.url).catch((err: unknown) => {
+      console.warn("[inteligir] could not open the browser:", err);
+    });
+  }
+}
+
+main().catch((err: unknown) => {
+  console.error("inteligir failed to start:", err instanceof Error ? err.message : err);
+  process.exit(1);
+});

--- a/packages/cli/src/server-platform.ts
+++ b/packages/cli/src/server-platform.ts
@@ -1,0 +1,63 @@
+// ---------------------------------------------------------------------------
+// The headless-node implementation of HostPlatform — the cli counterpart of
+// the desktop shell's electron-platform.ts. No native dialogs (the vault is
+// fixed at boot, so pickDirectory is absent and the UI hides the affordance)
+// and no OS keychain (secrets ride the file-key AES-GCM cipher).
+// ---------------------------------------------------------------------------
+
+import { createRequire } from "node:module";
+import os from "node:os";
+import path from "node:path";
+import open from "open";
+
+import { createFileKeyCipher } from "@repo/host/lib/file-key-cipher";
+import { inteligirPath } from "@repo/host/lib/json-store";
+import type { HostPlatform } from "@repo/host/platform";
+
+/**
+ * Per-user data dir for large assets that must survive logout (voice
+ * models). NOT ~/.inteligir — logout rm -rf's that dir. Mirrors Electron's
+ * per-platform userData location so a desktop install and the cli share one
+ * model download.
+ */
+function userDataDir(): string {
+  const home = os.homedir();
+  switch (process.platform) {
+    case "darwin":
+      return path.join(home, "Library", "Application Support", "Inteligir");
+    case "win32":
+      return path.join(
+        process.env["APPDATA"] ?? path.join(home, "AppData", "Roaming"),
+        "Inteligir",
+      );
+    default:
+      return path.join(
+        process.env["XDG_DATA_HOME"] ?? path.join(home, ".local", "share"),
+        "inteligir",
+      );
+  }
+}
+
+export function createServerPlatform(): HostPlatform {
+  // Bundled agent resources (skills/, AGENTS.md) ship inside @repo/host;
+  // resolve them through the package instead of guessing repo layout.
+  const hostPackageJson = createRequire(import.meta.url).resolve("@repo/host/package.json");
+  const resourcesDir = path.join(path.dirname(hostPackageJson), "resources", "agent");
+
+  return {
+    userDataDir: userDataDir(),
+    resourcesDir,
+    // A source checkout / npm install missing optional resources is a
+    // warn-and-continue, not a corrupt packaged app.
+    strictResources: false,
+    secretCipher: createFileKeyCipher(inteligirPath("secret.key")),
+    openExternal: async (url) => {
+      await open(url);
+    },
+    notify: (notification) => {
+      console.log(`[notify] ${notification.title} — ${notification.body}`);
+    },
+    // No window focus signal in a headless server: always deliver.
+    anyUiFocused: () => false,
+  };
+}

--- a/packages/cli/tsconfig.json
+++ b/packages/cli/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "lib": ["ES2023"],
+    "types": ["node"],
+    // bin/inteligir.js imports the TS entry directly (tsx runs it pre-publish).
+    "allowImportingTsExtensions": true,
+    "paths": {
+      "@repo/core/*": ["../core/src/*"],
+      "@repo/host/*": ["../host/src/*"],
+      "@repo/server/*": ["../server/src/*"],
+      "@repo/pi-driver/*": ["../pi-driver/src/*"],
+      "@repo/agent-runtime/*": ["../agent-runtime/src/*"]
+    }
+  },
+  "include": ["src", "bin", "../host/src/voice/sherpa-onnx-node.d.ts"]
+}

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -9,6 +9,7 @@
   },
   "scripts": {
     "clean": "git clean -xdf .cache .turbo dist node_modules",
+    "test": "vitest run",
     "typecheck": "tsc --noEmit --emitDeclarationOnly false"
   },
   "dependencies": {
@@ -16,6 +17,7 @@
     "@sinclair/typebox": "catalog:"
   },
   "devDependencies": {
-    "typescript": "catalog:"
+    "typescript": "catalog:",
+    "vitest": "^4.1.7"
   }
 }

--- a/packages/core/src/__tests__/bridge-wire.test.ts
+++ b/packages/core/src/__tests__/bridge-wire.test.ts
@@ -1,0 +1,154 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  BINARY_TAG_STT_PCM,
+  BINARY_TAG_TTS_PCM,
+  decodeBinaryFrame,
+  encodeBinaryFrame,
+  parseClientFrame,
+  parseServerFrame,
+  WIRE_EVENT_METHODS,
+  WIRE_REQUEST_METHODS,
+  WIRE_SEND_METHODS,
+} from "../bridge-wire";
+import { IPC, IPC_METHODS, UPDATE_METHODS } from "../ipc-registry";
+
+describe("method partitions", () => {
+  it("request methods cover every host invoke/invoke-void and nothing else", () => {
+    const expected = IPC_METHODS.filter((m) => {
+      const kind = IPC[m].kind;
+      return (
+        (kind === "invoke" || kind === "invoke-void") &&
+        !(UPDATE_METHODS as readonly string[]).includes(m)
+      );
+    });
+    expect([...WIRE_REQUEST_METHODS].toSorted()).toEqual(expected.toSorted());
+  });
+
+  it("excludes the update trio from requests", () => {
+    for (const method of UPDATE_METHODS) {
+      expect(WIRE_REQUEST_METHODS).not.toContain(method);
+    }
+  });
+
+  it("excludes sendSttAudio from send envelopes (binary-only)", () => {
+    expect(WIRE_SEND_METHODS).not.toContain("sendSttAudio");
+    expect(WIRE_SEND_METHODS).toContain("ttsSend");
+  });
+
+  it("excludes onTtsAudio from event envelopes (binary-only)", () => {
+    expect(WIRE_EVENT_METHODS).not.toContain("onTtsAudio");
+    expect(WIRE_EVENT_METHODS).toContain("onVaultChanged");
+  });
+});
+
+describe("parseClientFrame", () => {
+  it("round-trips a request envelope", () => {
+    const text = JSON.stringify({
+      t: "req",
+      id: 7,
+      method: "readVaultDoc",
+      payload: { path: "a.md" },
+    });
+    expect(parseClientFrame(text)).toEqual({
+      ok: true,
+      frame: { t: "req", id: 7, method: "readVaultDoc", payload: { path: "a.md" } },
+    });
+  });
+
+  it("round-trips a payload-less request", () => {
+    expect(parseClientFrame(JSON.stringify({ t: "req", id: 1, method: "getVaultRoot" }))).toEqual({
+      ok: true,
+      frame: { t: "req", id: 1, method: "getVaultRoot" },
+    });
+  });
+
+  it("round-trips a send envelope", () => {
+    const text = JSON.stringify({ t: "snd", method: "ttsSend", payload: { text: "hi" } });
+    expect(parseClientFrame(text)).toEqual({
+      ok: true,
+      frame: { t: "snd", method: "ttsSend", payload: { text: "hi" } },
+    });
+  });
+
+  it("rejects unknown methods, wrong kinds, and non-JSON", () => {
+    expect(parseClientFrame(JSON.stringify({ t: "req", id: 1, method: "nope" })).ok).toBe(false);
+    // update trio never crosses the wire
+    expect(
+      parseClientFrame(JSON.stringify({ t: "req", id: 1, method: "checkForUpdates" })).ok,
+    ).toBe(false);
+    // STT audio is binary-only
+    expect(
+      parseClientFrame(JSON.stringify({ t: "snd", method: "sendSttAudio", payload: [1, 2] })).ok,
+    ).toBe(false);
+    // an event method is not callable
+    expect(parseClientFrame(JSON.stringify({ t: "req", id: 1, method: "onVaultChanged" })).ok).toBe(
+      false,
+    );
+    expect(parseClientFrame("not json").ok).toBe(false);
+  });
+});
+
+describe("parseServerFrame", () => {
+  it("round-trips ok / error responses", () => {
+    expect(parseServerFrame(JSON.stringify({ t: "res", id: 3, ok: true, result: "x" }))).toEqual({
+      ok: true,
+      frame: { t: "res", id: 3, ok: true, result: "x" },
+    });
+    expect(parseServerFrame(JSON.stringify({ t: "res", id: 3, ok: true }))).toEqual({
+      ok: true,
+      frame: { t: "res", id: 3, ok: true },
+    });
+    expect(parseServerFrame(JSON.stringify({ t: "res", id: 4, ok: false, error: "bad" }))).toEqual({
+      ok: true,
+      frame: { t: "res", id: 4, ok: false, error: "bad" },
+    });
+  });
+
+  it("round-trips event envelopes and rejects binary-only events", () => {
+    const text = JSON.stringify({ t: "evt", method: "onVaultChanged", payload: { root: "/v" } });
+    expect(parseServerFrame(text)).toEqual({
+      ok: true,
+      frame: { t: "evt", method: "onVaultChanged", payload: { root: "/v" } },
+    });
+    expect(
+      parseServerFrame(JSON.stringify({ t: "evt", method: "onTtsAudio", payload: {} })).ok,
+    ).toBe(false);
+  });
+});
+
+describe("binary frames", () => {
+  it("round-trips tag + payload", () => {
+    const pcm = new Uint8Array([1, 2, 3, 4, 5, 6, 7, 8]);
+    const frame = encodeBinaryFrame(BINARY_TAG_STT_PCM, pcm);
+    expect(new Uint8Array(frame)[0]).toBe(BINARY_TAG_STT_PCM);
+    const decoded = decodeBinaryFrame(frame);
+    expect(decoded?.tag).toBe(BINARY_TAG_STT_PCM);
+    expect([...(decoded?.payload ?? [])]).toEqual([1, 2, 3, 4, 5, 6, 7, 8]);
+  });
+
+  it("returns an alignment-safe payload (viewable as Float32/Int16)", () => {
+    const samples = new Float32Array([0.5, -0.25, 1]);
+    const frame = encodeBinaryFrame(
+      BINARY_TAG_STT_PCM,
+      new Uint8Array(samples.buffer, samples.byteOffset, samples.byteLength),
+    );
+    const decoded = decodeBinaryFrame(frame);
+    expect(decoded).not.toBeNull();
+    if (!decoded) return;
+    expect(decoded.payload.byteOffset).toBe(0);
+    const view = new Float32Array(decoded.payload.buffer, 0, 3);
+    expect([...view]).toEqual([0.5, -0.25, 1]);
+  });
+
+  it("decodes an offset view (node Buffer subarray) without shifting bytes", () => {
+    const backing = new Uint8Array([9, 9, BINARY_TAG_TTS_PCM, 10, 20]);
+    const decoded = decodeBinaryFrame(backing.subarray(2));
+    expect(decoded?.tag).toBe(BINARY_TAG_TTS_PCM);
+    expect([...(decoded?.payload ?? [])]).toEqual([10, 20]);
+  });
+
+  it("rejects an empty frame", () => {
+    expect(decodeBinaryFrame(new ArrayBuffer(0))).toBeNull();
+  });
+});

--- a/packages/core/src/__tests__/bridge-ws-client.test.ts
+++ b/packages/core/src/__tests__/bridge-ws-client.test.ts
@@ -1,0 +1,221 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { BINARY_TAG_STT_PCM, BINARY_TAG_TTS_PCM } from "../bridge-wire";
+import { createWsBridge, type WsBridgeConnectionState } from "../bridge-ws-client";
+
+type Listener = (event: { data?: unknown }) => void;
+
+class FakeSocket {
+  static CONNECTING = 0;
+  static OPEN = 1;
+  static CLOSING = 2;
+  static CLOSED = 3;
+  static instances: FakeSocket[] = [];
+
+  url: string;
+  readyState = FakeSocket.CONNECTING;
+  binaryType = "blob";
+  sent: unknown[] = [];
+  private listeners = new Map<string, Set<Listener>>();
+
+  constructor(url: string) {
+    this.url = url;
+    FakeSocket.instances.push(this);
+  }
+
+  addEventListener(type: string, listener: Listener): void {
+    const set = this.listeners.get(type) ?? new Set();
+    set.add(listener);
+    this.listeners.set(type, set);
+  }
+
+  send(data: unknown): void {
+    this.sent.push(data);
+  }
+
+  private emit(type: string, event: { data?: unknown }): void {
+    for (const listener of this.listeners.get(type) ?? []) listener(event);
+  }
+
+  open(): void {
+    this.readyState = FakeSocket.OPEN;
+    this.emit("open", {});
+  }
+
+  message(data: unknown): void {
+    this.emit("message", { data });
+  }
+
+  close(): void {
+    this.readyState = FakeSocket.CLOSED;
+    this.emit("close", {});
+  }
+
+  sentJson(): Array<Record<string, unknown>> {
+    return this.sent
+      .filter((f): f is string => typeof f === "string")
+      .map((f) => JSON.parse(f) as Record<string, unknown>);
+  }
+}
+
+function lastSocket(): FakeSocket {
+  const socket = FakeSocket.instances.at(-1);
+  if (!socket) throw new Error("no socket created");
+  return socket;
+}
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  FakeSocket.instances = [];
+  vi.stubGlobal("WebSocket", FakeSocket);
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.useRealTimers();
+});
+
+describe("createWsBridge", () => {
+  it("sends a req envelope and resolves with the res result", async () => {
+    const bridge = createWsBridge("ws://test/bridge");
+    const socket = lastSocket();
+    socket.open();
+
+    const promise = bridge.readVaultDoc({ path: "a.md" });
+    expect(socket.sentJson()).toEqual([
+      { t: "req", id: 1, method: "readVaultDoc", payload: { path: "a.md" } },
+    ]);
+
+    socket.message(JSON.stringify({ t: "res", id: 1, ok: true, result: "# hi" }));
+    await expect(promise).resolves.toBe("# hi");
+  });
+
+  it("rejects on an error response", async () => {
+    const bridge = createWsBridge("ws://test/bridge");
+    const socket = lastSocket();
+    socket.open();
+
+    const promise = bridge.getVaultRoot();
+    socket.message(JSON.stringify({ t: "res", id: 1, ok: false, error: "boom" }));
+    await expect(promise).rejects.toThrow("boom");
+  });
+
+  it("queues requests made while the socket is connecting", async () => {
+    const bridge = createWsBridge("ws://test/bridge");
+    const socket = lastSocket();
+
+    const promise = bridge.getVaultRoot();
+    expect(socket.sent).toHaveLength(0);
+
+    socket.open();
+    expect(socket.sentJson()).toEqual([{ t: "req", id: 1, method: "getVaultRoot" }]);
+    socket.message(JSON.stringify({ t: "res", id: 1, ok: true, result: "/v" }));
+    await expect(promise).resolves.toBe("/v");
+  });
+
+  it("dispatches evt envelopes to subscribers, with unsubscribe", () => {
+    const bridge = createWsBridge("ws://test/bridge");
+    const socket = lastSocket();
+    socket.open();
+
+    const seen: Array<{ root: string }> = [];
+    const unsubscribe = bridge.onVaultChanged((event) => seen.push(event));
+    socket.message(JSON.stringify({ t: "evt", method: "onVaultChanged", payload: { root: "/v" } }));
+    expect(seen).toEqual([{ root: "/v" }]);
+
+    unsubscribe();
+    socket.message(JSON.stringify({ t: "evt", method: "onVaultChanged", payload: { root: "/w" } }));
+    expect(seen).toEqual([{ root: "/v" }]);
+  });
+
+  it("routes tagged TTS binary frames to onTtsAudio", () => {
+    const bridge = createWsBridge("ws://test/bridge");
+    const socket = lastSocket();
+    socket.open();
+
+    const audio: ArrayBuffer[] = [];
+    bridge.onTtsAudio((event) => audio.push(event.audio));
+
+    const pcm = new Int16Array([1000, -2000]);
+    const frame = new Uint8Array(1 + pcm.byteLength);
+    frame[0] = BINARY_TAG_TTS_PCM;
+    frame.set(new Uint8Array(pcm.buffer), 1);
+    socket.message(frame.buffer);
+
+    expect(audio).toHaveLength(1);
+    const first = audio[0];
+    expect(first).toBeDefined();
+    if (!first) return;
+    expect([...new Int16Array(first)]).toEqual([1000, -2000]);
+  });
+
+  it("sends STT PCM as a tagged binary frame, honoring typed-array views", () => {
+    const bridge = createWsBridge("ws://test/bridge");
+    const socket = lastSocket();
+    socket.open();
+
+    const backing = new Float32Array([9, 0.5, -0.5, 9]);
+    bridge.sendSttAudio(backing.subarray(1, 3));
+
+    const frame = socket.sent.at(-1);
+    expect(frame).toBeInstanceOf(ArrayBuffer);
+    if (!(frame instanceof ArrayBuffer)) return;
+    const bytes = new Uint8Array(frame);
+    expect(bytes[0]).toBe(BINARY_TAG_STT_PCM);
+    const samples = new Float32Array(new Uint8Array(bytes.subarray(1)).buffer);
+    expect([...samples]).toEqual([0.5, -0.5]);
+  });
+
+  it("drops STT audio while disconnected (stale realtime data)", () => {
+    const bridge = createWsBridge("ws://test/bridge");
+    const socket = lastSocket();
+    bridge.sendSttAudio(new Float32Array([1]));
+    expect(socket.sent).toHaveLength(0);
+  });
+
+  it("rejects in-flight requests on close, fails fast while down, reconnects and resyncs", async () => {
+    const states: WsBridgeConnectionState[] = [];
+    const bridge = createWsBridge("ws://test/bridge", {
+      onConnectionState: (state) => states.push(state),
+    });
+    const first = lastSocket();
+    first.open();
+
+    const inflight = bridge.getVaultRoot();
+    first.close();
+    await expect(inflight).rejects.toThrow("connection lost");
+    expect(states).toEqual(["connecting", "open", "reconnecting"]);
+
+    // Fully down (between retries): fail fast instead of queueing forever.
+    await expect(bridge.getAppState()).rejects.toThrow("connection lost");
+
+    // Backoff elapses → a fresh socket; on open the bridge resyncs by
+    // re-requesting vault root + app state and re-emitting the events.
+    vi.advanceTimersByTime(500);
+    const second = lastSocket();
+    expect(second).not.toBe(first);
+
+    const roots: string[] = [];
+    bridge.onVaultChanged(({ root }) => roots.push(root));
+    second.open();
+    const methods = second.sentJson().map((f) => f["method"]);
+    expect(methods).toContain("getVaultRoot");
+    expect(methods).toContain("getAppState");
+
+    const rootReq = second.sentJson().find((f) => f["method"] === "getVaultRoot");
+    second.message(JSON.stringify({ t: "res", id: rootReq?.["id"], ok: true, result: "/v2" }));
+    await vi.advanceTimersByTimeAsync(0);
+    expect(roots).toEqual(["/v2"]);
+  });
+
+  it("answers the update trio locally without wire traffic", async () => {
+    const bridge = createWsBridge("ws://test/bridge");
+    const socket = lastSocket();
+    socket.open();
+
+    await expect(bridge.checkForUpdates()).resolves.toMatchObject({ status: "not-available" });
+    await expect(bridge.downloadUpdate()).resolves.toMatchObject({ accepted: false });
+    await expect(bridge.installUpdate()).resolves.toMatchObject({ accepted: false });
+    expect(socket.sent).toHaveLength(0);
+  });
+});

--- a/packages/core/src/bridge-wire.ts
+++ b/packages/core/src/bridge-wire.ts
@@ -1,0 +1,254 @@
+// ---------------------------------------------------------------------------
+// Bridge wire protocol — the WebSocket encoding of the IPC registry, shared
+// verbatim by the browser client (bridge-ws-client.ts) and the node server
+// (@repo/server). Method lists are derived from the registry at runtime, so
+// a new channel needs no change here.
+//
+// Text frames — JSON envelopes, one per message:
+//   → { t: "req", id, method, payload? }   invoke / invoke-void call
+//   ← { t: "res", id, ok: true,  result? } resolved call
+//   ← { t: "res", id, ok: false, error }   rejected call
+//   → { t: "snd", method, payload? }       send-kind (fire-and-forget)
+//   ← { t: "evt", method, payload? }       event-kind fan-out
+//
+// Binary frames — 1-byte tag ‖ payload, reserved for the realtime voice PCM
+// paths (base64-in-JSON would add 33% + GC churn):
+//   0x01 client → server  STT mic PCM: Float32, little-endian, mono, 16 kHz
+//   0x02 server → client  TTS speech PCM: int16, little-endian, mono, 24 kHz
+//
+// Exactly two registry methods ride binary instead of JSON: `sendSttAudio`
+// (never a "snd" envelope) and `onTtsAudio` (never an "evt" envelope). The
+// UPDATE_METHODS trio never crosses the wire at all — a WS host has no
+// self-update, so the client answers those locally.
+// ---------------------------------------------------------------------------
+
+import { Type } from "@sinclair/typebox";
+import { Value } from "@sinclair/typebox/value";
+
+import {
+  IPC,
+  IPC_METHODS,
+  UPDATE_METHODS,
+  type EventMethod,
+  type HostMethod,
+  type IpcMethod,
+} from "./ipc-registry";
+
+// ---------------------------------------------------------------------------
+// Method partitions
+// ---------------------------------------------------------------------------
+
+type IpcKind<K extends IpcMethod> = (typeof IPC)[K]["kind"];
+
+/** Methods a client calls with a `req` envelope (awaits a `res`). */
+export type WireRequestMethod = {
+  [K in HostMethod]: IpcKind<K> extends "invoke" | "invoke-void" ? K : never;
+}[HostMethod];
+
+/** Methods a client fires with a `snd` envelope (no reply). */
+export type WireSendMethod = Exclude<
+  { [K in HostMethod]: IpcKind<K> extends "send" ? K : never }[HostMethod],
+  "sendSttAudio"
+>;
+
+/** Events the server pushes as `evt` envelopes. */
+export type WireEventMethod = Exclude<EventMethod, "onTtsAudio">;
+
+const updateMethods: ReadonlySet<string> = new Set(UPDATE_METHODS);
+
+function isWireRequestMethod(method: IpcMethod): method is WireRequestMethod {
+  const kind = IPC[method].kind;
+  return (kind === "invoke" || kind === "invoke-void") && !updateMethods.has(method);
+}
+
+function isWireSendMethod(method: IpcMethod): method is WireSendMethod {
+  return IPC[method].kind === "send" && method !== "sendSttAudio";
+}
+
+function isWireEventMethod(method: IpcMethod): method is WireEventMethod {
+  return IPC[method].kind === "event" && method !== "onTtsAudio";
+}
+
+export const WIRE_REQUEST_METHODS: readonly WireRequestMethod[] =
+  IPC_METHODS.filter(isWireRequestMethod);
+export const WIRE_SEND_METHODS: readonly WireSendMethod[] = IPC_METHODS.filter(isWireSendMethod);
+export const WIRE_EVENT_METHODS: readonly WireEventMethod[] = IPC_METHODS.filter(isWireEventMethod);
+
+// ---------------------------------------------------------------------------
+// JSON envelope schemas + typed frames
+// ---------------------------------------------------------------------------
+
+const methodLiteral = (methods: readonly string[]) =>
+  Type.Union(methods.map((method) => Type.Literal(method)));
+
+export const WireRequestSchema = Type.Object(
+  {
+    t: Type.Literal("req"),
+    id: Type.Integer({ minimum: 1 }),
+    method: methodLiteral(WIRE_REQUEST_METHODS),
+    payload: Type.Optional(Type.Unknown()),
+  },
+  { additionalProperties: false },
+);
+
+export const WireSendSchema = Type.Object(
+  {
+    t: Type.Literal("snd"),
+    method: methodLiteral(WIRE_SEND_METHODS),
+    payload: Type.Optional(Type.Unknown()),
+  },
+  { additionalProperties: false },
+);
+
+export const WireResponseSchema = Type.Union([
+  Type.Object(
+    {
+      t: Type.Literal("res"),
+      id: Type.Integer({ minimum: 1 }),
+      ok: Type.Literal(true),
+      result: Type.Optional(Type.Unknown()),
+    },
+    { additionalProperties: false },
+  ),
+  Type.Object(
+    {
+      t: Type.Literal("res"),
+      id: Type.Integer({ minimum: 1 }),
+      ok: Type.Literal(false),
+      error: Type.String(),
+    },
+    { additionalProperties: false },
+  ),
+]);
+
+export const WireEventSchema = Type.Object(
+  {
+    t: Type.Literal("evt"),
+    method: methodLiteral(WIRE_EVENT_METHODS),
+    payload: Type.Optional(Type.Unknown()),
+  },
+  { additionalProperties: false },
+);
+
+export type WireRequestFrame = {
+  t: "req";
+  id: number;
+  method: WireRequestMethod;
+  payload?: unknown;
+};
+export type WireSendFrame = { t: "snd"; method: WireSendMethod; payload?: unknown };
+export type WireClientFrame = WireRequestFrame | WireSendFrame;
+
+export type WireResponseFrame =
+  | { t: "res"; id: number; ok: true; result?: unknown }
+  | { t: "res"; id: number; ok: false; error: string };
+export type WireEventFrame = { t: "evt"; method: WireEventMethod; payload?: unknown };
+export type WireServerFrame = WireResponseFrame | WireEventFrame;
+
+export type ParseResult<F> = { ok: true; frame: F } | { ok: false; error: string };
+
+// The schemas' literal unions widen to `string` in Static (they're built from
+// a runtime list, not a tuple), so parsing re-proves membership against the
+// typed list to hand back a narrow frame without a cast.
+function findMethod<T extends string>(list: readonly T[], method: string): T | null {
+  for (const item of list) {
+    if (item === method) return item;
+  }
+  return null;
+}
+
+function parseJson(text: string): unknown {
+  try {
+    return JSON.parse(text);
+  } catch {
+    return undefined;
+  }
+}
+
+/** Server side: decode a client's text frame into a typed envelope. */
+export function parseClientFrame(text: string): ParseResult<WireClientFrame> {
+  const raw = parseJson(text);
+  if (Value.Check(WireRequestSchema, raw)) {
+    const method = findMethod(WIRE_REQUEST_METHODS, raw.method);
+    if (method !== null) {
+      return {
+        ok: true,
+        frame: {
+          t: "req",
+          id: raw.id,
+          method,
+          ...("payload" in raw ? { payload: raw.payload } : {}),
+        },
+      };
+    }
+  }
+  if (Value.Check(WireSendSchema, raw)) {
+    const method = findMethod(WIRE_SEND_METHODS, raw.method);
+    if (method !== null) {
+      return {
+        ok: true,
+        frame: { t: "snd", method, ...("payload" in raw ? { payload: raw.payload } : {}) },
+      };
+    }
+  }
+  return { ok: false, error: "unrecognized client frame" };
+}
+
+/** Client side: decode a server's text frame into a typed envelope. */
+export function parseServerFrame(text: string): ParseResult<WireServerFrame> {
+  const raw = parseJson(text);
+  if (Value.Check(WireResponseSchema, raw)) {
+    if (raw.ok) {
+      return {
+        ok: true,
+        frame: {
+          t: "res",
+          id: raw.id,
+          ok: true,
+          ...("result" in raw ? { result: raw.result } : {}),
+        },
+      };
+    }
+    return { ok: true, frame: { t: "res", id: raw.id, ok: false, error: raw.error } };
+  }
+  if (Value.Check(WireEventSchema, raw)) {
+    const method = findMethod(WIRE_EVENT_METHODS, raw.method);
+    if (method !== null) {
+      return {
+        ok: true,
+        frame: { t: "evt", method, ...("payload" in raw ? { payload: raw.payload } : {}) },
+      };
+    }
+  }
+  return { ok: false, error: "unrecognized server frame" };
+}
+
+// ---------------------------------------------------------------------------
+// Binary frames
+// ---------------------------------------------------------------------------
+
+/** Client → server: Float32 little-endian mono PCM @ 16 kHz (STT mic audio). */
+export const BINARY_TAG_STT_PCM = 0x01;
+/** Server → client: int16 little-endian mono PCM @ 24 kHz (TTS speech). */
+export const BINARY_TAG_TTS_PCM = 0x02;
+
+export function encodeBinaryFrame(tag: number, payload: Uint8Array): ArrayBuffer {
+  const frame = new Uint8Array(1 + payload.byteLength);
+  frame[0] = tag;
+  frame.set(payload, 1);
+  return frame.buffer;
+}
+
+export type BinaryFrame = {
+  tag: number;
+  /** A fresh offset-0 copy: the in-frame payload starts 1 byte in, which
+   * breaks the 2/4-byte alignment Int16Array/Float32Array views require. */
+  payload: Uint8Array<ArrayBuffer>;
+};
+
+export function decodeBinaryFrame(data: ArrayBuffer | Uint8Array): BinaryFrame | null {
+  const bytes = data instanceof Uint8Array ? data : new Uint8Array(data);
+  const tag = bytes[0];
+  if (tag === undefined) return null;
+  return { tag, payload: new Uint8Array(bytes.subarray(1)) };
+}

--- a/packages/core/src/bridge-ws-client.ts
+++ b/packages/core/src/bridge-ws-client.ts
@@ -1,0 +1,329 @@
+// ---------------------------------------------------------------------------
+// Browser WebSocket Bridge — folds the IPC registry into the bridge-wire
+// protocol so the portable app runs against @repo/server in a plain browser.
+// Browser APIs only (WebSocket, timers); the node counterpart lives in
+// @repo/server/create-server.
+//
+// Connection policy: on socket close every in-flight request rejects with
+// "connection lost" and the bridge reconnects forever with capped exponential
+// backoff. Requests made while a socket is still CONNECTING are queued and
+// flushed on open (covers the app's boot burst); requests made while fully
+// disconnected reject immediately. After a *re*connect the bridge re-emits
+// the two refresh events the app already handles — `onVaultChanged` (sidebar
+// re-list + open-file reload) and `onAppState` (auth/agent phase) — so the UI
+// converges on the host's current state without a bespoke resync channel.
+// ---------------------------------------------------------------------------
+
+import {
+  BINARY_TAG_STT_PCM,
+  BINARY_TAG_TTS_PCM,
+  decodeBinaryFrame,
+  encodeBinaryFrame,
+  parseServerFrame,
+  type WireRequestMethod,
+  type WireSendMethod,
+} from "./bridge-wire";
+import type { Bridge, EventMethod, UpdateState } from "./ipc-registry";
+
+const RECONNECT_MIN_MS = 500;
+const RECONNECT_MAX_MS = 10_000;
+
+/** `connecting` = first socket attempt, `reconnecting` = lost after being
+ * open (or a failed retry) — the state a UI overlay should surface. */
+export type WsBridgeConnectionState = "connecting" | "open" | "reconnecting";
+
+export type WsBridgeOptions = {
+  onConnectionState?: (state: WsBridgeConnectionState) => void;
+};
+
+// A WS host has no self-update; the trio never crosses the wire.
+const IDLE_UPDATE: UpdateState = {
+  status: "not-available",
+  version: null,
+  downloadPercent: null,
+  message: null,
+};
+
+type Pending = { resolve: (value: unknown) => void; reject: (error: Error) => void };
+
+export function createWsBridge(url: string, options: WsBridgeOptions = {}): Bridge {
+  let socket: WebSocket | null = null;
+  let everOpened = false;
+  let backoffMs = RECONNECT_MIN_MS;
+  let nextId = 1;
+
+  const pending = new Map<number, Pending>();
+  /** JSON frames written while the socket is still CONNECTING. */
+  const outbox: string[] = [];
+  const listeners = new Map<EventMethod, Set<(payload: unknown) => void>>();
+
+  function setState(state: WsBridgeConnectionState): void {
+    options.onConnectionState?.(state);
+  }
+
+  function dispatch(method: EventMethod, payload: unknown): void {
+    const set = listeners.get(method);
+    if (!set) return;
+    for (const listener of set) {
+      try {
+        listener(payload);
+      } catch (err) {
+        console.error(`[bridge-ws] ${method} listener failed:`, err);
+      }
+    }
+  }
+
+  function addListener(method: EventMethod, listener: (payload: unknown) => void): () => void {
+    let set = listeners.get(method);
+    if (!set) {
+      set = new Set();
+      listeners.set(method, set);
+    }
+    set.add(listener);
+    return () => {
+      set.delete(listener);
+    };
+  }
+
+  function failAllPending(reason: string): void {
+    const rejects = [...pending.values()];
+    pending.clear();
+    outbox.length = 0;
+    for (const entry of rejects) entry.reject(new Error(reason));
+  }
+
+  /** Post-reconnect resync: fetch the authoritative state and re-emit it
+   * through the same event channels a live host would use. */
+  function refreshAfterReconnect(): void {
+    void request("getVaultRoot", undefined)
+      .then((root) => {
+        if (typeof root === "string") dispatch("onVaultChanged", { root });
+        return undefined;
+      })
+      .catch(() => {});
+    void request("getAppState", undefined)
+      .then((state) => dispatch("onAppState", state))
+      .catch(() => {});
+  }
+
+  function handleMessage(data: unknown): void {
+    if (typeof data === "string") {
+      const parsed = parseServerFrame(data);
+      if (!parsed.ok) {
+        console.error(`[bridge-ws] dropped frame: ${parsed.error}`);
+        return;
+      }
+      const frame = parsed.frame;
+      if (frame.t === "evt") {
+        dispatch(frame.method, frame.payload);
+        return;
+      }
+      const entry = pending.get(frame.id);
+      if (!entry) return;
+      pending.delete(frame.id);
+      if (frame.ok) entry.resolve(frame.result);
+      else entry.reject(new Error(frame.error));
+      return;
+    }
+    if (data instanceof ArrayBuffer) {
+      const frame = decodeBinaryFrame(data);
+      if (frame?.tag === BINARY_TAG_TTS_PCM) {
+        dispatch("onTtsAudio", { audio: frame.payload.buffer });
+      }
+    }
+  }
+
+  function connect(): void {
+    const ws = new WebSocket(url);
+    ws.binaryType = "arraybuffer";
+    socket = ws;
+
+    ws.addEventListener("open", () => {
+      if (socket !== ws) return;
+      backoffMs = RECONNECT_MIN_MS;
+      const wasReconnect = everOpened;
+      everOpened = true;
+      setState("open");
+      for (const frame of outbox.splice(0)) ws.send(frame);
+      if (wasReconnect) refreshAfterReconnect();
+    });
+
+    ws.addEventListener("message", (event) => {
+      if (socket === ws) handleMessage(event.data);
+    });
+
+    ws.addEventListener("close", () => {
+      if (socket !== ws) return;
+      socket = null;
+      failAllPending("connection lost");
+      setState(everOpened ? "reconnecting" : "connecting");
+      const delay = backoffMs;
+      backoffMs = Math.min(backoffMs * 2, RECONNECT_MAX_MS);
+      setTimeout(() => {
+        if (socket === null) connect();
+      }, delay);
+    });
+  }
+
+  /** Send a JSON frame now (open), queue it (connecting), or fail (down). */
+  function writeFrame(frame: string): boolean {
+    if (socket?.readyState === WebSocket.OPEN) {
+      socket.send(frame);
+      return true;
+    }
+    if (socket?.readyState === WebSocket.CONNECTING) {
+      outbox.push(frame);
+      return true;
+    }
+    return false;
+  }
+
+  function request(method: WireRequestMethod, payload: unknown): Promise<unknown> {
+    return new Promise((resolve, reject) => {
+      const id = nextId++;
+      const frame = JSON.stringify({
+        t: "req",
+        id,
+        method,
+        ...(payload === undefined ? {} : { payload }),
+      });
+      pending.set(id, { resolve, reject });
+      if (!writeFrame(frame)) {
+        pending.delete(id);
+        reject(new Error("connection lost"));
+      }
+    });
+  }
+
+  function fireAndForget(method: WireSendMethod, payload: unknown): void {
+    writeFrame(JSON.stringify({ t: "snd", method, ...(payload === undefined ? {} : { payload }) }));
+  }
+
+  // The wire carries untyped JSON; each registry method's payload/result types
+  // are proven by the registry entry the helper is keyed with, so the single
+  // widening below is sound (same pattern as the desktop preload fold, in the
+  // other direction). Everything else in this file is cast-free.
+  function rpc<K extends WireRequestMethod>(method: K): Bridge[K] {
+    const fn = (payload?: unknown) => request(method, payload);
+    // oxlint-disable-next-line typescript/consistent-type-assertions -- registry-correlated fold, see comment above
+    return fn as Bridge[K];
+  }
+
+  function snd<K extends WireSendMethod>(method: K): Bridge[K] {
+    const fn = (payload?: unknown) => fireAndForget(method, payload);
+    // oxlint-disable-next-line typescript/consistent-type-assertions -- registry-correlated fold, see comment above
+    return fn as Bridge[K];
+  }
+
+  function sub<K extends EventMethod>(method: K): Bridge[K] {
+    const fn = (listener: (payload: unknown) => void) => addListener(method, listener);
+    // oxlint-disable-next-line typescript/consistent-type-assertions -- registry-correlated fold, see comment above
+    return fn as Bridge[K];
+  }
+
+  /** STT PCM rides a tagged binary frame, never JSON. Dropped (not queued)
+   * when the socket isn't open — stale realtime audio is worthless. */
+  function sendSttAudio(payload: unknown): void {
+    if (socket?.readyState !== WebSocket.OPEN) return;
+    let bytes: Uint8Array;
+    if (payload instanceof ArrayBuffer) {
+      bytes = new Uint8Array(payload);
+    } else if (ArrayBuffer.isView(payload) && payload.buffer instanceof ArrayBuffer) {
+      bytes = new Uint8Array(payload.buffer, payload.byteOffset, payload.byteLength);
+    } else {
+      return;
+    }
+    socket.send(encodeBinaryFrame(BINARY_TAG_STT_PCM, bytes));
+  }
+
+  setState("connecting");
+  connect();
+
+  return {
+    // Desktop / updates — no self-update over a WS host; answered locally.
+    checkForUpdates: async () => IDLE_UPDATE,
+    downloadUpdate: async () => ({ accepted: false, state: IDLE_UPDATE }),
+    installUpdate: async () => ({ accepted: false, state: IDLE_UPDATE }),
+    onUpdateState: sub("onUpdateState"),
+
+    // App lifecycle
+    getAppState: rpc("getAppState"),
+    transition: rpc("transition"),
+    onAppState: sub("onAppState"),
+    onSetupProgress: sub("onSetupProgress"),
+
+    // Agent
+    onAgentEvent: sub("onAgentEvent"),
+    sendAgentCommand: rpc("sendAgentCommand"),
+    getAgentHistory: rpc("getAgentHistory"),
+    reauthenticate: rpc("reauthenticate"),
+
+    // Voice — PCM in both directions rides tagged binary frames.
+    isTtsAvailable: rpc("isTtsAvailable"),
+    ttsSend: snd("ttsSend"),
+    ttsFlush: snd("ttsFlush"),
+    ttsInterrupt: snd("ttsInterrupt"),
+    onTtsAudio: sub("onTtsAudio"),
+    startStt: rpc("startStt"),
+    sendSttAudio,
+    stopStt: rpc("stopStt"),
+    onSttTranscript: sub("onSttTranscript"),
+    getVoiceModelStatus: rpc("getVoiceModelStatus"),
+    downloadVoiceModel: rpc("downloadVoiceModel"),
+    onVoiceModelState: sub("onVoiceModelState"),
+
+    // Notifications
+    getNotificationSettings: rpc("getNotificationSettings"),
+    updateNotificationSettings: rpc("updateNotificationSettings"),
+
+    // UI state
+    getUiState: rpc("getUiState"),
+    setUiState: rpc("setUiState"),
+
+    // Vault
+    getVaultRoot: rpc("getVaultRoot"),
+    chooseVaultRoot: rpc("chooseVaultRoot"),
+    listVault: rpc("listVault"),
+    readVaultDoc: rpc("readVaultDoc"),
+    writeVaultDoc: rpc("writeVaultDoc"),
+    deleteVaultEntry: rpc("deleteVaultEntry"),
+    renameVaultEntry: rpc("renameVaultEntry"),
+    onVaultChanged: sub("onVaultChanged"),
+
+    // Delegation
+    createDelegation: rpc("createDelegation"),
+    listDelegations: rpc("listDelegations"),
+    cancelDelegation: rpc("cancelDelegation"),
+    onDelegationsUpdated: sub("onDelegationsUpdated"),
+    onDelegationStreamed: sub("onDelegationStreamed"),
+
+    // Inline AI
+    generateInlineAi: rpc("generateInlineAi"),
+    onAiStreamed: sub("onAiStreamed"),
+
+    // Executor
+    executorStatus: rpc("executorStatus"),
+    listExecutorIntegrations: rpc("listExecutorIntegrations"),
+    detectExecutorIntegration: rpc("detectExecutorIntegration"),
+    addMcpIntegration: rpc("addMcpIntegration"),
+    addOpenApiIntegration: rpc("addOpenApiIntegration"),
+    addGraphqlIntegration: rpc("addGraphqlIntegration"),
+    removeExecutorIntegration: rpc("removeExecutorIntegration"),
+    listExecutorConnections: rpc("listExecutorConnections"),
+    createExecutorConnection: rpc("createExecutorConnection"),
+    removeExecutorConnection: rpc("removeExecutorConnection"),
+    listExecutorOAuthClients: rpc("listExecutorOAuthClients"),
+    createExecutorOAuthClient: rpc("createExecutorOAuthClient"),
+    ensureGoogleOAuthClient: rpc("ensureGoogleOAuthClient"),
+    registerExecutorOAuthClientDynamic: rpc("registerExecutorOAuthClientDynamic"),
+    executorOAuthProbe: rpc("executorOAuthProbe"),
+    executorOAuthStart: rpc("executorOAuthStart"),
+    executorOAuthAwait: rpc("executorOAuthAwait"),
+    executorOpenExternal: rpc("executorOpenExternal"),
+
+    // Skills / integrations
+    listSkills: rpc("listSkills"),
+    listIntegrations: rpc("listIntegrations"),
+    repairIntegrations: rpc("repairIntegrations"),
+  };
+}

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -1,10 +1,13 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
+    // dom: the WS bridge client (bridge-ws-client.ts) is browser code — the
+    // package stays free of *node* types by design.
+    "lib": ["ES2023", "dom"],
     "paths": {
       "@repo/core/*": ["./src/*"],
       "@repo/pi-driver/*": ["../pi-driver/src/*"]
     }
   },
-  "include": ["src"]
+  "include": ["src", "vitest.config.ts"]
 }

--- a/packages/core/vitest.config.ts
+++ b/packages/core/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "node",
+    include: ["src/**/*.test.ts"],
+  },
+});

--- a/packages/host/package.json
+++ b/packages/host/package.json
@@ -5,6 +5,7 @@
   "description": "Platform-agnostic node backend for Inteligir: vault, pi sessions, delegation, executor, voice, and agent extensions behind createHost(). No electron imports — shells inject a HostPlatform and fold the handler map into their transport.",
   "type": "module",
   "exports": {
+    "./package.json": "./package.json",
     "./*": "./src/*.ts"
   },
   "scripts": {

--- a/packages/host/src/create-host.ts
+++ b/packages/host/src/create-host.ts
@@ -5,6 +5,8 @@
 // start()/dispose() around its own lifecycle.
 // ---------------------------------------------------------------------------
 
+import path from "node:path";
+
 import { configurePaths } from "./agent/paths";
 import { initMachine, shutdown } from "./app/app-machine";
 import { emitEvent, subscribeEvents } from "./events";
@@ -90,6 +92,16 @@ export function createHost(platform: HostPlatform, options: HostOptions = {}): H
 
       // Must run before any pi-coding-agent call that consults getAgentDir().
       configurePaths();
+
+      // Boot-time vault preset (cli): repoint the persisted root before the
+      // watcher starts. setRoot creates the dir and enforces the
+      // not-inside-~/.inteligir guard; a violation throws out to the shell.
+      if (options.vaultPath !== undefined) {
+        const requested = path.resolve(options.vaultPath);
+        if (requested !== getVaultManager().getRoot()) {
+          getVaultManager().setRoot(requested);
+        }
+      }
 
       // Vault: ensure the folder + agent symlink exist and stream file changes
       // to the UI so the sidebar and editor stay live. The notifier is

--- a/packages/host/src/platform.ts
+++ b/packages/host/src/platform.ts
@@ -83,4 +83,10 @@ export type HostOptions = {
   bundledGoogleClient?: { clientId: string; clientSecret: string };
   /** Mirror console to ~/.inteligir/logs/agent.log (default true). */
   agentLog?: boolean;
+  /** Open this vault folder at boot (cli mode: the vault is chosen on the
+   * command line, no native picker). Persisted through the same setRoot()
+   * path the picker uses, so all its guards apply — a root inside
+   * ~/.inteligir throws out of host.start(). Absent → the stored
+   * settings.json pointer (desktop). */
+  vaultPath?: string;
 };

--- a/packages/server/README.md
+++ b/packages/server/README.md
@@ -1,0 +1,34 @@
+# `@repo/server` — the browser host
+
+The loopback HTTP + WebSocket shell over `@repo/host`, the browser counterpart
+of the Electron desktop's preload. `createServer({ host, assetsDir, port })`
+(`src/create-server.ts`):
+
+- serves the `@repo/app` static build (`dist-web/`) with an SPA fallback (sirv,
+  `single: true`);
+- folds `host.handlers` into the bridge-wire protocol (`@repo/core/bridge-wire`)
+  over a `/bridge` WebSocket — JSON envelopes for the registry, tagged binary
+  frames for voice PCM (STT `0x01` in, TTS `0x02` out);
+- fans `host.events` out to every connected client (single local user, possibly
+  several tabs).
+
+## Security posture — loopback is the auth gate
+
+Local single-user; no accounts, no tokens. Three layers, all defense against a
+browser the user points at a hostile page:
+
+1. **Bind 127.0.0.1 only** — asserted after `listen`; a non-loopback bind throws.
+2. **Host-header allowlist** — every HTTP request and WS upgrade must carry a
+   loopback Host (`127.0.0.1` / `localhost` / `[::1]`). Guards DNS rebinding.
+3. **Origin allowlist on the WS upgrade** — a WebSocket handshake bypasses CORS,
+   so any page could otherwise open `ws://127.0.0.1/bridge` and drive the vault.
+   Browsers attach an unforgeable Origin; it must be loopback. A missing Origin
+   is a non-browser local client (already machine-trusted) and passes.
+
+## Wire protocol
+
+Derived from the IPC registry at runtime (`@repo/core/bridge-wire`) — a new
+channel needs no change here. The browser client is `@repo/core/bridge-ws-client`
+(`createWsBridge`), which reconnects forever with capped backoff and resyncs on
+reopen. The `UPDATE_METHODS` trio never crosses the wire (no self-update over a
+WS host); the client answers it locally.

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "@repo/server",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Local HTTP + WebSocket host for Inteligir: serves the @repo/app static build and folds a @repo/host handler map into the bridge-wire protocol. Loopback-only by design — the bind address is the auth gate for a single local user.",
+  "type": "module",
+  "exports": {
+    "./*": "./src/*.ts"
+  },
+  "scripts": {
+    "clean": "git clean -xdf .cache .turbo dist node_modules",
+    "test": "vitest run",
+    "typecheck": "tsc --noEmit --emitDeclarationOnly false"
+  },
+  "dependencies": {
+    "@repo/core": "workspace:^",
+    "@repo/host": "workspace:^",
+    "sirv": "^3.0.2",
+    "ws": "^8.19.0"
+  },
+  "devDependencies": {
+    "@types/node": "catalog:",
+    "@types/ws": "^8.18.1",
+    "typescript": "catalog:",
+    "vitest": "^4.1.7"
+  }
+}

--- a/packages/server/src/__tests__/create-server.test.ts
+++ b/packages/server/src/__tests__/create-server.test.ts
@@ -1,0 +1,268 @@
+import fs from "node:fs";
+import http from "node:http";
+import os from "node:os";
+import path from "node:path";
+import { afterAll, afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { BINARY_TAG_STT_PCM, BINARY_TAG_TTS_PCM, encodeBinaryFrame } from "@repo/core/bridge-wire";
+import { createWsBridge } from "@repo/core/bridge-ws-client";
+import type { EventMethod, IpcEvent } from "@repo/core/ipc-registry";
+import type { Host } from "@repo/host/create-host";
+import type { WireHandler } from "@repo/host/lib/handler-registry";
+
+import { createServer, type RunningServer } from "../create-server";
+
+// A minimal Host double: only the handlers a test calls are real; the rest
+// throw loudly (the completeness of the real map is host's own test).
+function fakeHost(handlers: Record<string, WireHandler>) {
+  const listeners = new Set<(method: EventMethod, payload: unknown) => void>();
+  const handlerMap = new Proxy(handlers, {
+    get(target, prop: string) {
+      const handler = target[prop];
+      if (handler) return handler;
+      return () => {
+        throw new Error(`no fake handler for "${prop}"`);
+      };
+    },
+  });
+  const host = {
+    handlers: handlerMap as Host["handlers"],
+    events: {
+      onAny: (listener: (method: EventMethod, payload: unknown) => void) => {
+        listeners.add(listener);
+        return () => listeners.delete(listener);
+      },
+    },
+    capabilities: { canPickVault: false, canSelfUpdate: false },
+    start: () => {},
+    dispose: async () => {},
+  } as Host;
+  const emit = <K extends EventMethod>(method: K, payload: IpcEvent<K>) => {
+    for (const listener of listeners) listener(method, payload);
+  };
+  return { host, emit };
+}
+
+function waitForOpen(socket: WebSocket): Promise<void> {
+  return new Promise((resolve, reject) => {
+    socket.addEventListener("open", () => resolve(), { once: true });
+    socket.addEventListener("error", () => reject(new Error("socket error")), { once: true });
+  });
+}
+
+function nextMessage(socket: WebSocket): Promise<unknown> {
+  return new Promise((resolve) => {
+    socket.addEventListener("message", (event) => resolve(event.data), { once: true });
+  });
+}
+
+let assetsDir: string;
+let running: RunningServer | null = null;
+const sockets: WebSocket[] = [];
+
+beforeEach(() => {
+  assetsDir = fs.mkdtempSync(path.join(os.tmpdir(), "inteligir-assets-"));
+  fs.writeFileSync(path.join(assetsDir, "index.html"), "<!doctype html><title>app</title>");
+  fs.writeFileSync(path.join(assetsDir, "app.js"), "console.log('app')");
+});
+
+afterEach(async () => {
+  for (const socket of sockets.splice(0)) socket.close();
+  await running?.close();
+  running = null;
+  fs.rmSync(assetsDir, { recursive: true, force: true });
+});
+
+afterAll(() => {
+  // createWsBridge reconnects forever by design. Once the suite is done, swap
+  // in an inert socket so its retry chain ends instead of keeping the worker
+  // alive on backoff timers.
+  vi.stubGlobal(
+    "WebSocket",
+    class InertSocket {
+      binaryType = "";
+      addEventListener(): void {}
+      send(): void {}
+      close(): void {}
+    },
+  );
+});
+
+async function boot(handlers: Record<string, WireHandler> = {}) {
+  const fake = fakeHost(handlers);
+  running = await createServer({ host: fake.host, assetsDir });
+  return { ...fake, server: running };
+}
+
+function connect(server: RunningServer): WebSocket {
+  const socket = new WebSocket(`ws://127.0.0.1:${server.port}/bridge`);
+  socket.binaryType = "arraybuffer";
+  sockets.push(socket);
+  return socket;
+}
+
+describe("createServer", () => {
+  it("binds loopback only and reports a usable url", async () => {
+    const { server } = await boot();
+    expect(server.url).toBe(`http://127.0.0.1:${server.port}`);
+    expect(server.port).toBeGreaterThan(0);
+  });
+
+  it("serves static assets with an SPA fallback", async () => {
+    const { server } = await boot();
+    const asset = await fetch(`${server.url}/app.js`);
+    expect(await asset.text()).toContain("console.log");
+    const fallback = await fetch(`${server.url}/some/client/route`);
+    expect(fallback.status).toBe(200);
+    expect(await fallback.text()).toContain("<title>app</title>");
+  });
+
+  it("rejects non-loopback Host headers (DNS rebinding)", async () => {
+    const { server } = await boot();
+    // fetch() silently drops the forbidden Host header — go through raw http.
+    const statusFor = (host: string) =>
+      new Promise<number>((resolve, reject) => {
+        const req = http.get(
+          { host: "127.0.0.1", port: server.port, path: "/", headers: { host } },
+          (res) => {
+            res.resume();
+            resolve(res.statusCode ?? 0);
+          },
+        );
+        req.on("error", reject);
+      });
+    await expect(statusFor("evil.example.com")).resolves.toBe(403);
+    await expect(statusFor(`localhost:${server.port}`)).resolves.toBe(200);
+  });
+
+  it("answers req envelopes from host handlers, including errors", async () => {
+    const { server } = await boot({
+      getVaultRoot: () => "/tmp/vault",
+      readVaultDoc: () => {
+        throw new Error("no such file");
+      },
+    });
+    const socket = connect(server);
+    await waitForOpen(socket);
+
+    socket.send(JSON.stringify({ t: "req", id: 1, method: "getVaultRoot" }));
+    expect(JSON.parse(String(await nextMessage(socket)))).toEqual({
+      t: "res",
+      id: 1,
+      ok: true,
+      result: "/tmp/vault",
+    });
+
+    socket.send(
+      JSON.stringify({ t: "req", id: 2, method: "readVaultDoc", payload: { path: "x" } }),
+    );
+    expect(JSON.parse(String(await nextMessage(socket)))).toEqual({
+      t: "res",
+      id: 2,
+      ok: false,
+      error: "no such file",
+    });
+  });
+
+  it("routes snd envelopes without a reply", async () => {
+    const ttsSend = vi.fn();
+    const { server } = await boot({ ttsSend });
+    const socket = connect(server);
+    await waitForOpen(socket);
+    socket.send(JSON.stringify({ t: "snd", method: "ttsSend", payload: { text: "hello" } }));
+    await vi.waitFor(() => expect(ttsSend).toHaveBeenCalledWith({ text: "hello" }));
+  });
+
+  it("broadcasts host events as evt envelopes to every client", async () => {
+    const { server, emit } = await boot();
+    const a = connect(server);
+    const b = connect(server);
+    await Promise.all([waitForOpen(a), waitForOpen(b)]);
+
+    const [messageA, messageB] = [nextMessage(a), nextMessage(b)];
+    emit("onVaultChanged", { root: "/v" });
+    expect(JSON.parse(String(await messageA))).toEqual({
+      t: "evt",
+      method: "onVaultChanged",
+      payload: { root: "/v" },
+    });
+    expect(JSON.parse(String(await messageB))).toEqual({
+      t: "evt",
+      method: "onVaultChanged",
+      payload: { root: "/v" },
+    });
+  });
+
+  it("routes STT binary frames to sendSttAudio with alignment-safe bytes", async () => {
+    const received: Float32Array[] = [];
+    const { server } = await boot({
+      sendSttAudio: (raw) => {
+        if (!(raw instanceof Uint8Array)) throw new Error("expected bytes");
+        received.push(new Float32Array(raw.buffer, raw.byteOffset, raw.byteLength / 4));
+      },
+    });
+    const socket = connect(server);
+    await waitForOpen(socket);
+
+    const pcm = new Float32Array([0.25, -1]);
+    socket.send(
+      encodeBinaryFrame(BINARY_TAG_STT_PCM, new Uint8Array(pcm.buffer, 0, pcm.byteLength)),
+    );
+    await vi.waitFor(() => expect(received).toHaveLength(1));
+    expect([...(received[0] ?? [])]).toEqual([0.25, -1]);
+  });
+
+  it("sends onTtsAudio as a tagged binary frame, not JSON", async () => {
+    const { server, emit } = await boot();
+    const socket = connect(server);
+    await waitForOpen(socket);
+
+    const message = nextMessage(socket);
+    const pcm = new Int16Array([300, -400]);
+    // Slice to a standalone ArrayBuffer, as tts-proxy broadcasts.
+    emit("onTtsAudio", { audio: pcm.buffer.slice(0) });
+
+    const data = await message;
+    expect(data).toBeInstanceOf(ArrayBuffer);
+    if (!(data instanceof ArrayBuffer)) return;
+    const bytes = new Uint8Array(data);
+    expect(bytes[0]).toBe(BINARY_TAG_TTS_PCM);
+    expect([...new Int16Array(new Uint8Array(bytes.subarray(1)).buffer)]).toEqual([300, -400]);
+  });
+
+  it("interoperates with createWsBridge end to end", async () => {
+    const { server, emit } = await boot({
+      getVaultRoot: () => "/wire/vault",
+      listVault: () => [{ path: "a.md", name: "a.md", kind: "doc" }],
+    });
+    const bridge = createWsBridge(`ws://127.0.0.1:${server.port}/bridge`);
+    await expect(bridge.getVaultRoot()).resolves.toBe("/wire/vault");
+    await expect(bridge.listVault()).resolves.toEqual([
+      { path: "a.md", name: "a.md", kind: "doc" },
+    ]);
+
+    const roots: string[] = [];
+    bridge.onVaultChanged(({ root }) => roots.push(root));
+    emit("onVaultChanged", { root: "/wire/vault" });
+    await vi.waitFor(() => expect(roots).toEqual(["/wire/vault"]));
+  });
+
+  it("drops malformed and unknown frames without crashing", async () => {
+    const { server } = await boot({ getVaultRoot: () => "/v" });
+    const socket = connect(server);
+    await waitForOpen(socket);
+
+    socket.send("not json");
+    socket.send(JSON.stringify({ t: "req", id: 1, method: "notAMethod" }));
+    socket.send(JSON.stringify({ t: "req", id: 2, method: "checkForUpdates" }));
+
+    // Server is still healthy afterwards.
+    socket.send(JSON.stringify({ t: "req", id: 3, method: "getVaultRoot" }));
+    expect(JSON.parse(String(await nextMessage(socket)))).toEqual({
+      t: "res",
+      id: 3,
+      ok: true,
+      result: "/v",
+    });
+  });
+});

--- a/packages/server/src/__tests__/create-server.test.ts
+++ b/packages/server/src/__tests__/create-server.test.ts
@@ -135,6 +135,37 @@ describe("createServer", () => {
     await expect(statusFor(`localhost:${server.port}`)).resolves.toBe(200);
   });
 
+  it("rejects WS upgrades from a cross-origin page", async () => {
+    const { server } = await boot();
+    // A browser at evil.example.com hits the loopback bridge directly: Host is
+    // 127.0.0.1 (allowed) but the browser attaches its own unforgeable Origin.
+    const upgrade = (origin: string | undefined) =>
+      new Promise<"open" | "rejected">((resolve) => {
+        const req = http.request({
+          host: "127.0.0.1",
+          port: server.port,
+          path: "/bridge",
+          headers: {
+            connection: "Upgrade",
+            upgrade: "websocket",
+            "sec-websocket-version": "13",
+            "sec-websocket-key": "dGhlIHNhbXBsZSBub25jZQ==",
+            ...(origin === undefined ? {} : { origin }),
+          },
+        });
+        req.on("upgrade", (_res, socket) => {
+          socket.destroy();
+          resolve("open");
+        });
+        req.on("response", () => resolve("rejected"));
+        req.on("error", () => resolve("rejected"));
+        req.end();
+      });
+    await expect(upgrade("http://evil.example.com")).resolves.toBe("rejected");
+    await expect(upgrade(`http://127.0.0.1:${server.port}`)).resolves.toBe("open");
+    await expect(upgrade(undefined)).resolves.toBe("open");
+  });
+
   it("answers req envelopes from host handlers, including errors", async () => {
     const { server } = await boot({
       getVaultRoot: () => "/tmp/vault",

--- a/packages/server/src/create-server.ts
+++ b/packages/server/src/create-server.ts
@@ -1,0 +1,206 @@
+// ---------------------------------------------------------------------------
+// createServer — the WebSocket sibling of the desktop's host-fold: binds a
+// @repo/host to the bridge-wire protocol (JSON envelopes + tagged binary
+// voice frames) and serves the @repo/app static build with an SPA fallback.
+//
+// Security posture: local single-user, loopback IS the auth gate. The server
+// binds 127.0.0.1 only (asserted after listen), and every HTTP request and
+// WS upgrade must carry a loopback Host header (DNS-rebinding guard). No
+// accounts, no tokens — anything that can speak to 127.0.0.1 is the user.
+// ---------------------------------------------------------------------------
+
+import http from "node:http";
+import sirv from "sirv";
+import { WebSocketServer, type WebSocket } from "ws";
+
+import {
+  BINARY_TAG_STT_PCM,
+  BINARY_TAG_TTS_PCM,
+  decodeBinaryFrame,
+  encodeBinaryFrame,
+  parseClientFrame,
+} from "@repo/core/bridge-wire";
+import { toErrorMessage } from "@repo/core/ipc";
+import type { Host } from "@repo/host/create-host";
+
+const LOOPBACK_ADDRESS = "127.0.0.1";
+const BRIDGE_PATH = "/bridge";
+
+export type ServerOptions = {
+  host: Host;
+  /** Directory holding the @repo/app web build (index.html + assets). */
+  assetsDir: string;
+  /** TCP port; 0 (default) picks a free one. */
+  port?: number;
+};
+
+export type RunningServer = {
+  port: number;
+  url: string;
+  close: () => Promise<void>;
+};
+
+const ALLOWED_HOSTNAMES = new Set([LOOPBACK_ADDRESS, "localhost", "[::1]"]);
+
+/** DNS-rebinding guard: a hostile page at attacker.com resolving to
+ * 127.0.0.1 still sends its own Host header — reject anything that isn't
+ * explicitly loopback. */
+function isAllowedHostHeader(header: string | undefined): boolean {
+  if (!header) return false;
+  try {
+    return ALLOWED_HOSTNAMES.has(new URL(`http://${header}`).hostname);
+  } catch {
+    return false;
+  }
+}
+
+function toBytes(data: unknown): Uint8Array | null {
+  if (data instanceof Uint8Array) return data;
+  if (data instanceof ArrayBuffer) return new Uint8Array(data);
+  if (Array.isArray(data) && data.every((chunk) => chunk instanceof Uint8Array)) {
+    return Buffer.concat(data);
+  }
+  return null;
+}
+
+function isTtsAudioPayload(payload: unknown): payload is { audio: ArrayBuffer } {
+  return (
+    typeof payload === "object" &&
+    payload !== null &&
+    "audio" in payload &&
+    payload.audio instanceof ArrayBuffer
+  );
+}
+
+export async function createServer(options: ServerOptions): Promise<RunningServer> {
+  const { host, assetsDir } = options;
+
+  const serveAssets = sirv(assetsDir, { single: true, etag: true });
+
+  const httpServer = http.createServer((req, res) => {
+    if (!isAllowedHostHeader(req.headers.host)) {
+      res.writeHead(403, { "content-type": "text/plain" });
+      res.end("Forbidden");
+      return;
+    }
+    serveAssets(req, res);
+  });
+
+  const wss = new WebSocketServer({ noServer: true });
+
+  httpServer.on("upgrade", (req, socket, head) => {
+    const pathname = new URL(req.url ?? "/", `http://${LOOPBACK_ADDRESS}`).pathname;
+    if (!isAllowedHostHeader(req.headers.host) || pathname !== BRIDGE_PATH) {
+      socket.destroy();
+      return;
+    }
+    wss.handleUpgrade(req, socket, head, (ws) => {
+      wss.emit("connection", ws, req);
+    });
+  });
+
+  function broadcast(frame: string | ArrayBuffer): void {
+    for (const client of wss.clients) {
+      if (client.readyState === client.OPEN) client.send(frame);
+    }
+  }
+
+  // One host-event subscription for the whole server; every connected client
+  // sees every event (single local user, possibly several tabs). TTS audio
+  // rides a tagged binary frame instead of JSON — see bridge-wire.ts.
+  const unsubscribeEvents = host.events.onAny((method, payload) => {
+    if (method === "onTtsAudio") {
+      if (isTtsAudioPayload(payload)) {
+        broadcast(encodeBinaryFrame(BINARY_TAG_TTS_PCM, new Uint8Array(payload.audio)));
+      }
+      return;
+    }
+    broadcast(JSON.stringify({ t: "evt", method, payload }));
+  });
+
+  function handleBinary(data: unknown): void {
+    const bytes = toBytes(data);
+    if (!bytes) return;
+    const frame = decodeBinaryFrame(bytes);
+    // decodeBinaryFrame copies the payload to offset 0, so the Float32 view
+    // the STT handler builds over it is alignment-safe.
+    if (frame?.tag === BINARY_TAG_STT_PCM) {
+      host.handlers.sendSttAudio(frame.payload);
+    }
+  }
+
+  async function handleText(ws: WebSocket, text: string): Promise<void> {
+    const parsed = parseClientFrame(text);
+    if (!parsed.ok) {
+      console.warn(`[server] dropped client frame: ${parsed.error}`);
+      return;
+    }
+    const frame = parsed.frame;
+    if (frame.t === "snd") {
+      // Fire-and-forget; the host's handler wrapper already swallows + logs.
+      host.handlers[frame.method](frame.payload);
+      return;
+    }
+    let response: string;
+    try {
+      const result = await host.handlers[frame.method](frame.payload);
+      response = JSON.stringify({
+        t: "res",
+        id: frame.id,
+        ok: true,
+        ...(result === undefined ? {} : { result }),
+      });
+    } catch (err) {
+      response = JSON.stringify({ t: "res", id: frame.id, ok: false, error: toErrorMessage(err) });
+    }
+    if (ws.readyState === ws.OPEN) ws.send(response);
+  }
+
+  wss.on("connection", (ws) => {
+    ws.on("message", (data, isBinary) => {
+      if (isBinary) {
+        handleBinary(data);
+        return;
+      }
+      // ws hands text frames over as a Buffer; the protocol is UTF-8 JSON.
+      const bytes = toBytes(data);
+      if (bytes) void handleText(ws, Buffer.from(bytes).toString("utf8"));
+    });
+    ws.on("error", (err) => {
+      console.warn("[server] websocket error:", err);
+    });
+  });
+
+  await new Promise<void>((resolve, reject) => {
+    httpServer.once("error", reject);
+    httpServer.listen(options.port ?? 0, LOOPBACK_ADDRESS, resolve);
+  });
+
+  const address = httpServer.address();
+  if (address === null || typeof address === "string") {
+    throw new Error("server bound to a pipe instead of a TCP port");
+  }
+  // Loopback is the auth gate — refuse to run on anything else.
+  if (address.address !== LOOPBACK_ADDRESS) {
+    httpServer.close();
+    throw new Error(`refusing non-loopback bind: ${address.address}`);
+  }
+
+  return {
+    port: address.port,
+    url: `http://${LOOPBACK_ADDRESS}:${address.port}`,
+    close: async () => {
+      unsubscribeEvents();
+      for (const client of wss.clients) client.terminate();
+      await new Promise<void>((resolve) => {
+        wss.close(() => resolve());
+      });
+      await new Promise<void>((resolve, reject) => {
+        httpServer.close((err) => {
+          if (err) reject(err);
+          else resolve();
+        });
+      });
+    },
+  };
+}

--- a/packages/server/src/create-server.ts
+++ b/packages/server/src/create-server.ts
@@ -5,8 +5,13 @@
 //
 // Security posture: local single-user, loopback IS the auth gate. The server
 // binds 127.0.0.1 only (asserted after listen), and every HTTP request and
-// WS upgrade must carry a loopback Host header (DNS-rebinding guard). No
-// accounts, no tokens — anything that can speak to 127.0.0.1 is the user.
+// WS upgrade must carry a loopback Host header (DNS-rebinding guard). The WS
+// upgrade additionally enforces an Origin allowlist: a WebSocket handshake
+// is NOT subject to CORS, so any page the user visits could otherwise open
+// ws://127.0.0.1/bridge and drive the vault. Browsers always attach an
+// unforgeable Origin, so a loopback-only allowlist shuts that out; a missing
+// Origin means a non-browser local client (which already has machine access).
+// No accounts, no tokens — anything that can speak to 127.0.0.1 is the user.
 // ---------------------------------------------------------------------------
 
 import http from "node:http";
@@ -54,6 +59,19 @@ function isAllowedHostHeader(header: string | undefined): boolean {
   }
 }
 
+/** WS handshakes bypass CORS, so a cross-origin page could otherwise drive
+ * the bridge. Browsers always send an unforgeable Origin — require it to be
+ * loopback. An absent Origin is a non-browser local client (native tooling
+ * that already has full machine access), so it's allowed through. */
+function isAllowedOrigin(origin: string | undefined): boolean {
+  if (origin === undefined) return true;
+  try {
+    return ALLOWED_HOSTNAMES.has(new URL(origin).hostname);
+  } catch {
+    return false;
+  }
+}
+
 function toBytes(data: unknown): Uint8Array | null {
   if (data instanceof Uint8Array) return data;
   if (data instanceof ArrayBuffer) return new Uint8Array(data);
@@ -90,7 +108,11 @@ export async function createServer(options: ServerOptions): Promise<RunningServe
 
   httpServer.on("upgrade", (req, socket, head) => {
     const pathname = new URL(req.url ?? "/", `http://${LOOPBACK_ADDRESS}`).pathname;
-    if (!isAllowedHostHeader(req.headers.host) || pathname !== BRIDGE_PATH) {
+    if (
+      !isAllowedHostHeader(req.headers.host) ||
+      !isAllowedOrigin(req.headers.origin) ||
+      pathname !== BRIDGE_PATH
+    ) {
       socket.destroy();
       return;
     }

--- a/packages/server/tsconfig.json
+++ b/packages/server/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "lib": ["ES2023"],
+    "types": ["node"],
+    "paths": {
+      "@repo/core/*": ["../core/src/*"],
+      "@repo/host/*": ["../host/src/*"],
+      "@repo/pi-driver/*": ["../pi-driver/src/*"],
+      "@repo/agent-runtime/*": ["../agent-runtime/src/*"]
+    }
+  },
+  "include": ["src", "vitest.config.ts", "../host/src/voice/sherpa-onnx-node.d.ts"]
+}

--- a/packages/server/vitest.config.ts
+++ b/packages/server/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "node",
+    include: ["src/**/*.test.ts"],
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -391,6 +391,34 @@ importers:
         specifier: 'catalog:'
         version: 6.0.3
 
+  packages/server:
+    dependencies:
+      '@repo/core':
+        specifier: workspace:^
+        version: link:../core
+      '@repo/host':
+        specifier: workspace:^
+        version: link:../host
+      sirv:
+        specifier: ^3.0.2
+        version: 3.0.2
+      ws:
+        specifier: ^8.19.0
+        version: 8.21.0
+    devDependencies:
+      '@types/node':
+        specifier: 'catalog:'
+        version: 25.9.1
+      '@types/ws':
+        specifier: ^8.18.1
+        version: 8.18.1
+      typescript:
+        specifier: 'catalog:'
+        version: 6.0.3
+      vitest:
+        specifier: ^4.1.7
+        version: 4.1.7(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(msw@2.14.6(@types/node@25.9.1)(typescript@6.0.3))(vite@8.0.14(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.44.1)(tsx@4.22.3)(yaml@2.9.0))
+
   packages/ui:
     dependencies:
       '@base-ui/react':
@@ -2864,6 +2892,9 @@ packages:
       react: '>=18.0.0'
       react-dom: '>=18.0.0'
 
+  '@polka/url@1.0.0-next.29':
+    resolution: {integrity: sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww==}
+
   '@protobufjs/aspromise@1.1.2':
     resolution: {integrity: sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==}
 
@@ -4013,6 +4044,9 @@ packages:
 
   '@types/webxr@0.5.24':
     resolution: {integrity: sha512-h8fgEd/DpoS9CBrjEQXR+dIDraopAEfu4wYVNY2tEPwk60stPWhvZMf4Foo5FakuQ7HFZoa8WceaWFervK2Ovg==}
+
+  '@types/ws@8.18.1':
+    resolution: {integrity: sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==}
 
   '@types/yargs-parser@21.0.3':
     resolution: {integrity: sha512-I4q9QU9MQv4oEOz4tAHJtNz1cwuLxn2F3xcc2iV5WdqLPpUnj30aUuxt1mAxYTG+oe8CZMV/+6rU4S4gRDzqtQ==}
@@ -6761,6 +6795,10 @@ packages:
       react-dom:
         optional: true
 
+  mrmime@2.0.1:
+    resolution: {integrity: sha512-Y3wQdFg2Va6etvQ5I82yUhGdsKrcYox6p7FfL1LbK2J4V01F9TGlepTIhnK24t7koZibmg82KGglhA1XK5IsLQ==}
+    engines: {node: '>=10'}
+
   ms@2.0.0:
     resolution: {integrity: sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==}
 
@@ -7825,6 +7863,10 @@ packages:
     resolution: {integrity: sha512-a2B9Y0KlNXl9u/vsW6sTIu9vGEpfKu2wRV6l1H3XEas/0gUIzGzBoP/IouTcUQbm9JWZLH3COxyn03TYlFax6w==}
     engines: {node: '>=10'}
 
+  sirv@3.0.2:
+    resolution: {integrity: sha512-2wcC/oGxHis/BoHkkPwldgiPSYcpZK3JU28WoMVv55yHJgcZ8rlXvuG9iZggz+sU1d4bRgIGASwyWqjxu3FM0g==}
+    engines: {node: '>=18'}
+
   sisteransi@1.0.5:
     resolution: {integrity: sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==}
 
@@ -8173,6 +8215,10 @@ packages:
 
   toqr@0.1.1:
     resolution: {integrity: sha512-FWAPzCIHZHnrE/5/w9MPk0kK25hSQSH2IKhYh9PyjS3SG/+IEMvlwIHbhz+oF7xl54I+ueZlVnMjyzdSwLmAwA==}
+
+  totalist@3.0.1:
+    resolution: {integrity: sha512-sf4i37nQ2LBx4m3wB74y+ubopq6W/dIzXg0FDGjsYnZHVa1Da8FH853wlL2gtUhg+xJXjfk3kUZS3BRoQeoQBQ==}
+    engines: {node: '>=6'}
 
   tough-cookie@6.0.1:
     resolution: {integrity: sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw==}
@@ -11313,6 +11359,8 @@ snapshots:
       - scheduler
       - use-sync-external-store
 
+  '@polka/url@1.0.0-next.29': {}
+
   '@protobufjs/aspromise@1.1.2': {}
 
   '@protobufjs/base64@1.1.2': {}
@@ -11849,7 +11897,9 @@ snapshots:
       metro-runtime: 0.84.4
     transitivePeerDependencies:
       - '@babel/core'
+      - bufferutil
       - supports-color
+      - utf-8-validate
     optional: true
 
   '@react-native/normalize-colors@0.85.3':
@@ -12481,6 +12531,10 @@ snapshots:
     optional: true
 
   '@types/webxr@0.5.24': {}
+
+  '@types/ws@8.18.1':
+    dependencies:
+      '@types/node': 25.9.1
 
   '@types/yargs-parser@21.0.3':
     optional: true
@@ -16017,6 +16071,8 @@ snapshots:
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
 
+  mrmime@2.0.1: {}
+
   ms@2.0.0:
     optional: true
 
@@ -17446,6 +17502,12 @@ snapshots:
     dependencies:
       semver: 7.8.1
 
+  sirv@3.0.2:
+    dependencies:
+      '@polka/url': 1.0.0-next.29
+      mrmime: 2.0.1
+      totalist: 3.0.1
+
   sisteransi@1.0.5: {}
 
   slate-dom@0.124.1(slate@0.124.1):
@@ -17797,6 +17859,8 @@ snapshots:
 
   toqr@0.1.1:
     optional: true
+
+  totalist@3.0.1: {}
 
   tough-cookie@6.0.1:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -307,6 +307,31 @@ importers:
         specifier: ^4.1.7
         version: 4.1.7(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(msw@2.14.6(@types/node@25.9.1)(typescript@6.0.3))(vite@8.0.14(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.44.1)(tsx@4.22.3)(yaml@2.9.0))
 
+  packages/cli:
+    dependencies:
+      '@repo/app':
+        specifier: workspace:^
+        version: link:../app
+      '@repo/host':
+        specifier: workspace:^
+        version: link:../host
+      '@repo/server':
+        specifier: workspace:^
+        version: link:../server
+      open:
+        specifier: ^11.0.0
+        version: 11.0.0
+      tsx:
+        specifier: ^4.21.1
+        version: 4.22.3
+    devDependencies:
+      '@types/node':
+        specifier: 'catalog:'
+        version: 25.9.1
+      typescript:
+        specifier: 'catalog:'
+        version: 6.0.3
+
   packages/core:
     dependencies:
       '@repo/pi-driver':
@@ -13924,7 +13949,6 @@ snapshots:
       '@esbuild/win32-arm64': 0.28.0
       '@esbuild/win32-ia32': 0.28.0
       '@esbuild/win32-x64': 0.28.0
-    optional: true
 
   escalade@3.2.0: {}
 
@@ -17900,7 +17924,6 @@ snapshots:
       esbuild: 0.28.0
     optionalDependencies:
       fsevents: 2.3.3
-    optional: true
 
   turbo@2.9.14:
     optionalDependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -319,6 +319,9 @@ importers:
       typescript:
         specifier: 'catalog:'
         version: 6.0.3
+      vitest:
+        specifier: ^4.1.7
+        version: 4.1.7(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(msw@2.14.6(@types/node@25.9.1)(typescript@6.0.3))(vite@8.0.14(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.44.1)(tsx@4.22.3)(yaml@2.9.0))
 
   packages/host:
     dependencies:

--- a/turbo.json
+++ b/turbo.json
@@ -9,6 +9,12 @@
       "dependsOn": ["^build"],
       "outputs": [".cache/tsbuildinfo.json", "dist/**", ".next/**", "!.next/cache/**", ".output/**"]
     },
+    // Static web build served by @repo/server (dist-web/, non-default
+    // outDir); the cli resolves it at runtime, so `pnpm build` must emit it.
+    "@repo/app#build": {
+      "dependsOn": ["^build"],
+      "outputs": ["dist-web/**"]
+    },
     "@repo/desktop#build": {
       "dependsOn": ["^build"],
       "outputs": [".cache/tsbuildinfo.json", ".output/**"],


### PR DESCRIPTION
Phase 4 of docs/replatform-plan.md: first browser-native run via `inteligir <vault>`.

## What

- **Wire protocol in @repo/core** (`bridge-wire.ts`): t-tagged envelope union (`req`/`res`/`snd`/`evt`) with TypeBox schemas derived from the IPC registry at runtime — zero duplicated channel lists. Binary frames: 1-byte tag + payload (0x01 STT Float32LE 16kHz up, 0x02 TTS s16le 24kHz down), copied to offset 0 (Buffer pooling misaligns typed-array views otherwise).
- **Browser WS Bridge client** (`createWsBridge`): satisfies `Bridge` exactly; reconnect = reject in-flight, backoff 500ms→10s, resync on reopen via the app's existing `onVaultChanged`/`onAppState` refresh paths. Updater trio answered locally, never on the wire.
- **@repo/server**: node http + ws, binds 127.0.0.1 only, Host-header allowlist, **Origin-gated WS upgrade** (review caught that cross-origin WS bypasses CORS — live-proven exploitable, now rejected + regression-tested), static serving of @repo/app's new `dist-web` build with SPA fallback.
- **@repo/cli**: `inteligir [vault]` — ServerPlatform (file-key cipher, no native picker), vault preset via `HostOptions.vaultPath` with the same guards as the picker, free-port boot, browser open, SIGINT/SIGTERM dispose + lock release. userDataDir deliberately ≠ `~/.inteligir` so logout's wipe can't nuke the 140MB voice model; desktop + cli share one model dir.

## Verification

- Gates green ×2. Live drive (real Chrome via agent-browser, cli-served temp vault): Rich editor over WS, paragraph edit → disk byte-check (rest of file byte-identical), external append → watcher → editor refresh, todos + Delegate affordances render, Host-header 403 live-verified, evil-Origin handshake rejected live, SIGTERM → clean exit + lock removed, reconnect overlay → resync on restart.
- Voice over the wire covered by unit + real-socket interop tests (STT/TTS frame alignment both directions).
- Electron desktop regression-booted: workspace renders, quit clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> New loopback server exposes full vault/agent IPC over WebSocket; security relies on bind address and Host/Origin allowlists rather than accounts, and misconfiguration could let malicious pages reach the bridge.
> 
> **Overview**
> **Phase 4** adds a second product entry: the same `@repo/host` backend and `@repo/app` UI, but in a normal browser via **`inteligir [vault]`** instead of Electron only.
> 
> **@repo/core** introduces **`bridge-wire`** (JSON `req`/`res`/`snd`/`evt` envelopes plus tagged binary PCM for STT/TTS, method lists derived from the IPC registry) and **`createWsBridge`**, a full **`Bridge`** implementation with reconnect/backoff, in-flight rejection on disconnect, post-reconnect resync via `getVaultRoot`/`getAppState`, and local stubs for the self-update trio.
> 
> **@repo/server** **`createServer`** binds **127.0.0.1 only**, serves **`dist-web/`** with SPA fallback, folds **`host.handlers`** over **`/bridge`**, broadcasts **`host.events`** to all tabs, and enforces **loopback Host + Origin** on HTTP/WS upgrades (DNS rebinding / cross-origin page driving the vault). **@repo/cli** wires **`createHost(createServerPlatform(), { vaultPath })`**, resolves the app build at runtime, opens the browser, and shuts down cleanly on signals.
> 
> **@repo/app** gains a **`web/`** Vite entry (`vite.web.config.ts` → **`dist-web/`**) that installs the WS bridge and a reconnect overlay. **@repo/host** accepts **`HostOptions.vaultPath`** at boot (same **`setRoot`** guards as the desktop picker). Tooling updates cover **`dist-web`**, turbo **`@repo/app#build`**, knip, and oxlint boundaries for **server/cli/core/app/web**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ef9e899ff570c695fc30a95c448d3de5000ae50f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a browser run path: a loopback HTTP+WS server and CLI that serve the app and connect it to the host over WebSocket. Ships a typed wire protocol, a reconnecting browser bridge, and a web build of the app.

- **New Features**
  - `@repo/core`: WebSocket wire protocol (`req`/`res`/`snd`/`evt`) plus tagged binary PCM (STT up, TTS down); `createWsBridge` with backoff reconnect and resync; tests.
  - `@repo/app`: web entry that installs `createWsBridge` and shows a reconnect overlay; new `build` emits `dist-web/`.
  - `@repo/server`: serves `dist-web/` with SPA fallback and exposes `/bridge` WS that folds host handlers/events; binds 127.0.0.1 only with Host and Origin allowlists.
  - `@repo/cli`: `inteligir [vault]` boots `@repo/host` + `@repo/server`, presets the vault via `HostOptions.vaultPath`, opens the browser, and shuts down cleanly on SIGINT/SIGTERM.

- **Migration**
  - Build the web app: `pnpm build` (emits `@repo/app` `dist-web/`).
  - Run in a browser: `pnpm --filter @repo/cli exec tsx src/main.ts <vault> [--port N] [--no-open]` or `inteligir <vault>`.

<sup>Written for commit ef9e899ff570c695fc30a95c448d3de5000ae50f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kyh/inteligir/pull/355?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

