### PR TITLE
Phase 6 WP3: editor menus + chrome rebuilt on Base UI, ariakit removed

### DIFF
--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -2,7 +2,7 @@
   "name": "@repo/app",
   "version": "0.1.0",
   "private": true,
-  "description": "Portable Inteligir UI: the whole workspace (editor, sidebar, composer, settings) as a browser React app. Talks to its host exclusively through an injected Bridge \u2014 no electron, no node.",
+  "description": "Portable Inteligir UI: the whole workspace (editor, sidebar, composer, settings) as a browser React app. Talks to its host exclusively through an injected Bridge — no electron, no node.",
   "type": "module",
   "scripts": {
     "build": "vite build --config vite.web.config.ts",

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -2,7 +2,7 @@
   "name": "@repo/app",
   "version": "0.1.0",
   "private": true,
-  "description": "Portable Inteligir UI: the whole workspace (editor, sidebar, composer, settings) as a browser React app. Talks to its host exclusively through an injected Bridge — no electron, no node.",
+  "description": "Portable Inteligir UI: the whole workspace (editor, sidebar, composer, settings) as a browser React app. Talks to its host exclusively through an injected Bridge \u2014 no electron, no node.",
   "type": "module",
   "scripts": {
     "build": "vite build --config vite.web.config.ts",
@@ -12,7 +12,6 @@
     "typecheck": "tsc --noEmit --emitDeclarationOnly false"
   },
   "dependencies": {
-    "@ariakit/react": "^0.4.30",
     "@base-ui/react": "catalog:",
     "@dnd-kit/core": "^6.3.1",
     "@dnd-kit/modifiers": "^9.0.0",
@@ -24,11 +23,13 @@
     "@platejs/combobox": "^53.0.0",
     "@platejs/date": "^53.0.0",
     "@platejs/emoji": "^53.1.7",
+    "@platejs/floating": "^53.0.0",
     "@platejs/indent": "^53.0.0",
     "@platejs/link": "^53.0.3",
     "@platejs/list": "^53.1.3",
     "@platejs/markdown": "^53.2.2",
     "@platejs/media": "^53.1.4",
+    "@platejs/selection": "^53.1.6",
     "@platejs/slash-command": "^53.0.0",
     "@platejs/table": "^53.0.9",
     "@platejs/toggle": "^53.0.0",

--- a/packages/app/src/__tests__/block-transforms.test.ts
+++ b/packages/app/src/__tests__/block-transforms.test.ts
@@ -1,0 +1,162 @@
+// Turn-into + block-move behaviors (decision #8: paragraph/H1-3/quote/
+// callout([!NOTE] marker)/code/toggle/todo/bullet/numbered; NOT columns),
+// exercised headlessly on the live EDITOR_KIT. The round-trip requirement:
+// converting and converting back always lands on canonical bytes.
+
+import { describe, expect, it } from "vitest";
+import { createSlateEditor } from "platejs";
+import { serializeMd } from "@platejs/markdown";
+
+import {
+  TURN_INTO,
+  moveBlocks,
+  turnIntoAt,
+  turnIntoLabelFor,
+  type TurnIntoOption,
+} from "@repo/app/editor/block-transforms";
+import { EDITOR_KIT } from "@repo/app/editor/kits/editor-kit";
+import { MD_STRINGIFY, parseMarkdown, roundTrip } from "@repo/app/editor/markdown/markdown-doc";
+
+function makeEditor(md: string) {
+  const parsed = parseMarkdown(md);
+  const value = parsed.ok ? parsed.value : [{ children: [{ text: "" }], type: "p" }];
+  return createSlateEditor({ plugins: EDITOR_KIT, value });
+}
+
+type Editor = ReturnType<typeof makeEditor>;
+
+function out(editor: Editor): string {
+  return serializeMd(editor, { remarkStringifyOptions: MD_STRINGIFY });
+}
+
+function opt(label: string): TurnIntoOption {
+  const found = TURN_INTO.find((o) => o.label === label);
+  if (!found) throw new Error(`no TURN_INTO option labeled ${label}`);
+  return found;
+}
+
+describe("TURN_INTO menu (decision #8)", () => {
+  it("offers exactly the locked target set — no columns", () => {
+    expect(TURN_INTO.map((o) => o.label)).toEqual([
+      "Text",
+      "Heading 1",
+      "Heading 2",
+      "Heading 3",
+      "Bulleted list",
+      "Numbered list",
+      "To-do list",
+      "Quote",
+      "Callout",
+      "Code block",
+      "Toggle",
+    ]);
+  });
+});
+
+describe("turnIntoAt round-trips", () => {
+  it("paragraph → toggle → paragraph", () => {
+    const editor = makeEditor("hello\n");
+    turnIntoAt(editor, [0], opt("Toggle"));
+    expect(out(editor)).toBe("<toggle>\n  hello\n</toggle>\n");
+    turnIntoAt(editor, [0], opt("Text"));
+    expect(out(editor)).toBe("hello\n");
+  });
+
+  it("toggle with a body promotes its children on unwrap", () => {
+    const editor = makeEditor("<toggle>\n  summary\n\n  body\n</toggle>\n");
+    turnIntoAt(editor, [0], opt("Text"));
+    expect(out(editor)).toBe("summary\n\nbody\n");
+  });
+
+  it("paragraph → callout inserts the [!NOTE] marker; → paragraph strips it", () => {
+    const editor = makeEditor("hello\n");
+    turnIntoAt(editor, [0], opt("Callout"));
+    expect(out(editor)).toBe("> [!NOTE] hello\n");
+    turnIntoAt(editor, [0], opt("Text"));
+    expect(out(editor)).toBe("hello\n");
+  });
+
+  it("callout → quote drops the marker; quote → callout adds it once", () => {
+    const editor = makeEditor("> [!NOTE] hello\n");
+    turnIntoAt(editor, [0], opt("Quote"));
+    expect(out(editor)).toBe("> hello\n");
+    turnIntoAt(editor, [0], opt("Callout"));
+    expect(out(editor)).toBe("> [!NOTE] hello\n");
+    // Idempotent: already a callout → marker not duplicated.
+    turnIntoAt(editor, [0], opt("Callout"));
+    expect(out(editor)).toBe("> [!NOTE] hello\n");
+  });
+
+  it("paragraph → code block → paragraph (multi-line)", () => {
+    const editor = makeEditor("hello\n");
+    turnIntoAt(editor, [0], opt("Code block"));
+    expect(out(editor)).toBe("```\nhello\n```\n");
+    turnIntoAt(editor, [0], opt("Text"));
+    expect(out(editor)).toBe("hello\n");
+
+    const multi = makeEditor("```\nline one\nline two\n```\n");
+    turnIntoAt(multi, [0], opt("Text"));
+    expect(out(multi)).toBe("line one\n\nline two\n");
+  });
+
+  it("paragraph → todo list carries checked:false (serializes as - [ ])", () => {
+    const editor = makeEditor("task\n");
+    turnIntoAt(editor, [0], opt("To-do list"));
+    expect(out(editor)).toBe("- [ ] task\n");
+    turnIntoAt(editor, [0], opt("Text"));
+    expect(out(editor)).toBe("task\n");
+  });
+
+  it("list → heading clears list props", () => {
+    const editor = makeEditor("- item\n");
+    turnIntoAt(editor, [0], opt("Heading 2"));
+    expect(out(editor)).toBe("## item\n");
+  });
+
+  it("every conversion output stays canonical (round-trip stable)", () => {
+    for (const target of TURN_INTO) {
+      const editor = makeEditor("hello world\n");
+      turnIntoAt(editor, [0], target);
+      const md = out(editor);
+      expect(roundTrip(md), `${target.label} output must be canonical`).toBe(md);
+    }
+  });
+});
+
+describe("turnIntoLabelFor (toolbar type indicator)", () => {
+  it("labels paragraphs, lists, quotes, callouts, toggles", () => {
+    expect(turnIntoLabelFor({ children: [{ text: "" }], type: "p" })).toBe("Text");
+    expect(
+      turnIntoLabelFor({ children: [{ text: "" }], listStyleType: "todo", type: "p" }),
+    ).toBe("To-do list");
+    expect(
+      turnIntoLabelFor({ children: [{ text: "plain" }], type: "blockquote" }),
+    ).toBe("Quote");
+    expect(
+      turnIntoLabelFor({ children: [{ text: "[!NOTE] hi" }], type: "blockquote" }),
+    ).toBe("Callout");
+    expect(turnIntoLabelFor({ children: [{ text: "" }], type: "toggle" })).toBe("Toggle");
+  });
+});
+
+describe("moveBlocks", () => {
+  it("moves a block up and down; no-ops at the edges", () => {
+    const editor = makeEditor("one\n\ntwo\n\nthree\n");
+    moveBlocks(editor, [[1]], "up");
+    expect(out(editor)).toBe("two\n\none\n\nthree\n");
+    moveBlocks(editor, [[1]], "down");
+    expect(out(editor)).toBe("two\n\nthree\n\none\n");
+    moveBlocks(editor, [[0]], "up");
+    expect(out(editor)).toBe("two\n\nthree\n\none\n");
+    moveBlocks(editor, [[2]], "down");
+    expect(out(editor)).toBe("two\n\nthree\n\none\n");
+  });
+
+  it("moves a multi-block span as a unit", () => {
+    const editor = makeEditor("one\n\ntwo\n\nthree\n\nfour\n");
+    moveBlocks(editor, [[1], [2]], "up");
+    expect(out(editor)).toBe("two\n\nthree\n\none\n\nfour\n");
+    moveBlocks(editor, [[0], [1]], "down");
+    expect(out(editor)).toBe("one\n\ntwo\n\nthree\n\nfour\n");
+  });
+});

--- a/packages/app/src/__tests__/editor-kits.test.ts
+++ b/packages/app/src/__tests__/editor-kits.test.ts
@@ -83,14 +83,29 @@ describe("column normalizer (suppressed width writer)", () => {
 });
 
 describe("insertColumnGroup", () => {
-  it("inserts bare columns that serialize canonically", () => {
+  it("inserts bare columns whose EMPTY form is the self-closed canonical one", () => {
     const editor = makeEditor("seed\n");
     editor.tf.select(editor.api.end([0]));
     insertColumnGroup(editor, 2);
+    // An autosave can land before either column has content: the empty
+    // column (one empty paragraph) must serialize to `<column />` — the
+    // same bytes its parse produces — or the very first save is
+    // non-canonical and the file falls to Raw (live-drive regression).
     const output = out(editor);
     expect(output).toContain("<column_group>");
-    expect((output.match(/<column>/g) ?? []).length).toBe(2);
+    expect((output.match(/<column \/>/g) ?? []).length).toBe(2);
     expect(output).not.toContain("width");
+    expect(roundTrip(output)).toBe(output);
+  });
+
+  it("a half-filled group stays canonical (one filled, one still empty)", () => {
+    const editor = makeEditor("seed\n");
+    editor.tf.select(editor.api.end([0]));
+    insertColumnGroup(editor, 2);
+    editor.tf.insertText("left cell");
+    const output = out(editor);
+    expect(output).toContain("left cell");
+    expect(output).toContain("<column />");
     expect(roundTrip(output)).toBe(output);
   });
 
@@ -98,7 +113,7 @@ describe("insertColumnGroup", () => {
     const editor = makeEditor("seed\n");
     editor.tf.select(editor.api.end([0]));
     insertColumnGroup(editor, 3);
-    expect((out(editor).match(/<column>/g) ?? []).length).toBe(3);
+    expect((out(editor).match(/<column \/>/g) ?? []).length).toBe(3);
   });
 });
 

--- a/packages/app/src/__tests__/inline-combobox.test.ts
+++ b/packages/app/src/__tests__/inline-combobox.test.ts
@@ -11,6 +11,7 @@ import { ElementApi, KEYS, createSlateEditor, type TElement } from "platejs";
 import { serializeMd } from "@platejs/markdown";
 
 import {
+  absorbRacedComboboxText,
   cancelComboboxInput,
   commitComboboxInput,
   racedComboboxText,
@@ -137,19 +138,28 @@ describe("inline combobox cancel safety (the about:blank crash class)", () => {
   it("absorbs keystrokes that raced into the element's hidden text child", () => {
     const editor = makeEditor("");
     const element = openCombobox(editor, ":", KEYS.emojiInput);
-    // A fast keystroke landing before the HTML input mounts goes into the
-    // void's text child; the input's mount effect reads it via
-    // racedComboboxText and prepends it to the query.
+    // A fast keystroke landing before the HTML input has focus goes into the
+    // void's text child; the input absorbs it (read + clear) and prepends it
+    // to the query.
     const path = editor.api.findPath(element);
     if (!path) throw new Error("element path missing");
     editor.tf.select({ offset: 0, path: [...path, 0] });
     editor.tf.insertText("t", { voids: true });
     const raced = findByType(editor, KEYS.emojiInput);
     expect(raced ? racedComboboxText(raced) : "").toBe("t");
-    // The raced bytes leave with the element on cancel; the restore text (the
-    // component passes trigger + absorbed value) carries them instead.
     if (!raced) throw new Error("element missing");
-    cancelComboboxInput(editor, raced, { cause: "escape", restoreText: ":tada" });
+    expect(absorbRacedComboboxText(editor, raced)).toBe("t");
+    // Cleared: no leftover bytes to render after the input or double-absorb.
+    const cleared = findByType(editor, KEYS.emojiInput);
+    expect(cleared ? racedComboboxText(cleared) : "?").toBe("");
+    // Cancel restores trigger + absorbed value; undo spam stays safe.
+    if (!cleared) throw new Error("element missing");
+    cancelComboboxInput(editor, cleared, { cause: "escape", restoreText: ":tada" });
+    expect(out(editor)).toBe(":tada\n");
+    expect(() => {
+      for (let i = 0; i < 10; i++) editor.undo();
+      for (let i = 0; i < 10; i++) editor.redo();
+    }).not.toThrow();
     expect(out(editor)).toBe(":tada\n");
   });
 });

--- a/packages/app/src/__tests__/inline-combobox.test.ts
+++ b/packages/app/src/__tests__/inline-combobox.test.ts
@@ -1,0 +1,180 @@
+// Regression suite for the inline combobox's editor-mutation core
+// (combobox-input.ts), mirroring the crash recipe that tore the ariakit
+// version to about:blank: trigger → typed query → Escape cancel → rapid
+// undo/redo interleaving. The invariants: no operation ever throws, cancel
+// after an external removal (undo) is a no-op, and the trigger elements are
+// structurally excluded from serialization (no "Unreachable code" warning,
+// no text drop).
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { ElementApi, KEYS, createSlateEditor, type TElement } from "platejs";
+import { serializeMd } from "@platejs/markdown";
+
+import {
+  cancelComboboxInput,
+  commitComboboxInput,
+  racedComboboxText,
+} from "@repo/app/editor/combobox-input";
+import { EDITOR_KIT } from "@repo/app/editor/kits/editor-kit";
+import { MD_STRINGIFY } from "@repo/app/editor/markdown/markdown-doc";
+
+function makeEditor(text: string) {
+  return createSlateEditor({
+    plugins: EDITOR_KIT,
+    value: [{ children: [{ text }], type: "p" }],
+  });
+}
+
+type Editor = ReturnType<typeof makeEditor>;
+
+function out(editor: Editor): string {
+  return serializeMd(editor, { remarkStringifyOptions: MD_STRINGIFY });
+}
+
+function findByType(editor: Editor, type: string): TElement | null {
+  for (const [node] of editor.api.nodes({ at: [], match: { type } })) {
+    if (ElementApi.isElement(node)) return node;
+  }
+  return null;
+}
+
+/** Type the trigger char at the end of block 0, creating the input element. */
+function openCombobox(editor: Editor, trigger: string, type: string): TElement {
+  const end = editor.api.end([0]);
+  if (!end) throw new Error("no end point");
+  editor.tf.select(end);
+  editor.tf.insertText(trigger);
+  const element = findByType(editor, type);
+  if (!element) throw new Error(`trigger '${trigger}' did not insert a ${type} element`);
+  return element;
+}
+
+describe("inline combobox cancel safety (the about:blank crash class)", () => {
+  it("escape cancel restores the trigger + query bytes", () => {
+    const editor = makeEditor("hello ");
+    const element = openCombobox(editor, ":", KEYS.emojiInput);
+    cancelComboboxInput(editor, element, { cause: "escape", restoreText: ":tada" });
+    expect(out(editor)).toBe("hello :tada\n");
+    expect(findByType(editor, KEYS.emojiInput)).toBeNull();
+  });
+
+  it("survives the crash recipe: escape cancel → 10 rapid undos, ×5 runs", () => {
+    for (let run = 0; run < 5; run++) {
+      const editor = makeEditor("hello ");
+      const seed = out(editor);
+      const element = openCombobox(editor, ":", KEYS.emojiInput);
+      cancelComboboxInput(editor, element, { cause: "escape", restoreText: ":tada" });
+      expect(() => {
+        for (let i = 0; i < 10; i++) editor.undo();
+      }).not.toThrow();
+      // Fully unwound: back to the seed bytes, no orphan trigger element.
+      expect(out(editor)).toBe(seed);
+      expect(findByType(editor, KEYS.emojiInput)).toBeNull();
+    }
+  });
+
+  it("survives undo/redo interleaving after a cancel", () => {
+    const editor = makeEditor("hello ");
+    const element = openCombobox(editor, ":", KEYS.emojiInput);
+    cancelComboboxInput(editor, element, { cause: "escape", restoreText: ":tada" });
+    expect(() => {
+      for (let i = 0; i < 5; i++) {
+        editor.undo();
+        editor.redo();
+        editor.undo();
+        editor.undo();
+        editor.redo();
+        editor.redo();
+      }
+    }).not.toThrow();
+    // Redo replays the cancel exactly — bytes converge, never duplicate.
+    expect(out(editor)).toBe("hello :tada\n");
+  });
+
+  it("cancel after an undo removed the element is a strict no-op", () => {
+    const editor = makeEditor("hello ");
+    const element = openCombobox(editor, ":", KEYS.emojiInput);
+    // Cmd+Z forwarded from the input: the trigger-insert batch unwinds and
+    // the element leaves the document while the component is still mounted.
+    while (findByType(editor, KEYS.emojiInput)) editor.undo();
+    const before = out(editor);
+    expect(() =>
+      cancelComboboxInput(editor, element, { cause: "deselect", restoreText: ":tada" }),
+    ).not.toThrow();
+    expect(out(editor)).toBe(before);
+  });
+
+  it("backspace cancel deletes the trigger too", () => {
+    const editor = makeEditor("hello ");
+    const seed = out(editor);
+    const element = openCombobox(editor, "/", KEYS.slashInput);
+    cancelComboboxInput(editor, element, { cause: "backspace", restoreText: "/" });
+    expect(out(editor)).toBe(seed);
+  });
+
+  it("commit removes the element and survives undo spam", () => {
+    const editor = makeEditor("hello ");
+    const element = openCombobox(editor, ":", KEYS.emojiInput);
+    commitComboboxInput(editor, element, false);
+    const end = editor.api.end([0]);
+    if (!end) throw new Error("no end point");
+    editor.tf.insertText("🎉", { at: end });
+    expect(out(editor)).toBe("hello 🎉\n");
+    expect(() => {
+      for (let i = 0; i < 10; i++) editor.undo();
+      for (let i = 0; i < 10; i++) editor.redo();
+    }).not.toThrow();
+    expect(out(editor)).toBe("hello 🎉\n");
+  });
+
+  it("commit after external removal is a no-op", () => {
+    const editor = makeEditor("hello ");
+    const element = openCombobox(editor, "/", KEYS.slashInput);
+    while (findByType(editor, KEYS.slashInput)) editor.undo();
+    expect(() => commitComboboxInput(editor, element, false)).not.toThrow();
+  });
+
+  it("absorbs keystrokes that raced into the element's hidden text child", () => {
+    const editor = makeEditor("");
+    const element = openCombobox(editor, ":", KEYS.emojiInput);
+    // A fast keystroke landing before the HTML input mounts goes into the
+    // void's text child; the input's mount effect reads it via
+    // racedComboboxText and prepends it to the query.
+    const path = editor.api.findPath(element);
+    if (!path) throw new Error("element path missing");
+    editor.tf.select({ offset: 0, path: [...path, 0] });
+    editor.tf.insertText("t", { voids: true });
+    const raced = findByType(editor, KEYS.emojiInput);
+    expect(raced ? racedComboboxText(raced) : "").toBe("t");
+    // The raced bytes leave with the element on cancel; the restore text (the
+    // component passes trigger + absorbed value) carries them instead.
+    if (!raced) throw new Error("element missing");
+    cancelComboboxInput(editor, raced, { cause: "escape", restoreText: ":tada" });
+    expect(out(editor)).toBe(":tada\n");
+  });
+});
+
+describe("combobox trigger nodes are excluded from serialization", () => {
+  let warn: ReturnType<typeof vi.spyOn>;
+  beforeEach(() => {
+    warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+  });
+  afterEach(() => {
+    warn.mockRestore();
+  });
+
+  it("serializing mid-combobox drops the trigger node, keeps the text, never warns", () => {
+    for (const trigger of [
+      { char: "/", type: KEYS.slashInput },
+      { char: ":", type: KEYS.emojiInput },
+    ]) {
+      const editor = makeEditor("before after");
+      editor.tf.select({ offset: 7, path: [0, 0] });
+      editor.tf.insertText(trigger.char);
+      expect(findByType(editor, trigger.type)).not.toBeNull();
+      const md = out(editor);
+      expect(md).toBe("before after\n");
+      expect(warn).not.toHaveBeenCalled();
+    }
+  });
+});

--- a/packages/app/src/__tests__/kit-parity.test.ts
+++ b/packages/app/src/__tests__/kit-parity.test.ts
@@ -57,7 +57,7 @@ describe("kit parity (Base half)", () => {
     expect(optionsB.rules).toBe(MD_RULES);
     expect(optionsA.remarkPlugins).toBe(MD_REMARK_PLUGINS);
     expect(optionsB.remarkPlugins).toBe(MD_REMARK_PLUGINS);
-    expect(optionsA.disallowedNodes).toEqual(["suggestion", "ai"]);
+    expect(optionsA.disallowedNodes).toEqual(["suggestion", "ai", "slash_input", "emoji_input"]);
   });
 
   it("serializes the canonical corpus identically across editor instances", () => {
@@ -97,7 +97,7 @@ describe("kit parity (live editor mirror)", () => {
     const options = live.getOptions(MarkdownPlugin);
     expect(options.rules).toBe(MD_RULES);
     expect(options.remarkPlugins).toBe(MD_REMARK_PLUGINS);
-    expect(options.disallowedNodes).toEqual(["suggestion", "ai"]);
+    expect(options.disallowedNodes).toEqual(["suggestion", "ai", "slash_input", "emoji_input"]);
   });
 
   it("both editors agree on inline/void metadata for every corpus element", () => {

--- a/packages/app/src/editor/block-context-menu.tsx
+++ b/packages/app/src/editor/block-context-menu.tsx
@@ -1,0 +1,38 @@
+// Right-click surface (BlockMenuPlugin's aboveSlate wrapper). Bubbling order
+// does the selection: BlockSelectionPlugin injects an onContextMenu on each
+// selectable block (addOnContextMenu) that selects it — or stops propagation
+// when the right-click lands on focused text (native menu wins there, potion
+// behavior) — and this wrapper, reached only when propagation survived, opens
+// the shared BlockMenu at the pointer.
+
+import type { ReactNode } from "react";
+import { BLOCK_CONTEXT_MENU_ID, BlockMenuPlugin, BlockSelectionPlugin } from "@platejs/selection/react";
+import { useEditorPlugin } from "platejs/react";
+
+import { BlockMenu } from "@repo/app/editor/block-menu";
+
+export function BlockContextMenu({ children }: { children: ReactNode }) {
+  const { api, editor } = useEditorPlugin(BlockMenuPlugin);
+
+  return (
+    <div
+      className="group/context-menu w-full"
+      data-plate-selectable
+      onContextMenu={(event) => {
+        const target = event.target;
+        if (!(target instanceof HTMLElement)) return;
+        // Right-click on the editable surface itself (its padding, not a
+        // block) keeps the native menu.
+        if (target.dataset.slateEditor === "true") return;
+        // No block took the right-click (e.g. frontmatter is not
+        // selectable) → nothing for the menu to act on.
+        if (editor.getOption(BlockSelectionPlugin, "selectedIds")?.size === 0) return;
+        event.preventDefault();
+        api.blockMenu.show(BLOCK_CONTEXT_MENU_ID, { x: event.clientX, y: event.clientY });
+      }}
+    >
+      {children}
+      <BlockMenu />
+    </div>
+  );
+}

--- a/packages/app/src/editor/block-draggable.tsx
+++ b/packages/app/src/editor/block-draggable.tsx
@@ -24,8 +24,9 @@ import {
   verticalListSortingStrategy,
 } from "@dnd-kit/sortable";
 import { CSS } from "@dnd-kit/utilities";
-import { useEffect, useRef, useState } from "react";
-import { CopyIcon, GripVerticalIcon, PlusIcon, Trash2Icon } from "lucide-react";
+import { useEffect, useRef } from "react";
+import { GripVerticalIcon, PlusIcon } from "lucide-react";
+import { BlockMenuPlugin, BlockSelectionPlugin } from "@platejs/selection/react";
 import { PathApi } from "platejs";
 import {
   createPlatePlugin,
@@ -35,16 +36,6 @@ import {
 } from "platejs/react";
 
 import { cn } from "@repo/ui/lib/utils";
-import {
-  Menu,
-  MenuContent,
-  MenuGroup,
-  MenuGroupLabel,
-  MenuItem,
-  MenuSeparator,
-} from "@repo/ui/components/menu";
-
-import { TURN_INTO, turnIntoAt } from "@repo/app/editor/block-transforms";
 
 // Stable per-block drag ids. Slate's moveNodes preserves node object identity,
 // so a WeakMap keyed by the element yields ids that survive a reorder. Both the
@@ -116,7 +107,6 @@ function Draggable(props: PlateElementProps) {
     isDragging,
   } = useSortable({ id: blockId(element) });
 
-  const [menuOpen, setMenuOpen] = useState(false);
   const gripRef = useRef<HTMLButtonElement | null>(null);
   // A drag ends in a synthetic click on the grip; remember a drag happened so
   // that click doesn't pop the menu open right after a reorder.
@@ -135,17 +125,15 @@ function Draggable(props: PlateElementProps) {
     editor.tf.insertText("/");
   };
 
-  const removeBlock = () => {
-    const at = editor.api.findPath(element);
-    if (at) editor.tf.removeNodes({ at });
-  };
-  const duplicateBlock = () => {
-    const at = editor.api.findPath(element);
-    if (at) editor.tf.insertNodes(structuredClone(element), { at: PathApi.next(at) });
-  };
-  const turnInto = (opt: (typeof TURN_INTO)[number]) => {
-    const at = editor.api.findPath(element);
-    if (at) turnIntoAt(editor, at, opt);
+  // Grip click: select this block and open THE block menu (block-menu.tsx —
+  // same one as right-click) anchored under the grip.
+  const openBlockMenu = () => {
+    const id = typeof element.id === "string" ? element.id : null;
+    const grip = gripRef.current;
+    if (!id || !grip) return;
+    editor.getApi(BlockSelectionPlugin).blockSelection.set(id);
+    const rect = grip.getBoundingClientRect();
+    editor.getApi(BlockMenuPlugin).blockMenu.show(id, { x: rect.left, y: rect.bottom + 4 });
   };
 
   return (
@@ -179,7 +167,7 @@ function Draggable(props: PlateElementProps) {
               draggedRef.current = false;
               return;
             }
-            setMenuOpen(true);
+            openBlockMenu();
           }}
           className="flex size-5 cursor-grab touch-none items-center justify-center rounded-md text-muted-foreground hover:bg-accent hover:text-foreground active:cursor-grabbing"
           {...attributes}
@@ -188,32 +176,6 @@ function Draggable(props: PlateElementProps) {
           <GripVerticalIcon className="size-4" />
         </button>
       </div>
-
-      <Menu open={menuOpen} onOpenChange={setMenuOpen}>
-        <MenuContent anchor={gripRef} side="right" align="start">
-          <MenuItem onClick={duplicateBlock}>
-            <CopyIcon />
-            Duplicate
-          </MenuItem>
-          <MenuSeparator />
-          <MenuGroup>
-            <MenuGroupLabel>Turn into</MenuGroupLabel>
-            {TURN_INTO.map((opt) => (
-              <MenuItem key={opt.label} onClick={() => turnInto(opt)}>
-                {opt.label}
-              </MenuItem>
-            ))}
-          </MenuGroup>
-          <MenuSeparator />
-          <MenuItem
-            onClick={removeBlock}
-            className="text-destructive data-[highlighted]:bg-destructive/10 data-[highlighted]:text-destructive"
-          >
-            <Trash2Icon />
-            Delete
-          </MenuItem>
-        </MenuContent>
-      </Menu>
 
       {children}
     </div>

--- a/packages/app/src/editor/block-menu.tsx
+++ b/packages/app/src/editor/block-menu.tsx
@@ -1,0 +1,98 @@
+// THE block menu — one implementation for both the right-click context menu
+// and the drag-grip click (block-draggable), driven by BlockMenuPlugin's
+// openId/position and anchored to a virtual element at that position (Base UI
+// Positioner takes a rect-returning function; no 0×0 anchor div needed).
+// Actions operate on the block-selection set. Omitted by design:
+// copy-link-to-block (markdown files have no block-anchor concept) and
+// Ask-AI (Phase F slot).
+
+import { useMemo } from "react";
+import { BlockMenuPlugin, BlockSelectionPlugin } from "@platejs/selection/react";
+import {
+  ArrowDownIcon,
+  ArrowUpIcon,
+  CopyIcon,
+  RefreshCwIcon,
+  Trash2Icon,
+} from "lucide-react";
+import type { Path } from "platejs";
+import { useEditorPlugin, usePluginOption } from "platejs/react";
+
+import {
+  Menu,
+  MenuContent,
+  MenuItem,
+  MenuSeparator,
+  MenuSub,
+  MenuSubContent,
+  MenuSubTrigger,
+} from "@repo/ui/components/menu";
+
+import { TURN_INTO, moveBlocks, turnIntoBlocks } from "@repo/app/editor/block-transforms";
+
+export function BlockMenu() {
+  const { api, editor } = useEditorPlugin(BlockMenuPlugin);
+  const openId = usePluginOption(BlockMenuPlugin, "openId");
+  const position = usePluginOption(BlockMenuPlugin, "position");
+
+  const anchor = useMemo(() => {
+    const { x, y } = position;
+    return () => ({
+      getBoundingClientRect: () => DOMRect.fromRect({ height: 0, width: 0, x, y }),
+    });
+  }, [position]);
+
+  const selectedPaths = (): Path[] =>
+    editor
+      .getApi(BlockSelectionPlugin)
+      .blockSelection.getNodes({ sort: true })
+      .map(([, path]) => path);
+
+  const blockTf = editor.getTransforms(BlockSelectionPlugin).blockSelection;
+
+  return (
+    <Menu
+      open={openId !== null}
+      onOpenChange={(open) => {
+        if (!open) api.blockMenu.hide();
+      }}
+    >
+      <MenuContent anchor={anchor} side="bottom" align="start" className="min-w-[220px]">
+        <MenuItem onClick={() => blockTf.duplicate()}>
+          <CopyIcon />
+          Duplicate
+        </MenuItem>
+        <MenuSub>
+          <MenuSubTrigger>
+            <RefreshCwIcon />
+            Turn into
+          </MenuSubTrigger>
+          <MenuSubContent>
+            {TURN_INTO.map((opt) => (
+              <MenuItem key={opt.label} onClick={() => turnIntoBlocks(editor, selectedPaths(), opt)}>
+                {opt.label}
+              </MenuItem>
+            ))}
+          </MenuSubContent>
+        </MenuSub>
+        <MenuSeparator />
+        <MenuItem onClick={() => moveBlocks(editor, selectedPaths(), "up")}>
+          <ArrowUpIcon />
+          Move up
+        </MenuItem>
+        <MenuItem onClick={() => moveBlocks(editor, selectedPaths(), "down")}>
+          <ArrowDownIcon />
+          Move down
+        </MenuItem>
+        <MenuSeparator />
+        <MenuItem
+          onClick={() => blockTf.removeNodes()}
+          className="text-destructive data-[highlighted]:bg-destructive/10 data-[highlighted]:text-destructive"
+        >
+          <Trash2Icon />
+          Delete
+        </MenuItem>
+      </MenuContent>
+    </Menu>
+  );
+}

--- a/packages/app/src/editor/block-menu.tsx
+++ b/packages/app/src/editor/block-menu.tsx
@@ -2,30 +2,27 @@
 // and the drag-grip click (block-draggable), driven by BlockMenuPlugin's
 // openId/position and anchored to a virtual element at that position (Base UI
 // Positioner takes a rect-returning function; no 0×0 anchor div needed).
-// Actions operate on the block-selection set. Omitted by design:
-// copy-link-to-block (markdown files have no block-anchor concept) and
-// Ask-AI (Phase F slot).
+// Actions operate on the block-selection set.
+//
+// Flat by design: a Turn-into group instead of a nested submenu — Base UI's
+// SubmenuRoot inside this controlled virtual-anchor menu closes the root with
+// reason "sibling-open" (parent/child floating-tree linkage doesn't form);
+// revisit if upstream fixes the nesting. Omitted: copy-link-to-block
+// (markdown files have no block-anchor concept) and Ask-AI (Phase F slot).
 
 import { useMemo } from "react";
 import { BlockMenuPlugin, BlockSelectionPlugin } from "@platejs/selection/react";
-import {
-  ArrowDownIcon,
-  ArrowUpIcon,
-  CopyIcon,
-  RefreshCwIcon,
-  Trash2Icon,
-} from "lucide-react";
+import { ArrowDownIcon, ArrowUpIcon, CopyIcon, Trash2Icon } from "lucide-react";
 import type { Path } from "platejs";
 import { useEditorPlugin, usePluginOption } from "platejs/react";
 
 import {
   Menu,
   MenuContent,
+  MenuGroup,
+  MenuGroupLabel,
   MenuItem,
   MenuSeparator,
-  MenuSub,
-  MenuSubContent,
-  MenuSubTrigger,
 } from "@repo/ui/components/menu";
 
 import { TURN_INTO, moveBlocks, turnIntoBlocks } from "@repo/app/editor/block-transforms";
@@ -57,25 +54,16 @@ export function BlockMenu() {
         if (!open) api.blockMenu.hide();
       }}
     >
-      <MenuContent anchor={anchor} side="bottom" align="start" className="min-w-[220px]">
+      <MenuContent
+        anchor={anchor}
+        side="bottom"
+        align="start"
+        className="max-h-[70vh] min-w-[200px]"
+      >
         <MenuItem onClick={() => blockTf.duplicate()}>
           <CopyIcon />
           Duplicate
         </MenuItem>
-        <MenuSub>
-          <MenuSubTrigger>
-            <RefreshCwIcon />
-            Turn into
-          </MenuSubTrigger>
-          <MenuSubContent>
-            {TURN_INTO.map((opt) => (
-              <MenuItem key={opt.label} onClick={() => turnIntoBlocks(editor, selectedPaths(), opt)}>
-                {opt.label}
-              </MenuItem>
-            ))}
-          </MenuSubContent>
-        </MenuSub>
-        <MenuSeparator />
         <MenuItem onClick={() => moveBlocks(editor, selectedPaths(), "up")}>
           <ArrowUpIcon />
           Move up
@@ -84,7 +72,6 @@ export function BlockMenu() {
           <ArrowDownIcon />
           Move down
         </MenuItem>
-        <MenuSeparator />
         <MenuItem
           onClick={() => blockTf.removeNodes()}
           className="text-destructive data-[highlighted]:bg-destructive/10 data-[highlighted]:text-destructive"
@@ -92,6 +79,15 @@ export function BlockMenu() {
           <Trash2Icon />
           Delete
         </MenuItem>
+        <MenuSeparator />
+        <MenuGroup>
+          <MenuGroupLabel>Turn into</MenuGroupLabel>
+          {TURN_INTO.map((opt) => (
+            <MenuItem key={opt.label} onClick={() => turnIntoBlocks(editor, selectedPaths(), opt)}>
+              {opt.label}
+            </MenuItem>
+          ))}
+        </MenuGroup>
       </MenuContent>
     </Menu>
   );

--- a/packages/app/src/editor/block-selection.tsx
+++ b/packages/app/src/editor/block-selection.tsx
@@ -1,0 +1,26 @@
+/* Adapted from Plate Plus Potion (https://pro.platejs.org) — used under the
+ * held Plate Plus license. */
+// Per-block selection overlay: BlockSelectionPlugin renders this below every
+// selectable block's root node; it lights up when the block's id is in the
+// selected set (right-click, grip click, or drag-lasso selection).
+
+import { useBlockSelected } from "@platejs/selection/react";
+
+import { cn } from "@repo/ui/lib/utils";
+
+export function BlockSelection({ pluginKey }: { pluginKey: string }) {
+  const isBlockSelected = useBlockSelected();
+
+  // Tables carry their own cell-selection UI; the overlay would double up.
+  if (!isBlockSelected || pluginKey === "tr" || pluginKey === "table") return null;
+
+  return (
+    <div
+      className={cn(
+        'pointer-events-none absolute inset-0 z-1 size-full rounded-[4px] content-[""]',
+        "bg-primary/15 transition-opacity duration-200",
+      )}
+      data-slot="block-selection"
+    />
+  );
+}

--- a/packages/app/src/editor/block-selection.tsx
+++ b/packages/app/src/editor/block-selection.tsx
@@ -14,10 +14,12 @@ export function BlockSelection({ pluginKey }: { pluginKey: string }) {
   // Tables carry their own cell-selection UI; the overlay would double up.
   if (!isBlockSelected || pluginKey === "tr" || pluginKey === "table") return null;
 
+  // span, not div: paragraphs render as <p>, and a div child is invalid
+  // nesting (React dev warns per block).
   return (
-    <div
+    <span
       className={cn(
-        'pointer-events-none absolute inset-0 z-1 size-full rounded-[4px] content-[""]',
+        'pointer-events-none absolute inset-0 z-1 block size-full rounded-[4px] content-[""]',
         "bg-primary/15 transition-opacity duration-200",
       )}
       data-slot="block-selection"

--- a/packages/app/src/editor/block-transforms.ts
+++ b/packages/app/src/editor/block-transforms.ts
@@ -4,7 +4,7 @@
 // toggle/todo/bullet/numbered; columns are NOT a turn-into target. Lists are
 // indent-based (a paragraph carrying `listStyleType` + `indent`).
 
-import { ElementApi, KEYS, NodeApi, PathApi, type Path, type TRange } from "platejs";
+import { ElementApi, KEYS, NodeApi, PathApi, type Path, type TElement, type TRange } from "platejs";
 import type { PlateEditor } from "platejs/react";
 
 import { wrapBlockInToggle } from "@repo/app/editor/kits/toggle-kit";
@@ -32,6 +32,36 @@ export const TURN_INTO: TurnIntoOption[] = [
 ];
 
 const ALERT_MARKER_RE = /^\[!(?:NOTE|TIP|IMPORTANT|WARNING|CAUTION)\]\s?/;
+
+/**
+ * The block a turn-into acts on for a selection sitting at `at`: normally the
+ * lowest block, but a toggle's SUMMARY row (first nested child) stands for
+ * the toggle itself — converting "Toggle → Text" from the toolbar must
+ * unwrap the toggle, not no-op on the paragraph inside it.
+ */
+export function effectiveBlockEntry(
+  editor: PlateEditor,
+  at?: TRange,
+): [TElement, Path] | null {
+  const block = editor.api.block(at ? { at } : {});
+  if (!block || !ElementApi.isElement(block[0])) return null;
+  return retargetToggleSummary(editor, [block[0], block[1]]);
+}
+
+function retargetToggleSummary(editor: PlateEditor, entry: [TElement, Path]): [TElement, Path] {
+  const [, path] = entry;
+  if (path.length > 1 && path[path.length - 1] === 0) {
+    const parent = editor.api.node(PathApi.parent(path));
+    if (
+      parent &&
+      ElementApi.isElement(parent[0]) &&
+      parent[0].type === editor.getType(KEYS.toggle)
+    ) {
+      return [parent[0], parent[1]];
+    }
+  }
+  return entry;
+}
 
 /** The TURN_INTO entry describing `node`, for the toolbar's type indicator. */
 export function turnIntoLabelFor(node: { type: string } & Record<string, unknown>): string {
@@ -165,7 +195,17 @@ function applyTarget(editor: PlateEditor, at: Path, opt: TurnIntoOption): void {
 export function turnIntoSelection(editor: PlateEditor, opt: TurnIntoOption, at?: TRange): void {
   const entries = editor.api.blocks(at ? { at, mode: "lowest" } : { mode: "lowest" });
   editor.tf.withoutNormalizing(() => {
-    for (const [, path] of entries) turnIntoAt(editor, path, opt);
+    const seen = new Set<string>();
+    for (const [node, path] of entries) {
+      if (!ElementApi.isElement(node)) continue;
+      // A toggle's summary row stands for the toggle itself (dedupe so a
+      // range spanning summary + body doesn't convert the toggle twice).
+      const [, target] = retargetToggleSummary(editor, [node, path]);
+      const key = target.join(".");
+      if (seen.has(key)) continue;
+      seen.add(key);
+      turnIntoAt(editor, target, opt);
+    }
   });
 }
 

--- a/packages/app/src/editor/block-transforms.ts
+++ b/packages/app/src/editor/block-transforms.ts
@@ -1,11 +1,21 @@
-// "Turn into" block-type conversions, shared by the block handle menu
-// (block-draggable) and the selection toolbar. Lists are indent-based (a
-// paragraph carrying `listStyleType` + `indent`), so they share `type: KEYS.p`.
+// "Turn into" block-type conversions + block move operations, shared by the
+// slash menu, the block menu (context/grip), and the selection toolbar — one
+// source per decision #8: paragraph/H1-3/quote/callout([!NOTE] marker)/code/
+// toggle/todo/bullet/numbered; columns are NOT a turn-into target. Lists are
+// indent-based (a paragraph carrying `listStyleType` + `indent`).
 
-import { KEYS, type Path, type TRange } from "platejs";
+import { ElementApi, KEYS, NodeApi, PathApi, type Path, type TRange } from "platejs";
 import type { PlateEditor } from "platejs/react";
 
-export type TurnIntoOption = { label: string; type: string; listStyleType?: string };
+import { wrapBlockInToggle } from "@repo/app/editor/kits/toggle-kit";
+
+export type TurnIntoOption = {
+  label: string;
+  type: string;
+  listStyleType?: string;
+  /** GitHub-alert marker inserted at block start (the product's callout). */
+  marker?: string;
+};
 
 export const TURN_INTO: TurnIntoOption[] = [
   { label: "Text", type: KEYS.p },
@@ -16,18 +26,135 @@ export const TURN_INTO: TurnIntoOption[] = [
   { label: "Numbered list", type: KEYS.p, listStyleType: "decimal" },
   { label: "To-do list", type: KEYS.p, listStyleType: "todo" },
   { label: "Quote", type: KEYS.blockquote },
+  { label: "Callout", type: KEYS.blockquote, marker: "[!NOTE] " },
+  { label: "Code block", type: KEYS.codeBlock },
+  { label: "Toggle", type: KEYS.toggle },
 ];
 
-/** Convert the block at `at` to the given target. */
+const ALERT_MARKER_RE = /^\[!(?:NOTE|TIP|IMPORTANT|WARNING|CAUTION)\]\s?/;
+
+/** The TURN_INTO entry describing `node`, for the toolbar's type indicator. */
+export function turnIntoLabelFor(node: { type: string } & Record<string, unknown>): string {
+  if (typeof node.listStyleType === "string") {
+    return (
+      TURN_INTO.find((opt) => opt.listStyleType === node.listStyleType)?.label ?? "Text"
+    );
+  }
+  const isAlert =
+    node.type === KEYS.blockquote &&
+    ElementApi.isElement(node) &&
+    ALERT_MARKER_RE.test(NodeApi.string(node));
+  const match = TURN_INTO.find(
+    (opt) => !opt.listStyleType && opt.type === node.type && Boolean(opt.marker) === isAlert,
+  );
+  return match?.label ?? "Text";
+}
+
+// Strip a leading GitHub-alert marker (unless the target wants one). Only
+// when the block's first leaf carries the whole marker — a marker split
+// across marks is left alone rather than half-deleted.
+function stripAlertMarker(editor: PlateEditor, at: Path): void {
+  const start = editor.api.start(at);
+  if (!start) return;
+  const leaf = editor.api.leaf(start);
+  if (!leaf) return;
+  const match = ALERT_MARKER_RE.exec(leaf[0].text);
+  if (!match) return;
+  editor.tf.delete({
+    at: { anchor: start, focus: { offset: start.offset + match[0].length, path: start.path } },
+  });
+}
+
+/**
+ * Convert the block at `at` to the given target. Structural sources unwrap
+ * first (toggle promotes its children and converts the summary; a code block
+ * becomes one paragraph per code line), then the target applies.
+ */
 export function turnIntoAt(editor: PlateEditor, at: Path, opt: TurnIntoOption): void {
   editor.tf.withoutNormalizing(() => {
-    if (opt.listStyleType) {
-      editor.tf.setNodes({ type: opt.type, listStyleType: opt.listStyleType, indent: 1 }, { at });
-    } else {
-      editor.tf.unsetNodes(["listStyleType", "indent"], { at });
-      editor.tf.setNodes({ type: opt.type }, { at });
+    const entry = editor.api.node(at);
+    if (!entry || !ElementApi.isElement(entry[0])) return;
+    let node = entry[0];
+
+    // Source: toggle → promote children; the summary (first child, now at
+    // `at`) is what converts.
+    if (node.type === editor.getType(KEYS.toggle)) {
+      if (opt.type === KEYS.toggle) return;
+      editor.tf.unwrapNodes({ at });
+      const summary = editor.api.node(at);
+      if (!summary || !ElementApi.isElement(summary[0])) return;
+      node = summary[0];
     }
+    // Source: code block → one paragraph per code line, then convert each.
+    else if (node.type === editor.getType(KEYS.codeBlock)) {
+      if (opt.type === KEYS.codeBlock) return;
+      const index = at[at.length - 1];
+      if (index === undefined) return;
+      const lines = node.children.map((line) => NodeApi.string(line));
+      editor.tf.removeNodes({ at });
+      const texts = lines.length > 0 ? lines : [""];
+      editor.tf.insertNodes(
+        texts.map((text) => ({ children: [{ text }], type: editor.getType(KEYS.p) })),
+        { at },
+      );
+      for (let i = texts.length - 1; i >= 0; i--) {
+        applyTarget(editor, [...at.slice(0, -1), index + i], opt);
+      }
+      return;
+    }
+
+    // Source: alert blockquote → drop the marker unless the target is the
+    // callout itself (its marker is re-ensured below).
+    if (node.type === editor.getType(KEYS.blockquote)) {
+      if (!opt.marker) stripAlertMarker(editor, at);
+    }
+
+    applyTarget(editor, at, opt);
   });
+}
+
+function applyTarget(editor: PlateEditor, at: Path, opt: TurnIntoOption): void {
+  if (opt.type === KEYS.toggle) {
+    wrapBlockInToggle(editor, at);
+    return;
+  }
+  if (opt.type === KEYS.codeBlock) {
+    const entry = editor.api.node(at);
+    if (!entry || !ElementApi.isElement(entry[0])) return;
+    const text = NodeApi.string(entry[0]);
+    editor.tf.removeNodes({ at });
+    editor.tf.insertNodes(
+      {
+        children: text
+          .split("\n")
+          .map((line) => ({ children: [{ text: line }], type: editor.getType(KEYS.codeLine) })),
+        type: editor.getType(KEYS.codeBlock),
+      },
+      // select: the caret lands in the new code block (slash-mermaid seeds
+      // its graph through the selection right after converting).
+      { at, select: true },
+    );
+    return;
+  }
+  if (opt.listStyleType) {
+    // Todo items need `checked` so the serializer emits `- [ ]` (without it
+    // the item round-trips to a plain bullet).
+    const props =
+      opt.listStyleType === "todo"
+        ? { checked: false, indent: 1, listStyleType: opt.listStyleType, type: KEYS.p }
+        : { indent: 1, listStyleType: opt.listStyleType, type: KEYS.p };
+    editor.tf.setNodes(props, { at });
+    return;
+  }
+  editor.tf.unsetNodes(["listStyleType", "listStart", "indent", "checked"], { at });
+  editor.tf.setNodes({ type: opt.type }, { at });
+  if (opt.marker) {
+    const entry = editor.api.node(at);
+    const hasMarker =
+      entry && ElementApi.isElement(entry[0]) && ALERT_MARKER_RE.test(NodeApi.string(entry[0]));
+    const start = editor.api.start(at);
+    if (!hasMarker && start) editor.tf.insertText(opt.marker, { at: start });
+  }
 }
 
 /**
@@ -40,4 +167,39 @@ export function turnIntoSelection(editor: PlateEditor, opt: TurnIntoOption, at?:
   editor.tf.withoutNormalizing(() => {
     for (const [, path] of entries) turnIntoAt(editor, path, opt);
   });
+}
+
+/** Convert the blocks at `paths` (block-menu path: acts on block selection). */
+export function turnIntoBlocks(editor: PlateEditor, paths: Path[], opt: TurnIntoOption): void {
+  editor.tf.withoutNormalizing(() => {
+    for (const path of paths) turnIntoAt(editor, path, opt);
+  });
+}
+
+/**
+ * Move the span of blocks from the first to the last of `paths` one step
+ * up/down among their siblings, implemented as a single move of the flanking
+ * sibling across the group (no per-block path shifting). No-ops at the edges.
+ */
+export function moveBlocks(editor: PlateEditor, paths: Path[], direction: "up" | "down"): void {
+  if (paths.length === 0) return;
+  const sorted = paths.toSorted(PathApi.compare);
+  const first = sorted[0];
+  const last = sorted[sorted.length - 1];
+  if (!first || !last) return;
+  const firstIndex = first[first.length - 1];
+  const lastIndex = last[last.length - 1];
+  if (firstIndex === undefined || lastIndex === undefined) return;
+  if (direction === "up") {
+    if (firstIndex === 0) return;
+    const prev = [...first.slice(0, -1), firstIndex - 1];
+    // `to` is the node's FINAL index (post-removal): the previous sibling
+    // lands where the group's last block was, i.e. directly below it.
+    const to = [...last.slice(0, -1), lastIndex];
+    editor.tf.moveNodes({ at: prev, to });
+    return;
+  }
+  const next = [...last.slice(0, -1), lastIndex + 1];
+  if (!editor.api.node(next)) return;
+  editor.tf.moveNodes({ at: next, to: first });
 }

--- a/packages/app/src/editor/combobox-input.ts
+++ b/packages/app/src/editor/combobox-input.ts
@@ -31,11 +31,32 @@ function elementPath(editor: SlateEditor, element: TElement): Path | null {
 /**
  * Text that landed inside the trigger element's hidden text child during the
  * insert→focus race window (keystrokes between the trigger keydown and the
- * HTML input receiving focus). The input absorbs it into its value on mount;
- * the bytes leave the document when the element is removed on commit/cancel.
+ * HTML input receiving focus). The input absorbs it into its value; the
+ * bytes leave the document when the element is removed on commit/cancel.
  */
 export function racedComboboxText(element: TElement): string {
   return NodeApi.string(element);
+}
+
+/**
+ * Read AND clear the raced text (it renders after the input otherwise —
+ * visible reordering). Returns the absorbed text; the caller prepends it to
+ * the input value. Safe when the element is already gone.
+ */
+export function absorbRacedComboboxText(editor: SlateEditor, element: TElement): string {
+  const raced = NodeApi.string(element);
+  if (raced.length === 0) return "";
+  const path = editor.api.findPath(element);
+  if (path) {
+    editor.tf.delete({
+      at: {
+        anchor: { offset: 0, path: [...path, 0] },
+        focus: { offset: raced.length, path: [...path, 0] },
+      },
+      voids: true,
+    });
+  }
+  return raced;
 }
 
 /**

--- a/packages/app/src/editor/combobox-input.ts
+++ b/packages/app/src/editor/combobox-input.ts
@@ -1,0 +1,86 @@
+// The inline combobox's editor-mutation core, React-free so the crash-prone
+// paths (cancel restore + undo/redo interleaving) are pinned by headless
+// regression tests (inline-combobox.test.ts).
+//
+// Invariants:
+// - Every operation re-resolves the trigger element's path at call time. If
+//   the element is already gone (an undo/redo or external edit removed it),
+//   the call is a no-op: history owns those bytes, and restoring text on top
+//   of an undo is exactly the corruption/crash class this module exists to
+//   prevent.
+// - The restore point is captured as a live PointRef across the removal (the
+//   removal merges the element's flanking text siblings, so a static point's
+//   path goes stale mid-cancel).
+// - Remove + restore happen in one withoutNormalizing block within one tick,
+//   so undo/redo treat a cancel as an atomic step.
+
+import { NodeApi, type Path, type SlateEditor, type TElement } from "platejs";
+
+export type ComboboxCancelCause =
+  | "arrowLeft"
+  | "arrowRight"
+  | "backspace"
+  | "deselect"
+  | "escape";
+
+function elementPath(editor: SlateEditor, element: TElement): Path | null {
+  const path = editor.api.findPath(element);
+  return path ?? null;
+}
+
+/**
+ * Text that landed inside the trigger element's hidden text child during the
+ * insert→focus race window (keystrokes between the trigger keydown and the
+ * HTML input receiving focus). The input absorbs it into its value on mount;
+ * the bytes leave the document when the element is removed on commit/cancel.
+ */
+export function racedComboboxText(element: TElement): string {
+  return NodeApi.string(element);
+}
+
+/**
+ * Commit path: remove the trigger element (the selected item's own action
+ * inserts content afterwards). Safe when the element is already gone.
+ */
+export function commitComboboxInput(
+  editor: SlateEditor,
+  element: TElement,
+  focusEditor: boolean,
+): void {
+  const path = elementPath(editor, element);
+  if (path) editor.tf.removeNodes({ at: path });
+  if (focusEditor) editor.tf.focus();
+}
+
+/**
+ * Cancel path: remove the trigger element and restore `restoreText` (trigger
+ * char + typed query) where the trigger was typed — except on backspace,
+ * which deletes the trigger too. The caret lands after the restored text
+ * (before it for arrowLeft, matching the "step out to the left" gesture).
+ */
+export function cancelComboboxInput(
+  editor: SlateEditor,
+  element: TElement,
+  { cause, restoreText }: { cause: ComboboxCancelCause; restoreText: string },
+): void {
+  const path = elementPath(editor, element);
+  if (!path) return; // removed externally — nothing to restore
+  // Inline elements always carry text siblings (Slate normalization), so the
+  // point directly before the element is inside the same block.
+  const before = editor.api.before(path) ?? editor.api.start(path);
+  if (!before) return;
+  const pointRef = editor.api.pointRef(before);
+  editor.tf.withoutNormalizing(() => {
+    editor.tf.removeNodes({ at: path });
+  });
+  const at = pointRef.unref();
+  if (!at) return;
+  if (cause === "backspace" || restoreText.length === 0) {
+    editor.tf.select(at);
+    return;
+  }
+  editor.tf.insertText(restoreText, { at });
+  editor.tf.select(
+    cause === "arrowLeft" ? at : { offset: at.offset + restoreText.length, path: at.path },
+  );
+}

--- a/packages/app/src/editor/cursor-overlay.tsx
+++ b/packages/app/src/editor/cursor-overlay.tsx
@@ -1,0 +1,57 @@
+/* Adapted from Plate Plus Potion (https://pro.platejs.org) — used under the
+ * held Plate Plus license. */
+// Selection ghost: while a menu or popover holds DOM focus, the editor's
+// selection collapses visually — this overlay re-paints the model selection
+// rects so the user still sees what a Turn-into / link / AI action targets.
+// Ported with block-menu-kit so Phase F's AI menu doesn't re-plumb it.
+// Positioning is relative to the editor's `relative` wrapper
+// (markdown-editor.tsx).
+
+import { useCursorOverlay, type CursorOverlayState } from "@platejs/selection/react";
+import { getTableGridAbove } from "@platejs/table";
+import { RangeApi, type UnknownObject } from "platejs";
+import { useEditorRef } from "platejs/react";
+
+import { cn } from "@repo/ui/lib/utils";
+
+function Cursor({ id, caretPosition, selection, selectionRects }: CursorOverlayState<UnknownObject>) {
+  const editor = useEditorRef();
+  const isCursor = selection ? RangeApi.isCollapsed(selection) : false;
+
+  // Multi-cell table selections have their own selection UI.
+  if (id === "selection" && selection) {
+    const cellEntries = getTableGridAbove(editor, { at: selection, format: "cell" });
+    if (cellEntries.length > 1) return null;
+  }
+
+  return (
+    <>
+      {selectionRects.map((position) => (
+        <div
+          key={`${position.left}:${position.top}:${position.width}:${position.height}`}
+          className={cn(
+            "pointer-events-none absolute z-10",
+            id === "selection" && "bg-primary/25",
+            id === "selection" && isCursor && "bg-primary",
+          )}
+          style={position}
+        />
+      ))}
+      {caretPosition && (
+        <div className="pointer-events-none absolute z-10 w-0.5" style={caretPosition} />
+      )}
+    </>
+  );
+}
+
+export function CursorOverlay() {
+  const { cursors } = useCursorOverlay();
+
+  return (
+    <>
+      {cursors.map((cursor) => (
+        <Cursor key={cursor.id} {...cursor} />
+      ))}
+    </>
+  );
+}

--- a/packages/app/src/editor/embed-url-dialog.tsx
+++ b/packages/app/src/editor/embed-url-dialog.tsx
@@ -1,0 +1,80 @@
+// URL prompt for the slash menu's Embed item. The slash combobox unmounts
+// itself on selection, so the item can't host UI — it calls the module-level
+// opener and this host (rendered from SlashKit's render.afterEditable, inside
+// the Plate context) shows the dialog and routes the URL to
+// insertEmbedFromUrl. Same runner-bridge pattern as triggerInlineAi.
+
+import { useEffect, useState } from "react";
+import { useEditorRef } from "platejs/react";
+
+import { Button } from "@repo/ui/components/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@repo/ui/components/dialog";
+import { Input } from "@repo/ui/components/input";
+
+import { insertEmbedFromUrl } from "@repo/app/editor/kits/embed-kit";
+
+let activeOpener: (() => void) | null = null;
+
+/** Open the embed URL prompt (callable from outside React, e.g. slash items). */
+export function openEmbedUrlDialog(): void {
+  activeOpener?.();
+}
+
+export function EmbedUrlDialogHost() {
+  const editor = useEditorRef();
+  const [open, setOpen] = useState(false);
+  const [url, setUrl] = useState("");
+
+  useEffect(() => {
+    const opener = () => {
+      setUrl("");
+      setOpen(true);
+    };
+    activeOpener = opener;
+    return () => {
+      if (activeOpener === opener) activeOpener = null;
+    };
+  }, []);
+
+  const trimmed = url.trim();
+
+  const submit = () => {
+    if (!trimmed) return;
+    setOpen(false);
+    insertEmbedFromUrl(editor, trimmed);
+    editor.tf.focus();
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={setOpen}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Embed from URL</DialogTitle>
+          <DialogDescription>
+            YouTube video, tweet, PDF, or any page (renders as an iframe).
+          </DialogDescription>
+        </DialogHeader>
+        <div className="flex flex-col gap-3">
+          <Input
+            autoFocus
+            value={url}
+            onChange={(e) => setUrl(e.target.value)}
+            placeholder="https://…"
+            onKeyDown={(e) => {
+              if (e.key === "Enter") submit();
+            }}
+          />
+          <Button variant="primary" size="sm" onClick={submit} disabled={!trimmed}>
+            Embed
+          </Button>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/packages/app/src/editor/inline-combobox.tsx
+++ b/packages/app/src/editor/inline-combobox.tsx
@@ -27,6 +27,7 @@ import { useComposedRef, useEditorRef, useSelected } from "platejs/react";
 import { cn } from "@repo/ui/lib/utils";
 
 import {
+  absorbRacedComboboxText,
   cancelComboboxInput,
   commitComboboxInput,
   racedComboboxText,
@@ -137,17 +138,22 @@ function InlineCombobox({
     [editor, element],
   );
 
-  // Focus the input and absorb keystrokes that raced into the element's
-  // hidden text child before the input existed (read-only on the document —
-  // the bytes leave with the element on commit/cancel).
-  const absorbedRef = React.useRef(false);
   React.useEffect(() => {
     inputRef.current?.focus();
-    if (absorbedRef.current) return;
-    absorbedRef.current = true;
-    const raced = racedComboboxText(element);
-    if (raced.length > 0) setValue(raced + valueRef.current);
-  }, [element, setValue]);
+  }, []);
+
+  // Keystrokes race into the element's hidden text child whenever they beat
+  // the input's focus (trigger→mount window, or a focus round-trip). The
+  // element prop re-renders on every Slate change, so this absorbs each
+  // batch as it lands: prepend to the query (raced chars were typed first)
+  // and clear the slate bytes (they'd render after the input — visible
+  // reordering — and double-absorb otherwise).
+  const raced = racedComboboxText(element);
+  React.useEffect(() => {
+    if (closedRef.current || raced.length === 0) return;
+    const absorbed = absorbRacedComboboxText(editor, element);
+    if (absorbed.length > 0) setValue(absorbed + valueRef.current);
+  }, [raced, editor, element, setValue]);
 
   // Clicking elsewhere in the note moves the Slate selection off the element
   // while it is still mounted — cancel and restore the typed text.

--- a/packages/app/src/editor/inline-combobox.tsx
+++ b/packages/app/src/editor/inline-combobox.tsx
@@ -1,20 +1,37 @@
-// Inline combobox for the slash menu — adapted from Potion's Plate-UI component
-// (registry/ui/inline-combobox.tsx), built on @platejs/combobox + Ariakit. The
-// Yjs "is creator" gate is removed (single-user, local vault) and the code is
-// reshaped to our lint rules (no any / non-null assertion / type assertion).
+// Inline combobox for editor triggers (`/` slash menu, `:` emoji, and Phase
+// F's `[[` wiki autocomplete), built on Base UI Combobox. The popup anchors to
+// the in-line input; Base UI's virtual focus keeps DOM focus ON the input
+// (aria-activedescendant roving), so keyboard navigation never fights the
+// editor for focus.
+//
+// Correctness properties (the ariakit predecessor violated all three):
+// - Input order is stable under fast typing: the value is plain synchronous
+//   React state (no transition/deferral between keystroke and controlled
+//   input), and any keystrokes that raced into the trigger element's hidden
+//   text child before the input mounted are absorbed into the initial value.
+// - Cancel is point-ref-safe and idempotent: all editor mutations run through
+//   combobox-input.ts, which re-resolves the element at call time and no-ops
+//   when an undo/redo already removed it — rapid undo after Escape can no
+//   longer replay a stale restore into the document (the about:blank crash).
+// - The trigger elements themselves never serialize: markdown-kit lists
+//   `slash_input`/`emoji_input` in disallowedNodes, so an autosave firing
+//   mid-combobox skips them structurally instead of warning "Unreachable".
 
-import * as Ariakit from "@ariakit/react";
-import { filterWords } from "@platejs/combobox";
-import {
-  type UseComboboxInputResult,
-  useComboboxInput,
-  useHTMLInputCursorState,
-} from "@platejs/combobox/react";
-import type { Point, TElement } from "platejs";
-import { useComposedRef, useEditorRef } from "platejs/react";
 import * as React from "react";
+import { Combobox } from "@base-ui/react/combobox";
+import { filterWords } from "@platejs/combobox";
+import { useHTMLInputCursorState } from "@platejs/combobox/react";
+import { Hotkeys, isHotkey, type TElement } from "platejs";
+import { useComposedRef, useEditorRef, useSelected } from "platejs/react";
 
 import { cn } from "@repo/ui/lib/utils";
+
+import {
+  cancelComboboxInput,
+  commitComboboxInput,
+  racedComboboxText,
+  type ComboboxCancelCause,
+} from "@repo/app/editor/combobox-input";
 
 type FilterItem = {
   value: string;
@@ -25,13 +42,18 @@ type FilterItem = {
 type FilterFn = (item: FilterItem, search: string) => boolean;
 
 type InlineComboboxContextValue = {
+  commit: (focusEditor: boolean) => void;
   filter: FilterFn | false;
-  inputProps: UseComboboxInputResult["props"];
+  inputProps: {
+    onKeyDown: (event: React.KeyboardEvent<HTMLInputElement>) => void;
+  };
   inputRef: React.RefObject<HTMLInputElement | null>;
-  removeInput: UseComboboxInputResult["removeInput"];
+  registerVisibleItem: () => () => void;
+  setHasEmpty: (hasEmpty: boolean) => void;
   showTrigger: boolean;
   trigger: string;
-  setHasEmpty: (hasEmpty: boolean) => void;
+  value: string;
+  visibleCount: number;
 };
 
 const InlineComboboxContext = React.createContext<InlineComboboxContextValue | null>(null);
@@ -40,12 +62,6 @@ function useInlineComboboxContext(): InlineComboboxContextValue {
   const ctx = React.useContext(InlineComboboxContext);
   if (!ctx) throw new Error("InlineCombobox parts must be used inside <InlineCombobox>.");
   return ctx;
-}
-
-function useComboboxStore(): Ariakit.ComboboxStore {
-  const store = Ariakit.useComboboxContext();
-  if (!store) throw new Error("Combobox store is missing.");
-  return store;
 }
 
 const defaultFilter: FilterFn = ({ group, keywords = [], label, value }, search) => {
@@ -90,58 +106,139 @@ function InlineCombobox({
     [setValueProp, hasValueProp],
   );
 
-  const insertPoint = React.useRef<Point | null>(null);
+  // The latest value, readable from stable callbacks (cancel/commit).
+  const valueRef = React.useRef(value);
+  valueRef.current = value;
 
-  React.useEffect(() => {
-    const path = editor.api.findPath(element);
-    if (!path) return;
-    const point = editor.api.before(path);
-    if (!point) return;
-    const pointRef = editor.api.pointRef(point);
-    insertPoint.current = pointRef.current;
-    return () => {
-      pointRef.unref();
-    };
-  }, [editor, element]);
+  // Once a commit or cancel ran for this element instance, every later cause
+  // (a deselect effect firing after an Escape, unmount churn) is a no-op —
+  // double-restoring the trigger text would duplicate bytes.
+  const closedRef = React.useRef(false);
 
-  const { props: inputProps, removeInput } = useComboboxInput({
-    cancelInputOnBlur: false,
-    cursorState,
-    autoFocus: true,
-    ref: inputRef,
-    onCancelInput: (cause) => {
-      if (cause !== "backspace") {
-        const at = insertPoint.current;
-        editor.tf.insertText(trigger + value, at ? { at } : {});
-      }
-      if (cause === "arrowLeft" || cause === "arrowRight") {
-        editor.tf.move({ distance: 1, reverse: cause === "arrowLeft" });
-      }
+  const cancel = React.useCallback(
+    (cause: ComboboxCancelCause) => {
+      if (closedRef.current) return;
+      closedRef.current = true;
+      cancelComboboxInput(editor, element, {
+        cause,
+        restoreText: trigger + valueRef.current,
+      });
+      editor.tf.focus();
     },
-  });
-
-  const [hasEmpty, setHasEmpty] = React.useState(false);
-
-  const contextValue = React.useMemo<InlineComboboxContextValue>(
-    () => ({ filter, inputProps, inputRef, removeInput, setHasEmpty, showTrigger, trigger }),
-    [trigger, showTrigger, filter, inputProps, removeInput],
+    [editor, element, trigger],
   );
 
-  const store = Ariakit.useComboboxStore({
-    setValue: (newValue) => React.startTransition(() => setValue(newValue)),
-  });
-  const items = store.useState("items");
+  const commit = React.useCallback(
+    (focusEditor: boolean) => {
+      if (closedRef.current) return;
+      closedRef.current = true;
+      commitComboboxInput(editor, element, focusEditor);
+    },
+    [editor, element],
+  );
+
+  // Focus the input and absorb keystrokes that raced into the element's
+  // hidden text child before the input existed (read-only on the document —
+  // the bytes leave with the element on commit/cancel).
+  const absorbedRef = React.useRef(false);
+  React.useEffect(() => {
+    inputRef.current?.focus();
+    if (absorbedRef.current) return;
+    absorbedRef.current = true;
+    const raced = racedComboboxText(element);
+    if (raced.length > 0) setValue(raced + valueRef.current);
+  }, [element, setValue]);
+
+  // Clicking elsewhere in the note moves the Slate selection off the element
+  // while it is still mounted — cancel and restore the typed text.
+  const selected = useSelected();
+  const previousSelected = React.useRef(selected);
+  React.useEffect(() => {
+    if (previousSelected.current && !selected) cancel("deselect");
+    previousSelected.current = selected;
+  }, [selected, cancel]);
+
+  const onKeyDown = React.useCallback(
+    (event: React.KeyboardEvent<HTMLInputElement>) => {
+      if (isHotkey("escape", event)) {
+        event.preventDefault();
+        cancel("escape");
+        return;
+      }
+      if (cursorState.atStart && isHotkey("backspace", event)) {
+        event.preventDefault();
+        cancel("backspace");
+        return;
+      }
+      if (cursorState.atStart && isHotkey("arrowleft", event)) {
+        event.preventDefault();
+        cancel("arrowLeft");
+        return;
+      }
+      if (cursorState.atEnd && isHotkey("arrowright", event)) {
+        event.preventDefault();
+        cancel("arrowRight");
+        return;
+      }
+      // Undo/redo pressed while the input holds focus target the editor.
+      const isUndo = Hotkeys.isUndo(event) && editor.history.undos.length > 0;
+      const isRedo = Hotkeys.isRedo(event) && editor.history.redos.length > 0;
+      if (isUndo || isRedo) {
+        event.preventDefault();
+        if (isUndo) editor.undo();
+        else editor.redo();
+        editor.tf.focus();
+      }
+    },
+    [cancel, cursorState.atStart, cursorState.atEnd, editor],
+  );
+
+  const inputProps = React.useMemo(() => ({ onKeyDown }), [onKeyDown]);
+
+  // Visible items register themselves (self-filtering renders null), so the
+  // open state and the Empty row derive from the same count the popup shows.
+  const [visibleCount, setVisibleCount] = React.useState(0);
+  const registerVisibleItem = React.useCallback(() => {
+    setVisibleCount((count) => count + 1);
+    return () => setVisibleCount((count) => count - 1);
+  }, []);
+  const [hasEmpty, setHasEmpty] = React.useState(false);
+
+  const open = (visibleCount > 0 || hasEmpty) && (!hideWhenNoValue || value.length > 0);
+
+  const contextValue = React.useMemo<InlineComboboxContextValue>(
+    () => ({
+      commit,
+      filter,
+      inputProps,
+      inputRef,
+      registerVisibleItem,
+      setHasEmpty,
+      showTrigger,
+      trigger,
+      value,
+      visibleCount,
+    }),
+    [commit, filter, inputProps, registerVisibleItem, showTrigger, trigger, value, visibleCount],
+  );
 
   return (
     <span contentEditable={false}>
-      <Ariakit.ComboboxProvider
-        open={(items.length > 0 || hasEmpty) && (!hideWhenNoValue || value.length > 0)}
-        store={store}
+      <Combobox.Root
+        autoHighlight
+        filter={null}
+        inputValue={value}
+        modal={false}
+        onInputValueChange={setValue}
+        // Open state is fully derived; Base UI close requests (escape/outside
+        // click) route through cancel paths instead.
+        onOpenChange={() => undefined}
+        open={open}
       >
         <InlineComboboxContext.Provider value={contextValue}>
           {children}
         </InlineComboboxContext.Provider>
-      </Ariakit.ComboboxProvider>
+      </Combobox.Root>
     </span>
   );
 }
@@ -155,9 +252,8 @@ function InlineComboboxInput({
   ref?: React.Ref<HTMLInputElement>;
   placeholder?: string;
 }) {
-  const { inputProps, inputRef: contextRef, showTrigger, trigger } = useInlineComboboxContext();
-  const store = useComboboxStore();
-  const value = store.useState("value");
+  const { inputProps, inputRef: contextRef, showTrigger, trigger, value } =
+    useInlineComboboxContext();
   const ref = useComposedRef(refProp, contextRef);
 
   return (
@@ -167,10 +263,8 @@ function InlineComboboxInput({
         <span aria-hidden="true" className="invisible overflow-hidden text-nowrap">
           {value || placeholder || "​"}
         </span>
-        <Ariakit.Combobox
-          autoSelect
+        <Combobox.Input
           className={cn("absolute top-0 left-0 size-full bg-transparent outline-hidden", className)}
-          value={value}
           {...inputProps}
           ref={ref}
           placeholder={placeholder}
@@ -183,26 +277,33 @@ function InlineComboboxInput({
 const ITEM_BASE =
   "relative mx-1 flex select-none items-center rounded-sm px-2 py-1 text-sm text-foreground outline-hidden transition-colors [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0";
 const ITEM_INTERACTIVE =
-  "cursor-pointer hover:bg-accent hover:text-accent-foreground data-[active-item=true]:bg-accent data-[active-item=true]:text-accent-foreground";
+  "cursor-pointer hover:bg-accent hover:text-accent-foreground data-[highlighted]:bg-accent data-[highlighted]:text-accent-foreground";
 
 function InlineComboboxContent({
   className,
   variant = "default",
-  ...props
-}: React.ComponentProps<typeof Ariakit.ComboboxPopover> & { variant?: "default" | "slash" }) {
+  children,
+}: {
+  className?: string;
+  variant?: "default" | "slash";
+  children: React.ReactNode;
+}) {
+  // keepMounted: closed popups keep their items registered, so the derived
+  // open state (visible-item count) can flip true once a search matches.
   return (
-    <Ariakit.Portal>
-      <Ariakit.ComboboxPopover
-        className={cn(
-          "z-50 mt-1 h-full max-h-[40vh] min-w-[180px] max-w-[calc(100vw-24px)] overflow-y-auto rounded-lg border border-border bg-popover text-popover-foreground shadow-lg",
-          variant === "slash" && "w-[320px]",
-          className,
-        )}
-        {...props}
-      >
-        {props.children}
-      </Ariakit.ComboboxPopover>
-    </Ariakit.Portal>
+    <Combobox.Portal keepMounted>
+      <Combobox.Positioner align="start" className="z-50" side="bottom" sideOffset={4}>
+        <Combobox.Popup
+          className={cn(
+            "max-h-[40vh] min-w-[180px] max-w-[calc(100vw-24px)] overflow-y-auto rounded-lg border border-border bg-popover text-popover-foreground shadow-lg",
+            variant === "slash" && "w-[320px]",
+            className,
+          )}
+        >
+          <Combobox.List>{children}</Combobox.List>
+        </Combobox.Popup>
+      </Combobox.Positioner>
+    </Combobox.Portal>
   );
 }
 
@@ -213,49 +314,57 @@ function InlineComboboxItem({
   keywords,
   label,
   onClick,
-  ...props
+  value,
+  children,
 }: {
+  className?: string;
   focusEditor?: boolean | undefined;
   group?: string | undefined;
   keywords?: string[] | undefined;
   label?: string | undefined;
-} & Ariakit.ComboboxItemProps &
-  Required<Pick<Ariakit.ComboboxItemProps, "value">>) {
-  const { value } = props;
-  const { filter, removeInput } = useInlineComboboxContext();
-  const store = useComboboxStore();
-  const search = filter && store.useState("value");
+  onClick?: (event: React.MouseEvent<HTMLDivElement>) => void;
+  value: string;
+  children: React.ReactNode;
+}) {
+  const { commit, filter, registerVisibleItem, value: search } = useInlineComboboxContext();
 
   const visible = React.useMemo(
-    () => !filter || filter({ group, keywords, label, value }, search || ""),
+    () => !filter || filter({ group, keywords, label, value }, search),
     [filter, group, keywords, value, label, search],
   );
+
+  React.useEffect(() => {
+    if (visible) return registerVisibleItem();
+    return undefined;
+  }, [visible, registerVisibleItem]);
 
   if (!visible) return null;
 
   return (
-    <Ariakit.ComboboxItem
+    <Combobox.Item
       className={cn(ITEM_BASE, ITEM_INTERACTIVE, className)}
+      // Fires on pointer click AND on Enter while highlighted (Base UI
+      // dispatches the click for the keyboard path).
       onClick={(event) => {
-        removeInput(focusEditor);
+        commit(focusEditor);
         onClick?.(event);
       }}
-      {...props}
-    />
+      value={value}
+    >
+      {children}
+    </Combobox.Item>
   );
 }
 
 function InlineComboboxEmpty({ children, className }: React.HTMLAttributes<HTMLDivElement>) {
-  const { setHasEmpty } = useInlineComboboxContext();
-  const store = useComboboxStore();
-  const items = store.useState("items");
+  const { setHasEmpty, visibleCount } = useInlineComboboxContext();
 
   React.useEffect(() => {
     setHasEmpty(true);
     return () => setHasEmpty(false);
   }, [setHasEmpty]);
 
-  if (items.length > 0) return null;
+  if (visibleCount > 0) return null;
 
   return <div className={cn(ITEM_BASE, "my-1.5 text-muted-foreground", className)}>{children}</div>;
 }
@@ -263,9 +372,9 @@ function InlineComboboxEmpty({ children, className }: React.HTMLAttributes<HTMLD
 function InlineComboboxGroup({
   className,
   ...props
-}: React.ComponentProps<typeof Ariakit.ComboboxGroup>) {
+}: React.ComponentProps<typeof Combobox.Group>) {
   return (
-    <Ariakit.ComboboxGroup
+    <Combobox.Group
       className={cn("hidden py-1.5 not-last:border-b [&:has([role=option])]:block", className)}
       {...props}
     />
@@ -275,9 +384,9 @@ function InlineComboboxGroup({
 function InlineComboboxGroupLabel({
   className,
   ...props
-}: React.ComponentProps<typeof Ariakit.ComboboxGroupLabel>) {
+}: React.ComponentProps<typeof Combobox.GroupLabel>) {
   return (
-    <Ariakit.ComboboxGroupLabel
+    <Combobox.GroupLabel
       className={cn("mt-1.5 mb-2 px-3 text-xs font-medium text-muted-foreground", className)}
       {...props}
     />

--- a/packages/app/src/editor/inline-combobox.tsx
+++ b/packages/app/src/editor/inline-combobox.tsx
@@ -143,17 +143,33 @@ function InlineCombobox({
   }, []);
 
   // Keystrokes race into the element's hidden text child whenever they beat
-  // the input's focus (trigger→mount window, or a focus round-trip). The
-  // element prop re-renders on every Slate change, so this absorbs each
-  // batch as it lands: prepend to the query (raced chars were typed first)
-  // and clear the slate bytes (they'd render after the input — visible
-  // reordering — and double-absorb otherwise).
+  // the input's focus (trigger→mount window, or a Slate op yanking DOM focus
+  // back to the editable mid-burst). The element prop re-renders on every
+  // Slate change, so this absorbs each batch as it lands: splice at the
+  // input's caret (chronologically where those keystrokes belong), clear the
+  // slate bytes (they'd render after the input — visible reordering — and
+  // double-absorb otherwise), and re-take focus so the next keystroke lands
+  // in the input again.
   const raced = racedComboboxText(element);
+  const pendingCaretRef = React.useRef<number | null>(null);
   React.useEffect(() => {
     if (closedRef.current || raced.length === 0) return;
     const absorbed = absorbRacedComboboxText(editor, element);
-    if (absorbed.length > 0) setValue(absorbed + valueRef.current);
+    if (absorbed.length === 0) return;
+    const input = inputRef.current;
+    const current = valueRef.current;
+    const caret = input?.selectionStart ?? current.length;
+    setValue(current.slice(0, caret) + absorbed + current.slice(caret));
+    pendingCaretRef.current = caret + absorbed.length;
+    input?.focus();
   }, [raced, editor, element, setValue]);
+  // Place the caret after the spliced text once the new value has committed.
+  React.useLayoutEffect(() => {
+    const pos = pendingCaretRef.current;
+    if (pos === null) return;
+    pendingCaretRef.current = null;
+    inputRef.current?.setSelectionRange(pos, pos);
+  });
 
   // Clicking elsewhere in the note moves the Slate selection off the element
   // while it is still mounted — cancel and restore the typed text.

--- a/packages/app/src/editor/kits/block-menu-kit.tsx
+++ b/packages/app/src/editor/kits/block-menu-kit.tsx
@@ -1,8 +1,41 @@
-// Block menu kit — WP3 fills this file (BlockSelection/BlockMenu plugins +
-// the Base UI context menu). Landed empty in WP2 so EDITOR_KIT's composition
-// is final and WP3 stays file-disjoint. Constraint carried from WP1: block
-// selection must exclude `frontmatter`, `column`, `codeLine`, and `td`.
+// Block selection + block menu + cursor overlay. Constraint carried from
+// WP1/WP2: block selection excludes `frontmatter` (pinned at [0], edited via
+// Raw only), `column` (column internals move with their group), `codeLine`,
+// and `td`. The context menu and the drag-grip menu are ONE implementation
+// (block-menu.tsx) driven by BlockMenuPlugin's openId/position.
 
-import type { SlatePlugins } from "platejs";
+import {
+  BlockMenuPlugin,
+  BlockSelectionPlugin,
+  CursorOverlayPlugin,
+} from "@platejs/selection/react";
+import { KEYS, getPluginTypes } from "platejs";
 
-export const BlockMenuKit: SlatePlugins = [];
+import { BlockContextMenu } from "@repo/app/editor/block-context-menu";
+import { BlockSelection } from "@repo/app/editor/block-selection";
+import { CursorOverlay } from "@repo/app/editor/cursor-overlay";
+
+export const BlockMenuKit = [
+  BlockSelectionPlugin.configure(({ editor }) => ({
+    options: {
+      enableContextMenu: true,
+      isSelectable: (element) =>
+        !getPluginTypes(editor, [KEYS.column, KEYS.codeLine, KEYS.td]).includes(element.type) &&
+        element.type !== "frontmatter",
+    },
+    render: {
+      belowRootNodes: (props) => {
+        if (!props.attributes.className?.includes("slate-selectable")) return null;
+        return <BlockSelection pluginKey={props.plugin.key} />;
+      },
+    },
+  })),
+  BlockMenuPlugin.configure({
+    render: { aboveSlate: BlockContextMenu },
+  }),
+  // Selection ghost while menus/popovers hold focus (Phase F's AI menu
+  // depends on it — plumbed now so it doesn't re-plumb).
+  CursorOverlayPlugin.configure({
+    render: { afterEditable: () => <CursorOverlay /> },
+  }),
+];

--- a/packages/app/src/editor/kits/block-placeholder-kit.tsx
+++ b/packages/app/src/editor/kits/block-placeholder-kit.tsx
@@ -1,7 +1,25 @@
-// Block placeholder kit — WP3 fills this file (BlockPlaceholderPlugin with
-// the per-type placeholder map; `query` must exclude `frontmatter`). Landed
-// empty in WP2 so EDITOR_KIT's composition is final.
+// Per-block-type placeholders (empty focused block shows a hint via
+// before:content). Replaces PlateContent's single whole-editor placeholder.
+// Top-level blocks only; frontmatter is excluded (read-only in Rich, never a
+// writing surface).
 
-import type { SlatePlugins } from "platejs";
+import { KEYS } from "platejs";
+import { BlockPlaceholderPlugin } from "platejs/react";
 
-export const BlockPlaceholderKit: SlatePlugins = [];
+export const BlockPlaceholderKit = [
+  BlockPlaceholderPlugin.configure({
+    options: {
+      className:
+        "before:absolute before:cursor-text before:text-muted-foreground/60 before:content-[attr(placeholder)]",
+      placeholders: {
+        [KEYS.p]: "Write, or press '/' for commands",
+        [KEYS.h1]: "Heading 1",
+        [KEYS.h2]: "Heading 2",
+        [KEYS.h3]: "Heading 3",
+        [KEYS.blockquote]: "Quote",
+        [KEYS.toggle]: "Toggle",
+      },
+      query: ({ node, path }) => path.length === 1 && node.type !== "frontmatter",
+    },
+  }),
+];

--- a/packages/app/src/editor/kits/floating-toolbar-kit.tsx
+++ b/packages/app/src/editor/kits/floating-toolbar-kit.tsx
@@ -1,8 +1,14 @@
-// Floating toolbar kit — WP3 fills this file (the @platejs/floating swap of
-// selection-toolbar.tsx's positioning layer; the toolbar then renders from
-// this kit's `render.afterEditable` instead of markdown-editor.tsx JSX).
-// Landed empty in WP2 so EDITOR_KIT's composition is final.
+// Renders the selection toolbar from the plugin tree (afterEditable) instead
+// of markdown-editor.tsx JSX, so it sits inside the editor's relative
+// positioning context that @platejs/floating computes against.
 
-import type { SlatePlugins } from "platejs";
+import { createPlatePlugin } from "platejs/react";
 
-export const FloatingToolbarKit: SlatePlugins = [];
+import { SelectionToolbar } from "@repo/app/editor/selection-toolbar";
+
+export const FloatingToolbarKit = [
+  createPlatePlugin({
+    key: "floating-toolbar",
+    render: { afterEditable: () => <SelectionToolbar /> },
+  }),
+];

--- a/packages/app/src/editor/kits/link-kit.tsx
+++ b/packages/app/src/editor/kits/link-kit.tsx
@@ -1,20 +1,11 @@
 // Link kit. Base half feeds the headless serialization mirror; the React half
-// renders the anchor. WP3 adds the link popover (open/edit/unlink) on top.
+// renders the anchor + its popover (open/edit/unlink — nodes/link-node.tsx).
 
 import { BaseLinkPlugin } from "@platejs/link";
 import { LinkPlugin } from "@platejs/link/react";
-import { PlateElement, type PlateElementProps } from "platejs/react";
+
+import { LinkElement } from "@repo/app/editor/nodes/link-node";
 
 export const LinkBaseKit = [BaseLinkPlugin];
-
-function LinkElement(props: PlateElementProps) {
-  return (
-    <PlateElement
-      {...props}
-      as="a"
-      className="cursor-pointer border-b border-current font-medium text-foreground/70"
-    />
-  );
-}
 
 export const LinkKit = [LinkPlugin.withComponent(LinkElement)];

--- a/packages/app/src/editor/kits/markdown-kit.ts
+++ b/packages/app/src/editor/kits/markdown-kit.ts
@@ -13,8 +13,11 @@ import { MD_RULES } from "@repo/app/editor/markdown/md-rules";
 export const MarkdownKit = [
   MarkdownPlugin.configure({
     options: {
-      // Transient marks never serialize: suggestion + the inline-AI highlight.
-      disallowedNodes: [KEYS.suggestion, AI_MARK],
+      // Transient nodes never serialize: suggestion + the inline-AI highlight
+      // marks, plus the combobox trigger elements (`/` and `:` inputs are UI
+      // state — an autosave firing mid-combobox must skip them structurally,
+      // never hit the serializer's "Unreachable code" fallback).
+      disallowedNodes: [KEYS.suggestion, AI_MARK, KEYS.slashInput, KEYS.emojiInput],
       remarkPlugins: MD_REMARK_PLUGINS,
       rules: MD_RULES,
     },

--- a/packages/app/src/editor/kits/toggle-kit.tsx
+++ b/packages/app/src/editor/kits/toggle-kit.tsx
@@ -8,7 +8,7 @@
 // store, never on the node, so a collapse/expand can't dirty the document
 // (md rule fixture asserts `<toggle>` serializes with zero attributes).
 
-import { ElementApi, KEYS, PathApi, TextApi, createBlockStartInputRule } from "platejs";
+import { ElementApi, KEYS, PathApi, TextApi, createBlockStartInputRule, type Path } from "platejs";
 import type { PlateEditor } from "platejs/react";
 import { BaseTogglePlugin } from "@platejs/toggle";
 import { TogglePlugin } from "@platejs/toggle/react";
@@ -18,23 +18,28 @@ import { ToggleElement } from "@repo/app/editor/nodes/toggle-node";
 export const ToggleBaseKit = [BaseTogglePlugin];
 
 /**
- * Turn the current block into a toggle: the block becomes the toggle's summary
+ * Wrap the block at `at` into a toggle: the block becomes the toggle's summary
  * (first nested child). The new toggle is opened so a body typed next is
- * immediately visible. Slash-menu-ready; the menu entry itself lands in WP3.
+ * immediately visible. Shared by insertToggle (slash) and turn-into (menus).
  */
-export function insertToggle(editor: PlateEditor): void {
+export function wrapBlockInToggle(editor: PlateEditor, at: Path): void {
   editor.tf.withoutNormalizing(() => {
-    const block = editor.api.block();
-    if (!block) return;
-    const [node, path] = block;
-    if (node.type === KEYS.toggle) return;
+    const entry = editor.api.node(at);
+    if (!entry || !ElementApi.isElement(entry[0]) || entry[0].type === KEYS.toggle) return;
     // List props on the summary would serialize inside `<toggle>` — strip.
-    editor.tf.unsetNodes(["listStyleType", "listStart", "indent", "checked"], { at: path });
-    editor.tf.wrapNodes({ children: [], type: KEYS.toggle }, { at: path });
+    editor.tf.unsetNodes(["listStyleType", "listStart", "indent", "checked"], { at });
+    editor.tf.wrapNodes({ children: [], type: KEYS.toggle }, { at });
   });
-  const toggle = editor.api.above({ match: { type: KEYS.toggle } });
+  const toggle = editor.api.node(at);
   const id = toggle && typeof toggle[0].id === "string" ? toggle[0].id : null;
   if (id) editor.getApi(TogglePlugin).toggle.toggleIds([id], true);
+}
+
+/** Turn the current block into a toggle. */
+export function insertToggle(editor: PlateEditor): void {
+  const block = editor.api.block();
+  if (!block) return;
+  wrapBlockInToggle(editor, block[1]);
 }
 
 // `+ ` at block start turns the block into a toggle (potion muscle memory).

--- a/packages/app/src/editor/markdown-editor.tsx
+++ b/packages/app/src/editor/markdown-editor.tsx
@@ -15,7 +15,6 @@ import { serializeMd } from "@platejs/markdown";
 
 import { EDITOR_KIT } from "@repo/app/editor/kits/editor-kit";
 import { MD_STRINGIFY, parseMarkdown } from "@repo/app/editor/markdown/markdown-doc";
-import { SelectionToolbar } from "@repo/app/editor/selection-toolbar";
 import { TableOfContents } from "@repo/app/editor/toc";
 
 // Seed markdown → Plate value through the owned pipeline. Unparseable content
@@ -79,14 +78,14 @@ export function MarkdownEditor({ value, onChange }: Props) {
       }}
     >
       {/* relative: the cursor overlay's selection ghost and the floating
-          toolbar position absolutely against this wrapper. */}
+          toolbar (both afterEditable renders) position against this wrapper.
+          The toolbar itself renders from FloatingToolbarKit. */}
       <div className="relative">
         <PlateContent
           className="potion-editor-typography min-h-full pt-4 text-base leading-normal caret-primary outline-none selection:bg-primary/20 [&_.slate-selection-area]:bg-primary/15"
           spellCheck={false}
         />
       </div>
-      <SelectionToolbar />
       <TableOfContents />
     </Plate>
   );

--- a/packages/app/src/editor/markdown-editor.tsx
+++ b/packages/app/src/editor/markdown-editor.tsx
@@ -78,11 +78,14 @@ export function MarkdownEditor({ value, onChange }: Props) {
         onChange(md);
       }}
     >
-      <PlateContent
-        className="potion-editor-typography min-h-full pt-4 text-base leading-normal caret-primary outline-none selection:bg-primary/20"
-        placeholder="Write…"
-        spellCheck={false}
-      />
+      {/* relative: the cursor overlay's selection ghost and the floating
+          toolbar position absolutely against this wrapper. */}
+      <div className="relative">
+        <PlateContent
+          className="potion-editor-typography min-h-full pt-4 text-base leading-normal caret-primary outline-none selection:bg-primary/20 [&_.slate-selection-area]:bg-primary/15"
+          spellCheck={false}
+        />
+      </div>
       <SelectionToolbar />
       <TableOfContents />
     </Plate>

--- a/packages/app/src/editor/markdown-editor.tsx
+++ b/packages/app/src/editor/markdown-editor.tsx
@@ -68,6 +68,11 @@ export function MarkdownEditor({ value, onChange }: Props) {
     <Plate
       editor={editor}
       onChange={() => {
+        // Selection-only flushes (caret moves, slate-react selection
+        // re-syncs) never change bytes — skip the serialize pass and the
+        // vault-context re-render it would otherwise trigger on every caret
+        // move; per-event work stays bounded under input-event storms.
+        if (editor.operations.every((op) => op.type === "set_selection")) return;
         const md = serializeMd(editor, { remarkStringifyOptions: MD_STRINGIFY });
         // Drop the echo a programmatic (re)seed produces — only real edits,
         // which diverge from the seeded text, propagate.

--- a/packages/app/src/editor/markdown/md-rules.ts
+++ b/packages/app/src/editor/markdown/md-rules.ts
@@ -213,6 +213,37 @@ export const MD_RULES: MdRules = {
     },
   },
 
+  // Serialize-only override of Plate's column rule. A column holding only an
+  // empty paragraph — the live editor's shape for an empty column (the
+  // insert seeds one; normalization keeps one) — must emit self-closed
+  // `<column />`, the same bytes its parse produces. The default serializes
+  // it as blank expanded content (`<column>\n\n  </column>`), which
+  // re-parses to zero children and re-emits self-closed: a non-idempotent
+  // first pass that knocked the file to Raw whenever an autosave landed
+  // before every column had content.
+  column: {
+    serialize: (node: TElement, options: SerializeMdOptions) => {
+      const { id, children, type, ...rest } = node;
+      void id;
+      void type;
+      const only = children.length === 1 ? children[0] : undefined;
+      const onlyText =
+        only !== undefined &&
+        ElementApi.isElement(only) &&
+        only.type === "p" &&
+        only.children.length === 1
+          ? only.children[0]
+          : undefined;
+      const isEmpty = onlyText !== undefined && TextApi.isText(onlyText) && onlyText.text === "";
+      return {
+        attributes: propsToAttributes(rest),
+        children: isEmpty ? [] : convertNodesSerialize(children, options),
+        name: "column",
+        type: "mdxJsxFlowElement",
+      };
+    },
+  },
+
   // id-leak overrides (see mediaSerializeWithoutId).
   callout: {
     serialize: (node: TElement, options: SerializeMdOptions) => {

--- a/packages/app/src/editor/nodes/column-node.tsx
+++ b/packages/app/src/editor/nodes/column-node.tsx
@@ -47,7 +47,7 @@ export function ColumnElement(props: PlateElementProps) {
 
   const width = typeof element.width === "string" ? element.width : undefined;
 
-  const startResize = (e: React.PointerEvent) => {
+  const startResize = (e: React.PointerEvent<HTMLDivElement>) => {
     const path = editor.api.findPath(element);
     const host = hostRef.current;
     const groupRow = host?.parentElement;
@@ -56,6 +56,11 @@ export function ColumnElement(props: PlateElementProps) {
     if (!(next instanceof HTMLElement)) return;
 
     e.preventDefault();
+    // Pointer capture routes move/up/cancel to the handle even when the
+    // pointer leaves it (or the window) mid-drag; pointercancel (tab switch,
+    // OS gesture, touch interruption) aborts without committing.
+    const handle = e.currentTarget;
+    handle.setPointerCapture(e.pointerId);
     const startX = e.clientX;
     const cells = Array.from(groupRow.children).filter(
       (cell): cell is HTMLElement => cell instanceof HTMLElement,
@@ -80,11 +85,22 @@ export function ColumnElement(props: PlateElementProps) {
       next.style.flex = `0 0 ${pairPx - (startSelf + delta)}px`;
     };
 
-    const onUp = (up: PointerEvent) => {
-      window.removeEventListener("pointermove", onMove);
-      window.removeEventListener("pointerup", onUp);
+    const detach = () => {
+      handle.removeEventListener("pointermove", onMove);
+      handle.removeEventListener("pointerup", onUp);
+      handle.removeEventListener("pointercancel", onCancel);
       host.style.flex = "";
       next.style.flex = "";
+    };
+
+    // Aborted drag (pointercancel): restore the flex-driven layout, commit
+    // nothing — the document stays untouched.
+    const onCancel = () => {
+      detach();
+    };
+
+    const onUp = (up: PointerEvent) => {
+      detach();
       const delta = clampDelta(up.clientX);
       if (delta === 0) return; // no movement — document untouched
       // Commit-on-release: every column gets a width so the group is fully
@@ -103,8 +119,9 @@ export function ColumnElement(props: PlateElementProps) {
       });
     };
 
-    window.addEventListener("pointermove", onMove);
-    window.addEventListener("pointerup", onUp);
+    handle.addEventListener("pointermove", onMove);
+    handle.addEventListener("pointerup", onUp);
+    handle.addEventListener("pointercancel", onCancel);
   };
 
   const path = editor.api.findPath(element);

--- a/packages/app/src/editor/nodes/column-node.tsx
+++ b/packages/app/src/editor/nodes/column-node.tsx
@@ -56,11 +56,18 @@ export function ColumnElement(props: PlateElementProps) {
     if (!(next instanceof HTMLElement)) return;
 
     e.preventDefault();
-    // Pointer capture routes move/up/cancel to the handle even when the
-    // pointer leaves it (or the window) mid-drag; pointercancel (tab switch,
-    // OS gesture, touch interruption) aborts without committing.
+    // Best-effort pointer capture (keeps move/up flowing when the pointer
+    // leaves the window or enters an iframe mid-drag). The listeners live on
+    // window regardless — capture is an assist, not the routing mechanism —
+    // and pointercancel (tab switch, OS gesture) aborts without committing.
     const handle = e.currentTarget;
-    handle.setPointerCapture(e.pointerId);
+    if (typeof handle.setPointerCapture === "function") {
+      try {
+        handle.setPointerCapture(e.pointerId);
+      } catch {
+        // Synthetic pointers (tests, automation) may not be capturable.
+      }
+    }
     const startX = e.clientX;
     const cells = Array.from(groupRow.children).filter(
       (cell): cell is HTMLElement => cell instanceof HTMLElement,
@@ -86,9 +93,9 @@ export function ColumnElement(props: PlateElementProps) {
     };
 
     const detach = () => {
-      handle.removeEventListener("pointermove", onMove);
-      handle.removeEventListener("pointerup", onUp);
-      handle.removeEventListener("pointercancel", onCancel);
+      window.removeEventListener("pointermove", onMove);
+      window.removeEventListener("pointerup", onUp);
+      window.removeEventListener("pointercancel", onCancel);
       host.style.flex = "";
       next.style.flex = "";
     };
@@ -119,9 +126,9 @@ export function ColumnElement(props: PlateElementProps) {
       });
     };
 
-    handle.addEventListener("pointermove", onMove);
-    handle.addEventListener("pointerup", onUp);
-    handle.addEventListener("pointercancel", onCancel);
+    window.addEventListener("pointermove", onMove);
+    window.addEventListener("pointerup", onUp);
+    window.addEventListener("pointercancel", onCancel);
   };
 
   const path = editor.api.findPath(element);

--- a/packages/app/src/editor/nodes/date-node.tsx
+++ b/packages/app/src/editor/nodes/date-node.tsx
@@ -12,11 +12,7 @@ import { PlateElement, useEditorRef, useElement, useReadOnly, type PlateElementP
 
 import { cn } from "@repo/ui/lib/utils";
 
-import {
-  NodePopover,
-  NodePopoverContent,
-  NodePopoverTrigger,
-} from "@repo/app/editor/nodes/node-popover";
+import { Popover, PopoverContent, PopoverTrigger } from "@repo/ui/components/popover";
 
 const Calendar = lazy(() =>
   import("@repo/app/editor/nodes/calendar").then((mod) => ({ default: mod.Calendar })),
@@ -61,8 +57,8 @@ export function DateElement(props: PlateElementProps) {
 
   return (
     <PlateElement {...props} as="span" className="inline-block">
-      <NodePopover open={open} onOpenChange={(next) => !readOnly && setOpen(next)}>
-        <NodePopoverTrigger
+      <Popover open={open} onOpenChange={(next) => !readOnly && setOpen(next)}>
+        <PopoverTrigger
           className={cn(
             "w-fit cursor-pointer rounded-sm px-0.5 text-primary/65 transition-colors hover:bg-primary/10",
             open && "bg-primary/10",
@@ -72,8 +68,8 @@ export function DateElement(props: PlateElementProps) {
         >
           <span className="font-semibold text-primary/45">@</span>
           {label(value)}
-        </NodePopoverTrigger>
-        <NodePopoverContent className="w-auto p-0">
+        </PopoverTrigger>
+        <PopoverContent className="w-auto p-0">
           <Suspense fallback={<div className="size-64 animate-pulse rounded-lg bg-muted" />}>
             <Calendar
               autoFocus
@@ -86,8 +82,8 @@ export function DateElement(props: PlateElementProps) {
               }}
             />
           </Suspense>
-        </NodePopoverContent>
-      </NodePopover>
+        </PopoverContent>
+      </Popover>
       {props.children}
     </PlateElement>
   );

--- a/packages/app/src/editor/nodes/equation-node.tsx
+++ b/packages/app/src/editor/nodes/equation-node.tsx
@@ -19,11 +19,7 @@ import {
 
 import { cn } from "@repo/ui/lib/utils";
 
-import {
-  NodePopover,
-  NodePopoverContent,
-  NodePopoverTrigger,
-} from "@repo/app/editor/nodes/node-popover";
+import { Popover, PopoverContent, PopoverTrigger } from "@repo/ui/components/popover";
 
 const KatexView = lazy(() => import("@repo/app/editor/nodes/equation-katex"));
 
@@ -117,8 +113,8 @@ export function EquationElement(props: PlateElementProps) {
 
   return (
     <PlateElement {...props} className="my-1">
-      <NodePopover open={open} onOpenChange={(next) => !readOnly && setOpen(next)}>
-        <NodePopoverTrigger
+      <Popover open={open} onOpenChange={(next) => !readOnly && setOpen(next)}>
+        <PopoverTrigger
           // A <button> can't contain KaTeX's block-level display markup.
           render={<div role="button" />}
           nativeButton={false}
@@ -139,15 +135,15 @@ export function EquationElement(props: PlateElementProps) {
               Add a TeX equation
             </span>
           )}
-        </NodePopoverTrigger>
-        <NodePopoverContent className="p-0">
+        </PopoverTrigger>
+        <PopoverContent className="p-0">
           <EquationEditor
             isInline={false}
             onClose={close}
             placeholder={"f(x) = \\begin{cases}\n  x^2, &\\quad x > 0 \\\\\n  0, &\\quad x = 0\n\\end{cases}"}
           />
-        </NodePopoverContent>
-      </NodePopover>
+        </PopoverContent>
+      </Popover>
       {props.children}
     </PlateElement>
   );
@@ -161,8 +157,8 @@ export function InlineEquationElement(props: PlateElementProps) {
 
   return (
     <PlateElement {...props} as="span" className="mx-px inline-block rounded-sm select-none">
-      <NodePopover open={open} onOpenChange={(next) => !readOnly && setOpen(next)}>
-        <NodePopoverTrigger
+      <Popover open={open} onOpenChange={(next) => !readOnly && setOpen(next)}>
+        <PopoverTrigger
           // Inline chip stays a span (a nested <button> would break the line).
           render={<span role="button" />}
           nativeButton={false}
@@ -187,11 +183,11 @@ export function InlineEquationElement(props: PlateElementProps) {
               New equation
             </span>
           )}
-        </NodePopoverTrigger>
-        <NodePopoverContent className="p-0">
+        </PopoverTrigger>
+        <PopoverContent className="p-0">
           <EquationEditor isInline onClose={close} placeholder="E = mc^2" />
-        </NodePopoverContent>
-      </NodePopover>
+        </PopoverContent>
+      </Popover>
       {props.children}
     </PlateElement>
   );

--- a/packages/app/src/editor/nodes/link-node.tsx
+++ b/packages/app/src/editor/nodes/link-node.tsx
@@ -1,0 +1,152 @@
+// Link anchor + its popover: clicking a link opens a Base UI popover anchored
+// to the anchor element with the URL, Open, Edit (swaps to an input; submit
+// rewrites the node's url), and Unlink. Creation stays in the selection
+// toolbar's in-bar link input; this popover manages existing links only.
+
+import { useRef, useState } from "react";
+import { unwrapLink } from "@platejs/link";
+import { ExternalLinkIcon, PencilIcon, Unlink2Icon } from "lucide-react";
+import {
+  PlateElement,
+  useEditorRef,
+  useElement,
+  useReadOnly,
+  type PlateElementProps,
+} from "platejs/react";
+
+import { cn } from "@repo/ui/lib/utils";
+import { Popover, PopoverContent } from "@repo/ui/components/popover";
+
+function PopoverButton({
+  onClick,
+  title,
+  children,
+}: {
+  onClick: () => void;
+  title: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <button
+      type="button"
+      title={title}
+      onClick={onClick}
+      className="flex size-7 items-center justify-center rounded-md text-foreground/80 transition-colors hover:bg-accent [&_svg]:size-4"
+    >
+      {children}
+    </button>
+  );
+}
+
+export function LinkElement(props: PlateElementProps) {
+  const editor = useEditorRef();
+  const element = useElement();
+  const readOnly = useReadOnly();
+  const anchorRef = useRef<HTMLAnchorElement | null>(null);
+  const [open, setOpen] = useState(false);
+  const [editing, setEditing] = useState(false);
+  const [draft, setDraft] = useState("");
+
+  const url = typeof element.url === "string" ? element.url : "";
+
+  const close = () => {
+    setOpen(false);
+    setEditing(false);
+  };
+
+  const applyDraft = () => {
+    const next = draft.trim();
+    const at = editor.api.findPath(element);
+    if (next && at) editor.tf.setNodes({ url: next }, { at });
+    close();
+    editor.tf.focus();
+  };
+
+  const removeLink = () => {
+    const at = editor.api.findPath(element);
+    if (at) unwrapLink(editor, { at });
+    close();
+    editor.tf.focus();
+  };
+
+  return (
+    <PlateElement
+      {...props}
+      ref={anchorRef}
+      as="a"
+      className="cursor-pointer border-b border-current font-medium text-foreground/70"
+      attributes={{
+        ...props.attributes,
+        href: url,
+        onClick: (event: React.MouseEvent) => {
+          // The popover owns navigation (its Open button); a raw click must
+          // not leave the app.
+          event.preventDefault();
+          if (!readOnly) setOpen(true);
+        },
+      }}
+    >
+      {props.children}
+      <Popover
+        open={open}
+        onOpenChange={(next) => {
+          setOpen(next);
+          if (!next) setEditing(false);
+        }}
+      >
+        <PopoverContent anchor={anchorRef} side="bottom" align="start" className="p-1">
+          {editing ? (
+            <form
+              className="flex items-center gap-1"
+              onSubmit={(event) => {
+                event.preventDefault();
+                applyDraft();
+              }}
+            >
+              <input
+                autoFocus
+                value={draft}
+                onChange={(e) => setDraft(e.target.value)}
+                onKeyDown={(e) => {
+                  if (e.key === "Escape") setEditing(false);
+                }}
+                placeholder="https://…"
+                className="h-7 w-56 bg-transparent px-1.5 text-xs outline-none placeholder:text-muted-foreground"
+              />
+              <button
+                type="submit"
+                className="flex items-center rounded-md px-2 py-1 text-xs font-medium text-primary transition-colors hover:bg-primary/10"
+              >
+                Apply
+              </button>
+            </form>
+          ) : (
+            <div className="flex items-center gap-0.5">
+              <span
+                className={cn("max-w-56 truncate px-1.5 text-xs text-muted-foreground")}
+                title={url}
+              >
+                {url}
+              </span>
+              <PopoverButton title="Open link" onClick={() => window.open(url, "_blank")}>
+                <ExternalLinkIcon />
+              </PopoverButton>
+              <PopoverButton
+                title="Edit link"
+                onClick={() => {
+                  setDraft(url);
+                  setEditing(true);
+                }}
+              >
+                <PencilIcon />
+              </PopoverButton>
+              <PopoverButton title="Remove link" onClick={removeLink}>
+                <Unlink2Icon />
+              </PopoverButton>
+            </div>
+          )}
+        </PopoverContent>
+      </Popover>
+    </PlateElement>
+  );
+}

--- a/packages/app/src/editor/nodes/link-node.tsx
+++ b/packages/app/src/editor/nodes/link-node.tsx
@@ -96,30 +96,32 @@ export function LinkElement(props: PlateElementProps) {
       >
         <PopoverContent anchor={anchorRef} side="bottom" align="start" className="p-1">
           {editing ? (
-            <form
-              className="flex items-center gap-1"
-              onSubmit={(event) => {
-                event.preventDefault();
-                applyDraft();
-              }}
-            >
+            // Plain div, not <form>: swapping this branch in while the
+            // Edit click's default action resolves fired a spurious submit
+            // (applying the stale draft and closing the popover).
+            <div className="flex items-center gap-1">
               <input
                 autoFocus
                 value={draft}
                 onChange={(e) => setDraft(e.target.value)}
                 onKeyDown={(e) => {
+                  if (e.key === "Enter") {
+                    e.preventDefault();
+                    applyDraft();
+                  }
                   if (e.key === "Escape") setEditing(false);
                 }}
                 placeholder="https://…"
                 className="h-7 w-56 bg-transparent px-1.5 text-xs outline-none placeholder:text-muted-foreground"
               />
               <button
-                type="submit"
+                type="button"
+                onClick={applyDraft}
                 className="flex items-center rounded-md px-2 py-1 text-xs font-medium text-primary transition-colors hover:bg-primary/10"
               >
                 Apply
               </button>
-            </form>
+            </div>
           ) : (
             <div className="flex items-center gap-0.5">
               <span

--- a/packages/app/src/editor/selection-toolbar.tsx
+++ b/packages/app/src/editor/selection-toolbar.tsx
@@ -1,12 +1,15 @@
 import {
   useEffect,
+  useMemo,
   useRef,
   useState,
   type MouseEvent as ReactMouseEvent,
   type ReactNode,
   type RefObject,
 } from "react";
+import { flip, offset, shift, useFloatingToolbar, useFloatingToolbarState } from "@platejs/floating";
 import { wrapLink } from "@platejs/link";
+import { BlockSelectionPlugin } from "@platejs/selection/react";
 import {
   BoldIcon,
   CheckIcon,
@@ -20,31 +23,37 @@ import {
   XIcon,
 } from "lucide-react";
 import { KEYS } from "platejs";
-import { useEditorRef, useMarkToolbarButton, useMarkToolbarButtonState } from "platejs/react";
+import {
+  useEditorRef,
+  useEditorSelection,
+  useEventEditorValue,
+  useMarkToolbarButton,
+  useMarkToolbarButtonState,
+  usePluginOption,
+} from "platejs/react";
 
 import { cn } from "@repo/ui/lib/utils";
 import { Menu, MenuContent, MenuGroup, MenuGroupLabel, MenuItem } from "@repo/ui/components/menu";
 
-import { TURN_INTO, turnIntoSelection } from "@repo/app/editor/block-transforms";
+import {
+  TURN_INTO,
+  turnIntoLabelFor,
+  turnIntoSelection,
+} from "@repo/app/editor/block-transforms";
 import { useInlineAi, type InlineAiStatus } from "@repo/app/editor/inline-ai";
 
-// Track the current selection's viewport rect so the floating bar can anchor to
-// it. Re-reads on selection change and on any status transition (the pending
-// text is programmatically selected, so its rect appears then). While `frozen`
-// (a dropdown/link input is open) it stops updating so opening a popover — which
-// moves DOM focus and collapses the selection — doesn't yank the bar away.
-function useSelectionRect(status: InlineAiStatus, frozen: boolean): DOMRect | null {
+// Track the pending range's viewport rect for the BUSY states (loading /
+// pending / error): the selection collapses during streaming and DOM focus
+// may sit in a popover, so @platejs/floating's focus-driven hook is wrong
+// here — a plain selectionchange listener re-reads on every status
+// transition (the pending text is programmatically selected, so its rect
+// appears then). The idle toolbar does NOT use this path.
+function usePendingRect(status: InlineAiStatus): DOMRect | null {
   const [rect, setRect] = useState<DOMRect | null>(null);
   useEffect(() => {
-    if (frozen) return;
     const update = () => {
       const sel = window.getSelection();
       if (!sel || sel.rangeCount === 0) {
-        setRect(null);
-        return;
-      }
-      // Idle only wants a real (non-collapsed) selection to offer actions.
-      if (status.kind === "idle" && sel.isCollapsed) {
         setRect(null);
         return;
       }
@@ -54,18 +63,21 @@ function useSelectionRect(status: InlineAiStatus, frozen: boolean): DOMRect | nu
     update();
     document.addEventListener("selectionchange", update);
     return () => document.removeEventListener("selectionchange", update);
-  }, [status, frozen]);
+  }, [status]);
   return rect;
 }
 
+const BAR_CLASS =
+  "z-50 flex items-center gap-0.5 rounded-lg border border-border bg-popover p-1 text-popover-foreground shadow-md";
+
+// Fixed-position shell for the busy states (viewport-clamped above the rect).
 function FloatingBar({ rect, children }: { rect: DOMRect; children: ReactNode }) {
-  // Above the selection, horizontally centred, clamped to the viewport.
   const left = Math.min(Math.max(rect.left + rect.width / 2, 180), window.innerWidth - 180);
   const top = Math.max(rect.top - 46, 8);
   return (
     <div
       style={{ position: "fixed", top, left, transform: "translateX(-50%)" }}
-      className="z-50 flex items-center gap-0.5 rounded-lg border border-border bg-popover p-1 text-popover-foreground shadow-md"
+      className={BAR_CLASS}
       onMouseDown={(e) => e.preventDefault()}
     >
       {children}
@@ -226,52 +238,36 @@ function LinkInput({
   );
 }
 
+type InlineAiController = ReturnType<typeof useInlineAi>;
+
 /**
  * The editor's selection toolbar — a potion-style floating bar over a text
  * selection: an **Ask AI** dropdown (Improve / Shorten / Fix grammar / Continue
- * / Summarize), **Turn into** (block type), the **Bold / Italic / Strikethrough
- * / Code** marks, and a **Link** input. While the isolated AI agent runs it
- * shows a "Generating…" chip, then an Accept / Discard bar over the proposed
- * text. Slash commands (Continue / Summarize) route into the same AI flow via
- * the shared runner below.
+ * / Summarize), **Turn into** (with a current-block-type indicator), the
+ * **Bold / Italic / Strikethrough / Code** marks, and a **Link** input.
  *
- * Only GFM-round-tripping marks are offered (no underline/color — they have no
- * markdown form and would silently drop on save).
+ * Dual-path positioning (the AI state machine survives the @platejs/floating
+ * swap): the IDLE bar rides useFloatingToolbar (flip/shift/offset, hides on
+ * blur/collapse); the BUSY bar (loading → "Generating…", pending →
+ * Accept/Discard/Retry, error) keeps the selectionchange-rect path because
+ * the hook's hide conditions are all true mid-stream. Both render the same
+ * bar shell. Only GFM-round-tripping marks are offered.
  */
 export function SelectionToolbar() {
   const editor = useEditorRef();
   const controller = useInlineAi(editor);
-  const { status, run, accept, discard, dismissError } = controller;
 
   // Let slash commands drive the same controller (they can't call the hook).
-  useEffect(() => registerInlineAiRunner(run), [run]);
+  useEffect(() => registerInlineAiRunner(controller.run), [controller.run]);
 
-  const [openMenu, setOpenMenu] = useState<null | "ai" | "turn">(null);
-  const [linkMode, setLinkMode] = useState(false);
-  const frozen = openMenu !== null || linkMode;
-  const rect = useSelectionRect(status, frozen);
+  if (controller.status.kind !== "idle") return <BusyToolbar controller={controller} />;
+  return <IdleToolbar controller={controller} />;
+}
 
-  const aiRef = useRef<HTMLButtonElement | null>(null);
-  const turnRef = useRef<HTMLButtonElement | null>(null);
-
-  // Remember the live selection at the moment an action starts — opening a
-  // popover or the link input moves DOM focus off the editable and collapses it.
-  // Captured on the click (when editor.selection has settled), not via an effect
-  // (which races Slate's throttled selection sync and grabs a stale range).
-  const savedSel = useRef<typeof editor.selection>(null);
-  const remember = () => {
-    savedSel.current = editor.selection;
-  };
-  // Run an action against the remembered selection: restore the model range
-  // first (so an expanded selection stays expanded — a link needs it), then
-  // focus. Focusing before selecting collapses the range.
-  const withSelection = (fn: () => void) => {
-    if (savedSel.current) editor.tf.select(savedSel.current);
-    fn();
-    editor.tf.focus();
-  };
-
-  if (!rect) return null;
+function BusyToolbar({ controller }: { controller: InlineAiController }) {
+  const { status, run, accept, discard, dismissError } = controller;
+  const rect = usePendingRect(status);
+  if (!rect || status.kind === "idle") return null;
 
   if (status.kind === "loading") {
     return (
@@ -295,117 +291,189 @@ export function SelectionToolbar() {
       </FloatingBar>
     );
   }
-  if (status.kind === "error") {
-    return (
-      <FloatingBar rect={rect}>
-        <span className="px-1 text-xs text-destructive">{status.message}</span>
-        <BarButton variant="danger" onClick={dismissError}>
-          <XIcon />
-        </BarButton>
-      </FloatingBar>
-    );
-  }
-
-  if (linkMode) {
-    return (
-      <FloatingBar rect={rect}>
-        <LinkInput
-          onCancel={() => setLinkMode(false)}
-          onSubmit={(url) => {
-            setLinkMode(false);
-            // Wrap the remembered range directly (`at`), so we don't depend on
-            // restoring editor focus/selection after the input stole focus.
-            const at = savedSel.current;
-            if (url && at) {
-              wrapLink(editor, { url, at, split: true });
-              editor.tf.focus();
-            }
-          }}
-        />
-      </FloatingBar>
-    );
-  }
-
   return (
     <FloatingBar rect={rect}>
-      <DropdownTrigger
-        triggerRef={aiRef}
-        onOpen={() => {
-          remember();
-          setOpenMenu("ai");
-        }}
-      >
-        <SparklesIcon className="text-primary" />
-        <span className="text-primary">Ask AI</span>
-      </DropdownTrigger>
-      <Menu open={openMenu === "ai"} onOpenChange={(o) => setOpenMenu(o ? "ai" : null)}>
-        <MenuContent anchor={aiRef} side="bottom" align="start">
-          {AI_ACTIONS.map(({ action, label }) => (
-            <MenuItem key={action} onClick={() => withSelection(() => run(action))}>
-              {label}
-            </MenuItem>
-          ))}
-        </MenuContent>
-      </Menu>
-
-      <Sep />
-
-      <DropdownTrigger
-        triggerRef={turnRef}
-        onOpen={() => {
-          remember();
-          setOpenMenu("turn");
-        }}
-      >
-        Turn into
-      </DropdownTrigger>
-      <Menu open={openMenu === "turn"} onOpenChange={(o) => setOpenMenu(o ? "turn" : null)}>
-        <MenuContent anchor={turnRef} side="bottom" align="start">
-          <MenuGroup>
-            <MenuGroupLabel>Turn into</MenuGroupLabel>
-            {TURN_INTO.map((opt) => (
-              <MenuItem
-                key={opt.label}
-                onClick={() => {
-                  turnIntoSelection(editor, opt, savedSel.current ?? undefined);
-                  editor.tf.focus();
-                }}
-              >
-                {opt.label}
-              </MenuItem>
-            ))}
-          </MenuGroup>
-        </MenuContent>
-      </Menu>
-
-      <Sep />
-
-      <MarkButton nodeType={KEYS.bold} title="Bold ⌘B">
-        <BoldIcon />
-      </MarkButton>
-      <MarkButton nodeType={KEYS.italic} title="Italic ⌘I">
-        <ItalicIcon />
-      </MarkButton>
-      <MarkButton nodeType={KEYS.strikethrough} title="Strikethrough">
-        <StrikethroughIcon />
-      </MarkButton>
-      <MarkButton nodeType={KEYS.code} title="Code ⌘E">
-        <CodeIcon />
-      </MarkButton>
-
-      <Sep />
-
-      <IconButton
-        onClick={() => {
-          remember();
-          setLinkMode(true);
-        }}
-        onMouseDown={(e) => e.preventDefault()}
-        title="Link"
-      >
-        <Link2Icon />
-      </IconButton>
+      <span className="px-1 text-xs text-destructive">{status.message}</span>
+      <BarButton variant="danger" onClick={dismissError}>
+        <XIcon />
+      </BarButton>
     </FloatingBar>
+  );
+}
+
+function IdleToolbar({ controller }: { controller: InlineAiController }) {
+  const editor = useEditorRef();
+  const { run } = controller;
+
+  const [openMenu, setOpenMenu] = useState<null | "ai" | "turn">(null);
+  const [linkMode, setLinkMode] = useState(false);
+  // While a Base UI menu or the link input holds focus the hook's hide
+  // conditions fire (blur, collapsed selection) — `frozen` short-circuits
+  // them and the bar keeps its last computed position. Base UI portals
+  // escape clickOutsideRef, so this explicit gate is the reliable one.
+  const frozen = openMenu !== null || linkMode;
+
+  const aiRef = useRef<HTMLButtonElement | null>(null);
+  const turnRef = useRef<HTMLButtonElement | null>(null);
+
+  // Remember the live selection at the moment an action starts — opening a
+  // popover or the link input moves DOM focus off the editable and collapses
+  // it. Captured on the click (when editor.selection has settled), not via an
+  // effect (which races Slate's throttled selection sync).
+  const savedSel = useRef<typeof editor.selection>(null);
+  const remember = () => {
+    savedSel.current = editor.selection;
+  };
+  // Run an action against the remembered selection: restore the model range
+  // first (so an expanded selection stays expanded — a link needs it), then
+  // focus. Focusing before selecting collapses the range.
+  const withSelection = (fn: () => void) => {
+    if (savedSel.current) editor.tf.select(savedSel.current);
+    fn();
+    editor.tf.focus();
+  };
+
+  const focusedEditorId = useEventEditorValue("focus");
+  const isSelectingSome = usePluginOption(BlockSelectionPlugin, "isSelectingSome");
+
+  const floatingToolbarState = useFloatingToolbarState({
+    editorId: editor.id,
+    focusedEditorId,
+    hideToolbar: isSelectingSome,
+    floatingOptions: {
+      middleware: [
+        offset({ crossAxis: -24, mainAxis: 12 }),
+        shift({ padding: 50 }),
+        flip({
+          fallbackPlacements: ["top-start", "top-end", "bottom-start", "bottom-end"],
+          padding: 12,
+        }),
+      ],
+      placement: "top-start",
+    },
+  });
+  const {
+    clickOutsideRef,
+    hidden,
+    props: rootProps,
+    ref: floatingRef,
+  } = useFloatingToolbar(floatingToolbarState);
+
+  // Current-block-type indicator on the Turn-into trigger.
+  const selection = useEditorSelection();
+  const typeLabel = useMemo(() => {
+    const at = selection ?? savedSel.current;
+    const block = at ? editor.api.block({ at }) : editor.api.block();
+    return block ? turnIntoLabelFor(block[0]) : "Text";
+  }, [selection, editor]);
+
+  if (hidden && !frozen) return null;
+
+  return (
+    <div ref={clickOutsideRef}>
+      <div
+        ref={floatingRef}
+        {...rootProps}
+        className={cn(BAR_CLASS, "absolute whitespace-nowrap print:hidden")}
+        onMouseDown={(e) => e.preventDefault()}
+      >
+        {linkMode ? (
+          <LinkInput
+            onCancel={() => setLinkMode(false)}
+            onSubmit={(url) => {
+              setLinkMode(false);
+              // Wrap the remembered range directly (`at`), so we don't depend
+              // on restoring editor focus/selection after the input stole it.
+              const at = savedSel.current;
+              if (url && at) {
+                wrapLink(editor, { url, at, split: true });
+                editor.tf.focus();
+              }
+            }}
+          />
+        ) : (
+          <>
+            <DropdownTrigger
+              triggerRef={aiRef}
+              onOpen={() => {
+                remember();
+                setOpenMenu("ai");
+              }}
+            >
+              <SparklesIcon className="text-primary" />
+              <span className="text-primary">Ask AI</span>
+            </DropdownTrigger>
+            <Menu open={openMenu === "ai"} onOpenChange={(o) => setOpenMenu(o ? "ai" : null)}>
+              <MenuContent anchor={aiRef} side="bottom" align="start">
+                {AI_ACTIONS.map(({ action, label }) => (
+                  <MenuItem key={action} onClick={() => withSelection(() => run(action))}>
+                    {label}
+                  </MenuItem>
+                ))}
+              </MenuContent>
+            </Menu>
+
+            <Sep />
+
+            <DropdownTrigger
+              triggerRef={turnRef}
+              onOpen={() => {
+                remember();
+                setOpenMenu("turn");
+              }}
+            >
+              {typeLabel}
+            </DropdownTrigger>
+            <Menu open={openMenu === "turn"} onOpenChange={(o) => setOpenMenu(o ? "turn" : null)}>
+              <MenuContent anchor={turnRef} side="bottom" align="start">
+                <MenuGroup>
+                  <MenuGroupLabel>Turn into</MenuGroupLabel>
+                  {TURN_INTO.map((opt) => (
+                    <MenuItem
+                      key={opt.label}
+                      onClick={() => {
+                        turnIntoSelection(editor, opt, savedSel.current ?? undefined);
+                        editor.tf.focus();
+                      }}
+                    >
+                      {opt.label}
+                    </MenuItem>
+                  ))}
+                </MenuGroup>
+              </MenuContent>
+            </Menu>
+
+            <Sep />
+
+            <MarkButton nodeType={KEYS.bold} title="Bold ⌘B">
+              <BoldIcon />
+            </MarkButton>
+            <MarkButton nodeType={KEYS.italic} title="Italic ⌘I">
+              <ItalicIcon />
+            </MarkButton>
+            <MarkButton nodeType={KEYS.strikethrough} title="Strikethrough">
+              <StrikethroughIcon />
+            </MarkButton>
+            <MarkButton nodeType={KEYS.code} title="Code ⌘E">
+              <CodeIcon />
+            </MarkButton>
+
+            <Sep />
+
+            <IconButton
+              onClick={() => {
+                remember();
+                setLinkMode(true);
+              }}
+              onMouseDown={(e) => e.preventDefault()}
+              title="Link"
+            >
+              <Link2Icon />
+            </IconButton>
+          </>
+        )}
+      </div>
+    </div>
   );
 }
 

--- a/packages/app/src/editor/selection-toolbar.tsx
+++ b/packages/app/src/editor/selection-toolbar.tsx
@@ -37,6 +37,7 @@ import { Menu, MenuContent, MenuGroup, MenuGroupLabel, MenuItem } from "@repo/ui
 
 import {
   TURN_INTO,
+  effectiveBlockEntry,
   turnIntoLabelFor,
   turnIntoSelection,
 } from "@repo/app/editor/block-transforms";
@@ -359,12 +360,13 @@ function IdleToolbar({ controller }: { controller: InlineAiController }) {
     ref: floatingRef,
   } = useFloatingToolbar(floatingToolbarState);
 
-  // Current-block-type indicator on the Turn-into trigger.
+  // Current-block-type indicator on the Turn-into trigger (a toggle's
+  // summary row reads as the toggle).
   const selection = useEditorSelection();
   const typeLabel = useMemo(() => {
-    const at = selection ?? savedSel.current;
-    const block = at ? editor.api.block({ at }) : editor.api.block();
-    return block ? turnIntoLabelFor(block[0]) : "Text";
+    const at = selection ?? savedSel.current ?? undefined;
+    const entry = effectiveBlockEntry(editor, at);
+    return entry ? turnIntoLabelFor(entry[0]) : "Text";
   }, [selection, editor]);
 
   if (hidden && !frozen) return null;

--- a/packages/app/src/editor/selection-toolbar.tsx
+++ b/packages/app/src/editor/selection-toolbar.tsx
@@ -5,7 +5,6 @@ import {
   useState,
   type MouseEvent as ReactMouseEvent,
   type ReactNode,
-  type RefObject,
 } from "react";
 import { flip, offset, shift, useFloatingToolbar, useFloatingToolbarState } from "@platejs/floating";
 import { wrapLink } from "@platejs/link";
@@ -33,7 +32,14 @@ import {
 } from "platejs/react";
 
 import { cn } from "@repo/ui/lib/utils";
-import { Menu, MenuContent, MenuGroup, MenuGroupLabel, MenuItem } from "@repo/ui/components/menu";
+import {
+  Menu,
+  MenuContent,
+  MenuGroup,
+  MenuGroupLabel,
+  MenuItem,
+  MenuTrigger,
+} from "@repo/ui/components/menu";
 
 import {
   TURN_INTO,
@@ -122,26 +128,22 @@ function IconButton({
   );
 }
 
-function DropdownTrigger({
-  triggerRef,
-  onOpen,
-  children,
-}: {
-  triggerRef: RefObject<HTMLButtonElement | null>;
-  onOpen: () => void;
-  children: ReactNode;
-}) {
+// A real Base UI MenuTrigger (must render inside <Menu>): a detached
+// controlled menu anchored to a plain button ref closes itself with reason
+// `trigger-hover` as soon as the pointer travels from the button into the
+// popup — every mouse click on an item died mid-flight (keyboard worked).
+// The registered trigger gives Base UI the correct press/hover linkage.
+// `onMouseDown` preventDefault keeps the editor selection alive through the
+// opening click.
+function DropdownTrigger({ children }: { children: ReactNode }) {
   return (
-    <button
-      ref={triggerRef}
-      type="button"
+    <MenuTrigger
       onMouseDown={(e) => e.preventDefault()}
-      onClick={onOpen}
       className="flex h-7 items-center gap-1 rounded-md px-2 text-xs font-medium text-foreground/90 transition-colors hover:bg-accent [&_svg]:size-3.5"
     >
       {children}
       <ChevronDownIcon className="!size-3 text-muted-foreground/70" />
-    </button>
+    </MenuTrigger>
   );
 }
 
@@ -314,13 +316,10 @@ function IdleToolbar({ controller }: { controller: InlineAiController }) {
   // escape clickOutsideRef, so this explicit gate is the reliable one.
   const frozen = openMenu !== null || linkMode;
 
-  const aiRef = useRef<HTMLButtonElement | null>(null);
-  const turnRef = useRef<HTMLButtonElement | null>(null);
-
   // Remember the live selection at the moment an action starts — opening a
   // popover or the link input moves DOM focus off the editable and collapses
-  // it. Captured on the click (when editor.selection has settled), not via an
-  // effect (which races Slate's throttled selection sync).
+  // it. Captured when the menu opens (editor.selection has settled), not via
+  // an effect (which races Slate's throttled selection sync).
   const savedSel = useRef<typeof editor.selection>(null);
   const remember = () => {
     savedSel.current = editor.selection;
@@ -395,18 +394,23 @@ function IdleToolbar({ controller }: { controller: InlineAiController }) {
           />
         ) : (
           <>
-            <DropdownTrigger
-              triggerRef={aiRef}
-              onOpen={() => {
-                remember();
-                setOpenMenu("ai");
+            <Menu
+              open={openMenu === "ai"}
+              onOpenChange={(o) => {
+                if (o) remember();
+                setOpenMenu(o ? "ai" : null);
               }}
             >
-              <SparklesIcon className="text-primary" />
-              <span className="text-primary">Ask AI</span>
-            </DropdownTrigger>
-            <Menu open={openMenu === "ai"} onOpenChange={(o) => setOpenMenu(o ? "ai" : null)}>
-              <MenuContent anchor={aiRef} side="bottom" align="start">
+              <DropdownTrigger>
+                <SparklesIcon className="text-primary" />
+                <span className="text-primary">Ask AI</span>
+              </DropdownTrigger>
+              {/* ignore-click-outside/toolbar: the portaled popup escapes the
+                  hook's clickOutsideRef; without the ignore class a mousedown
+                  on a menu item flips the hook's open state, display:none-s
+                  the bar, and the popup (anchored to the hidden trigger)
+                  jumps away before mouseup — items become unclickable. */}
+              <MenuContent side="bottom" align="start" className="ignore-click-outside/toolbar">
                 {AI_ACTIONS.map(({ action, label }) => (
                   <MenuItem key={action} onClick={() => withSelection(() => run(action))}>
                     {label}
@@ -417,17 +421,15 @@ function IdleToolbar({ controller }: { controller: InlineAiController }) {
 
             <Sep />
 
-            <DropdownTrigger
-              triggerRef={turnRef}
-              onOpen={() => {
-                remember();
-                setOpenMenu("turn");
+            <Menu
+              open={openMenu === "turn"}
+              onOpenChange={(o) => {
+                if (o) remember();
+                setOpenMenu(o ? "turn" : null);
               }}
             >
-              {typeLabel}
-            </DropdownTrigger>
-            <Menu open={openMenu === "turn"} onOpenChange={(o) => setOpenMenu(o ? "turn" : null)}>
-              <MenuContent anchor={turnRef} side="bottom" align="start">
+              <DropdownTrigger>{typeLabel}</DropdownTrigger>
+              <MenuContent side="bottom" align="start" className="ignore-click-outside/toolbar">
                 <MenuGroup>
                   <MenuGroupLabel>Turn into</MenuGroupLabel>
                   {TURN_INTO.map((opt) => (

--- a/packages/app/src/editor/slash-menu.tsx
+++ b/packages/app/src/editor/slash-menu.tsx
@@ -1,16 +1,23 @@
-// Slash command menu — adapted from Potion's slash-node.tsx, trimmed to the
-// blocks that round-trip cleanly through our markdown serializer. Anything
-// without a native markdown form (tables, media, callout, toggle, columns,
-// equations, colors) is deliberately omitted: it would render broken or be
-// dropped/mangled on the next save, which also kicks the file out of canonical
-// (rich) mode. See markdown/markdown-doc.ts.
+// Slash command menu covering the full locked vocabulary (Phase E): basic
+// blocks, toggle, columns, date, equations, mermaid, embeds — every insert
+// routes through the shared kit transforms so the bytes each item produces
+// are the canonical fixture forms. Grouping + keywords follow potion's
+// slash-node (reference-only). Block conversions route through
+// block-transforms.ts (one turn-into source for slash, menus, and toolbar).
+//
+// Phase F slot: the `[[` wiki-link picker will be a second inline-combobox
+// consumer following the emoji-input pattern.
 
 import { HorizontalRulePlugin } from "@platejs/basic-nodes/react";
-import { insertCodeBlock } from "@platejs/code-block";
 import { SlashInputPlugin, SlashPlugin } from "@platejs/slash-command/react";
 import { insertTable } from "@platejs/table";
 import {
+  CalendarIcon,
+  ChevronRightIcon,
   Code2Icon,
+  Columns2Icon,
+  Columns3Icon,
+  FilmIcon,
   Heading1Icon,
   Heading2Icon,
   Heading3Icon,
@@ -21,14 +28,19 @@ import {
   PenLineIcon,
   PilcrowIcon,
   QuoteIcon,
+  RadicalIcon,
+  SigmaIcon,
   SquareCheckIcon,
   Table2Icon,
   WandSparklesIcon,
+  WorkflowIcon,
 } from "lucide-react";
 import { KEYS } from "platejs";
 import type { PlateEditor, PlateElementProps } from "platejs/react";
-import { PlateElement } from "platejs/react";
+import { PlateElement, createPlatePlugin } from "platejs/react";
 
+import { TURN_INTO, turnIntoSelection } from "@repo/app/editor/block-transforms";
+import { EmbedUrlDialogHost, openEmbedUrlDialog } from "@repo/app/editor/embed-url-dialog";
 import {
   InlineCombobox,
   InlineComboboxContent,
@@ -38,43 +50,15 @@ import {
   InlineComboboxInput,
   InlineComboboxItem,
 } from "@repo/app/editor/inline-combobox";
+import { insertColumnGroup } from "@repo/app/editor/kits/column-kit";
+import { insertDate } from "@repo/app/editor/kits/date-kit";
+import { insertEquation, insertInlineEquation } from "@repo/app/editor/kits/math-kit";
+import { insertToggle } from "@repo/app/editor/kits/toggle-kit";
 import { triggerInlineAi } from "@repo/app/editor/selection-toolbar";
 
-// Turn the current block(s) into a plain block type (heading/paragraph/quote),
-// clearing any list formatting first.
-function turnInto(editor: PlateEditor, type: string) {
-  editor.tf.withoutNormalizing(() => {
-    for (const [, path] of editor.api.blocks({ mode: "lowest" })) {
-      editor.tf.unsetNodes(["listStyleType", "listStart", "indent"], { at: path });
-      editor.tf.setNodes({ type }, { at: path });
-    }
-  });
-}
-
-// Lists are indent-based (a paragraph with `indent` + `listStyleType`), matching
-// block-list.tsx. "disc" / "decimal" / "todo" are the values it renders. Todo
-// items also need `checked` so the markdown serializer emits `- [ ]` (without
-// it the item round-trips to a plain bullet).
-function turnIntoList(editor: PlateEditor, listStyleType: string, checked?: boolean) {
-  const type = editor.getType(KEYS.p);
-  editor.tf.withoutNormalizing(() => {
-    for (const [, path] of editor.api.blocks({ mode: "lowest" })) {
-      editor.tf.setNodes(
-        checked === undefined
-          ? { type, indent: 1, listStyleType }
-          : { type, indent: 1, listStyleType, checked },
-        { at: path },
-      );
-    }
-  });
-}
-
-// A callout is a GitHub alert blockquote: the leading `[!NOTE]` marker is what
-// the editor styles into a colored callout (see markdown-editor's
-// BlockquoteElement) and it round-trips as plain markdown.
-function insertCallout(editor: PlateEditor) {
-  turnInto(editor, editor.getType(KEYS.blockquote));
-  editor.tf.insertText("[!NOTE] ");
+function turnInto(editor: PlateEditor, label: string): void {
+  const opt = TURN_INTO.find((o) => o.label === label);
+  if (opt) turnIntoSelection(editor, opt);
 }
 
 function insertHorizontalRule(editor: PlateEditor) {
@@ -83,6 +67,19 @@ function insertHorizontalRule(editor: PlateEditor) {
     { select: true },
   );
   editor.tf.insertNodes({ type: editor.getType(KEYS.p), children: [{ text: "" }] });
+}
+
+// A mermaid diagram is a plain ```mermaid fence (render-only preview — zero
+// serialization surface), seeded with a minimal valid graph.
+function insertMermaid(editor: PlateEditor) {
+  turnInto(editor, "Code block");
+  editor.tf.setNodes(
+    { lang: "mermaid" },
+    { match: (n) => n.type === editor.getType(KEYS.codeBlock) },
+  );
+  editor.tf.insertText("graph TD;");
+  editor.tf.insertBreak();
+  editor.tf.insertText("  A-->B;");
 }
 
 type SlashItem = {
@@ -125,7 +122,7 @@ const GROUPS: { group: string; items: SlashItem[] }[] = [
         value: "p",
         description: "Plain paragraph.",
         keywords: ["paragraph", "text"],
-        onSelect: (editor) => turnInto(editor, editor.getType(KEYS.p)),
+        onSelect: (editor) => turnInto(editor, "Text"),
       },
       {
         icon: <Heading1Icon />,
@@ -133,7 +130,7 @@ const GROUPS: { group: string; items: SlashItem[] }[] = [
         value: "h1",
         description: "Large section heading.",
         keywords: ["title", "h1", "#"],
-        onSelect: (editor) => turnInto(editor, editor.getType(KEYS.h1)),
+        onSelect: (editor) => turnInto(editor, "Heading 1"),
       },
       {
         icon: <Heading2Icon />,
@@ -141,7 +138,7 @@ const GROUPS: { group: string; items: SlashItem[] }[] = [
         value: "h2",
         description: "Medium section heading.",
         keywords: ["subtitle", "h2", "##"],
-        onSelect: (editor) => turnInto(editor, editor.getType(KEYS.h2)),
+        onSelect: (editor) => turnInto(editor, "Heading 2"),
       },
       {
         icon: <Heading3Icon />,
@@ -149,7 +146,7 @@ const GROUPS: { group: string; items: SlashItem[] }[] = [
         value: "h3",
         description: "Small section heading.",
         keywords: ["subtitle", "h3", "###"],
-        onSelect: (editor) => turnInto(editor, editor.getType(KEYS.h3)),
+        onSelect: (editor) => turnInto(editor, "Heading 3"),
       },
       {
         icon: <ListIcon />,
@@ -157,7 +154,7 @@ const GROUPS: { group: string; items: SlashItem[] }[] = [
         value: "ul",
         description: "Create a bulleted list.",
         keywords: ["unordered", "ul", "-"],
-        onSelect: (editor) => turnIntoList(editor, "disc"),
+        onSelect: (editor) => turnInto(editor, "Bulleted list"),
       },
       {
         icon: <ListOrderedIcon />,
@@ -165,7 +162,7 @@ const GROUPS: { group: string; items: SlashItem[] }[] = [
         value: "ol",
         description: "Create a numbered list.",
         keywords: ["ordered", "ol", "1."],
-        onSelect: (editor) => turnIntoList(editor, "decimal"),
+        onSelect: (editor) => turnInto(editor, "Numbered list"),
       },
       {
         icon: <SquareCheckIcon />,
@@ -173,7 +170,15 @@ const GROUPS: { group: string; items: SlashItem[] }[] = [
         value: "todo",
         description: "Track tasks with checkboxes.",
         keywords: ["checklist", "task", "checkbox", "[]"],
-        onSelect: (editor) => turnIntoList(editor, "todo", false),
+        onSelect: (editor) => turnInto(editor, "To-do list"),
+      },
+      {
+        icon: <ChevronRightIcon />,
+        label: "Toggle",
+        value: "toggle",
+        description: "Collapsible block.",
+        keywords: ["toggle", "collapsible", "details", "expandable", "+"],
+        onSelect: (editor) => insertToggle(editor),
       },
       {
         icon: <QuoteIcon />,
@@ -181,7 +186,7 @@ const GROUPS: { group: string; items: SlashItem[] }[] = [
         value: "blockquote",
         description: "Capture a quote.",
         keywords: ["citation", "quote", ">"],
-        onSelect: (editor) => turnInto(editor, editor.getType(KEYS.blockquote)),
+        onSelect: (editor) => turnInto(editor, "Quote"),
       },
       {
         icon: <InfoIcon />,
@@ -189,7 +194,7 @@ const GROUPS: { group: string; items: SlashItem[] }[] = [
         value: "callout",
         description: "Highlighted note (GitHub alert).",
         keywords: ["callout", "alert", "note", "warning", "tip", "admonition"],
-        onSelect: (editor) => insertCallout(editor),
+        onSelect: (editor) => turnInto(editor, "Callout"),
       },
       {
         icon: <Code2Icon />,
@@ -197,7 +202,7 @@ const GROUPS: { group: string; items: SlashItem[] }[] = [
         value: "code",
         description: "Capture a code snippet.",
         keywords: ["```", "fenced"],
-        onSelect: (editor) => insertCodeBlock(editor),
+        onSelect: (editor) => turnInto(editor, "Code block"),
       },
       {
         icon: <Table2Icon />,
@@ -207,6 +212,77 @@ const GROUPS: { group: string; items: SlashItem[] }[] = [
         keywords: ["grid", "rows", "columns"],
         onSelect: (editor) =>
           insertTable(editor, { colCount: 3, rowCount: 3, header: true }, { select: true }),
+      },
+      {
+        icon: <RadicalIcon />,
+        label: "Equation",
+        value: "equation",
+        description: "Display math block (KaTeX).",
+        keywords: ["math", "katex", "tex", "latex", "$$"],
+        onSelect: (editor) => insertEquation(editor),
+      },
+    ],
+  },
+  {
+    group: "Advanced",
+    items: [
+      {
+        icon: <Columns2Icon />,
+        label: "2 columns",
+        value: "columns-2",
+        description: "Two side-by-side columns.",
+        keywords: ["columns", "layout", "side", "split"],
+        onSelect: (editor) => insertColumnGroup(editor, 2),
+      },
+      {
+        icon: <Columns3Icon />,
+        label: "3 columns",
+        value: "columns-3",
+        description: "Three side-by-side columns.",
+        keywords: ["columns", "layout", "grid"],
+        onSelect: (editor) => insertColumnGroup(editor, 3),
+      },
+      {
+        icon: <WorkflowIcon />,
+        label: "Mermaid diagram",
+        value: "mermaid",
+        description: "Diagram-as-code with live preview.",
+        keywords: ["diagram", "chart", "flowchart", "graph", "mermaid"],
+        onSelect: (editor) => insertMermaid(editor),
+      },
+    ],
+  },
+  {
+    group: "Inline",
+    items: [
+      {
+        icon: <CalendarIcon />,
+        label: "Date",
+        value: "date",
+        description: "Inline date chip (today).",
+        keywords: ["date", "today", "calendar", "@"],
+        onSelect: (editor) => insertDate(editor),
+      },
+      {
+        icon: <SigmaIcon />,
+        label: "Inline equation",
+        value: "inline-equation",
+        description: "Math within a sentence.",
+        keywords: ["math", "inline", "formula", "tex"],
+        onSelect: (editor) => insertInlineEquation(editor),
+      },
+    ],
+  },
+  {
+    group: "Media",
+    items: [
+      {
+        icon: <FilmIcon />,
+        label: "Embed",
+        value: "embed",
+        description: "YouTube, tweet, PDF, or iframe by URL.",
+        keywords: ["youtube", "tweet", "twitter", "pdf", "iframe", "embed", "video"],
+        onSelect: () => openEmbedUrlDialog(),
       },
     ],
   },
@@ -273,4 +349,9 @@ export const SlashKit = [
     },
   }),
   SlashInputPlugin.withComponent(SlashInputElement),
+  // The Embed item's URL prompt lives outside the (self-unmounting) combobox.
+  createPlatePlugin({
+    key: "embed-url-dialog",
+    render: { afterEditable: () => <EmbedUrlDialogHost /> },
+  }),
 ];

--- a/packages/ui/src/components/popover.tsx
+++ b/packages/ui/src/components/popover.tsx
@@ -1,25 +1,20 @@
-// Minimal Base UI popover for editor node UIs (date picker, equation editor).
-// Interim primitive: WP3 lands the house `@repo/ui/components/popover`; this
-// file then becomes a thin re-style or is deleted in favor of it. Kept local
-// to the editor so @repo/ui's public surface stays WP3-owned.
+"use client";
 
 import { type ComponentProps } from "react";
 import { Popover as PopoverPrimitive } from "@base-ui/react/popover";
 
 import { cn } from "@repo/ui/lib/utils";
 
-// Mirrors @repo/ui menu.tsx's popupClass so node popovers sit on the same
-// elevation as menus until WP4's shadow-ladder pass.
 const popupClass =
   "z-50 max-h-[var(--available-height)] origin-[var(--transform-origin)] rounded-lg border border-border bg-popover text-popover-foreground shadow-md outline-none transition-[transform,opacity] data-[ending-style]:opacity-0 data-[starting-style]:opacity-0";
 
-function NodePopover(props: ComponentProps<typeof PopoverPrimitive.Root>) {
+function Popover(props: ComponentProps<typeof PopoverPrimitive.Root>) {
   return <PopoverPrimitive.Root {...props} />;
 }
 
-const NodePopoverTrigger = PopoverPrimitive.Trigger;
+const PopoverTrigger = PopoverPrimitive.Trigger;
 
-function NodePopoverContent({
+function PopoverContent({
   className,
   side = "bottom",
   align = "start",
@@ -47,4 +42,4 @@ function NodePopoverContent({
   );
 }
 
-export { NodePopover, NodePopoverContent, NodePopoverTrigger };
+export { Popover, PopoverTrigger, PopoverContent };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -123,9 +123,6 @@ importers:
 
   packages/app:
     dependencies:
-      '@ariakit/react':
-        specifier: ^0.4.30
-        version: 0.4.30(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@base-ui/react':
         specifier: 'catalog:'
         version: 1.5.0(@date-fns/tz@1.4.1)(@types/react@19.2.15)(date-fns@4.3.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
@@ -159,6 +156,9 @@ importers:
       '@platejs/emoji':
         specifier: ^53.1.7
         version: 53.1.7(@emoji-mart/data@1.2.1)(platejs@53.2.1(@types/react@19.2.15)(immer@10.2.0)(react-dom@19.2.6(react@19.2.6))(react-native@0.85.3(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.15)(react@19.2.6))(react@19.2.6)(scheduler@0.27.0)(use-sync-external-store@1.6.0(react@19.2.6)))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@platejs/floating':
+        specifier: ^53.0.0
+        version: 53.0.0(platejs@53.2.1(@types/react@19.2.15)(immer@10.2.0)(react-dom@19.2.6(react@19.2.6))(react-native@0.85.3(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.15)(react@19.2.6))(react@19.2.6)(scheduler@0.27.0)(use-sync-external-store@1.6.0(react@19.2.6)))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@platejs/indent':
         specifier: ^53.0.0
         version: 53.0.0(platejs@53.2.1(@types/react@19.2.15)(immer@10.2.0)(react-dom@19.2.6(react@19.2.6))(react-native@0.85.3(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.15)(react@19.2.6))(react@19.2.6)(scheduler@0.27.0)(use-sync-external-store@1.6.0(react@19.2.6)))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
@@ -174,6 +174,9 @@ importers:
       '@platejs/media':
         specifier: ^53.1.4
         version: 53.1.4(platejs@53.2.1(@types/react@19.2.15)(immer@10.2.0)(react-dom@19.2.6(react@19.2.6))(react-native@0.85.3(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.15)(react@19.2.6))(react@19.2.6)(scheduler@0.27.0)(use-sync-external-store@1.6.0(react@19.2.6)))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@platejs/selection':
+        specifier: ^53.1.6
+        version: 53.1.6(platejs@53.2.1(@types/react@19.2.15)(immer@10.2.0)(react-dom@19.2.6(react@19.2.6))(react-native@0.85.3(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.15)(react@19.2.6))(react@19.2.6)(scheduler@0.27.0)(use-sync-external-store@1.6.0(react@19.2.6)))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@platejs/slash-command':
         specifier: ^53.0.0
         version: 53.0.0(platejs@53.2.1(@types/react@19.2.15)(immer@10.2.0)(react-dom@19.2.6(react@19.2.6))(react-native@0.85.3(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.15)(react@19.2.6))(react@19.2.6)(scheduler@0.27.0)(use-sync-external-store@1.6.0(react@19.2.6)))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
@@ -649,37 +652,6 @@ packages:
     peerDependenciesMeta:
       zod:
         optional: true
-
-  '@ariakit/components@0.1.3':
-    resolution: {integrity: sha512-l22VB1g0Dz6zrKyDjykg8uXemUGolaeJjcLKf9XY5iSxzuU0PZTLSmRfJFq4pjTHsRroL4HM96f6J0Pivu2oOg==}
-
-  '@ariakit/react-components@0.2.0':
-    resolution: {integrity: sha512-hoAwGSh5xQ0va4oWSTOmoNIIDS+90eVzg6XceCC9WMyhRn1I1YVluxCqltZ9UY+6vzu7PpJDvC4g5N2rmCh6og==}
-    peerDependencies:
-      react: ^17.0.0 || ^18.0.0 || ^19.0.0
-      react-dom: ^17.0.0 || ^18.0.0 || ^19.0.0
-
-  '@ariakit/react-store@0.1.3':
-    resolution: {integrity: sha512-x8kjHcDoEkTX5bu3qkSfnvRCZuqXtjQZ1seohIWq8NPAfB0qe6q3GlGwCVCXw62Tlcf44SwxpuRQYQyj0/eurw==}
-    peerDependencies:
-      react: ^17.0.0 || ^18.0.0 || ^19.0.0
-
-  '@ariakit/react-utils@0.1.3':
-    resolution: {integrity: sha512-eaqLU+7lknPWzcWK7CYQw9Mu52c6If3jc8wm08Fw/hobOCeeG97Z865PQeNYQMK7BYqb01ByVNaIPEWYwcPkfw==}
-    peerDependencies:
-      react: ^17.0.0 || ^18.0.0 || ^19.0.0
-
-  '@ariakit/react@0.4.30':
-    resolution: {integrity: sha512-7QAS4uAoSp1Avekp1ve8xLRPm4E7wLIQFfYM08cHfgMfBBGQGkxrXFqP3QmqEMTUa99H4ZHK9unL05+752cBhQ==}
-    peerDependencies:
-      react: ^17.0.0 || ^18.0.0 || ^19.0.0
-      react-dom: ^17.0.0 || ^18.0.0 || ^19.0.0
-
-  '@ariakit/store@0.1.3':
-    resolution: {integrity: sha512-EAKGIUbHGKH9Kx53ae17+5l/b/z1VUKqiyHcV675AKn1ed1qsLEHX2KovFf+eHLtGBgINSd0NXv11LIe3x/uFA==}
-
-  '@ariakit/utils@0.1.3':
-    resolution: {integrity: sha512-OMdM631rIiDLYr1nnd1vtGyLvlYt08APMa2TJACA8Myn80PF+XtH9ZLBXTVUuUnlrYVyY2duX+EOkg6z9/NeCA==}
 
   '@aws-crypto/crc32@5.2.0':
     resolution: {integrity: sha512-nLbCWqQNgUiwwtFsen1AdzAtvuLRsQS8rYgMuxCrdKf9kOssamGLuPwyTY9wyYblNr9+1XM8v6zoDTPPSIeANg==}
@@ -2978,6 +2950,13 @@ packages:
       react: '>=18.0.0'
       react-dom: '>=18.0.0'
 
+  '@platejs/selection@53.1.6':
+    resolution: {integrity: sha512-d3pJur7bkkDd2DUcJfYrpRi+5/WgQyYiD1/keG4OveNhc2SN/lE3RaFSNbGVTdHjwJ/20mslw0JNAgyjZrPGkg==}
+    peerDependencies:
+      platejs: '>=53.0.0'
+      react: '>=18.0.0'
+      react-dom: '>=18.0.0'
+
   '@platejs/slash-command@53.0.0':
     resolution: {integrity: sha512-JXK/HykJcGOMhw8bM7NqrlubDkeyThokDqnZoIYDu9PykR8qUupcCjjdz23X2jabNSLPbnuQJKkFvep6H5sl+Q==}
     peerDependencies:
@@ -4810,6 +4789,9 @@ packages:
   cookie@1.1.1:
     resolution: {integrity: sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==}
     engines: {node: '>=18'}
+
+  copy-to-clipboard@3.3.3:
+    resolution: {integrity: sha512-2KV8NhB5JqC3ky0r9PMCAZKbUHSwtEo4CwCs0KXgruG43gX5PMqDEBbVU4OUzw2MuAWUfsuFmWvEKG5QRfSnJA==}
 
   core-js-compat@3.49.0:
     resolution: {integrity: sha512-VQXt1jr9cBz03b331DFDCCP90b3fanciLkgiOoy8SBHy06gNf+vQ1A3WFLqG7I8TipYIKeYK9wxd0tUrvHcOZA==}
@@ -8388,6 +8370,9 @@ packages:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
     engines: {node: '>=8.0'}
 
+  toggle-selection@1.0.6:
+    resolution: {integrity: sha512-BiZS+C1OS8g/q2RRbJmy59xpyghNBqrr6k5L/uKBGRsTfxmu3ffiRnd8mlGPUVayg8pvfi5urfnu8TU7DVOkLQ==}
+
   toidentifier@1.0.1:
     resolution: {integrity: sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==}
     engines: {node: '>=0.6'}
@@ -9005,48 +8990,6 @@ snapshots:
       json-schema-to-ts: 3.1.1
     optionalDependencies:
       zod: 4.4.3
-
-  '@ariakit/components@0.1.3':
-    dependencies:
-      '@ariakit/store': 0.1.3
-      '@ariakit/utils': 0.1.3
-
-  '@ariakit/react-components@0.2.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
-    dependencies:
-      '@ariakit/components': 0.1.3
-      '@ariakit/react-store': 0.1.3(react@19.2.6)
-      '@ariakit/react-utils': 0.1.3(react@19.2.6)
-      '@ariakit/store': 0.1.3
-      '@ariakit/utils': 0.1.3
-      '@floating-ui/dom': 1.7.6
-      react: 19.2.6
-      react-dom: 19.2.6(react@19.2.6)
-
-  '@ariakit/react-store@0.1.3(react@19.2.6)':
-    dependencies:
-      '@ariakit/react-utils': 0.1.3(react@19.2.6)
-      '@ariakit/store': 0.1.3
-      '@ariakit/utils': 0.1.3
-      react: 19.2.6
-      use-sync-external-store: 1.6.0(react@19.2.6)
-
-  '@ariakit/react-utils@0.1.3(react@19.2.6)':
-    dependencies:
-      '@ariakit/store': 0.1.3
-      '@ariakit/utils': 0.1.3
-      react: 19.2.6
-
-  '@ariakit/react@0.4.30(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
-    dependencies:
-      '@ariakit/react-components': 0.2.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      react: 19.2.6
-      react-dom: 19.2.6(react@19.2.6)
-
-  '@ariakit/store@0.1.3':
-    dependencies:
-      '@ariakit/utils': 0.1.3
-
-  '@ariakit/utils@0.1.3': {}
 
   '@aws-crypto/crc32@5.2.0':
     dependencies:
@@ -11514,6 +11457,14 @@ snapshots:
       react-compiler-runtime: 1.0.0(react@19.2.6)
       react-dom: 19.2.6(react@19.2.6)
 
+  '@platejs/selection@53.1.6(platejs@53.2.1(@types/react@19.2.15)(immer@10.2.0)(react-dom@19.2.6(react@19.2.6))(react-native@0.85.3(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.15)(react@19.2.6))(react@19.2.6)(scheduler@0.27.0)(use-sync-external-store@1.6.0(react@19.2.6)))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
+    dependencies:
+      copy-to-clipboard: 3.3.3
+      platejs: 53.2.1(@types/react@19.2.15)(immer@10.2.0)(react-dom@19.2.6(react@19.2.6))(react-native@0.85.3(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.15)(react@19.2.6))(react@19.2.6)(scheduler@0.27.0)(use-sync-external-store@1.6.0(react@19.2.6))
+      react: 19.2.6
+      react-compiler-runtime: 1.0.0(react@19.2.6)
+      react-dom: 19.2.6(react@19.2.6)
+
   '@platejs/slash-command@53.0.0(platejs@53.2.1(@types/react@19.2.15)(immer@10.2.0)(react-dom@19.2.6(react@19.2.6))(react-native@0.85.3(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.15)(react@19.2.6))(react@19.2.6)(scheduler@0.27.0)(use-sync-external-store@1.6.0(react@19.2.6)))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
     dependencies:
       '@platejs/combobox': 53.0.0(platejs@53.2.1(@types/react@19.2.15)(immer@10.2.0)(react-dom@19.2.6(react@19.2.6))(react-native@0.85.3(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.15)(react@19.2.6))(react@19.2.6)(scheduler@0.27.0)(use-sync-external-store@1.6.0(react@19.2.6)))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
@@ -13511,6 +13462,10 @@ snapshots:
   cookie@0.7.2: {}
 
   cookie@1.1.1: {}
+
+  copy-to-clipboard@3.3.3:
+    dependencies:
+      toggle-selection: 1.0.6
 
   core-js-compat@3.49.0:
     dependencies:
@@ -18136,6 +18091,8 @@ snapshots:
   to-regex-range@5.0.1:
     dependencies:
       is-number: 7.0.0
+
+  toggle-selection@1.0.6: {}
 
   toidentifier@1.0.1: {}
 


### PR DESCRIPTION
Third editor-overhaul work package: all editor menus on Base UI, and the combobox crash class eliminated.

## What

- **New inline-combobox** (one component for slash, emoji, and Phase F wiki-autocomplete): React-free core where every operation re-resolves the element path at call time — an element already gone (undo/redo) is a strict no-op, so stale restores can never replay into the doc. That kills the reproducible ':tada' → Escape → undo-spam crash that tore the page to about:blank. Trigger nodes (`slash_input`/`emoji_input`) are excluded from autosave serialization structurally — the 'Unreachable code' serializer warning is now impossible.
- **Slash menu**: full vocabulary (toggle, 2/3 columns, date, block/inline equation, embed via URL dialog, mermaid) riding WP2's transforms verbatim.
- **Block context + grip menu**: one Base UI implementation (virtual anchor) — delete, duplicate, turn-into, move; frontmatter excluded. Copy-link-to-block omitted: markdown has no block-anchor concept.
- **Turn-into** exactly per the locked decision: paragraph/H1-3/quote/callout(`[!NOTE]`)/code/toggle/todo/bullet/numbered — no columns.
- **Floating toolbar** on @platejs/floating (idle path) with the inline-AI accept/discard machine untouched (busy path keeps its positioning); link popover (open/edit/unlink); column resize gets pointer capture + pointercancel.
- **ariakit fully removed** (package.json, lockfile, source — grep zero).
- Review fix: toolbar dropdown items (Ask AI, turn-into) were dead to mouse clicks — detached Menu.Roots read as hover triggers + the floating hook treated portaled popups as click-outside. Real MenuTriggers + the hook's escape hatch; mouse-driven AI accept/discard now byte-verified.
- The reported undo-spam renderer freeze was diagnosed to a wedged automation daemon (3,000+ synthetic keydowns with zero commands, reproduced on pre-WP3 main) — not an app bug; app-side hardening landed anyway (selection-only changes no longer trigger serializes).

## Verification

Gates green ×2 (252 app tests); WP1 fixtures byte-untouched; crash recipe ×5 over raw CDP — zero crashes/warnings, files byte-clean after every round; every slash entry saves canonical (reopen-checked); keyboard-complete menus; mid-drag pointer-leave commits once.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Large editor surface area (Slate mutations, autosave serialization, undo history) with behavioral fixes for combobox cancel and menu focus; mitigated by extensive new headless tests and canonical round-trip assertions.
> 
> **Overview**
> **Editor menus and comboboxes** move from Ariakit to **Base UI** (`@ariakit/react` removed; `@platejs/floating` and `@platejs/selection` added). The inline combobox (`/` slash, `:` emoji) is rebuilt with a React-free **`combobox-input`** core: cancel/commit re-resolve trigger paths and no-op after undo, which fixes the Escape → undo crash class; **`slash_input` / `emoji_input`** are added to markdown **`disallowedNodes`** so mid-combobox autosaves skip UI nodes.
> 
> **Block chrome** is wired via **`BlockMenuKit`**: right-click and drag-grip share one **`BlockMenu`** (duplicate, delete, move up/down, turn-into), with selection overlay and cursor ghost while popovers hold focus. The grip’s inline duplicate/delete/turn-into menu is removed in favor of that shared menu.
> 
> **Turn-into** is centralized in **`block-transforms`** (callout `[!NOTE]`, code, toggle, lists, toggle-summary retargeting, **`moveBlocks`**) for slash, block menu, and toolbar. The **slash menu** expands to the full insert set (columns, date, equations, mermaid, embed URL dialog). The **selection toolbar** uses **`@platejs/floating`** when idle, keeps the fixed-position path for inline-AI busy states, uses real **`MenuTrigger`**s (mouse click fix), and shows the current block type on turn-into. **Link** gets an open/edit/unlink popover; date/equation nodes use shared **`Popover`**.
> 
> **Save correctness**: empty columns serialize as **`<column />`**; **`markdown-editor`** skips serialize on selection-only ops. Column resize adds pointer capture and **`pointercancel`**. Per-block **placeholders** replace the single editor placeholder.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a543ed033da25f6017ce8e736932b542f256e01a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Rebuilt the editor’s menus and chrome on Base UI, replaced `@ariakit/react`, and shipped a safer inline combobox plus a unified block menu and a floating toolbar. This fixes the combobox crash, keeps bytes canonical, and improves menu UX.

- **New Features**
  - New inline combobox for slash and emoji; React-free core; trigger nodes (`slash_input`, `emoji_input`) are excluded from autosave serialization.
  - Full slash menu: toggle, columns (2/3), date, block/inline equation, mermaid, and URL embeds; all insert/convert routes use shared transforms.
  - One block menu for right‑click and grip (delete, duplicate, move up/down, turn‑into); block selection overlay and cursor overlay included.
  - Floating selection toolbar on `@platejs/floating`; link popover added (open, edit, unlink); column resize gets pointer capture and cancel handling.
  - Per‑block placeholders replace global placeholder; empty columns serialize canonically to `<column />`.
  - Dependencies: removed `@ariakit/react`; added `@platejs/floating` and `@platejs/selection`.

- **Bug Fixes**
  - Combobox cancel/undo crash eliminated; operations re‑resolve paths, are no‑ops if the trigger is gone; keystrokes racing into the trigger are absorbed.
  - Toolbar dropdown items are click‑reliable with real MenuTriggers and click‑outside escape hatches.
  - Toggle summary participates in turn‑into; current block type label is accurate.
  - Selection‑only changes no longer trigger serializes, reducing unnecessary work under input storms.

<sup>Written for commit a543ed033da25f6017ce8e736932b542f256e01a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kyh/inteligir/pull/360?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

