### PR TITLE
Phase 6: delegation snapshots — pre-run file copy + Restore original

### DIFF
--- a/gates2.log
+++ b/gates2.log
@@ -1,0 +1,1330 @@
+
+> init@ typecheck /private/tmp/claude-501/-Users-kyh-Documents-Projects-inteligir/a9e356f6-5c77-4f57-9f17-0c475958a892/scratchpad/ci-repro
+> turbo run typecheck
+
+• turbo 2.9.14
+
+   • Packages in scope: @repo/agent-runtime, @repo/app, @repo/cli, @repo/core, @repo/desktop, @repo/host, @repo/pi-driver, @repo/server, @repo/ui, @repo/web
+   • Running typecheck in 10 packages
+   • Remote caching disabled
+
+@repo/agent-runtime:typecheck: cache hit, replaying logs ed0daff82d38d675
+@repo/agent-runtime:typecheck: 
+@repo/agent-runtime:typecheck: > @repo/agent-runtime@0.1.0 typecheck /private/tmp/claude-501/-Users-kyh-Documents-Projects-inteligir/a9e356f6-5c77-4f57-9f17-0c475958a892/scratchpad/ci-repro/packages/agent-runtime
+@repo/agent-runtime:typecheck: > tsc --noEmit --emitDeclarationOnly false
+@repo/agent-runtime:typecheck: 
+@repo/pi-driver:typecheck: cache hit, replaying logs f58083beff9ba57a
+@repo/pi-driver:typecheck: 
+@repo/pi-driver:typecheck: > @repo/pi-driver@0.1.0 typecheck /private/tmp/claude-501/-Users-kyh-Documents-Projects-inteligir/a9e356f6-5c77-4f57-9f17-0c475958a892/scratchpad/ci-repro/packages/pi-driver
+@repo/pi-driver:typecheck: > tsc --noEmit --emitDeclarationOnly false
+@repo/pi-driver:typecheck: 
+@repo/ui:typecheck: cache hit, replaying logs d5f654d739d5bfcb
+@repo/ui:typecheck: 
+@repo/ui:typecheck: > @repo/ui@0.1.0 typecheck /private/tmp/claude-501/-Users-kyh-Documents-Projects-inteligir/a9e356f6-5c77-4f57-9f17-0c475958a892/scratchpad/ci-repro/packages/ui
+@repo/ui:typecheck: > tsc --noEmit --emitDeclarationOnly false
+@repo/ui:typecheck: 
+@repo/web:typecheck: cache hit, replaying logs 6497bfaf1d85b2ab
+@repo/web:typecheck: 
+@repo/web:typecheck: > @repo/web@0.1.0 typecheck /private/tmp/claude-501/-Users-kyh-Documents-Projects-inteligir/a9e356f6-5c77-4f57-9f17-0c475958a892/scratchpad/ci-repro/apps/web
+@repo/web:typecheck: > tsc --noEmit
+@repo/web:typecheck: 
+@repo/core:typecheck: cache hit, replaying logs 7c3d8948541391e5
+@repo/core:typecheck: 
+@repo/core:typecheck: > @repo/core@0.1.0 typecheck /private/tmp/claude-501/-Users-kyh-Documents-Projects-inteligir/a9e356f6-5c77-4f57-9f17-0c475958a892/scratchpad/ci-repro/packages/core
+@repo/core:typecheck: > tsc --noEmit --emitDeclarationOnly false
+@repo/core:typecheck: 
+@repo/app:typecheck: cache hit, replaying logs 106f80a6d6b032be
+@repo/app:typecheck: 
+@repo/app:typecheck: > @repo/app@0.1.0 typecheck /private/tmp/claude-501/-Users-kyh-Documents-Projects-inteligir/a9e356f6-5c77-4f57-9f17-0c475958a892/scratchpad/ci-repro/packages/app
+@repo/app:typecheck: > tsc --noEmit --emitDeclarationOnly false
+@repo/app:typecheck: 
+@repo/host:typecheck: cache miss, executing af9bf4fca54c4546
+@repo/server:typecheck: cache miss, executing 3e5c4710dfc8aa5f
+@repo/desktop:typecheck: cache miss, executing 8fbd56e38349d3f4
+@repo/cli:typecheck: cache miss, executing 28fe9351fadcecc6
+@repo/desktop:typecheck: 
+@repo/desktop:typecheck: > @repo/desktop@0.3.0 typecheck /private/tmp/claude-501/-Users-kyh-Documents-Projects-inteligir/a9e356f6-5c77-4f57-9f17-0c475958a892/scratchpad/ci-repro/packages/desktop
+@repo/desktop:typecheck: > tsc --noEmit
+@repo/desktop:typecheck: 
+@repo/cli:typecheck: 
+@repo/cli:typecheck: > @repo/cli@0.1.0 typecheck /private/tmp/claude-501/-Users-kyh-Documents-Projects-inteligir/a9e356f6-5c77-4f57-9f17-0c475958a892/scratchpad/ci-repro/packages/cli
+@repo/cli:typecheck: > tsc --noEmit --emitDeclarationOnly false
+@repo/cli:typecheck: 
+@repo/server:typecheck: 
+@repo/server:typecheck: > @repo/server@0.1.0 typecheck /private/tmp/claude-501/-Users-kyh-Documents-Projects-inteligir/a9e356f6-5c77-4f57-9f17-0c475958a892/scratchpad/ci-repro/packages/server
+@repo/server:typecheck: > tsc --noEmit --emitDeclarationOnly false
+@repo/server:typecheck: 
+@repo/host:typecheck: 
+@repo/host:typecheck: > @repo/host@0.1.0 typecheck /private/tmp/claude-501/-Users-kyh-Documents-Projects-inteligir/a9e356f6-5c77-4f57-9f17-0c475958a892/scratchpad/ci-repro/packages/host
+@repo/host:typecheck: > tsc --noEmit --emitDeclarationOnly false
+@repo/host:typecheck: 
+
+ Tasks:    10 successful, 10 total
+Cached:    6 cached, 10 total
+  Time:    3.643s 
+
+
+> init@ lint /private/tmp/claude-501/-Users-kyh-Documents-Projects-inteligir/a9e356f6-5c77-4f57-9f17-0c475958a892/scratchpad/ci-repro
+> oxlint --report-unused-disable-directives
+
+
+> init@ format /private/tmp/claude-501/-Users-kyh-Documents-Projects-inteligir/a9e356f6-5c77-4f57-9f17-0c475958a892/scratchpad/ci-repro
+> oxfmt --check
+
+Checking formatting...
+
+All matched files use the correct format.
+Finished in 308ms on 382 files using 10 threads.
+
+> init@ test /private/tmp/claude-501/-Users-kyh-Documents-Projects-inteligir/a9e356f6-5c77-4f57-9f17-0c475958a892/scratchpad/ci-repro
+> turbo run test
+
+• turbo 2.9.14
+
+   • Packages in scope: @repo/agent-runtime, @repo/app, @repo/cli, @repo/core, @repo/desktop, @repo/host, @repo/pi-driver, @repo/server, @repo/ui, @repo/web
+   • Running test in 10 packages
+   • Remote caching disabled
+
+@repo/agent-runtime:test: cache bypass, force executing 0b26ce0ab0072234
+@repo/core:test: cache bypass, force executing ee0193ff7bcdcd1b
+@repo/app:test: cache bypass, force executing 64e7654f4c7758cf
+@repo/host:test: cache bypass, force executing ccd0f10d0a3dce4c
+@repo/server:test: cache bypass, force executing ec141bd43f602cfa
+@repo/desktop:test: cache bypass, force executing 8d4e40bfce852609
+@repo/core:test: 
+@repo/core:test: > @repo/core@0.1.0 test /private/tmp/claude-501/-Users-kyh-Documents-Projects-inteligir/a9e356f6-5c77-4f57-9f17-0c475958a892/scratchpad/ci-repro/packages/core
+@repo/core:test: > vitest run
+@repo/core:test: 
+@repo/app:test: 
+@repo/app:test: > @repo/app@0.1.0 test /private/tmp/claude-501/-Users-kyh-Documents-Projects-inteligir/a9e356f6-5c77-4f57-9f17-0c475958a892/scratchpad/ci-repro/packages/app
+@repo/app:test: > vitest run
+@repo/app:test: 
+@repo/desktop:test: 
+@repo/desktop:test: > @repo/desktop@0.3.0 test /private/tmp/claude-501/-Users-kyh-Documents-Projects-inteligir/a9e356f6-5c77-4f57-9f17-0c475958a892/scratchpad/ci-repro/packages/desktop
+@repo/desktop:test: > vitest run
+@repo/desktop:test: 
+@repo/agent-runtime:test: 
+@repo/agent-runtime:test: > @repo/agent-runtime@0.1.0 test /private/tmp/claude-501/-Users-kyh-Documents-Projects-inteligir/a9e356f6-5c77-4f57-9f17-0c475958a892/scratchpad/ci-repro/packages/agent-runtime
+@repo/agent-runtime:test: > vitest run
+@repo/agent-runtime:test: 
+@repo/host:test: 
+@repo/host:test: > @repo/host@0.1.0 test /private/tmp/claude-501/-Users-kyh-Documents-Projects-inteligir/a9e356f6-5c77-4f57-9f17-0c475958a892/scratchpad/ci-repro/packages/host
+@repo/host:test: > vitest run
+@repo/host:test: 
+@repo/server:test: 
+@repo/server:test: > @repo/server@0.1.0 test /private/tmp/claude-501/-Users-kyh-Documents-Projects-inteligir/a9e356f6-5c77-4f57-9f17-0c475958a892/scratchpad/ci-repro/packages/server
+@repo/server:test: > vitest run
+@repo/server:test: 
+@repo/desktop:test: 
+@repo/desktop:test: [1m[30m[46m RUN [49m[39m[22m [36mv4.1.7 [39m[90m/private/tmp/claude-501/-Users-kyh-Documents-Projects-inteligir/a9e356f6-5c77-4f57-9f17-0c475958a892/scratchpad/ci-repro/packages/desktop[39m
+@repo/desktop:test: 
+@repo/app:test: 
+@repo/host:test: 
+@repo/app:test: [1m[30m[46m RUN [49m[39m[22m [36mv4.1.7 [39m[90m/private/tmp/claude-501/-Users-kyh-Documents-Projects-inteligir/a9e356f6-5c77-4f57-9f17-0c475958a892/scratchpad/ci-repro/packages/app[39m
+@repo/app:test: 
+@repo/host:test: [1m[30m[46m RUN [49m[39m[22m [36mv4.1.7 [39m[90m/private/tmp/claude-501/-Users-kyh-Documents-Projects-inteligir/a9e356f6-5c77-4f57-9f17-0c475958a892/scratchpad/ci-repro/packages/host[39m
+@repo/host:test: 
+@repo/core:test: 
+@repo/core:test: [1m[30m[46m RUN [49m[39m[22m [36mv4.1.7 [39m[90m/private/tmp/claude-501/-Users-kyh-Documents-Projects-inteligir/a9e356f6-5c77-4f57-9f17-0c475958a892/scratchpad/ci-repro/packages/core[39m
+@repo/core:test: 
+@repo/agent-runtime:test: 
+@repo/agent-runtime:test: [1m[30m[46m RUN [49m[39m[22m [36mv4.1.7 [39m[90m/private/tmp/claude-501/-Users-kyh-Documents-Projects-inteligir/a9e356f6-5c77-4f57-9f17-0c475958a892/scratchpad/ci-repro/packages/agent-runtime[39m
+@repo/agent-runtime:test: 
+@repo/server:test: 
+@repo/server:test: [1m[30m[46m RUN [49m[39m[22m [36mv4.1.7 [39m[90m/private/tmp/claude-501/-Users-kyh-Documents-Projects-inteligir/a9e356f6-5c77-4f57-9f17-0c475958a892/scratchpad/ci-repro/packages/server[39m
+@repo/server:test: 
+@repo/agent-runtime:test:  [32m✓[39m src/seed.test.ts [2m([22m[2m10 tests[22m[2m)[22m[32m 29[2mms[22m[39m
+@repo/desktop:test:  [32m✓[39m src/__tests__/agent-event-parser.test.ts [2m([22m[2m16 tests[22m[2m)[22m[32m 18[2mms[22m[39m
+@repo/host:test:  [32m✓[39m src/__tests__/agent-gateway.test.ts [2m([22m[2m4 tests[22m[2m)[22m[32m 185[2mms[22m[39m
+@repo/host:test:  [32m✓[39m src/__tests__/delegation-snapshots.test.ts [2m([22m[2m8 tests[22m[2m)[22m[32m 26[2mms[22m[39m
+@repo/host:test:  [32m✓[39m src/__tests__/vault.test.ts [2m([22m[2m9 tests[22m[2m)[22m[32m 35[2mms[22m[39m
+@repo/host:test:  [32m✓[39m src/__tests__/host-lock.test.ts [2m([22m[2m6 tests[22m[2m)[22m[32m 29[2mms[22m[39m
+@repo/host:test: [90mstderr[2m | src/__tests__/executor-daemon.test.ts[2m > [22m[2mexecutor daemon spawn[2m > [22m[2mfalls back to an auto-picked port when the pinned port is taken
+@repo/host:test: [22m[39m[executor] daemon start on pinned port 47888 failed, retrying on a free port: executor daemon exited (code 1) before becoming ready
+@repo/host:test: 
+@repo/host:test:  [32m✓[39m src/__tests__/agent-log.test.ts [2m([22m[2m12 tests[22m[2m)[22m[32m 31[2mms[22m[39m
+@repo/host:test:  [32m✓[39m src/__tests__/executor-daemon.test.ts [2m([22m[2m8 tests[22m[2m)[22m[32m 91[2mms[22m[39m
+@repo/core:test:  [32m✓[39m src/__tests__/bridge-wire.test.ts [2m([22m[2m14 tests[22m[2m)[22m[32m 5[2mms[22m[39m
+@repo/host:test:  [32m✓[39m src/__tests__/find-task-line.test.ts [2m([22m[2m15 tests[22m[2m)[22m[32m 101[2mms[22m[39m
+@repo/desktop:test:  [32m✓[39m src/__tests__/host-fold.test.ts [2m([22m[2m3 tests[22m[2m)[22m[32m 24[2mms[22m[39m
+@repo/core:test:  [32m✓[39m src/__tests__/bridge-ws-client.test.ts [2m([22m[2m9 tests[22m[2m)[22m[32m 38[2mms[22m[39m
+@repo/core:test: 
+@repo/core:test: [2m Test Files [22m [1m[32m2 passed[39m[22m[90m (2)[39m
+@repo/core:test: [2m      Tests [22m [1m[32m23 passed[39m[22m[90m (23)[39m
+@repo/core:test: [2m   Start at [22m 03:24:17
+@repo/core:test: [2m   Duration [22m 1.17s[2m (transform 1.01s, setup 0ms, import 1.46s, tests 42ms, environment 0ms)[22m
+@repo/core:test: 
+@repo/desktop:test:  [32m✓[39m src/__tests__/updater.test.ts [2m([22m[2m2 tests[22m[2m)[22m[32m 7[2mms[22m[39m
+@repo/desktop:test: 
+@repo/desktop:test: [2m Test Files [22m [1m[32m3 passed[39m[22m[90m (3)[39m
+@repo/desktop:test: [2m      Tests [22m [1m[32m21 passed[39m[22m[90m (21)[39m
+@repo/desktop:test: [2m   Start at [22m 03:24:17
+@repo/desktop:test: [2m   Duration [22m 1.19s[2m (transform 1.08s, setup 0ms, import 1.88s, tests 49ms, environment 0ms)[22m
+@repo/desktop:test: 
+@repo/host:test:  [32m✓[39m src/__tests__/json-store.test.ts [2m([22m[2m33 tests[22m[2m)[22m[32m 15[2mms[22m[39m
+@repo/host:test:  [32m✓[39m src/__tests__/extension.test.ts [2m([22m[2m9 tests[22m[2m)[22m[32m 62[2mms[22m[39m
+@repo/host:test:  [32m✓[39m src/__tests__/executor-restart.test.ts [2m([22m[2m3 tests[22m[2m)[22m[32m 39[2mms[22m[39m
+@repo/host:test:  [32m✓[39m src/__tests__/ui-state.test.ts [2m([22m[2m8 tests[22m[2m)[22m[32m 20[2mms[22m[39m
+@repo/host:test:  [32m✓[39m src/__tests__/handler-registry.test.ts [2m([22m[2m8 tests[22m[2m)[22m[32m 10[2mms[22m[39m
+@repo/host:test:  [32m✓[39m src/__tests__/file-key-cipher.test.ts [2m([22m[2m6 tests[22m[2m)[22m[32m 45[2mms[22m[39m
+@repo/host:test:  [32m✓[39m src/__tests__/secrets.test.ts [2m([22m[2m7 tests[22m[2m)[22m[32m 30[2mms[22m[39m
+@repo/host:test: [90mstdout[2m | src/__tests__/app-machine.test.ts[2m > [22m[2mAppMachine[2m > [22m[2mLOGIN -> logging_in -> login() -> logged_in
+@repo/host:test: [22m[39m[machine] logged_out -> logging_in
+@repo/host:test: 
+@repo/host:test: [90mstdout[2m | src/__tests__/app-machine.test.ts[2m > [22m[2mAppMachine[2m > [22m[2mLOGIN -> logging_in -> login() -> logged_in
+@repo/host:test: [22m[39m[machine] logging_in -> logged_in
+@repo/host:test: 
+@repo/host:test: [90mstdout[2m | src/__tests__/app-machine.test.ts[2m > [22m[2mAppMachine[2m > [22m[2mLOGIN failure -> error state
+@repo/host:test: [22m[39m[machine] logged_out -> logging_in
+@repo/host:test: 
+@repo/host:test: [90mstdout[2m | src/__tests__/app-machine.test.ts[2m > [22m[2mAppMachine[2m > [22m[2mLOGIN failure -> error state
+@repo/host:test: [22m[39m[machine] logging_in -> error
+@repo/host:test: 
+@repo/host:test: [90mstdout[2m | src/__tests__/app-machine.test.ts[2m > [22m[2mAppMachine[2m > [22m[2mSETUP -> setting_up -> seedResources() + startAgent() -> ready
+@repo/host:test: [22m[39m[machine] logged_in -> setting_up
+@repo/host:test: 
+@repo/host:test: [90mstdout[2m | src/__tests__/app-machine.test.ts[2m > [22m[2mAppMachine[2m > [22m[2mSETUP -> setting_up -> seedResources() + startAgent() -> ready
+@repo/host:test: [22m[39m[machine] setting_up -> ready
+@repo/host:test: 
+@repo/host:test: [90mstdout[2m | src/__tests__/app-machine.test.ts[2m > [22m[2mAppMachine[2m > [22m[2mLOGOUT -> logging_out -> teardown -> logged_out
+@repo/host:test: [22m[39m[machine] ready -> logging_out
+@repo/host:test: 
+@repo/host:test: [90mstdout[2m | src/__tests__/app-machine.test.ts[2m > [22m[2mAppMachine[2m > [22m[2mLOGOUT -> logging_out -> teardown -> logged_out
+@repo/host:test: [22m[39m[machine] logging_out -> logged_out
+@repo/host:test: 
+@repo/host:test: [90mstdout[2m | src/__tests__/app-machine.test.ts[2m > [22m[2mAppMachine[2m > [22m[2mLOGOUT failure surfaces as error instead of wedging in logging_out
+@repo/host:test: [22m[39m[machine] ready -> logging_out
+@repo/host:test: 
+@repo/host:test: [90mstdout[2m | src/__tests__/app-machine.test.ts[2m > [22m[2mAppMachine[2m > [22m[2mLOGOUT failure surfaces as error instead of wedging in logging_out
+@repo/host:test: [22m[39m[machine] logging_out -> error
+@repo/host:test: 
+@repo/host:test: [90mstdout[2m | src/__tests__/app-machine.test.ts[2m > [22m[2mAppMachine[2m > [22m[2mLOGOUT failure surfaces as error instead of wedging in logging_out
+@repo/host:test: [22m[39m[machine] error -> logging_out
+@repo/host:test: 
+@repo/host:test: [90mstdout[2m | src/__tests__/app-machine.test.ts[2m > [22m[2mAppMachine[2m > [22m[2mLOGOUT failure surfaces as error instead of wedging in logging_out
+@repo/host:test: [22m[39m[machine] logging_out -> logged_out
+@repo/host:test: 
+@repo/host:test: [90mstdout[2m | src/__tests__/app-machine.test.ts[2m > [22m[2mAppMachine[2m > [22m[2mNEW_SESSION failure surfaces as error instead of ready-with-no-agent
+@repo/host:test: [22m[39m[machine] ready -> ready
+@repo/host:test: 
+@repo/host:test: [90mstdout[2m | src/__tests__/app-machine.test.ts[2m > [22m[2mAppMachine[2m > [22m[2mNEW_SESSION failure surfaces as error instead of ready-with-no-agent
+@repo/host:test: [22m[39m[machine] ready -> error
+@repo/host:test: 
+@repo/host:test: [90mstdout[2m | src/__tests__/app-machine.test.ts[2m > [22m[2mAppMachine[2m > [22m[2mAGENT_START/AGENT_END toggle busy/idle
+@repo/host:test: [22m[39m[machine] ready -> ready
+@repo/host:test: 
+@repo/host:test: [90mstdout[2m | src/__tests__/app-machine.test.ts[2m > [22m[2mAppMachine[2m > [22m[2mAGENT_START/AGENT_END toggle busy/idle
+@repo/host:test: [22m[39m[machine] ready -> ready
+@repo/host:test: 
+@repo/host:test: [90mstdout[2m | src/__tests__/app-machine.test.ts[2m > [22m[2mAppMachine[2m > [22m[2mserializes concurrent sends
+@repo/host:test: [22m[39m[machine] logged_out -> logging_in
+@repo/host:test: 
+@repo/host:test:  [32m✓[39m src/__tests__/app-reducer.test.ts [2m([22m[2m27 tests[22m[2m)[22m[32m 5[2mms[22m[39m
+@repo/host:test: [90mstdout[2m | src/__tests__/app-machine.test.ts[2m > [22m[2mAppMachine[2m > [22m[2mserializes concurrent sends
+@repo/host:test: [22m[39m[machine] logging_in -> logged_in
+@repo/host:test: 
+@repo/host:test: [90mstdout[2m | src/__tests__/app-machine.test.ts[2m > [22m[2mAppMachine[2m > [22m[2mserializes concurrent sends
+@repo/host:test: [22m[39m[machine] logged_in -> setting_up
+@repo/host:test: 
+@repo/host:test: [90mstdout[2m | src/__tests__/app-machine.test.ts[2m > [22m[2mAppMachine[2m > [22m[2mserializes concurrent sends
+@repo/host:test: [22m[39m[machine] setting_up -> ready
+@repo/host:test: 
+@repo/host:test:  [32m✓[39m src/__tests__/google-oauth-client.test.ts [2m([22m[2m9 tests[22m[2m)[22m[32m 4[2mms[22m[39m
+@repo/host:test:  [32m✓[39m src/__tests__/app-machine.test.ts [2m([22m[2m12 tests[22m[2m)[22m[32m 63[2mms[22m[39m
+@repo/host:test:  [32m✓[39m src/__tests__/app-effects.test.ts [2m([22m[2m9 tests[22m[2m)[22m[32m 19[2mms[22m[39m
+@repo/host:test:  [32m✓[39m src/__tests__/delegation-manager.test.ts [2m([22m[2m27 tests[22m[2m)[22m[33m 821[2mms[22m[39m
+@repo/host:test:      [33m[2m✓[22m[39m never silently drops queued work at the cap (only terminal records evict) [33m 584[2mms[22m[39m
+@repo/host:test:  [32m✓[39m src/__tests__/bundles.test.ts [2m([22m[2m2 tests[22m[2m)[22m[32m 3[2mms[22m[39m
+@repo/host:test:  [32m✓[39m src/__tests__/prompt-failure-events.test.ts [2m([22m[2m3 tests[22m[2m)[22m[32m 5[2mms[22m[39m
+@repo/agent-runtime:test:  [32m✓[39m src/install.test.ts [2m([22m[2m25 tests[22m[2m)[22m[33m 2331[2mms[22m[39m
+@repo/agent-runtime:test:      [33m[2m✓[22m[39m never clobbers an existing install when the new download fails verification [33m 587[2mms[22m[39m
+@repo/agent-runtime:test: 
+@repo/agent-runtime:test: [2m Test Files [22m [1m[32m2 passed[39m[22m[90m (2)[39m
+@repo/agent-runtime:test: [2m      Tests [22m [1m[32m35 passed[39m[22m[90m (35)[39m
+@repo/agent-runtime:test: [2m   Start at [22m 03:24:17
+@repo/agent-runtime:test: [2m   Duration [22m 2.81s[2m (transform 152ms, setup 0ms, import 238ms, tests 2.36s, environment 0ms)[22m
+@repo/agent-runtime:test: 
+@repo/host:test:  [32m✓[39m src/__tests__/register-handlers.test.ts [2m([22m[2m1 test[22m[2m)[22m[32m 3[2mms[22m[39m
+@repo/host:test: 
+@repo/host:test: [2m Test Files [22m [1m[32m22 passed[39m[22m[90m (22)[39m
+@repo/host:test: [2m      Tests [22m [1m[32m226 passed[39m[22m[90m (226)[39m
+@repo/host:test: [2m   Start at [22m 03:24:17
+@repo/host:test: [2m   Duration [22m 2.99s[2m (transform 4.49s, setup 0ms, import 10.53s, tests 1.64s, environment 8ms)[22m
+@repo/host:test: 
+@repo/app:test:  [32m✓[39m src/__tests__/markdown-pipeline.test.ts [2m([22m[2m37 tests[22m[2m)[22m[33m 685[2mms[22m[39m
+@repo/app:test:  [32m✓[39m src/__tests__/inline-combobox.test.ts [2m([22m[2m9 tests[22m[2m)[22m[33m 411[2mms[22m[39m
+@repo/app:test:  [32m✓[39m src/__tests__/block-transforms.test.ts [2m([22m[2m12 tests[22m[2m)[22m[33m 482[2mms[22m[39m
+@repo/app:test:  [32m✓[39m src/__tests__/kit-parity.test.ts [2m([22m[2m8 tests[22m[2m)[22m[33m 537[2mms[22m[39m
+@repo/app:test:  [32m✓[39m src/__tests__/editor-kits.test.ts [2m([22m[2m22 tests[22m[2m)[22m[33m 589[2mms[22m[39m
+@repo/app:test:  [32m✓[39m src/__tests__/vault-editor.test.ts [2m([22m[2m11 tests[22m[2m)[22m[32m 20[2mms[22m[39m
+@repo/app:test:  [32m✓[39m src/__tests__/agent-store-send.test.ts [2m([22m[2m2 tests[22m[2m)[22m[32m 21[2mms[22m[39m
+@repo/app:test:  [32m✓[39m src/__tests__/note-context.test.ts [2m([22m[2m6 tests[22m[2m)[22m[32m 21[2mms[22m[39m
+@repo/app:test:  [32m✓[39m src/__tests__/markdown-corpus.test.ts [2m([22m[2m17 tests[22m[2m)[22m[33m 1248[2mms[22m[39m
+@repo/app:test:      [33m[2m✓[22m[39m docs/replatform-plan.md → letters-diverge [33m 346[2mms[22m[39m
+@repo/app:test:      [33m[2m✓[22m[39m round-trips rich-safe corpus files idempotently and letters-preserving [33m 674[2mms[22m[39m
+@repo/app:test:  [32m✓[39m src/__tests__/voice-store.test.ts [2m([22m[2m14 tests[22m[2m)[22m[32m 35[2mms[22m[39m
+@repo/app:test:  [32m✓[39m src/__tests__/vault-tree.test.ts [2m([22m[2m5 tests[22m[2m)[22m[32m 12[2mms[22m[39m
+@repo/app:test:  [32m✓[39m src/__tests__/voice-machine.test.ts [2m([22m[2m13 tests[22m[2m)[22m[32m 4[2mms[22m[39m
+@repo/app:test:  [32m✓[39m src/__tests__/markdown-roundtrip.test.ts [2m([22m[2m63 tests[22m[2m)[22m[33m 1545[2mms[22m[39m
+@repo/app:test:  [32m✓[39m src/__tests__/todo-item.test.ts [2m([22m[2m3 tests[22m[2m)[22m[32m 25[2mms[22m[39m
+@repo/app:test:  [32m✓[39m src/__tests__/markdown-fixpoint.test.ts [2m([22m[2m4 tests[22m[2m)[22m[32m 90[2mms[22m[39m
+@repo/app:test:  [32m✓[39m src/__tests__/connector-install.test.ts [2m([22m[2m25 tests[22m[2m)[22m[33m 3019[2mms[22m[39m
+@repo/app:test:      [33m[2m✓[22m[39m surfaces the consent URL in the browser and resolves once the callback lands [33m 1504[2mms[22m[39m
+@repo/app:test:      [33m[2m✓[22m[39m rolls back the created integration when consent fails (denied callback) [33m 1503[2mms[22m[39m
+@repo/app:test: [90mstderr[2m | src/__tests__/markdown-adversarial.test.ts[2m > [22m[2madversarial round-trip hunt[2m > [22m[2mhandcrafted corpus upholds the gate invariants
+@repo/app:test: [22m[39mUnreachable code: {"children":[{"text":"x"}],"type":"code_line"}
+@repo/app:test: Unreachable code: {"children":[{"text":"x"}],"type":"code_line"}
+@repo/app:test: 
+@repo/app:test: [90mstderr[2m | src/__tests__/markdown-adversarial.test.ts[2m > [22m[2madversarial round-trip hunt[2m > [22m[2mseeded fuzz corpus upholds the gate invariants
+@repo/app:test: [22m[39mUnreachable code: {"children":[{"text":""}],"type":"code_line"}
+@repo/app:test: Unreachable code: {"children":[{"text":""}],"type":"code_line"}
+@repo/app:test: 
+@repo/server:test: [90mstderr[2m | src/__tests__/create-server.test.ts[2m > [22m[2mcreateServer[2m > [22m[2mdrops malformed and unknown frames without crashing
+@repo/server:test: [22m[39m[server] dropped client frame: unrecognized client frame
+@repo/server:test: [server] dropped client frame: unrecognized client frame
+@repo/server:test: [server] dropped client frame: unrecognized client frame
+@repo/server:test: 
+@repo/server:test:  [32m✓[39m src/__tests__/create-server.test.ts [2m([22m[2m11 tests[22m[2m)[22m[33m 7283[2mms[22m[39m
+@repo/server:test:      [33m[2m✓[22m[39m serves static assets with an SPA fallback [33m 3072[2mms[22m[39m
+@repo/server:test:      [33m[2m✓[22m[39m rejects non-loopback Host headers (DNS rebinding) [33m 4008[2mms[22m[39m
+@repo/server:test: 
+@repo/server:test: [2m Test Files [22m [1m[32m1 passed[39m[22m[90m (1)[39m
+@repo/server:test: [2m      Tests [22m [1m[32m11 passed[39m[22m[90m (11)[39m
+@repo/server:test: [2m   Start at [22m 03:24:18
+@repo/server:test: [2m   Duration [22m 8.38s[2m (transform 457ms, setup 0ms, import 797ms, tests 7.28s, environment 0ms)[22m
+@repo/server:test: 
+@repo/app:test:  [32m✓[39m src/__tests__/markdown-adversarial.test.ts [2m([22m[2m3 tests[22m[2m)[22m[33m 10980[2mms[22m[39m
+@repo/app:test:      [33m[2m✓[22m[39m handcrafted corpus upholds the gate invariants [33m 2336[2mms[22m[39m
+@repo/app:test:      [33m[2m✓[22m[39m seeded fuzz corpus upholds the gate invariants [33m 1435[2mms[22m[39m
+@repo/app:test:      [33m[2m✓[22m[39m pathological nesting never escapes analyzeMarkdown [33m 7207[2mms[22m[39m
+@repo/app:test: 
+@repo/app:test: [2m Test Files [22m [1m[32m17 passed[39m[22m[90m (17)[39m
+@repo/app:test: [2m      Tests [22m [1m[32m254 passed[39m[22m[90m (254)[39m
+@repo/app:test: [2m   Start at [22m 03:24:17
+@repo/app:test: [2m   Duration [22m 13.36s[2m (transform 4.97s, setup 0ms, import 19.91s, tests 19.72s, environment 1ms)[22m
+@repo/app:test: 
+
+ Tasks:    6 successful, 6 total
+Cached:    0 cached, 6 total
+  Time:    13.907s 
+
+
+> init@ knip /private/tmp/claude-501/-Users-kyh-Documents-Projects-inteligir/a9e356f6-5c77-4f57-9f17-0c475958a892/scratchpad/ci-repro
+> knip
+
+
+> init@ build /private/tmp/claude-501/-Users-kyh-Documents-Projects-inteligir/a9e356f6-5c77-4f57-9f17-0c475958a892/scratchpad/ci-repro
+> turbo run build
+
+• turbo 2.9.14
+
+   • Packages in scope: @repo/agent-runtime, @repo/app, @repo/cli, @repo/core, @repo/desktop, @repo/host, @repo/pi-driver, @repo/server, @repo/ui, @repo/web
+   • Running build in 10 packages
+   • Remote caching disabled
+
+@repo/web:build: cache hit, replaying logs 56bce3b5524bb170
+@repo/web:build: 
+@repo/web:build: > @repo/web@0.1.0 build /private/tmp/claude-501/-Users-kyh-Documents-Projects-inteligir/a9e356f6-5c77-4f57-9f17-0c475958a892/scratchpad/ci-repro/apps/web
+@repo/web:build: > next build --turbopack
+@repo/web:build: 
+@repo/web:build: ⚠ Warning: Next.js inferred your workspace root, but it may not be correct.
+@repo/web:build:  We detected multiple lockfiles and selected the directory of /private/tmp/claude-501/-Users-kyh-Documents-Projects-inteligir/a9e356f6-5c77-4f57-9f17-0c475958a892/scratchpad/package-lock.json as the root directory.
+@repo/web:build:  To silence this warning, set `turbopack.root` in your Next.js config, or consider removing one of the lockfiles if it's not needed.
+@repo/web:build:    See https://nextjs.org/docs/app/api-reference/config/next-config-js/turbopack#root-directory for more information.
+@repo/web:build:  Detected additional lockfiles: 
+@repo/web:build:    * /private/tmp/claude-501/-Users-kyh-Documents-Projects-inteligir/a9e356f6-5c77-4f57-9f17-0c475958a892/scratchpad/ci-repro/pnpm-workspace.yaml
+@repo/web:build: 
+@repo/web:build: ▲ Next.js 16.2.6 (Turbopack)
+@repo/web:build: - Cache Components enabled
+@repo/web:build: 
+@repo/web:build:   Creating an optimized production build ...
+@repo/web:build: ✓ Compiled successfully in 3.3s
+@repo/web:build:   Running TypeScript ...
+@repo/web:build:   Finished TypeScript in 1960ms ...
+@repo/web:build:   Collecting page data using 5 workers ...
+@repo/web:build:   Generating static pages using 5 workers (0/4) ...
+@repo/web:build:   Generating static pages using 5 workers (1/4) 
+@repo/web:build:   Generating static pages using 5 workers (2/4) 
+@repo/web:build:   Generating static pages using 5 workers (3/4) 
+@repo/web:build: ✓ Generating static pages using 5 workers (4/4) in 381ms
+@repo/web:build:   Finalizing page optimization ...
+@repo/web:build: 
+@repo/web:build: Route (app)      Revalidate  Expire
+@repo/web:build: ┌ ○ /                    1h      1d
+@repo/web:build: ├ ○ /_not-found
+@repo/web:build: └ ○ /robots.txt
+@repo/web:build: 
+@repo/web:build: 
+@repo/web:build: ○  (Static)  prerendered as static content
+@repo/web:build: 
+@repo/app:build: cache hit, replaying logs de4b13bf74c063e3
+@repo/app:build: 
+@repo/app:build: > @repo/app@0.1.0 build /private/tmp/claude-501/-Users-kyh-Documents-Projects-inteligir/a9e356f6-5c77-4f57-9f17-0c475958a892/scratchpad/ci-repro/packages/app
+@repo/app:build: > vite build --config vite.web.config.ts
+@repo/app:build: 
+@repo/app:build: vite v8.0.14 building client environment for production...
+@repo/app:build: [2K@repo/app:build: transforming...✓ 7378 modules transformed.
+@repo/app:build: rendering chunks...
+@repo/app:build: computing gzip size...
+@repo/app:build: dist-web/index.html                                           0.38 kB │ gzip:     0.25 kB
+@repo/app:build: dist-web/assets/KaTeX_Size3-Regular-CTq5MqoE.woff             4.42 kB
+@repo/app:build: dist-web/assets/KaTeX_Size4-Regular-Dl5lxZxV.woff2            4.92 kB
+@repo/app:build: dist-web/assets/KaTeX_Size2-Regular-Dy4dx90m.woff2            5.20 kB
+@repo/app:build: dist-web/assets/KaTeX_Size1-Regular-mCD8mA8B.woff2            5.46 kB
+@repo/app:build: dist-web/assets/KaTeX_Size4-Regular-BF-4gkZK.woff             5.98 kB
+@repo/app:build: dist-web/assets/KaTeX_Size2-Regular-oD1tc_U0.woff             6.18 kB
+@repo/app:build: dist-web/assets/KaTeX_Size1-Regular-C195tn64.woff             6.49 kB
+@repo/app:build: dist-web/assets/KaTeX_Caligraphic-Regular-Di6jR-x-.woff2      6.90 kB
+@repo/app:build: dist-web/assets/KaTeX_Caligraphic-Bold-Dq_IR9rO.woff2         6.91 kB
+@repo/app:build: dist-web/assets/KaTeX_Size3-Regular-DgpXs0kz.ttf              7.58 kB
+@repo/app:build: dist-web/assets/KaTeX_Caligraphic-Regular-CTRA-rTL.woff       7.65 kB
+@repo/app:build: dist-web/assets/KaTeX_Caligraphic-Bold-BEiXGLvX.woff          7.71 kB
+@repo/app:build: dist-web/assets/KaTeX_Script-Regular-D3wIWfF6.woff2           9.64 kB
+@repo/app:build: dist-web/assets/KaTeX_SansSerif-Regular-DDBCnlJ7.woff2       10.34 kB
+@repo/app:build: dist-web/assets/KaTeX_Size4-Regular-DWFBv043.ttf             10.36 kB
+@repo/app:build: dist-web/assets/KaTeX_Script-Regular-D5yQViql.woff           10.58 kB
+@repo/app:build: dist-web/assets/KaTeX_Fraktur-Regular-CTYiF6lA.woff2         11.31 kB
+@repo/app:build: dist-web/assets/KaTeX_Fraktur-Bold-CL6g_b3V.woff2            11.34 kB
+@repo/app:build: dist-web/assets/KaTeX_Size2-Regular-B7gKUWhC.ttf             11.50 kB
+@repo/app:build: dist-web/assets/KaTeX_SansSerif-Italic-C3H0VqGB.woff2        12.02 kB
+@repo/app:build: dist-web/assets/KaTeX_SansSerif-Bold-D1sUS0GD.woff2          12.21 kB
+@repo/app:build: dist-web/assets/KaTeX_Size1-Regular-Dbsnue_I.ttf             12.22 kB
+@repo/app:build: dist-web/assets/KaTeX_SansSerif-Regular-CS6fqUqJ.woff        12.31 kB
+@repo/app:build: dist-web/assets/KaTeX_Caligraphic-Regular-wX97UBjC.ttf       12.34 kB
+@repo/app:build: dist-web/assets/KaTeX_Caligraphic-Bold-ATXxdsX0.ttf          12.36 kB
+@repo/app:build: dist-web/assets/KaTeX_Fraktur-Regular-Dxdc4cR9.woff          13.20 kB
+@repo/app:build: dist-web/assets/KaTeX_Fraktur-Bold-BsDP51OF.woff             13.29 kB
+@repo/app:build: dist-web/assets/KaTeX_Typewriter-Regular-CO6r4hn1.woff2      13.56 kB
+@repo/app:build: dist-web/assets/KaTeX_SansSerif-Italic-DN2j7dab.woff         14.11 kB
+@repo/app:build: dist-web/assets/KaTeX_SansSerif-Bold-DbIhKOiC.woff           14.40 kB
+@repo/app:build: dist-web/assets/KaTeX_Typewriter-Regular-C0xS9mPB.woff       16.02 kB
+@repo/app:build: dist-web/assets/KaTeX_Math-BoldItalic-CZnvNsCZ.woff2         16.40 kB
+@repo/app:build: dist-web/assets/KaTeX_Math-Italic-t53AETM-.woff2             16.44 kB
+@repo/app:build: dist-web/assets/KaTeX_Script-Regular-C5JkGWo-.ttf            16.64 kB
+@repo/app:build: dist-web/assets/KaTeX_Main-BoldItalic-DxDJ3AOS.woff2         16.78 kB
+@repo/app:build: dist-web/assets/KaTeX_Main-Italic-NWA7e6Wa.woff2             16.98 kB
+@repo/app:build: dist-web/assets/KaTeX_Math-BoldItalic-iY-2wyZ7.woff          18.66 kB
+@repo/app:build: dist-web/assets/KaTeX_Math-Italic-DA0__PXp.woff              18.74 kB
+@repo/app:build: dist-web/assets/KaTeX_Main-BoldItalic-SpSLRI95.woff          19.41 kB
+@repo/app:build: dist-web/assets/KaTeX_SansSerif-Regular-BNo7hRIc.ttf         19.43 kB
+@repo/app:build: dist-web/assets/KaTeX_Fraktur-Regular-CB_wures.ttf           19.57 kB
+@repo/app:build: dist-web/assets/KaTeX_Fraktur-Bold-BdnERNNW.ttf              19.58 kB
+@repo/app:build: dist-web/assets/KaTeX_Main-Italic-BMLOBm91.woff              19.67 kB
+@repo/app:build: dist-web/assets/KaTeX_SansSerif-Italic-YYjJ1zSn.ttf          22.36 kB
+@repo/app:build: dist-web/assets/KaTeX_SansSerif-Bold-CFMepnvq.ttf            24.50 kB
+@repo/app:build: dist-web/assets/KaTeX_Main-Bold-Cx986IdX.woff2               25.32 kB
+@repo/app:build: dist-web/assets/KaTeX_Main-Regular-B22Nviop.woff2            26.27 kB
+@repo/app:build: dist-web/assets/KaTeX_Typewriter-Regular-D3Ib7_Hf.ttf        27.55 kB
+@repo/app:build: dist-web/assets/KaTeX_AMS-Regular-BQhdFMY1.woff2             28.07 kB
+@repo/app:build: dist-web/assets/KaTeX_Main-Bold-Jm3AIy58.woff                29.91 kB
+@repo/app:build: dist-web/assets/KaTeX_Main-Regular-Dr94JaBh.woff             30.77 kB
+@repo/app:build: dist-web/assets/KaTeX_Math-BoldItalic-B3XSjfu4.ttf           31.19 kB
+@repo/app:build: dist-web/assets/KaTeX_Math-Italic-flOr_0UB.ttf               31.30 kB
+@repo/app:build: dist-web/assets/KaTeX_Main-BoldItalic-DzxPMmG6.ttf           32.96 kB
+@repo/app:build: dist-web/assets/KaTeX_AMS-Regular-DMm9YOAa.woff              33.51 kB
+@repo/app:build: dist-web/assets/KaTeX_Main-Italic-3WenGoN9.ttf               33.58 kB
+@repo/app:build: dist-web/assets/KaTeX_Main-Bold-waoOVXN0.ttf                 51.33 kB
+@repo/app:build: dist-web/assets/KaTeX_Main-Regular-ypZvNtVU.ttf              53.58 kB
+@repo/app:build: dist-web/assets/KaTeX_AMS-Regular-DRggAlZN.ttf               63.63 kB
+@repo/app:build: dist-web/assets/LiteYouTubeEmbed-B0sQn39F.css                 2.82 kB │ gzip:     1.30 kB
+@repo/app:build: dist-web/assets/index-Cj6wDIx1.css                           14.63 kB │ gzip:     3.05 kB
+@repo/app:build: dist-web/assets/equation-katex-DEcVZfaU.css                  28.83 kB │ gzip:     7.92 kB
+@repo/app:build: dist-web/assets/index-rer5jNjX.css                          102.08 kB │ gzip:    17.63 kB
+@repo/app:build: dist-web/assets/mermaid-GHXKKRXX-Bm1PALbu.js                  0.06 kB │ gzip:     0.07 kB
+@repo/app:build: dist-web/assets/pie-RZYD4A2V-BMuyGVjY.js                      0.08 kB │ gzip:     0.09 kB
+@repo/app:build: dist-web/assets/info-DKCQHKI2-DhhrOsMS.js                     0.08 kB │ gzip:     0.10 kB
+@repo/app:build: dist-web/assets/radar-I7S5WNFK-DrsZqCrE.js                    0.08 kB │ gzip:     0.09 kB
+@repo/app:build: dist-web/assets/packet-7NZHBO7P-DpzgHMPk.js                   0.08 kB │ gzip:     0.10 kB
+@repo/app:build: dist-web/assets/cynefin-VYW2F7L2-CLIH16zV.js                  0.08 kB │ gzip:     0.10 kB
+@repo/app:build: dist-web/assets/treemap-6X3UGDF4-BbpT5xpC.js                  0.08 kB │ gzip:     0.10 kB
+@repo/app:build: dist-web/assets/wardley-OPB4EBWU-DBDL2Fz8.js                  0.08 kB │ gzip:     0.10 kB
+@repo/app:build: dist-web/assets/gitGraph-TEB2WS4Q-apTlvGLi.js                 0.09 kB │ gzip:     0.10 kB
+@repo/app:build: dist-web/assets/railroad-3IZDKUUU-DuEJRpkx.js                 0.09 kB │ gzip:     0.10 kB
+@repo/app:build: dist-web/assets/treeView-QDETBFTQ-sh0EDxlu.js                 0.09 kB │ gzip:     0.10 kB
+@repo/app:build: dist-web/assets/railroad-peg-LSFZ7HO6-C8sy-zwJ.js             0.09 kB │ gzip:     0.10 kB
+@repo/app:build: dist-web/assets/architecture-TIHT7OUA-CXhfFiGU.js             0.09 kB │ gzip:     0.10 kB
+@repo/app:build: dist-web/assets/railroad-abnf-AHOZXSZD-CIAM-ZIM.js            0.09 kB │ gzip:     0.10 kB
+@repo/app:build: dist-web/assets/railroad-ebnf-EBAXGLYW-CaTkUGm-.js            0.09 kB │ gzip:     0.10 kB
+@repo/app:build: dist-web/assets/eventmodeling-45OFAUF4-2mIZ8CuV.js            0.09 kB │ gzip:     0.10 kB
+@repo/app:build: dist-web/assets/channel-CTQaNcGC.js                           0.10 kB │ gzip:     0.11 kB
+@repo/app:build: dist-web/assets/init-D6jRqBbL.js                              0.14 kB │ gzip:     0.12 kB
+@repo/app:build: dist-web/assets/chunk-2Q5K7J3B-DwpL6FDg.js                    0.18 kB │ gzip:     0.15 kB
+@repo/app:build: dist-web/assets/flowDiagram-23GEKE2U-Dt4EO6Yl.js              0.20 kB │ gzip:     0.16 kB
+@repo/app:build: dist-web/assets/chunk-JWPE2WC7-DJ6nI3FE.js                    0.21 kB │ gzip:     0.16 kB
+@repo/app:build: dist-web/assets/chunk-XXDRQBXY-B9gHvVWm.js                    0.22 kB │ gzip:     0.19 kB
+@repo/app:build: dist-web/assets/chunk-5VM5RSS4-Bl12cm1J.js                    0.35 kB │ gzip:     0.26 kB
+@repo/app:build: dist-web/assets/equation-katex-DYshkeiC.js                    0.37 kB │ gzip:     0.28 kB
+@repo/app:build: dist-web/assets/classDiagram-OUVF2IWQ-G-xuO9GE.js             0.37 kB │ gzip:     0.27 kB
+@repo/app:build: dist-web/assets/classDiagram-v2-EOCWNBFH-G-xuO9GE.js          0.37 kB │ gzip:     0.27 kB
+@repo/app:build: dist-web/assets/stateDiagram-v2-6OUMAXLB-CVBhchvX.js          0.37 kB │ gzip:     0.27 kB
+@repo/app:build: dist-web/assets/swimlanesDiagram-G3AALYLV-UNydWgV3.js         0.43 kB │ gzip:     0.30 kB
+@repo/app:build: dist-web/assets/highlighted-body-OFNGDK62-NDYE9U1m.js         0.48 kB │ gzip:     0.32 kB
+@repo/app:build: dist-web/assets/chunk-VR4S4FIN-40F1WVLb.js                    0.49 kB │ gzip:     0.34 kB
+@repo/app:build: dist-web/assets/infoDiagram-FWYZ7A6U-CwtSYTtX.js              0.53 kB │ gzip:     0.35 kB
+@repo/app:build: dist-web/assets/codeowners-C8r90Shi.js                        0.54 kB │ gzip:     0.31 kB
+@repo/app:build: dist-web/assets/shellsession-BcDoAbmD.js                      0.71 kB │ gzip:     0.43 kB
+@repo/app:build: dist-web/assets/tsv-sltzmVWM.js                               0.73 kB │ gzip:     0.33 kB
+@repo/app:build: dist-web/assets/html-derivative-DiDd-K3f.js                   0.84 kB │ gzip:     0.46 kB
+@repo/app:build: dist-web/assets/sizeCapture-X5ZJPWSS-BwYjiXST.js              0.86 kB │ gzip:     0.50 kB
+@repo/app:build: dist-web/assets/git-rebase-DIy2XMx-.js                        0.98 kB │ gzip:     0.44 kB
+@repo/app:build: dist-web/assets/qmldir-DCQb3MpD.js                            0.99 kB │ gzip:     0.44 kB
+@repo/app:build: dist-web/assets/csv-Dx-8-gkx.js                               1.13 kB │ gzip:     0.36 kB
+@repo/app:build: dist-web/assets/ordinal-hYBb2elL.js                           1.17 kB │ gzip:     0.56 kB
+@repo/app:build: dist-web/assets/git-commit-BSykSTBG.js                        1.22 kB │ gzip:     0.52 kB
+@repo/app:build: dist-web/assets/xsl-DTTdyXIh.js                               1.36 kB │ gzip:     0.50 kB
+@repo/app:build: dist-web/assets/dotenv-_5a1GRtc.js                            1.41 kB │ gzip:     0.52 kB
+@repo/app:build: dist-web/assets/sparql-D_iOobhT.js                            1.47 kB │ gzip:     0.81 kB
+@repo/app:build: dist-web/assets/ini-B5eOa1yu.js                               1.51 kB │ gzip:     0.49 kB
+@repo/app:build: dist-web/assets/railroadDiagram-RFXS5EU6-C83wIxX-.js          1.55 kB │ gzip:     0.72 kB
+@repo/app:build: dist-web/assets/fortran-fixed-form-DEKoE2YW.js                1.66 kB │ gzip:     0.68 kB
+@repo/app:build: dist-web/assets/docker-IyjqRm3v.js                            1.73 kB │ gzip:     0.59 kB
+@repo/app:build: dist-web/assets/hxml-B0Qn7Nwc.js                              1.74 kB │ gzip:     0.87 kB
+@repo/app:build: dist-web/assets/abnfDiagram-VRR7QNED-Du1kaXT5.js              1.74 kB │ gzip:     0.84 kB
+@repo/app:build: dist-web/assets/desktop-Dlh5hvp9.js                           1.82 kB │ gzip:     0.75 kB
+@repo/app:build: dist-web/assets/chunk-32BRIVSS-BmrU8qsQ.js                    1.86 kB │ gzip:     0.82 kB
+@repo/app:build: dist-web/assets/pegDiagram-2B236MQR-9YmsCuyl.js               1.90 kB │ gzip:     0.89 kB
+@repo/app:build: dist-web/assets/ebnfDiagram-CCIWWBDH-B5eE_4ju.js              1.95 kB │ gzip:     0.84 kB
+@repo/app:build: dist-web/assets/erb-CmTu2_fu.js                               2.13 kB │ gzip:     0.62 kB
+@repo/app:build: dist-web/assets/wenyan-C8pVoKbM.js                            2.15 kB │ gzip:     1.08 kB
+@repo/app:build: dist-web/assets/jssm-DXw9l8Rf.js                              2.23 kB │ gzip:     0.61 kB
+@repo/app:build: dist-web/assets/edge-j615zeE3.js                              2.30 kB │ gzip:     0.68 kB
+@repo/app:build: dist-web/assets/reg-CRGYupPL.js                               2.33 kB │ gzip:     0.69 kB
+@repo/app:build: dist-web/assets/diff-woXpYk--.js                              2.56 kB │ gzip:     0.68 kB
+@repo/app:build: dist-web/assets/gleam-CSRkHgEL.js                             2.57 kB │ gzip:     0.81 kB
+@repo/app:build: dist-web/assets/hy-CZbG8q4J.js                                2.64 kB │ gzip:     1.17 kB
+@repo/app:build: dist-web/assets/openscad-BUDT5pXO.js                          2.81 kB │ gzip:     1.00 kB
+@repo/app:build: dist-web/assets/log-BNLmms1o.js                               2.84 kB │ gzip:     0.89 kB
+@repo/app:build: dist-web/assets/json-BQqiAMSI.js                              2.88 kB │ gzip:     0.81 kB
+@repo/app:build: dist-web/assets/cairo-DLTphjLi.js                             2.93 kB │ gzip:     0.80 kB
+@repo/app:build: dist-web/assets/berry-DKpUyyne.js                             2.99 kB │ gzip:     0.80 kB
+@repo/app:build: dist-web/assets/jsonl-CmCQp5Yx.js                             3.00 kB │ gzip:     0.78 kB
+@repo/app:build: dist-web/assets/jsonc-CYpm1nAK.js                             3.10 kB │ gzip:     0.78 kB
+@repo/app:build: dist-web/assets/logo-Cluzi2Zq.js                              3.12 kB │ gzip:     1.46 kB
+@repo/app:build: dist-web/assets/po-BiJDBrnU.js                                3.23 kB │ gzip:     0.90 kB
+@repo/app:build: dist-web/assets/json5-BR5RXkoi.js                             3.24 kB │ gzip:     0.82 kB
+@repo/app:build: dist-web/assets/mipsasm-BMqwQI7S.js                           3.25 kB │ gzip:     1.17 kB
+@repo/app:build: dist-web/assets/tasl-DMoTqEGO.js                              3.28 kB │ gzip:     0.84 kB
+@repo/app:build: dist-web/assets/genie-CV2tkWYe.js                             3.34 kB │ gzip:     1.20 kB
+@repo/app:build: dist-web/assets/rel-BtDbiS_P.js                               3.36 kB │ gzip:     1.10 kB
+@repo/app:build: dist-web/assets/vala-zf12oZj6.js                              3.36 kB │ gzip:     1.18 kB
+@repo/app:build: dist-web/assets/splunk-BC2Px7Mm.js                            3.42 kB │ gzip:     1.51 kB
+@repo/app:build: dist-web/assets/arc-CibwlKHP.js                               3.46 kB │ gzip:     1.44 kB
+@repo/app:build: dist-web/assets/todo-delegation-aKfOQ5q0.js                   3.51 kB │ gzip:     1.51 kB
+@repo/app:build: dist-web/assets/hurl-3GryociP.js                              3.51 kB │ gzip:     1.09 kB
+@repo/app:build: dist-web/assets/fluent-C03EYrpw.js                            3.60 kB │ gzip:     0.89 kB
+@repo/app:build: dist-web/assets/ssh-config-BgfXC-Er.js                        3.61 kB │ gzip:     1.59 kB
+@repo/app:build: dist-web/assets/jsonnet-CJTPZ8u_.js                           3.61 kB │ gzip:     1.03 kB
+@repo/app:build: dist-web/assets/kdl-CsD5j6eV.js                               3.62 kB │ gzip:     1.03 kB
+@repo/app:build: dist-web/assets/narrat-_X_XdTYD.js                            3.66 kB │ gzip:     1.09 kB
+@repo/app:build: dist-web/assets/glsl-DftNR3ok.js                              3.68 kB │ gzip:     1.45 kB
+@repo/app:build: dist-web/assets/turtle-ByJddavk.js                            3.69 kB │ gzip:     0.96 kB
+@repo/app:build: dist-web/assets/zenscript-BnlCZFoB.js                         3.90 kB │ gzip:     1.28 kB
+@repo/app:build: dist-web/assets/ron-VUp2lXgN.js                               3.90 kB │ gzip:     0.97 kB
+@repo/app:build: dist-web/assets/gn-ilITqXS6.js                                3.99 kB │ gzip:     1.47 kB
+@repo/app:build: dist-web/assets/diagram-NH7WQ7WH-DisqB4t-.js                  4.13 kB │ gzip:     1.77 kB
+@repo/app:build: dist-web/assets/pascal-4ZHwLPI5.js                            4.14 kB │ gzip:     1.67 kB
+@repo/app:build: dist-web/assets/http-BScx3cvx.js                              4.41 kB │ gzip:     1.06 kB
+@repo/app:build: dist-web/assets/tcl-CZd0xW_V.js                               4.42 kB │ gzip:     1.50 kB
+@repo/app:build: dist-web/assets/nextflow-Bbiyy34d.js                          4.50 kB │ gzip:     1.16 kB
+@repo/app:build: dist-web/assets/rosmsg-CAekHB0j.js                            4.51 kB │ gzip:     1.05 kB
+@repo/app:build: dist-web/assets/defaultLocale-C8Fc0cco.js                     4.64 kB │ gzip:     2.12 kB
+@repo/app:build: dist-web/assets/polar-C7UOKdEL.js                             4.66 kB │ gzip:     1.12 kB
+@repo/app:build: dist-web/assets/sdbl-bTVj8UrX.js                              4.69 kB │ gzip:     2.00 kB
+@repo/app:build: dist-web/assets/fennel-DQxkIbk2.js                            4.76 kB │ gzip:     1.53 kB
+@repo/app:build: dist-web/assets/bibtex-Ci_nEsc7.js                            4.78 kB │ gzip:     0.83 kB
+@repo/app:build: dist-web/assets/map-DsCK-0Cs.js                               5.03 kB │ gzip:     2.05 kB
+@repo/app:build: dist-web/assets/llvm-Cm23YOpf.js                              5.04 kB │ gzip:     2.01 kB
+@repo/app:build: dist-web/assets/wgsl-BsKzXJz4.js                              5.13 kB │ gzip:     1.38 kB
+@repo/app:build: dist-web/assets/gdresource-C0sCabJj.js                        5.28 kB │ gzip:     1.33 kB
+@repo/app:build: dist-web/assets/zig-CMLA9XwU.js                               5.33 kB │ gzip:     1.55 kB
+@repo/app:build: dist-web/assets/qml-B-9cLsBP.js                               5.33 kB │ gzip:     1.38 kB
+@repo/app:build: dist-web/assets/dax-BkyTk9wS.js                               5.35 kB │ gzip:     2.21 kB
+@repo/app:build: dist-web/assets/bicep-CUHmPFLl.js                             5.37 kB │ gzip:     1.14 kB
+@repo/app:build: dist-web/assets/xml-DtHyQya8.js                               5.43 kB │ gzip:     1.24 kB
+@repo/app:build: dist-web/assets/awk-BWXHIvNe.js                               5.45 kB │ gzip:     1.37 kB
+@repo/app:build: dist-web/assets/linear-xQs_WxCu.js                            5.53 kB │ gzip:     2.26 kB
+@repo/app:build: dist-web/assets/coq-BrsZFFmf.js                               5.54 kB │ gzip:     1.91 kB
+@repo/app:build: dist-web/assets/jinja-Cc7Fy85_.js                             5.62 kB │ gzip:     1.36 kB
+@repo/app:build: dist-web/assets/diagram-WEI45ONY-DG0aMBqa.js                  5.76 kB │ gzip:     2.41 kB
+@repo/app:build: dist-web/assets/lean-CewbzKMR.js                              5.77 kB │ gzip:     1.91 kB
+@repo/app:build: dist-web/assets/moonbit-CaWjb8XO.js                           5.89 kB │ gzip:     1.67 kB
+@repo/app:build: dist-web/assets/powerquery-DNMTfnFr.js                        5.89 kB │ gzip:     1.51 kB
+@repo/app:build: dist-web/assets/shaderlab-TOUzSsQk.js                         5.91 kB │ gzip:     2.08 kB
+@repo/app:build: dist-web/assets/verilog-CiiDBU1e.js                           5.92 kB │ gzip:     1.89 kB
+@repo/app:build: dist-web/assets/cypher-ClKdZ_lG.js                            5.94 kB │ gzip:     1.71 kB
+@repo/app:build: dist-web/assets/pieDiagram-ENE6RG2P-BuDx-m9s.js               5.98 kB │ gzip:     2.49 kB
+@repo/app:build: dist-web/assets/vb-Djn5o6TS.js                                6.08 kB │ gzip:     2.33 kB
+@repo/app:build: dist-web/assets/red-CJ3rzSJv.js                               6.25 kB │ gzip:     1.59 kB
+@repo/app:build: dist-web/assets/min-dark-BSWPekZh.js                          6.28 kB │ gzip:     1.70 kB
+@repo/app:build: dist-web/assets/gdshader-CBce3t8t.js                          6.31 kB │ gzip:     1.72 kB
+@repo/app:build: dist-web/assets/prisma-BsRQq5mF.js                            6.32 kB │ gzip:     1.38 kB
+@repo/app:build: dist-web/assets/ara-4CJ0cIlV.js                               6.35 kB │ gzip:     1.80 kB
+@repo/app:build: dist-web/assets/clojure-DqKBuwfJ.js                           6.40 kB │ gzip:     1.41 kB
+@repo/app:build: dist-web/assets/postcss-BXeXVLqQ.js                           6.41 kB │ gzip:     1.90 kB
+@repo/app:build: dist-web/assets/toml-CcmNWLt0.js                              6.41 kB │ gzip:     1.28 kB
+@repo/app:build: dist-web/assets/solarized-light-DSh2HLQt.js                   6.47 kB │ gzip:     1.71 kB
+@repo/app:build: dist-web/assets/proto-DB4EqR-F.js                             6.54 kB │ gzip:     1.41 kB
+@repo/app:build: dist-web/assets/smalltalk-B16xEiuN.js                         6.58 kB │ gzip:     1.61 kB
+@repo/app:build: dist-web/assets/r-4ngvQdCW.js                                 6.59 kB │ gzip:     1.82 kB
+@repo/app:build: dist-web/assets/talonscript-CohzipZa.js                       6.75 kB │ gzip:     1.48 kB
+@repo/app:build: dist-web/assets/solarized-dark-DV17i1UV.js                    6.84 kB │ gzip:     1.78 kB
+@repo/app:build: dist-web/assets/riscv-Ckw8ddFX.js                             6.90 kB │ gzip:     1.97 kB
+@repo/app:build: dist-web/assets/soy-DiU4W8i8.js                               6.92 kB │ gzip:     1.62 kB
+@repo/app:build: dist-web/assets/min-light-DDpmG2fV.js                         6.96 kB │ gzip:     1.88 kB
+@repo/app:build: dist-web/assets/chunk-RYQCIY6F-DKZmRVKk.js                    6.98 kB │ gzip:     2.66 kB
+@repo/app:build: dist-web/assets/scheme-DQCgrYNe.js                            7.16 kB │ gzip:     2.04 kB
+@repo/app:build: dist-web/assets/hlsl-Cvrh5tZx.js                              7.25 kB │ gzip:     2.18 kB
+@repo/app:build: dist-web/assets/index.es-p3n7nOfJ.js                          7.43 kB │ gzip:     2.93 kB
+@repo/app:build: dist-web/assets/qss-Fe1Jh2GI.js                               7.46 kB │ gzip:     2.57 kB
+@repo/app:build: dist-web/assets/dart-DkHntEIa.js                              7.80 kB │ gzip:     1.91 kB
+@repo/app:build: dist-web/assets/systemd-BxMlprV5.js                           7.86 kB │ gzip:     2.54 kB
+@repo/app:build: dist-web/assets/monokai-CdkpiU2Y.js                           7.88 kB │ gzip:     1.90 kB
+@repo/app:build: dist-web/assets/regexp-DDoO3BgQ.js                            8.04 kB │ gzip:     1.46 kB
+@repo/app:build: dist-web/assets/diagram-OA4YK3LP-zKUEKD3p.js                  8.12 kB │ gzip:     3.61 kB
+@repo/app:build: dist-web/assets/haml-4gFiMxKs.js                              8.32 kB │ gzip:     1.85 kB
+@repo/app:build: dist-web/assets/typst-DI99ib-x.js                             8.38 kB │ gzip:     1.66 kB
+@repo/app:build: dist-web/assets/dagre-VKFMJZFB-D-uv2Rcu.js                    8.40 kB │ gzip:     3.22 kB
+@repo/app:build: dist-web/assets/vue-html-C2zHiNoV.js                          8.47 kB │ gzip:     1.68 kB
+@repo/app:build: dist-web/assets/plsql-DGHpHOYJ.js                             8.50 kB │ gzip:     2.99 kB
+@repo/app:build: dist-web/assets/horizon-CE9ld1lL.js                           8.77 kB │ gzip:     1.94 kB
+@repo/app:build: dist-web/assets/kotlin-DhhofPvG.js                            8.77 kB │ gzip:     2.12 kB
+@repo/app:build: dist-web/assets/horizon-bright-Br1oVSNq.js                    8.78 kB │ gzip:     1.96 kB
+@repo/app:build: dist-web/assets/ts-tags-DcwWJMot.js                           8.92 kB │ gzip:     1.21 kB
+@repo/app:build: dist-web/assets/make-Dixweg8N.js                              8.95 kB │ gzip:     1.76 kB
+@repo/app:build: dist-web/assets/andromeeda-vGVdxbeo.js                        9.01 kB │ gzip:     2.35 kB
+@repo/app:build: dist-web/assets/sas-SoYsWU-0.js                               9.06 kB │ gzip:     3.82 kB
+@repo/app:build: dist-web/assets/dark-plus-Cs2F2srj.js                         9.09 kB │ gzip:     2.10 kB
+@repo/app:build: dist-web/assets/slack-dark-DnToyrRv.js                        9.11 kB │ gzip:     1.96 kB
+@repo/app:build: dist-web/assets/sass-DXrisJhu.js                              9.28 kB │ gzip:     2.48 kB
+@repo/app:build: dist-web/assets/plastic-DQwYfKfQ.js                           9.29 kB │ gzip:     1.96 kB
+@repo/app:build: dist-web/assets/slack-ochin-B2OO5cIa.js                       9.42 kB │ gzip:     2.08 kB
+@repo/app:build: dist-web/assets/tex-X4LVp7IX.js                               9.67 kB │ gzip:     3.06 kB
+@repo/app:build: dist-web/assets/jison-Cw3r6xMx.js                             9.69 kB │ gzip:     1.86 kB
+@repo/app:build: dist-web/assets/cynefinDiagram-TSTJHNR4-BBPIPWlM.js           9.76 kB │ gzip:     3.43 kB
+@repo/app:build: dist-web/assets/cmake-Bj61d0ZC.js                             9.84 kB │ gzip:     3.37 kB
+@repo/app:build: dist-web/assets/light-plus-DVQuIRkW.js                        9.93 kB │ gzip:     2.27 kB
+@repo/app:build: dist-web/assets/hcl-Dh228itO.js                              10.04 kB │ gzip:     1.93 kB
+@repo/app:build: dist-web/assets/stateDiagram-2N3HPSRC-BlvQHwpE.js            10.19 kB │ gzip:     3.52 kB
+@repo/app:build: dist-web/assets/rst-CqKPDNhl.js                              10.31 kB │ gzip:     2.25 kB
+@repo/app:build: dist-web/assets/pkl-ot-7Btpt.js                              10.36 kB │ gzip:     1.37 kB
+@repo/app:build: dist-web/assets/beancount-D-usSTwE.js                        10.36 kB │ gzip:     1.43 kB
+@repo/app:build: dist-web/assets/nextflow-groovy-Dc_ddanL.js                  10.39 kB │ gzip:     2.12 kB
+@repo/app:build: dist-web/assets/dream-maker-DW3nJb8Q.js                      10.46 kB │ gzip:     2.25 kB
+@repo/app:build: dist-web/assets/raku-B3gFvitq.js                             10.46 kB │ gzip:     2.94 kB
+@repo/app:build: dist-web/assets/diagram-FQU43EPY-C-HVvkce.js                 10.51 kB │ gzip:     4.01 kB
+@repo/app:build: dist-web/assets/yaml-DTLdzFOR.js                             10.56 kB │ gzip:     2.31 kB
+@repo/app:build: dist-web/assets/just-JrV3fAS1.js                             10.76 kB │ gzip:     2.60 kB
+@repo/app:build: dist-web/assets/elm-D3jHf22-.js                              10.94 kB │ gzip:     2.09 kB
+@repo/app:build: dist-web/assets/github-light-EUqPIrTm.js                     11.18 kB │ gzip:     2.49 kB
+@repo/app:build: dist-web/assets/prolog-iXnhIJG7.js                           11.34 kB │ gzip:     3.84 kB
+@repo/app:build: dist-web/assets/terraform-DswuEJGm.js                        11.38 kB │ gzip:     2.51 kB
+@repo/app:build: dist-web/assets/github-dark-C-LZuMrd.js                      11.40 kB │ gzip:     2.53 kB
+@repo/app:build: dist-web/assets/puppet-CDv2pdJW.js                           11.43 kB │ gzip:     2.10 kB
+@repo/app:build: dist-web/assets/laserwave-C_8bwKvT.js                        11.49 kB │ gzip:     2.57 kB
+@repo/app:build: dist-web/assets/gherkin-DExj1W_8.js                          11.93 kB │ gzip:     5.04 kB
+@repo/app:build: dist-web/assets/wasm-ByWQv1Qj.js                             12.00 kB │ gzip:     2.17 kB
+@repo/app:build: dist-web/assets/hjson-CxZEssPk.js                            12.04 kB │ gzip:     1.64 kB
+@repo/app:build: dist-web/assets/handlebars-DuK_ATO7.js                       12.16 kB │ gzip:     2.38 kB
+@repo/app:build: dist-web/assets/apache-U0d_L8uA.js                           12.44 kB │ gzip:     3.71 kB
+@repo/app:build: dist-web/assets/vesper-D5bVUKB1.js                           12.68 kB │ gzip:     1.98 kB
+@repo/app:build: dist-web/assets/bat-Bo4NYOV-.js                              12.88 kB │ gzip:     3.22 kB
+@repo/app:build: dist-web/assets/fish-BJitypiv.js                             13.03 kB │ gzip:     1.73 kB
+@repo/app:build: dist-web/assets/v-DETTlOr0.js                                13.20 kB │ gzip:     2.73 kB
+@repo/app:build: dist-web/assets/vitesse-light-VbXTXTou.js                    13.61 kB │ gzip:     3.03 kB
+@repo/app:build: dist-web/assets/aurora-x-CDeNXAV0.js                         13.65 kB │ gzip:     2.28 kB
+@repo/app:build: dist-web/assets/vitesse-black-fwtXNY1n.js                    13.67 kB │ gzip:     3.05 kB
+@repo/app:build: dist-web/assets/vitesse-dark-BZCL-v6S.js                     13.75 kB │ gzip:     3.06 kB
+@repo/app:build: dist-web/assets/pug-COOhEXer.js                              13.84 kB │ gzip:     2.58 kB
+@repo/app:build: dist-web/assets/luau-CNKltnaQ.js                             13.95 kB │ gzip:     3.16 kB
+@repo/app:build: dist-web/assets/synthwave-84-nFMaYfgc.js                     14.03 kB │ gzip:     2.85 kB
+@repo/app:build: dist-web/assets/github-light-default-BXViO-2h.js             14.15 kB │ gzip:     3.02 kB
+@repo/app:build: dist-web/assets/clarity-SemFz856.js                          14.26 kB │ gzip:     2.46 kB
+@repo/app:build: dist-web/assets/github-light-high-contrast-B68TUdTA.js       14.27 kB │ gzip:     3.00 kB
+@repo/app:build: dist-web/assets/github-dark-dimmed-Bx1FflLF.js               14.43 kB │ gzip:     3.11 kB
+@repo/app:build: dist-web/assets/github-dark-default-DXG-b-1a.js              14.43 kB │ gzip:     3.12 kB
+@repo/app:build: dist-web/assets/github-dark-high-contrast-B_tTalzw.js        14.59 kB │ gzip:     3.07 kB
+@repo/app:build: dist-web/assets/gnuplot-7GGW24-e.js                          14.77 kB │ gzip:     3.27 kB
+@repo/app:build: dist-web/assets/rust-Cfkwpbl8.js                             15.06 kB │ gzip:     2.71 kB
+@repo/app:build: dist-web/assets/kusto-BUv0MjJC.js                            15.16 kB │ gzip:     3.93 kB
+@repo/app:build: dist-web/assets/actionscript-3--17pq3dv.js                   15.19 kB │ gzip:     2.67 kB
+@repo/app:build: dist-web/assets/nix-IvuFDN5E.js                              15.50 kB │ gzip:     2.47 kB
+@repo/app:build: dist-web/assets/chunk-MOJQB5TN-t19DZFkC.js                   15.53 kB │ gzip:     4.28 kB
+@repo/app:build: dist-web/assets/diagram-G47NLZAW-BoqRAyNn.js                 15.54 kB │ gzip:     5.42 kB
+@repo/app:build: dist-web/assets/lua-DZIPpaKe.js                              15.59 kB │ gzip:     3.18 kB
+@repo/app:build: dist-web/assets/abap-CLvhMVsD.js                             15.84 kB │ gzip:     5.93 kB
+@repo/app:build: dist-web/assets/solidity-CKzVLygQ.js                         16.06 kB │ gzip:     3.09 kB
+@repo/app:build: dist-web/assets/matlab-D7qyCx1q.js                           16.07 kB │ gzip:     3.06 kB
+@repo/app:build: dist-web/assets/cue-CE9AQfxI.js                              16.19 kB │ gzip:     2.04 kB
+@repo/app:build: dist-web/assets/elixir-BpILTe0-.js                           16.26 kB │ gzip:     2.76 kB
+@repo/app:build: dist-web/assets/odin-B1RWQWA5.js                             16.50 kB │ gzip:     2.92 kB
+@repo/app:build: dist-web/assets/bird2-C2hNVINV.js                            16.96 kB │ gzip:     3.84 kB
+@repo/app:build: dist-web/assets/kanagawa-wave-CTweb8Dz.js                    17.12 kB │ gzip:     2.90 kB
+@repo/app:build: dist-web/assets/kanagawa-lotus-BN08jTvb.js                   17.12 kB │ gzip:     2.90 kB
+@repo/app:build: dist-web/assets/kanagawa-dragon-CXtmUGW6.js                  17.12 kB │ gzip:     2.92 kB
+@repo/app:build: dist-web/assets/ishikawaDiagram-FXEZZL3T-zF6ICup4.js         17.16 kB │ gzip:     6.43 kB
+@repo/app:build: dist-web/assets/move-B1IS1UjX.js                             17.49 kB │ gzip:     3.06 kB
+@repo/app:build: dist-web/assets/graphql-CAlF6SGc.js                          18.07 kB │ gzip:     2.53 kB
+@repo/app:build: dist-web/assets/liquid-kw9TLki6.js                           18.10 kB │ gzip:     3.15 kB
+@repo/app:build: dist-web/assets/svelte-Bj32U0lO.js                           18.24 kB │ gzip:     3.14 kB
+@repo/app:build: dist-web/assets/material-theme-Bm3Qr25_.js                   18.61 kB │ gzip:     3.10 kB
+@repo/app:build: dist-web/assets/material-theme-darker-2IIEA8gg.js            18.62 kB │ gzip:     3.10 kB
+@repo/app:build: dist-web/assets/material-theme-ocean-CHQ94UKr.js             18.62 kB │ gzip:     3.12 kB
+@repo/app:build: dist-web/assets/material-theme-lighter-uhdI0v04.js           18.63 kB │ gzip:     3.10 kB
+@repo/app:build: dist-web/assets/material-theme-palenight-B5W6OYN7.js         18.63 kB │ gzip:     3.11 kB
+@repo/app:build: dist-web/assets/gdscript-Cp2uCuqX.js                         18.98 kB │ gzip:     3.75 kB
+@repo/app:build: dist-web/assets/groovy-CacY0gHj.js                           19.17 kB │ gzip:     3.59 kB
+@repo/app:build: dist-web/assets/mdc-DZNQGQXT.js                              19.54 kB │ gzip:     6.66 kB
+@repo/app:build: dist-web/assets/kanban-definition-HUTT4EX6-D8LmtA6g.js       19.92 kB │ gzip:     6.96 kB
+@repo/app:build: dist-web/assets/ayu-dark-DluEY0Gj.js                         20.07 kB │ gzip:     3.93 kB
+@repo/app:build: dist-web/assets/ayu-mirage-Bqwy1Gya.js                       20.08 kB │ gzip:     3.91 kB
+@repo/app:build: dist-web/assets/glimmer-js--wq0EIwz.js                       20.08 kB │ gzip:     2.94 kB
+@repo/app:build: dist-web/assets/glimmer-ts-DZc5GF8Q.js                       20.08 kB │ gzip:     2.93 kB
+@repo/app:build: dist-web/assets/powershell-DshXNtvi.js                       20.14 kB │ gzip:     4.05 kB
+@repo/app:build: dist-web/assets/ayu-light-C3h-C4tm.js                        20.14 kB │ gzip:     3.89 kB
+@repo/app:build: dist-web/assets/viml-DvXPmvsu.js                             20.35 kB │ gzip:     6.73 kB
+@repo/app:build: dist-web/assets/nushell-DcLAeLz5.js                          20.40 kB │ gzip:     5.21 kB
+@repo/app:build: dist-web/assets/snazzy-light-4G7pJPwS.js                     20.77 kB │ gzip:     3.80 kB
+@repo/app:build: dist-web/assets/twig-BSqkeWXt.js                             20.90 kB │ gzip:     3.66 kB
+@repo/app:build: dist-web/assets/dracula-BHWKrbxM.js                          21.06 kB │ gzip:     3.99 kB
+@repo/app:build: dist-web/assets/dracula-soft-5eyTD99u.js                     21.07 kB │ gzip:     4.02 kB
+@repo/app:build: dist-web/assets/wit-DdvCle-K.js                              21.46 kB │ gzip:     2.87 kB
+@repo/app:build: dist-web/assets/rose-pine-BthvhNj6.js                        21.74 kB │ gzip:     3.86 kB
+@repo/app:build: dist-web/assets/rose-pine-moon-hon4tzzS.js                   21.75 kB │ gzip:     3.87 kB
+@repo/app:build: dist-web/assets/rose-pine-dawn-Dg85fqjY.js                   21.75 kB │ gzip:     3.88 kB
+@repo/app:build: dist-web/assets/nim-C5AL19_L.js                              22.45 kB │ gzip:     3.15 kB
+@repo/app:build: dist-web/assets/common-lisp-Cv5bFMCO.js                      22.57 kB │ gzip:     6.07 kB
+@repo/app:build: dist-web/assets/surrealql-BcOTe-Jd.js                        22.58 kB │ gzip:     4.31 kB
+@repo/app:build: dist-web/assets/gruvbox-dark-hard-C820rvS2.js                22.63 kB │ gzip:     4.15 kB
+@repo/app:build: dist-web/assets/gruvbox-dark-soft-MrdJrrXF.js                22.63 kB │ gzip:     4.15 kB
+@repo/app:build: dist-web/assets/gruvbox-light-hard-BC_s9l72.js               22.63 kB │ gzip:     4.16 kB
+@repo/app:build: dist-web/assets/gruvbox-light-soft-BSMLrYjP.js               22.63 kB │ gzip:     4.16 kB
+@repo/app:build: dist-web/assets/gruvbox-dark-medium-BPjhmG05.js              22.63 kB │ gzip:     4.15 kB
+@repo/app:build: dist-web/assets/gruvbox-light-medium-BAWPOn9u.js             22.63 kB │ gzip:     4.16 kB
+@repo/app:build: dist-web/assets/sankeyDiagram-HTMAVEWB-CE516jcd.js           22.75 kB │ gzip:     8.21 kB
+@repo/app:build: dist-web/assets/mindmap-definition-LN4V7U3C-BqSP39bg.js      23.08 kB │ gzip:     7.79 kB
+@repo/app:build: dist-web/assets/journeyDiagram-5HDEW3XC-9lSzrL8u.js          23.13 kB │ gzip:     8.14 kB
+@repo/app:build: dist-web/assets/sql-FAWdXnNK.js                              23.46 kB │ gzip:     7.48 kB
+@repo/app:build: dist-web/assets/cadence-CQ2zXKGN.js                          23.66 kB │ gzip:     3.65 kB
+@repo/app:build: dist-web/assets/graphlib-B8gBHxth.js                         23.90 kB │ gzip:     8.31 kB
+@repo/app:build: dist-web/assets/typespec-B88KGewJ.js                         24.01 kB │ gzip:     2.58 kB
+@repo/app:build: dist-web/assets/astro-D1kcl0T1.js                            24.02 kB │ gzip:     7.59 kB
+@repo/app:build: dist-web/assets/apl-BwaUhsH8.js                              24.02 kB │ gzip:     4.17 kB
+@repo/app:build: dist-web/assets/templ-Dx2RPHYa.js                            24.06 kB │ gzip:     5.41 kB
+@repo/app:build: dist-web/assets/angular-html-DlcOUrRA.js                     24.23 kB │ gzip:     3.98 kB
+@repo/app:build: dist-web/assets/vhdl-BroJfC0k.js                             24.25 kB │ gzip:     3.86 kB
+@repo/app:build: dist-web/assets/vue-IVwP5Y6X.js                              24.48 kB │ gzip:     2.96 kB
+@repo/app:build: dist-web/assets/purescript-9MfHhQsQ.js                       24.67 kB │ gzip:     3.24 kB
+@repo/app:build: dist-web/assets/wardleyDiagram-EHGQE667-DihOYFW9.js          25.07 kB │ gzip:     6.47 kB
+@repo/app:build: dist-web/assets/one-light-D7Lr4KcI.js                        25.29 kB │ gzip:     3.63 kB
+@repo/app:build: dist-web/assets/fsharp-D13ZGOAj.js                           25.30 kB │ gzip:     4.12 kB
+@repo/app:build: dist-web/assets/marko-DeEHpbNX.js                            25.48 kB │ gzip:     3.59 kB
+@repo/app:build: dist-web/assets/c3-CnJL0r0V.js                               25.62 kB │ gzip:     3.85 kB
+@repo/app:build: dist-web/assets/night-owl-light-eJ-hLW7d.js                  25.89 kB │ gzip:     4.23 kB
+@repo/app:build: dist-web/assets/system-verilog-DJ5XKQeo.js                   26.19 kB │ gzip:     4.82 kB
+@repo/app:build: dist-web/assets/erDiagram-Q63AITRT-qHS2rcri.js               26.71 kB │ gzip:     9.22 kB
+@repo/app:build: dist-web/assets/nord-Cb4Vim4T.js                             26.72 kB │ gzip:     4.35 kB
+@repo/app:build: dist-web/assets/codeql-oeQT6MSM.js                           26.87 kB │ gzip:     3.79 kB
+@repo/app:build: dist-web/assets/scss-B7iQ1Hhv.js                             27.25 kB │ gzip:     4.22 kB
+@repo/app:build: dist-web/assets/java-rHd3onR1.js                             27.27 kB │ gzip:     4.30 kB
+@repo/app:build: dist-web/assets/coffee-B_ibxiMe.js                           27.42 kB │ gzip:     6.35 kB
+@repo/app:build: dist-web/assets/razor-Bm7mz99-.js                            27.45 kB │ gzip:     3.54 kB
+@repo/app:build: dist-web/assets/scala-DKOlJaKm.js                            28.87 kB │ gzip:     3.92 kB
+@repo/app:build: dist-web/assets/gitGraphDiagram-IHSO6WYX-BXK1Imhh.js         28.91 kB │ gzip:     8.50 kB
+@repo/app:build: dist-web/assets/night-owl-DhmEMT88.js                        28.91 kB │ gzip:     5.14 kB
+@repo/app:build: dist-web/assets/crystal-D3EkCxBz.js                          29.41 kB │ gzip:     4.44 kB
+@repo/app:build: dist-web/assets/mermaid-Bk4SNUv9.js                          29.50 kB │ gzip:     3.64 kB
+@repo/app:build: dist-web/assets/applescript-CCn79oCD.js                      29.56 kB │ gzip:     5.94 kB
+@repo/app:build: dist-web/assets/timeline-definition-FHXFAJF6-fQA8TdaK.js     30.27 kB │ gzip:     9.88 kB
+@repo/app:build: dist-web/assets/requirementDiagram-TGXJPOKE-ByLaTS50.js      30.62 kB │ gzip:     9.57 kB
+@repo/app:build: dist-web/assets/julia-B27BbXQc.js                            30.99 kB │ gzip:     4.30 kB
+@repo/app:build: dist-web/assets/stylus-B6D30XZt.js                           31.06 kB │ gzip:     8.01 kB
+@repo/app:build: dist-web/assets/index.client-DyK58TtQ.js                     31.25 kB │ gzip:    11.83 kB
+@repo/app:build: dist-web/assets/dagre-CXRCoUWR.js                            32.05 kB │ gzip:    11.58 kB
+@repo/app:build: dist-web/assets/quadrantDiagram-ABIIQ3AL-B3EmOgZu.js         33.48 kB │ gzip:     9.71 kB
+@repo/app:build: dist-web/assets/poimandres-DRFjx7u4.js                       33.49 kB │ gzip:     5.49 kB
+@repo/app:build: dist-web/assets/one-dark-pro-CLwyXe_n.js                     33.78 kB │ gzip:     5.50 kB
+@repo/app:build: dist-web/assets/bsl-BkkzgIyY.js                              33.86 kB │ gzip:     8.34 kB
+@repo/app:build: dist-web/assets/haxe-OTjmBuCE.js                             35.15 kB │ gzip:     5.90 kB
+@repo/app:build: dist-web/assets/nginx-COKWpStf.js                            35.35 kB │ gzip:     4.45 kB
+@repo/app:build: dist-web/assets/houston-CsvMBhTu.js                          35.41 kB │ gzip:     5.76 kB
+@repo/app:build: dist-web/assets/tokyo-night-oM2G3aXe.js                      35.66 kB │ gzip:     6.22 kB
+@repo/app:build: dist-web/assets/erlang-Cphh6RMH.js                           37.47 kB │ gzip:     4.36 kB
+@repo/app:build: dist-web/assets/chunk-EX3LRPZG-VOJgVSGV.js                   37.61 kB │ gzip:    12.22 kB
+@repo/app:build: dist-web/assets/cobol-7OcELK8S.js                            39.09 kB │ gzip:    10.89 kB
+@repo/app:build: dist-web/assets/asm-Cmm7eHzH.js                              40.71 kB │ gzip:     8.16 kB
+@repo/app:build: dist-web/assets/vennDiagram-L72KCM5P-D7IozaRb.js             41.00 kB │ gzip:    15.01 kB
+@repo/app:build: dist-web/assets/xychartDiagram-FW5EYKEG-CWdMCRGG.js          41.38 kB │ gzip:    11.58 kB
+@repo/app:build: dist-web/assets/haskell-D8IpX4py.js                          41.48 kB │ gzip:     6.41 kB
+@repo/app:build: dist-web/assets/shellscript-3Y2xWEcw.js                      41.53 kB │ gzip:     6.12 kB
+@repo/app:build: dist-web/assets/perl-6lMRGxz5.js                             43.14 kB │ gzip:     4.64 kB
+@repo/app:build: dist-web/assets/d-qD-0Kul2.js                                43.78 kB │ gzip:     8.43 kB
+@repo/app:build: dist-web/assets/ruby-GSt9d4aL.js                             45.83 kB │ gzip:     5.56 kB
+@repo/app:build: dist-web/assets/go-BJwz_mda.js                               46.80 kB │ gzip:     5.15 kB
+@repo/app:build: dist-web/assets/apex-CGTLDQj6.js                             46.97 kB │ gzip:     6.72 kB
+@repo/app:build: dist-web/assets/catppuccin-mocha-DYhrFGRu.js                 47.25 kB │ gzip:     7.98 kB
+@repo/app:build: dist-web/assets/catppuccin-latte-DwIHMF0Q.js                 47.25 kB │ gzip:     7.98 kB
+@repo/app:build: dist-web/assets/catppuccin-frappe-3VR1Za6u.js                47.25 kB │ gzip:     7.99 kB
+@repo/app:build: dist-web/assets/catppuccin-macchiato-DYnBP6_5.js             47.26 kB │ gzip:     7.99 kB
+@repo/app:build: dist-web/assets/ada-C5qYipkI.js                              48.07 kB │ gzip:     5.96 kB
+@repo/app:build: dist-web/assets/chunk-V7JOEXUC-C5ElQoaz.js                   48.70 kB │ gzip:    15.68 kB
+@repo/app:build: dist-web/assets/css-D0dC7NME.js                              49.07 kB │ gzip:    11.94 kB
+@repo/app:build: dist-web/assets/imba-DsUTQ-LC.js                             49.92 kB │ gzip:     9.47 kB
+@repo/app:build: dist-web/assets/everforest-dark-sB-x3p7T.js                  53.74 kB │ gzip:     8.37 kB
+@repo/app:build: dist-web/assets/everforest-light-Df2xbC6M.js                 53.74 kB │ gzip:     8.36 kB
+@repo/app:build: dist-web/assets/wikitext-ClFFjSW2.js                         55.87 kB │ gzip:     4.81 kB
+@repo/app:build: dist-web/assets/stata-DtgDu-TS.js                            56.99 kB │ gzip:    12.40 kB
+@repo/app:build: dist-web/assets/html-CXWV1MV8.js                             57.31 kB │ gzip:    11.78 kB
+@repo/app:build: dist-web/assets/ballerina-B7ZEbQpA.js                        58.68 kB │ gzip:     8.10 kB
+@repo/app:build: dist-web/assets/markdown-BYOwaDjH.js                         59.32 kB │ gzip:     5.66 kB
+@repo/app:build: dist-web/assets/chunk-PUDLZKDR-DYU0tskG.js                   59.97 kB │ gzip:    19.43 kB
+@repo/app:build: dist-web/assets/ocaml-O90oeIOV.js                            62.44 kB │ gzip:     5.04 kB
+@repo/app:build: dist-web/assets/calendar-CntN_6U_.js                         68.33 kB │ gzip:    20.16 kB
+@repo/app:build: dist-web/assets/c4Diagram-LMCZKHZV-CCFGCvcN.js               69.06 kB │ gzip:    19.28 kB
+@repo/app:build: dist-web/assets/ganttDiagram-NO4QXBWP-C8gXFKrV.js            69.28 kB │ gzip:    22.71 kB
+@repo/app:build: dist-web/assets/mojo-BgCJLMeH.js                             69.79 kB │ gzip:     9.21 kB
+@repo/app:build: dist-web/assets/python-gzcpVVnB.js                           69.94 kB │ gzip:     9.09 kB
+@repo/app:build: dist-web/assets/c-A0gf2AoI.js                                72.16 kB │ gzip:    10.55 kB
+@repo/app:build: dist-web/assets/blockDiagram-677ZJIJ3-CYW59JVn.js            72.48 kB │ gzip:    20.46 kB
+@repo/app:build: dist-web/assets/latex-CJo0tUs3.js                            72.61 kB │ gzip:     6.68 kB
+@repo/app:build: dist-web/assets/vyper-CgoNMtux.js                            74.64 kB │ gzip:    10.69 kB
+@repo/app:build: dist-web/assets/hack-B9Ofpm-w.js                             80.18 kB │ gzip:    26.27 kB
+@repo/app:build: dist-web/assets/cose-bilkent-JH36ORCC-CKkMp4Lc.js            81.37 kB │ gzip:    21.55 kB
+@repo/app:build: dist-web/assets/swift-DonLKvLd.js                            86.68 kB │ gzip:    14.69 kB
+@repo/app:build: dist-web/assets/fortran-free-form-CYNrtFtB.js                88.96 kB │ gzip:    11.18 kB
+@repo/app:build: dist-web/assets/csharp-Ct8U2NOr.js                           89.68 kB │ gzip:    10.64 kB
+@repo/app:build: dist-web/assets/racket-DcIDlBhZ.js                           92.38 kB │ gzip:    15.07 kB
+@repo/app:build: dist-web/assets/less-DVTAwKKz.js                             97.62 kB │ gzip:    14.84 kB
+@repo/app:build: dist-web/assets/blade-BpAVQgeN.js                           104.97 kB │ gzip:    28.30 kB
+@repo/app:build: dist-web/assets/objective-c-D1A_Heim.js                     105.40 kB │ gzip:    23.63 kB
+@repo/app:build: dist-web/assets/php-CmGUlA1q.js                             111.05 kB │ gzip:    28.65 kB
+@repo/app:build: dist-web/assets/swimlanes-5IMT3BWC-rMPdRdS1.js              113.70 kB │ gzip:    38.96 kB
+@repo/app:build: dist-web/assets/sequenceDiagram-DBY2YBRQ-CGWDfvEx.js        115.69 kB │ gzip:    30.57 kB
+@repo/app:build: dist-web/assets/asciidoc-DE70LPWp.js                        131.52 kB │ gzip:     9.31 kB
+@repo/app:build: dist-web/assets/mdx-DQZ5AkYe.js                             136.10 kB │ gzip:    23.54 kB
+@repo/app:build: dist-web/assets/architectureDiagram-ZJ3FMSHR-BSlr8754.js    148.64 kB │ gzip:    40.99 kB
+@repo/app:build: dist-web/assets/objective-cpp-BsSzOQcm.js                   171.96 kB │ gzip:    30.98 kB
+@repo/app:build: dist-web/assets/javascript-BCKoL0jx.js                      174.88 kB │ gzip:    16.67 kB
+@repo/app:build: dist-web/assets/tsx-37mKoKVg.js                             175.59 kB │ gzip:    16.67 kB
+@repo/app:build: dist-web/assets/jsx-CP98v9PI.js                             177.84 kB │ gzip:    16.76 kB
+@repo/app:build: dist-web/assets/typescript-B3JS6GTT.js                      181.13 kB │ gzip:    16.28 kB
+@repo/app:build: dist-web/assets/angular-ts-40Za3vvS.js                      183.73 kB │ gzip:    16.78 kB
+@repo/app:build: dist-web/assets/vue-vine-DsTIyx4s.js                        190.05 kB │ gzip:    18.07 kB
+@repo/app:build: dist-web/assets/wolfram-DLL8P-h_.js                         262.38 kB │ gzip:    77.63 kB
+@repo/app:build: dist-web/assets/pdf-BFsEplku.js                             425.24 kB │ gzip:   126.73 kB
+@repo/app:build: dist-web/assets/native-GDBYL4Zp.js                          428.98 kB │ gzip:    82.17 kB
+@repo/app:build: dist-web/assets/cytoscape.esm-FqbQrHcz.js                   434.29 kB │ gzip:   137.58 kB
+@repo/app:build: dist-web/assets/wasm-BnjxR4X6.js                            622.32 kB │ gzip:   232.09 kB
+@repo/app:build: dist-web/assets/cpp--M79Ks8y.js                             626.12 kB │ gzip:    48.09 kB
+@repo/app:build: dist-web/assets/mermaid-parser.core-qKCxhioj.js             678.04 kB │ gzip:   146.59 kB
+@repo/app:build: dist-web/assets/emacs-lisp-C9PiwqqW.js                      779.84 kB │ gzip:   197.53 kB
+@repo/app:build: dist-web/assets/index-D1AsiLGo.js                         4,690.62 kB │ gzip: 1,373.71 kB
+@repo/app:build: 
+@repo/app:build: [33m[INEFFECTIVE_DYNAMIC_IMPORT] [0m../../node_modules/.pnpm/mermaid@11.16.0/node_modules/mermaid/dist/mermaid.core.mjs is dynamically imported by src/editor/nodes/code-block-mermaid.tsx but also statically imported by ../../node_modules/.pnpm/@streamdown+mermaid@1.0.2_react@19.2.6/node_modules/@streamdown/mermaid/dist/index.js, dynamic import will not move module into another chunk.
+@repo/app:build: 
+@repo/app:build: [plugin builtin:vite-reporter] 
+@repo/app:build: (!) Some chunks are larger than 500 kB after minification. Consider:
+@repo/app:build: - Using dynamic import() to code-split the application
+@repo/app:build: - Use build.rolldownOptions.output.codeSplitting to improve chunking: https://rolldown.rs/reference/OutputOptions.codeSplitting
+@repo/app:build: - Adjust chunk size limit for this warning via build.chunkSizeWarningLimit.
+@repo/app:build: ✓ built in 1.75s
+@repo/desktop:build: cache miss, executing a19363b85542b38d
+@repo/desktop:build: 
+@repo/desktop:build: > @repo/desktop@0.3.0 build /private/tmp/claude-501/-Users-kyh-Documents-Projects-inteligir/a9e356f6-5c77-4f57-9f17-0c475958a892/scratchpad/ci-repro/packages/desktop
+@repo/desktop:build: > electron-vite build
+@repo/desktop:build: 
+@repo/desktop:build: vite v8.0.14 building ssr environment for production...
+@repo/desktop:build: [2K@repo/desktop:build: transforming...✓ 3261 modules transformed.
+@repo/desktop:build: rendering chunks...
+@repo/desktop:build: .output/app/main/chunks/headers-vTqbcpMN.js                      0.36 kB
+@repo/desktop:build: .output/app/main/chunks/hash-BpHrYuTq.js                         0.72 kB
+@repo/desktop:build: .output/app/main/chunks/github-copilot-headers-CcOdCb98.js       1.81 kB
+@repo/desktop:build: .output/app/main/chunks/azure-openai-responses-DRk9InGq.js       7.42 kB
+@repo/desktop:build: .output/app/main/chunks/transform-messages-C0_rA3EV.js           7.51 kB
+@repo/desktop:build: .output/app/main/chunks/openai-responses-BMT2GErK.js             7.82 kB
+@repo/desktop:build: .output/app/main/chunks/multipart-parser-DovRPwhw.js             8.76 kB
+@repo/desktop:build: .output/app/main/chunks/google-BDtB6x0M.js                      11.36 kB
+@repo/desktop:build: .output/app/main/chunks/google-vertex-OmSiwe2S.js               13.10 kB
+@repo/desktop:build: .output/app/main/chunks/openai-responses-shared-CVm0_uWq.js     14.61 kB
+@repo/desktop:build: .output/app/main/chunks/dist-DV3zTEQy.js                        15.55 kB
+@repo/desktop:build: .output/app/main/chunks/openai-completions-PUVrMy8B.js          28.87 kB
+@repo/desktop:build: .output/app/main/chunks/openai-codex-responses-BFBUcNqD.js      31.19 kB
+@repo/desktop:build: .output/app/main/chunks/src-CzsCSQYI.js                         42.78 kB
+@repo/desktop:build: .output/app/main/chunks/photon_rs-C35QPQ0n.js                  134.72 kB
+@repo/desktop:build: .output/app/main/chunks/from-CalfUFMV.js                       171.60 kB
+@repo/desktop:build: .output/app/main/chunks/anthropic-VLiK-v-C.js                  234.62 kB
+@repo/desktop:build: .output/app/main/chunks/openai-EvsgkeQ6.js                     252.64 kB
+@repo/desktop:build: .output/app/main/chunks/google-shared-BcT3sdeY.js            1,189.93 kB
+@repo/desktop:build: .output/app/main/chunks/mistral-DQB_3Ge_.js                  1,263.74 kB
+@repo/desktop:build: .output/app/main/index.js                                    8,234.45 kB
+@repo/desktop:build: 
+@repo/desktop:build: ✓ built in 716ms
+@repo/desktop:build: vite v8.0.14 building ssr environment for production...
+@repo/desktop:build: [2K@repo/desktop:build: transforming...✓ 209 modules transformed.
+@repo/desktop:build: rendering chunks...
+@repo/desktop:build: .output/app/preload/index.js  146.04 kB
+@repo/desktop:build: 
+@repo/desktop:build: ✓ built in 25ms
+@repo/desktop:build: vite v8.0.14 building client environment for production...
+@repo/desktop:build: [2K@repo/desktop:build: transforming...✓ 7371 modules transformed.
+@repo/desktop:build: rendering chunks...
+@repo/desktop:build: .output/app/renderer/index.html                                            1.53 kB
+@repo/desktop:build: .output/app/renderer/assets/KaTeX_Size3-Regular-CTq5MqoE.woff              4.42 kB
+@repo/desktop:build: .output/app/renderer/assets/KaTeX_Size4-Regular-Dl5lxZxV.woff2             4.92 kB
+@repo/desktop:build: .output/app/renderer/assets/KaTeX_Size2-Regular-Dy4dx90m.woff2             5.20 kB
+@repo/desktop:build: .output/app/renderer/assets/KaTeX_Size1-Regular-mCD8mA8B.woff2             5.46 kB
+@repo/desktop:build: .output/app/renderer/assets/KaTeX_Size4-Regular-BF-4gkZK.woff              5.98 kB
+@repo/desktop:build: .output/app/renderer/assets/KaTeX_Size2-Regular-oD1tc_U0.woff              6.18 kB
+@repo/desktop:build: .output/app/renderer/assets/KaTeX_Size1-Regular-C195tn64.woff              6.49 kB
+@repo/desktop:build: .output/app/renderer/assets/KaTeX_Caligraphic-Regular-Di6jR-x-.woff2       6.90 kB
+@repo/desktop:build: .output/app/renderer/assets/KaTeX_Caligraphic-Bold-Dq_IR9rO.woff2          6.91 kB
+@repo/desktop:build: .output/app/renderer/assets/KaTeX_Size3-Regular-DgpXs0kz.ttf               7.58 kB
+@repo/desktop:build: .output/app/renderer/assets/KaTeX_Caligraphic-Regular-CTRA-rTL.woff        7.65 kB
+@repo/desktop:build: .output/app/renderer/assets/KaTeX_Caligraphic-Bold-BEiXGLvX.woff           7.71 kB
+@repo/desktop:build: .output/app/renderer/assets/KaTeX_Script-Regular-D3wIWfF6.woff2            9.64 kB
+@repo/desktop:build: .output/app/renderer/assets/KaTeX_SansSerif-Regular-DDBCnlJ7.woff2        10.34 kB
+@repo/desktop:build: .output/app/renderer/assets/KaTeX_Size4-Regular-DWFBv043.ttf              10.36 kB
+@repo/desktop:build: .output/app/renderer/assets/KaTeX_Script-Regular-D5yQViql.woff            10.58 kB
+@repo/desktop:build: .output/app/renderer/assets/KaTeX_Fraktur-Regular-CTYiF6lA.woff2          11.31 kB
+@repo/desktop:build: .output/app/renderer/assets/KaTeX_Fraktur-Bold-CL6g_b3V.woff2             11.34 kB
+@repo/desktop:build: .output/app/renderer/assets/KaTeX_Size2-Regular-B7gKUWhC.ttf              11.50 kB
+@repo/desktop:build: .output/app/renderer/assets/KaTeX_SansSerif-Italic-C3H0VqGB.woff2         12.02 kB
+@repo/desktop:build: .output/app/renderer/assets/KaTeX_SansSerif-Bold-D1sUS0GD.woff2           12.21 kB
+@repo/desktop:build: .output/app/renderer/assets/KaTeX_Size1-Regular-Dbsnue_I.ttf              12.22 kB
+@repo/desktop:build: .output/app/renderer/assets/KaTeX_SansSerif-Regular-CS6fqUqJ.woff         12.31 kB
+@repo/desktop:build: .output/app/renderer/assets/KaTeX_Caligraphic-Regular-wX97UBjC.ttf        12.34 kB
+@repo/desktop:build: .output/app/renderer/assets/KaTeX_Caligraphic-Bold-ATXxdsX0.ttf           12.36 kB
+@repo/desktop:build: .output/app/renderer/assets/KaTeX_Fraktur-Regular-Dxdc4cR9.woff           13.20 kB
+@repo/desktop:build: .output/app/renderer/assets/KaTeX_Fraktur-Bold-BsDP51OF.woff              13.29 kB
+@repo/desktop:build: .output/app/renderer/assets/KaTeX_Typewriter-Regular-CO6r4hn1.woff2       13.56 kB
+@repo/desktop:build: .output/app/renderer/assets/KaTeX_SansSerif-Italic-DN2j7dab.woff          14.11 kB
+@repo/desktop:build: .output/app/renderer/assets/KaTeX_SansSerif-Bold-DbIhKOiC.woff            14.40 kB
+@repo/desktop:build: .output/app/renderer/assets/KaTeX_Typewriter-Regular-C0xS9mPB.woff        16.02 kB
+@repo/desktop:build: .output/app/renderer/assets/KaTeX_Math-BoldItalic-CZnvNsCZ.woff2          16.40 kB
+@repo/desktop:build: .output/app/renderer/assets/KaTeX_Math-Italic-t53AETM-.woff2              16.44 kB
+@repo/desktop:build: .output/app/renderer/assets/KaTeX_Script-Regular-C5JkGWo-.ttf             16.64 kB
+@repo/desktop:build: .output/app/renderer/assets/KaTeX_Main-BoldItalic-DxDJ3AOS.woff2          16.78 kB
+@repo/desktop:build: .output/app/renderer/assets/KaTeX_Main-Italic-NWA7e6Wa.woff2              16.98 kB
+@repo/desktop:build: .output/app/renderer/assets/KaTeX_Math-BoldItalic-iY-2wyZ7.woff           18.66 kB
+@repo/desktop:build: .output/app/renderer/assets/KaTeX_Math-Italic-DA0__PXp.woff               18.74 kB
+@repo/desktop:build: .output/app/renderer/assets/KaTeX_Main-BoldItalic-SpSLRI95.woff           19.41 kB
+@repo/desktop:build: .output/app/renderer/assets/KaTeX_SansSerif-Regular-BNo7hRIc.ttf          19.43 kB
+@repo/desktop:build: .output/app/renderer/assets/KaTeX_Fraktur-Regular-CB_wures.ttf            19.57 kB
+@repo/desktop:build: .output/app/renderer/assets/KaTeX_Fraktur-Bold-BdnERNNW.ttf               19.58 kB
+@repo/desktop:build: .output/app/renderer/assets/KaTeX_Main-Italic-BMLOBm91.woff               19.67 kB
+@repo/desktop:build: .output/app/renderer/assets/KaTeX_SansSerif-Italic-YYjJ1zSn.ttf           22.36 kB
+@repo/desktop:build: .output/app/renderer/assets/KaTeX_SansSerif-Bold-CFMepnvq.ttf             24.50 kB
+@repo/desktop:build: .output/app/renderer/assets/KaTeX_Main-Bold-Cx986IdX.woff2                25.32 kB
+@repo/desktop:build: .output/app/renderer/assets/KaTeX_Main-Regular-B22Nviop.woff2             26.27 kB
+@repo/desktop:build: .output/app/renderer/assets/KaTeX_Typewriter-Regular-D3Ib7_Hf.ttf         27.55 kB
+@repo/desktop:build: .output/app/renderer/assets/KaTeX_AMS-Regular-BQhdFMY1.woff2              28.07 kB
+@repo/desktop:build: .output/app/renderer/assets/KaTeX_Main-Bold-Jm3AIy58.woff                 29.91 kB
+@repo/desktop:build: .output/app/renderer/assets/KaTeX_Main-Regular-Dr94JaBh.woff              30.77 kB
+@repo/desktop:build: .output/app/renderer/assets/KaTeX_Math-BoldItalic-B3XSjfu4.ttf            31.19 kB
+@repo/desktop:build: .output/app/renderer/assets/KaTeX_Math-Italic-flOr_0UB.ttf                31.30 kB
+@repo/desktop:build: .output/app/renderer/assets/KaTeX_Main-BoldItalic-DzxPMmG6.ttf            32.96 kB
+@repo/desktop:build: .output/app/renderer/assets/KaTeX_AMS-Regular-DMm9YOAa.woff               33.51 kB
+@repo/desktop:build: .output/app/renderer/assets/KaTeX_Main-Italic-3WenGoN9.ttf                33.58 kB
+@repo/desktop:build: .output/app/renderer/assets/KaTeX_Main-Bold-waoOVXN0.ttf                  51.33 kB
+@repo/desktop:build: .output/app/renderer/assets/KaTeX_Main-Regular-ypZvNtVU.ttf               53.58 kB
+@repo/desktop:build: .output/app/renderer/assets/KaTeX_AMS-Regular-DRggAlZN.ttf                63.63 kB
+@repo/desktop:build: .output/app/renderer/assets/LiteYouTubeEmbed-D_9Lf7vw.css                  3.52 kB
+@repo/desktop:build: .output/app/renderer/assets/index-l41sxkIU.css                            17.75 kB
+@repo/desktop:build: .output/app/renderer/assets/equation-katex-DvZyl1bz.css                   28.94 kB
+@repo/desktop:build: .output/app/renderer/assets/index-B7Cg57am.css                           124.16 kB
+@repo/desktop:build: .output/app/renderer/assets/mermaid-GHXKKRXX-BEnDiACV.js                   0.07 kB
+@repo/desktop:build: .output/app/renderer/assets/pie-RZYD4A2V-BbN5ZX0E.js                       0.10 kB
+@repo/desktop:build: .output/app/renderer/assets/info-DKCQHKI2-CXc4h-nD.js                      0.10 kB
+@repo/desktop:build: .output/app/renderer/assets/radar-I7S5WNFK-DjK_Mr8V.js                     0.11 kB
+@repo/desktop:build: .output/app/renderer/assets/packet-7NZHBO7P-DXLvOanz.js                    0.11 kB
+@repo/desktop:build: .output/app/renderer/assets/cynefin-VYW2F7L2-L-Ieki4k.js                   0.11 kB
+@repo/desktop:build: .output/app/renderer/assets/treemap-6X3UGDF4-BSjRIc1J.js                   0.11 kB
+@repo/desktop:build: .output/app/renderer/assets/wardley-OPB4EBWU-Ci-vSIFx.js                   0.11 kB
+@repo/desktop:build: .output/app/renderer/assets/gitGraph-TEB2WS4Q-D5a2Md3M.js                  0.11 kB
+@repo/desktop:build: .output/app/renderer/assets/railroad-3IZDKUUU-ByMPQT9-.js                  0.11 kB
+@repo/desktop:build: .output/app/renderer/assets/treeView-QDETBFTQ-PGtRijfb.js                  0.11 kB
+@repo/desktop:build: .output/app/renderer/assets/railroad-peg-LSFZ7HO6-C6GYqWsd.js              0.12 kB
+@repo/desktop:build: .output/app/renderer/assets/architecture-TIHT7OUA-SLOR-GjW.js              0.12 kB
+@repo/desktop:build: .output/app/renderer/assets/railroad-abnf-AHOZXSZD-CMMiJX8I.js             0.12 kB
+@repo/desktop:build: .output/app/renderer/assets/railroad-ebnf-EBAXGLYW-BdYt7fzC.js             0.12 kB
+@repo/desktop:build: .output/app/renderer/assets/eventmodeling-45OFAUF4-BWFnhYx-.js             0.12 kB
+@repo/desktop:build: .output/app/renderer/assets/flowDiagram-23GEKE2U-iBXcxamc.js               0.22 kB
+@repo/desktop:build: .output/app/renderer/assets/channel-Bqhev_Ig.js                            0.28 kB
+@repo/desktop:build: .output/app/renderer/assets/init-0z_ZKhsI.js                               0.32 kB
+@repo/desktop:build: .output/app/renderer/assets/chunk-JWPE2WC7-CCYuqlwH.js                     0.45 kB
+@repo/desktop:build: .output/app/renderer/assets/chunk-2Q5K7J3B-BV3RAHuP.js                     0.48 kB
+@repo/desktop:build: .output/app/renderer/assets/chunk-5VM5RSS4-dAlHYhX0.js                     0.55 kB
+@repo/desktop:build: .output/app/renderer/assets/chunk-XXDRQBXY--8Ppyt36.js                     0.58 kB
+@repo/desktop:build: .output/app/renderer/assets/codeowners-CxEKPWu0.js                         0.66 kB
+@repo/desktop:build: .output/app/renderer/assets/swimlanesDiagram-G3AALYLV-CPxgUE6e.js          0.71 kB
+@repo/desktop:build: .output/app/renderer/assets/classDiagram-OUVF2IWQ-BO8oT77R.js              0.77 kB
+@repo/desktop:build: .output/app/renderer/assets/classDiagram-v2-EOCWNBFH-JWxXtSrT.js           0.78 kB
+@repo/desktop:build: .output/app/renderer/assets/stateDiagram-v2-6OUMAXLB-xY220B8M.js           0.78 kB
+@repo/desktop:build: .output/app/renderer/assets/equation-katex-DNu6Vk7i.js                     0.85 kB
+@repo/desktop:build: .output/app/renderer/assets/tsv-BorGVq2Z.js                                0.86 kB
+@repo/desktop:build: .output/app/renderer/assets/infoDiagram-FWYZ7A6U-w0jynch6.js               0.99 kB
+@repo/desktop:build: .output/app/renderer/assets/shellsession-DO3CjHbU.js                       0.99 kB
+@repo/desktop:build: .output/app/renderer/assets/highlighted-body-OFNGDK62-DcLhk19m.js          1.00 kB
+@repo/desktop:build: .output/app/renderer/assets/html-derivative-C83akMdI.js                    1.13 kB
+@repo/desktop:build: .output/app/renderer/assets/qmldir-Dz8ttxjf.js                             1.16 kB
+@repo/desktop:build: .output/app/renderer/assets/chunk-VR4S4FIN-BhdSWtq5.js                     1.18 kB
+@repo/desktop:build: .output/app/renderer/assets/git-rebase-D0S4zM7C.js                         1.30 kB
+@repo/desktop:build: .output/app/renderer/assets/csv-DqIVFkK7.js                                1.32 kB
+@repo/desktop:build: .output/app/renderer/assets/git-commit-BLzLIG8V.js                         1.57 kB
+@repo/desktop:build: .output/app/renderer/assets/dotenv-Dkdv7Sm2.js                             1.65 kB
+@repo/desktop:build: .output/app/renderer/assets/xsl-CQrW0p__.js                                1.70 kB
+@repo/desktop:build: .output/app/renderer/assets/sizeCapture-X5ZJPWSS-Cn8gXY9A.js               1.71 kB
+@repo/desktop:build: .output/app/renderer/assets/sparql-BXlZPJHp.js                             1.75 kB
+@repo/desktop:build: .output/app/renderer/assets/ini-C24lZfdM.js                                1.76 kB
+@repo/desktop:build: .output/app/renderer/assets/docker-PC1tuYpa.js                             1.96 kB
+@repo/desktop:build: .output/app/renderer/assets/hxml-BQXT-a9k.js                               2.03 kB
+@repo/desktop:build: .output/app/renderer/assets/desktop-BgOb7Aj4.js                            2.06 kB
+@repo/desktop:build: .output/app/renderer/assets/fortran-fixed-form-Dn0YRMXX.js                 2.11 kB
+@repo/desktop:build: .output/app/renderer/assets/ordinal-Dwc-c6sf.js                            2.30 kB
+@repo/desktop:build: .output/app/renderer/assets/wenyan-BeysbCrW.js                             2.43 kB
+@repo/desktop:build: .output/app/renderer/assets/jssm-Dx5A5sBR.js                               2.54 kB
+@repo/desktop:build: .output/app/renderer/assets/erb-C5Ia_lhC.js                                2.61 kB
+@repo/desktop:build: .output/app/renderer/assets/reg-DpJf71oO.js                                2.64 kB
+@repo/desktop:build: .output/app/renderer/assets/railroadDiagram-RFXS5EU6-Jjx28YZI.js           2.70 kB
+@repo/desktop:build: .output/app/renderer/assets/edge-B-N89Rok.js                               2.84 kB
+@repo/desktop:build: .output/app/renderer/assets/hy-CJKxDzbh.js                                 2.86 kB
+@repo/desktop:build: .output/app/renderer/assets/diff-Blb4MjsC.js                               2.89 kB
+@repo/desktop:build: .output/app/renderer/assets/gleam-CTllUdfC.js                              2.93 kB
+@repo/desktop:build: .output/app/renderer/assets/log-Dad54gsi.js                                3.15 kB
+@repo/desktop:build: .output/app/renderer/assets/openscad-jn-f1Ocl.js                           3.16 kB
+@repo/desktop:build: .output/app/renderer/assets/logo-DTXV8SKw.js                               3.26 kB
+@repo/desktop:build: .output/app/renderer/assets/abnfDiagram-VRR7QNED-JK5Mysra.js               3.29 kB
+@repo/desktop:build: .output/app/renderer/assets/berry-CgA2ea0_.js                              3.40 kB
+@repo/desktop:build: .output/app/renderer/assets/jsonl-Bp0qqr10.js                              3.41 kB
+@repo/desktop:build: .output/app/renderer/assets/json-COOml8Ya.js                               3.47 kB
+@repo/desktop:build: .output/app/renderer/assets/cairo-BewF190O.js                              3.49 kB
+@repo/desktop:build: .output/app/renderer/assets/jsonc-Cu6rqcrJ.js                              3.51 kB
+@repo/desktop:build: .output/app/renderer/assets/pegDiagram-2B236MQR-Brrpqqtv.js                3.52 kB
+@repo/desktop:build: .output/app/renderer/assets/mipsasm-EL46Y4Xg.js                            3.53 kB
+@repo/desktop:build: .output/app/renderer/assets/ebnfDiagram-CCIWWBDH-DsQZiFeL.js               3.59 kB
+@repo/desktop:build: .output/app/renderer/assets/chunk-32BRIVSS-D-paUxbH.js                     3.61 kB
+@repo/desktop:build: .output/app/renderer/assets/splunk-xP_ZjUH2.js                             3.65 kB
+@repo/desktop:build: .output/app/renderer/assets/po-IjpR1yHO.js                                 3.71 kB
+@repo/desktop:build: .output/app/renderer/assets/json5-xULSgPQI.js                              3.71 kB
+@repo/desktop:build: .output/app/renderer/assets/genie-DnK2KWIP.js                              3.72 kB
+@repo/desktop:build: .output/app/renderer/assets/vala-BnnASFsX.js                               3.74 kB
+@repo/desktop:build: .output/app/renderer/assets/rel-BT0iIKKw.js                                3.75 kB
+@repo/desktop:build: .output/app/renderer/assets/tasl-_AAbKiWM.js                               3.81 kB
+@repo/desktop:build: .output/app/renderer/assets/ssh-config-DXFPABYp.js                         3.82 kB
+@repo/desktop:build: .output/app/renderer/assets/jsonnet-BafgE6cE.js                            4.04 kB
+@repo/desktop:build: .output/app/renderer/assets/fluent-BjfpB34g.js                             4.04 kB
+@repo/desktop:build: .output/app/renderer/assets/glsl-CLX-Irlo.js                               4.08 kB
+@repo/desktop:build: .output/app/renderer/assets/kdl-DkTyxPcj.js                                4.10 kB
+@repo/desktop:build: .output/app/renderer/assets/narrat-D9rrR0H5.js                             4.11 kB
+@repo/desktop:build: .output/app/renderer/assets/turtle-BEG5g_eT.js                             4.20 kB
+@repo/desktop:build: .output/app/renderer/assets/hurl-Db80G3of.js                               4.22 kB
+@repo/desktop:build: .output/app/renderer/assets/gn-DDjbVPF4.js                                 4.31 kB
+@repo/desktop:build: .output/app/renderer/assets/zenscript-BoijL7rl.js                          4.37 kB
+@repo/desktop:build: .output/app/renderer/assets/pascal-D8-gNZ2I.js                             4.48 kB
+@repo/desktop:build: .output/app/renderer/assets/ron-DzAo6FTJ.js                                4.51 kB
+@repo/desktop:build: .output/app/renderer/assets/sdbl-CdQg5gu1.js                               4.94 kB
+@repo/desktop:build: .output/app/renderer/assets/tcl-DLe0Tsfm.js                                4.95 kB
+@repo/desktop:build: .output/app/renderer/assets/rosmsg-CyYq6XdT.js                             5.13 kB
+@repo/desktop:build: .output/app/renderer/assets/fennel-B3wtZRne.js                             5.21 kB
+@repo/desktop:build: .output/app/renderer/assets/http-DFSflbtc.js                               5.25 kB
+@repo/desktop:build: .output/app/renderer/assets/nextflow-CrLyU6--.js                           5.28 kB
+@repo/desktop:build: .output/app/renderer/assets/llvm-uY68ROGz.js                               5.31 kB
+@repo/desktop:build: .output/app/renderer/assets/polar-4pN1JrJ8.js                              5.38 kB
+@repo/desktop:build: .output/app/renderer/assets/bibtex-BzgdqG3s.js                             5.40 kB
+@repo/desktop:build: .output/app/renderer/assets/dax-S-Noo-ku.js                                5.73 kB
+@repo/desktop:build: .output/app/renderer/assets/wgsl-1s5rV5xS.js                               5.77 kB
+@repo/desktop:build: .output/app/renderer/assets/zig-lTQvxhLD.js                                5.97 kB
+@repo/desktop:build: .output/app/renderer/assets/bicep-CZ338dSk.js                              5.97 kB
+@repo/desktop:build: .output/app/renderer/assets/coq-Ds6Ye5el.js                                6.00 kB
+@repo/desktop:build: .output/app/renderer/assets/gdresource--3V3VPer.js                         6.06 kB
+@repo/desktop:build: .output/app/renderer/assets/awk-D6dA05Ye.js                                6.16 kB
+@repo/desktop:build: .output/app/renderer/assets/qml-ClYuA8pT.js                                6.24 kB
+@repo/desktop:build: .output/app/renderer/assets/lean-BwOKScIt.js                               6.28 kB
+@repo/desktop:build: .output/app/renderer/assets/xml-BPhql8r5.js                                6.40 kB
+@repo/desktop:build: .output/app/renderer/assets/verilog-BW5U03XW.js                            6.48 kB
+@repo/desktop:build: .output/app/renderer/assets/shaderlab-CgHnPxp3.js                          6.49 kB
+@repo/desktop:build: .output/app/renderer/assets/vb-DU29mvss.js                                 6.56 kB
+@repo/desktop:build: .output/app/renderer/assets/powerquery-SrvS_NBM.js                         6.58 kB
+@repo/desktop:build: .output/app/renderer/assets/cypher-D8Bb8Cq2.js                             6.58 kB
+@repo/desktop:build: .output/app/renderer/assets/moonbit-B_9L5rST.js                            6.61 kB
+@repo/desktop:build: .output/app/renderer/assets/jinja-CSxcspSV.js                              6.61 kB
+@repo/desktop:build: .output/app/renderer/assets/arc-D-vKaxms.js                                6.75 kB
+@repo/desktop:build: .output/app/renderer/assets/todo-delegation-Brg0_JfQ.js                    6.92 kB
+@repo/desktop:build: .output/app/renderer/assets/diagram-NH7WQ7WH-sjgdCMAu.js                   6.95 kB
+@repo/desktop:build: .output/app/renderer/assets/gdshader-D7JfdFV3.js                           7.08 kB
+@repo/desktop:build: .output/app/renderer/assets/ara-IxnQjO6j.js                                7.10 kB
+@repo/desktop:build: .output/app/renderer/assets/min-dark-BylWUWCP.js                           7.12 kB
+@repo/desktop:build: .output/app/renderer/assets/postcss-D1gKt4z_.js                            7.15 kB
+@repo/desktop:build: .output/app/renderer/assets/prisma-BWfa4-tI.js                             7.15 kB
+@repo/desktop:build: .output/app/renderer/assets/red-ak49U3N5.js                                7.18 kB
+@repo/desktop:build: .output/app/renderer/assets/clojure-DDsQ0FaV.js                            7.20 kB
+@repo/desktop:build: .output/app/renderer/assets/toml-B7BHZIqX.js                               7.22 kB
+@repo/desktop:build: .output/app/renderer/assets/smalltalk-BEQkVl4K.js                          7.31 kB
+@repo/desktop:build: .output/app/renderer/assets/solarized-light-DpsUOwPJ.js                    7.46 kB
+@repo/desktop:build: .output/app/renderer/assets/proto-ClkOcAW0.js                              7.47 kB
+@repo/desktop:build: .output/app/renderer/assets/riscv-CvzikGLb.js                              7.50 kB
+@repo/desktop:build: .output/app/renderer/assets/hlsl-BJLUNfne.js                               7.72 kB
+@repo/desktop:build: .output/app/renderer/assets/talonscript-CLxaFu-b.js                        7.73 kB
+@repo/desktop:build: .output/app/renderer/assets/r-DxdKT2wB.js                                  7.73 kB
+@repo/desktop:build: .output/app/renderer/assets/solarized-dark-CEJcHE8A.js                     7.86 kB
+@repo/desktop:build: .output/app/renderer/assets/scheme-D3A2QBtM.js                             7.86 kB
+@repo/desktop:build: .output/app/renderer/assets/min-light-DaOL9zie.js                          7.88 kB
+@repo/desktop:build: .output/app/renderer/assets/qss-Iltvkn1C.js                                7.97 kB
+@repo/desktop:build: .output/app/renderer/assets/soy-D54SeNMg.js                                8.12 kB
+@repo/desktop:build: .output/app/renderer/assets/systemd-DFbUltlW.js                            8.58 kB
+@repo/desktop:build: .output/app/renderer/assets/dart-CMsQly6B.js                               8.77 kB
+@repo/desktop:build: .output/app/renderer/assets/monokai-BzjsNH9R.js                            9.01 kB
+@repo/desktop:build: .output/app/renderer/assets/plsql-DCNXypXO.js                              9.03 kB
+@repo/desktop:build: .output/app/renderer/assets/regexp-CkYJyO9d.js                             9.13 kB
+@repo/desktop:build: .output/app/renderer/assets/typst-BV9w0z8-.js                              9.44 kB
+@repo/desktop:build: .output/app/renderer/assets/vue-html-CYWDyoIg.js                           9.68 kB
+@repo/desktop:build: .output/app/renderer/assets/haml-C53dL5aR.js                               9.69 kB
+@repo/desktop:build: .output/app/renderer/assets/sas-BUWBRxIl.js                                9.74 kB
+@repo/desktop:build: .output/app/renderer/assets/kotlin-BHE8CoV9.js                             9.85 kB
+@repo/desktop:build: .output/app/renderer/assets/horizon-CUoW3SxZ.js                            9.93 kB
+@repo/desktop:build: .output/app/renderer/assets/horizon-bright-DAm8M2PE.js                     9.96 kB
+@repo/desktop:build: .output/app/renderer/assets/make-B2ukzWs3.js                              10.02 kB
+@repo/desktop:build: .output/app/renderer/assets/andromeeda-S_u32-EO.js                        10.05 kB
+@repo/desktop:build: .output/app/renderer/assets/cmake-DPsCB_V6.js                             10.14 kB
+@repo/desktop:build: .output/app/renderer/assets/dark-plus-BqAYDMN1.js                         10.26 kB
+@repo/desktop:build: .output/app/renderer/assets/slack-dark-DRqiCUvS.js                        10.31 kB
+@repo/desktop:build: .output/app/renderer/assets/defaultLocale-5iMEeW9r.js                     10.36 kB
+@repo/desktop:build: .output/app/renderer/assets/plastic-DqscscdD.js                           10.41 kB
+@repo/desktop:build: .output/app/renderer/assets/sass-DI2zJwx7.js                              10.43 kB
+@repo/desktop:build: .output/app/renderer/assets/tex-BJvwfmu3.js                               10.51 kB
+@repo/desktop:build: .output/app/renderer/assets/diagram-WEI45ONY-CALS462T.js                  10.60 kB
+@repo/desktop:build: .output/app/renderer/assets/slack-ochin-CsH2FQ73.js                       10.72 kB
+@repo/desktop:build: .output/app/renderer/assets/index.es--pvxRE53.js                          10.80 kB
+@repo/desktop:build: .output/app/renderer/assets/raku-DI9yGpeW.js                              11.09 kB
+@repo/desktop:build: .output/app/renderer/assets/jison-C8Ry8kOH.js                             11.11 kB
+@repo/desktop:build: .output/app/renderer/assets/light-plus-B-oLOFif.js                        11.16 kB
+@repo/desktop:build: .output/app/renderer/assets/ts-tags-ByQXpvog.js                           11.31 kB
+@repo/desktop:build: .output/app/renderer/assets/hcl-DHg_Osgo.js                               11.38 kB
+@repo/desktop:build: .output/app/renderer/assets/pkl-C7lWzykI.js                               11.50 kB
+@repo/desktop:build: .output/app/renderer/assets/dream-maker-CngiPd8U.js                       11.65 kB
+@repo/desktop:build: .output/app/renderer/assets/beancount-CXtOQ8oS.js                         11.75 kB
+@repo/desktop:build: .output/app/renderer/assets/nextflow-groovy-BgkjwCrm.js                   11.78 kB
+@repo/desktop:build: .output/app/renderer/assets/yaml-nfLfKKCx.js                              11.86 kB
+@repo/desktop:build: .output/app/renderer/assets/prolog-Bacii3Ue.js                            11.89 kB
+@repo/desktop:build: .output/app/renderer/assets/pieDiagram-ENE6RG2P-CV1IMwme.js               11.90 kB
+@repo/desktop:build: .output/app/renderer/assets/rst-CAtuJOF8.js                               11.98 kB
+@repo/desktop:build: .output/app/renderer/assets/gherkin-D6Lr12YQ.js                           12.24 kB
+@repo/desktop:build: .output/app/renderer/assets/just-HaPh1BGj.js                              12.32 kB
+@repo/desktop:build: .output/app/renderer/assets/elm-C7cte0cn.js                               12.52 kB
+@repo/desktop:build: .output/app/renderer/assets/laserwave-CuH3K8QO.js                         12.62 kB
+@repo/desktop:build: .output/app/renderer/assets/github-light-BBGFqJQ_.js                      12.66 kB
+@repo/desktop:build: .output/app/renderer/assets/terraform-v0KN9QQh.js                         12.77 kB
+@repo/desktop:build: .output/app/renderer/assets/puppet-CQlPp728.js                            12.80 kB
+@repo/desktop:build: .output/app/renderer/assets/github-dark-DdkWvOFB.js                       12.89 kB
+@repo/desktop:build: .output/app/renderer/assets/linear-CZe2yWy-.js                            12.96 kB
+@repo/desktop:build: .output/app/renderer/assets/wasm-gNIKwGlD.js                              13.23 kB
+@repo/desktop:build: .output/app/renderer/assets/apache-BIl2qPOf.js                            13.38 kB
+@repo/desktop:build: .output/app/renderer/assets/hjson-Cuaphql8.js                             13.51 kB
+@repo/desktop:build: .output/app/renderer/assets/vesper-CchnAzZQ.js                            13.90 kB
+@repo/desktop:build: .output/app/renderer/assets/handlebars-B3rshJgR.js                        13.96 kB
+@repo/desktop:build: .output/app/renderer/assets/fish-D7qAeWQz.js                              13.97 kB
+@repo/desktop:build: .output/app/renderer/assets/bat-hQslfzu-.js                               14.18 kB
+@repo/desktop:build: .output/app/renderer/assets/v-DfbeXLo8.js                                 14.88 kB
+@repo/desktop:build: .output/app/renderer/assets/aurora-x-gzlQ0yRh.js                          15.02 kB
+@repo/desktop:build: .output/app/renderer/assets/diagram-OA4YK3LP-dz63EBDE.js                  15.09 kB
+@repo/desktop:build: .output/app/renderer/assets/vitesse-light-5WzvCeGW.js                     15.32 kB
+@repo/desktop:build: .output/app/renderer/assets/vitesse-black-DENf5Ic-.js                     15.39 kB
+@repo/desktop:build: .output/app/renderer/assets/luau-BrEqC1G7.js                              15.47 kB
+@repo/desktop:build: .output/app/renderer/assets/vitesse-dark-4bey4pJH.js                      15.47 kB
+@repo/desktop:build: .output/app/renderer/assets/synthwave-84-CriOHhqg.js                      15.79 kB
+@repo/desktop:build: .output/app/renderer/assets/clarity-2iIoRiLx.js                           15.82 kB
+@repo/desktop:build: .output/app/renderer/assets/pug-BlitNH0_.js                               15.87 kB
+@repo/desktop:build: .output/app/renderer/assets/github-light-default-C50vHIiD.js              15.94 kB
+@repo/desktop:build: .output/app/renderer/assets/github-light-high-contrast-uh3vjImY.js        16.09 kB
+@repo/desktop:build: .output/app/renderer/assets/dagre-VKFMJZFB-BTrhAxEY.js                    16.21 kB
+@repo/desktop:build: .output/app/renderer/assets/github-dark-dimmed-Bd3eZKu6.js                16.24 kB
+@repo/desktop:build: .output/app/renderer/assets/github-dark-default-BN39Z4BH.js               16.25 kB
+@repo/desktop:build: .output/app/renderer/assets/kusto-DcfHu_Xc.js                             16.28 kB
+@repo/desktop:build: .output/app/renderer/assets/gnuplot-DgWvVXI8.js                           16.30 kB
+@repo/desktop:build: .output/app/renderer/assets/github-dark-high-contrast-Bt80LzhV.js         16.44 kB
+@repo/desktop:build: .output/app/renderer/assets/abap-LtYK6g-v.js                              16.58 kB
+@repo/desktop:build: .output/app/renderer/assets/rust-COBzcmTx.js                              16.94 kB
+@repo/desktop:build: .output/app/renderer/assets/actionscript-3-Czo0lKSf.js                    17.00 kB
+@repo/desktop:build: .output/app/renderer/assets/chunk-RYQCIY6F-CuMp-hEE.js                    17.12 kB
+@repo/desktop:build: .output/app/renderer/assets/cynefinDiagram-TSTJHNR4-B3cy1yFy.js           17.36 kB
+@repo/desktop:build: .output/app/renderer/assets/lua-BNkSC8iO.js                               17.55 kB
+@repo/desktop:build: .output/app/renderer/assets/stateDiagram-2N3HPSRC-BH71J-jY.js             17.65 kB
+@repo/desktop:build: .output/app/renderer/assets/nix-CjLI_VO5.js                               17.70 kB
+@repo/desktop:build: .output/app/renderer/assets/matlab-CfRK6IMC.js                            17.96 kB
+@repo/desktop:build: .output/app/renderer/assets/solidity-lB9VjfB9.js                          18.07 kB
+@repo/desktop:build: .output/app/renderer/assets/cue-B5KneM5p.js                               18.21 kB
+@repo/desktop:build: .output/app/renderer/assets/elixir-C8Lmpyqw.js                            18.25 kB
+@repo/desktop:build: .output/app/renderer/assets/odin-vjOJSyfV.js                              18.58 kB
+@repo/desktop:build: .output/app/renderer/assets/bird2-CWvLaIcO.js                             18.71 kB
+@repo/desktop:build: .output/app/renderer/assets/kanagawa-wave-C2XuHGuk.js                     18.90 kB
+@repo/desktop:build: .output/app/renderer/assets/kanagawa-lotus-CkZnZfHg.js                    18.91 kB
+@repo/desktop:build: .output/app/renderer/assets/kanagawa-dragon-SzrUi2Pw.js                   18.91 kB
+@repo/desktop:build: .output/app/renderer/assets/diagram-FQU43EPY-BCBbQzIt.js                  19.88 kB
+@repo/desktop:build: .output/app/renderer/assets/move-Dqi5fhOb.js                              20.06 kB
+@repo/desktop:build: .output/app/renderer/assets/liquid-C-jvk1wx.js                            20.33 kB
+@repo/desktop:build: .output/app/renderer/assets/material-theme-N5R1DgZc.js                    20.51 kB
+@repo/desktop:build: .output/app/renderer/assets/material-theme-ocean-DSbmlkWr.js              20.55 kB
+@repo/desktop:build: .output/app/renderer/assets/material-theme-darker-KN8tlZeu.js             20.55 kB
+@repo/desktop:build: .output/app/renderer/assets/material-theme-lighter-BGGD2XQL.js            20.56 kB
+@repo/desktop:build: .output/app/renderer/assets/material-theme-palenight-BsJ9BQSi.js          20.56 kB
+@repo/desktop:build: .output/app/renderer/assets/graphql-CDLd9IVd.js                           20.57 kB
+@repo/desktop:build: .output/app/renderer/assets/mdc-JkbFYXfs.js                               20.73 kB
+@repo/desktop:build: .output/app/renderer/assets/svelte-C8pvSke_.js                            20.75 kB
+@repo/desktop:build: .output/app/renderer/assets/gdscript-jjgTGGzd.js                          21.00 kB
+@repo/desktop:build: .output/app/renderer/assets/viml-BReTXeDA.js                              21.20 kB
+@repo/desktop:build: .output/app/renderer/assets/groovy-Bw2Ku4bU.js                            21.56 kB
+@repo/desktop:build: .output/app/renderer/assets/powershell-CpTLv_ai.js                        21.95 kB
+@repo/desktop:build: .output/app/renderer/assets/nushell-r7hBzeS_.js                           22.36 kB
+@repo/desktop:build: .output/app/renderer/assets/ayu-dark-Dhl8YsIM.js                          22.46 kB
+@repo/desktop:build: .output/app/renderer/assets/ayu-mirage-B7ZdYmSB.js                        22.47 kB
+@repo/desktop:build: .output/app/renderer/assets/ayu-light-QTxP8Qx4.js                         22.53 kB
+@repo/desktop:build: .output/app/renderer/assets/glimmer-js-CflLO3Mr.js                        22.93 kB
+@repo/desktop:build: .output/app/renderer/assets/glimmer-ts-BOp24qu-.js                        22.93 kB
+@repo/desktop:build: .output/app/renderer/assets/snazzy-light-BAbqcTmv.js                      23.25 kB
+@repo/desktop:build: .output/app/renderer/assets/dracula-BfwyFE00.js                           23.26 kB
+@repo/desktop:build: .output/app/renderer/assets/dracula-soft-BgOK1gyW.js                      23.29 kB
+@repo/desktop:build: .output/app/renderer/assets/twig-CKF-1KLs.js                              23.56 kB
+@repo/desktop:build: .output/app/renderer/assets/common-lisp-DJtwvW4V.js                       23.60 kB
+@repo/desktop:build: .output/app/renderer/assets/map-CQY7RXjM.js                               23.86 kB
+@repo/desktop:build: .output/app/renderer/assets/wit-CeQiCbz_.js                               23.94 kB
+@repo/desktop:build: .output/app/renderer/assets/rose-pine-DU7kWoOS.js                         24.14 kB
+@repo/desktop:build: .output/app/renderer/assets/rose-pine-moon-DKOrkhLI.js                    24.16 kB
+@repo/desktop:build: .output/app/renderer/assets/rose-pine-dawn-DH19h9RN.js                    24.17 kB
+@repo/desktop:build: .output/app/renderer/assets/sql-B85sb8zx.js                               24.77 kB
+@repo/desktop:build: .output/app/renderer/assets/surrealql-LtekuWzq.js                         25.30 kB
+@repo/desktop:build: .output/app/renderer/assets/gruvbox-dark-hard-Y24GuWKy.js                 25.35 kB
+@repo/desktop:build: .output/app/renderer/assets/gruvbox-dark-soft-BPbnRnIt.js                 25.35 kB
+@repo/desktop:build: .output/app/renderer/assets/gruvbox-light-hard-ZMb8kKEw.js                25.35 kB
+@repo/desktop:build: .output/app/renderer/assets/gruvbox-light-soft-B4MS9-y0.js                25.35 kB
+@repo/desktop:build: .output/app/renderer/assets/gruvbox-dark-medium-BC6pC57i.js               25.36 kB
+@repo/desktop:build: .output/app/renderer/assets/gruvbox-light-medium-CnBwJ0qL.js              25.36 kB
+@repo/desktop:build: .output/app/renderer/assets/nim-DlzzHBd7.js                               25.62 kB
+@repo/desktop:build: .output/app/renderer/assets/astro-hwBLQQ4i.js                             25.84 kB
+@repo/desktop:build: .output/app/renderer/assets/templ-DJYa9y7i.js                             26.31 kB
+@repo/desktop:build: .output/app/renderer/assets/cadence-B1ELWULD.js                           26.36 kB
+@repo/desktop:build: .output/app/renderer/assets/typespec-5lVMAnov.js                          26.55 kB
+@repo/desktop:build: .output/app/renderer/assets/purescript-CLpaGMbw.js                        26.78 kB
+@repo/desktop:build: .output/app/renderer/assets/vhdl-Co2XFKY7.js                              26.79 kB
+@repo/desktop:build: .output/app/renderer/assets/apl-B3Pblpb4.js                               27.01 kB
+@repo/desktop:build: .output/app/renderer/assets/angular-html-Bh7Rr763.js                      27.66 kB
+@repo/desktop:build: .output/app/renderer/assets/one-light-DIzWgcxk.js                         28.19 kB
+@repo/desktop:build: .output/app/renderer/assets/vue-BadG8XXC.js                               28.26 kB
+@repo/desktop:build: .output/app/renderer/assets/chunk-MOJQB5TN-UEC0YJNT.js                    28.29 kB
+@repo/desktop:build: .output/app/renderer/assets/fsharp-Dr-2VlVS.js                            28.44 kB
+@repo/desktop:build: .output/app/renderer/assets/system-verilog-BEoxaBuU.js                    28.59 kB
+@repo/desktop:build: .output/app/renderer/assets/marko-Cqs02CBN.js                             28.69 kB
+@repo/desktop:build: .output/app/renderer/assets/c3-C3l2uuWJ.js                                29.00 kB
+@repo/desktop:build: .output/app/renderer/assets/night-owl-light-hdx3XV-T.js                   29.05 kB
+@repo/desktop:build: .output/app/renderer/assets/codeql-BwdvwJnv.js                            29.60 kB
+@repo/desktop:build: .output/app/renderer/assets/nord-CqJL6iQI.js                              29.64 kB
+@repo/desktop:build: .output/app/renderer/assets/coffee-BXx7Sh6l.js                            29.89 kB
+@repo/desktop:build: .output/app/renderer/assets/ishikawaDiagram-FXEZZL3T-DZSy7sQt.js          30.63 kB
+@repo/desktop:build: .output/app/renderer/assets/java-CyjgyFOg.js                              30.66 kB
+@repo/desktop:build: .output/app/renderer/assets/scss-qwxu4ehx.js                              30.70 kB
+@repo/desktop:build: .output/app/renderer/assets/razor-CsgPWXtg.js                             30.84 kB
+@repo/desktop:build: .output/app/renderer/assets/scala-CtSYTRYT.js                             31.32 kB
+@repo/desktop:build: .output/app/renderer/assets/diagram-G47NLZAW-CoDKIHRQ.js                  32.05 kB
+@repo/desktop:build: .output/app/renderer/assets/applescript-CJ80B5XJ.js                       32.08 kB
+@repo/desktop:build: .output/app/renderer/assets/night-owl-qyzJsoD2.js                         32.35 kB
+@repo/desktop:build: .output/app/renderer/assets/crystal-tqhGvi0q.js                           32.91 kB
+@repo/desktop:build: .output/app/renderer/assets/mermaid-r7OoIYpE.js                           33.20 kB
+@repo/desktop:build: .output/app/renderer/assets/julia-UbEgaZkF.js                             33.21 kB
+@repo/desktop:build: .output/app/renderer/assets/stylus-ZZDn1yUO.js                            33.22 kB
+@repo/desktop:build: .output/app/renderer/assets/kanban-definition-HUTT4EX6-DAMuelve.js        33.56 kB
+@repo/desktop:build: .output/app/renderer/assets/bsl-D0Oxti4u.js                               34.95 kB
+@repo/desktop:build: .output/app/renderer/assets/poimandres-Cn035vRR.js                        36.74 kB
+@repo/desktop:build: .output/app/renderer/assets/one-dark-pro-BP4RhJUN.js                      37.42 kB
+@repo/desktop:build: .output/app/renderer/assets/mindmap-definition-LN4V7U3C-Dkx1m48t.js       38.31 kB
+@repo/desktop:build: .output/app/renderer/assets/tokyo-night-D6CAurEN.js                       38.95 kB
+@repo/desktop:build: .output/app/renderer/assets/houston-whkyFfmE.js                           39.13 kB
+@repo/desktop:build: .output/app/renderer/assets/haxe-B0odltAZ.js                              39.37 kB
+@repo/desktop:build: .output/app/renderer/assets/nginx-DzkjB506.js                             39.44 kB
+@repo/desktop:build: .output/app/renderer/assets/journeyDiagram-5HDEW3XC-CDJUmZRa.js           40.08 kB
+@repo/desktop:build: .output/app/renderer/assets/cobol-DXs7SyPk.js                             41.49 kB
+@repo/desktop:build: .output/app/renderer/assets/erlang-JqgpZ59X.js                            41.69 kB
+@repo/desktop:build: .output/app/renderer/assets/wardleyDiagram-EHGQE667-gkstDBSQ.js           42.16 kB
+@repo/desktop:build: .output/app/renderer/assets/sankeyDiagram-HTMAVEWB-CcfjPQwX.js            42.20 kB
+@repo/desktop:build: .output/app/renderer/assets/asm-wBDSgBbA.js                               43.88 kB
+@repo/desktop:build: .output/app/renderer/assets/erDiagram-Q63AITRT-D8092dio.js                45.20 kB
+@repo/desktop:build: .output/app/renderer/assets/haskell-CfGsE1Cf.js                           45.57 kB
+@repo/desktop:build: .output/app/renderer/assets/shellscript-BhIOf2Zo.js                       45.74 kB
+@repo/desktop:build: .output/app/renderer/assets/perl-Dfqd9NBH.js                              48.57 kB
+@repo/desktop:build: .output/app/renderer/assets/d-BQY8TDgQ.js                                 48.93 kB
+@repo/desktop:build: .output/app/renderer/assets/requirementDiagram-TGXJPOKE-CsKeGoNq.js       51.01 kB
+@repo/desktop:build: .output/app/renderer/assets/ruby-Ctu36n7G.js                              51.74 kB
+@repo/desktop:build: .output/app/renderer/assets/go-BKaVBj1n.js                                51.84 kB
+@repo/desktop:build: .output/app/renderer/assets/apex-DV3SR8IZ.js                              52.20 kB
+@repo/desktop:build: .output/app/renderer/assets/catppuccin-mocha-CqLp86au.js                  52.24 kB
+@repo/desktop:build: .output/app/renderer/assets/catppuccin-latte-byiCqhsy.js                  52.24 kB
+@repo/desktop:build: .output/app/renderer/assets/catppuccin-frappe-Bi059oOw.js                 52.25 kB
+@repo/desktop:build: .output/app/renderer/assets/catppuccin-macchiato-BqO4SuCL.js              52.26 kB
+@repo/desktop:build: .output/app/renderer/assets/css-B9CY0sXE.js                               52.47 kB
+@repo/desktop:build: .output/app/renderer/assets/gitGraphDiagram-IHSO6WYX-CwTJdW0W.js          53.61 kB
+@repo/desktop:build: .output/app/renderer/assets/timeline-definition-FHXFAJF6-pQCqS_eo.js      54.17 kB
+@repo/desktop:build: .output/app/renderer/assets/ada-twHwrVWN.js                               54.61 kB
+@repo/desktop:build: .output/app/renderer/assets/imba-96qKoJCa.js                              54.85 kB
+@repo/desktop:build: .output/app/renderer/assets/quadrantDiagram-ABIIQ3AL-DIPZD_sD.js          58.19 kB
+@repo/desktop:build: .output/app/renderer/assets/everforest-dark-fk6o21I9.js                   58.65 kB
+@repo/desktop:build: .output/app/renderer/assets/everforest-light-Dj3Lvl79.js                  58.66 kB
+@repo/desktop:build: .output/app/renderer/assets/stata-B65lLoZL.js                             62.02 kB
+@repo/desktop:build: .output/app/renderer/assets/html-DFJ4kZpU.js                              62.30 kB
+@repo/desktop:build: .output/app/renderer/assets/wikitext-wjhjmmzD.js                          62.35 kB
+@repo/desktop:build: .output/app/renderer/assets/ballerina-DIdXD2KH.js                         64.73 kB
+@repo/desktop:build: .output/app/renderer/assets/markdown-CkmxmzqY.js                          65.34 kB
+@repo/desktop:build: .output/app/renderer/assets/chunk-EX3LRPZG-Bq90NHoR.js                    67.16 kB
+@repo/desktop:build: .output/app/renderer/assets/ocaml-vm1Y8An6.js                             67.28 kB
+@repo/desktop:build: .output/app/renderer/assets/xychartDiagram-FW5EYKEG-CniQnA7K.js           71.91 kB
+@repo/desktop:build: .output/app/renderer/assets/index.client-CPFAvMZt.js                      72.95 kB
+@repo/desktop:build: .output/app/renderer/assets/mojo-YCzvCoMT.js                              76.96 kB
+@repo/desktop:build: .output/app/renderer/assets/python-BjnOIxPe.js                            77.16 kB
+@repo/desktop:build: .output/app/renderer/assets/c-DerI8Nyp.js                                 78.38 kB
+@repo/desktop:build: .output/app/renderer/assets/latex-D6yNi11B.js                             80.19 kB
+@repo/desktop:build: .output/app/renderer/assets/vyper-C6KGx0YU.js                             82.04 kB
+@repo/desktop:build: .output/app/renderer/assets/chunk-V7JOEXUC-Cb_venYO.js                    83.71 kB
+@repo/desktop:build: .output/app/renderer/assets/hack-BhgQQWer.js                              85.00 kB
+@repo/desktop:build: .output/app/renderer/assets/vennDiagram-L72KCM5P-B_qOUhid.js              89.17 kB
+@repo/desktop:build: .output/app/renderer/assets/swift-BTPQlRLK.js                             93.97 kB
+@repo/desktop:build: .output/app/renderer/assets/racket-DRv7j6nv.js                            95.06 kB
+@repo/desktop:build: .output/app/renderer/assets/fortran-free-form-yxJ7igsv.js                 98.64 kB
+@repo/desktop:build: .output/app/renderer/assets/csharp-C31LYC1j.js                            99.42 kB
+@repo/desktop:build: .output/app/renderer/assets/chunk-PUDLZKDR-471uPuiB.js                   101.67 kB
+@repo/desktop:build: .output/app/renderer/assets/dagre-DOTN9VG9.js                            104.38 kB
+@repo/desktop:build: .output/app/renderer/assets/less-BzbdhFUi.js                             107.13 kB
+@repo/desktop:build: .output/app/renderer/assets/objective-c-6dJF64Dt.js                      111.92 kB
+@repo/desktop:build: .output/app/renderer/assets/blade-Dof0EsN4.js                            112.46 kB
+@repo/desktop:build: .output/app/renderer/assets/c4Diagram-LMCZKHZV-Czks2Tve.js               114.20 kB
+@repo/desktop:build: .output/app/renderer/assets/php-D6Oo9eq7.js                              118.50 kB
+@repo/desktop:build: .output/app/renderer/assets/ganttDiagram-NO4QXBWP-B7hP6EYn.js            124.61 kB
+@repo/desktop:build: .output/app/renderer/assets/blockDiagram-677ZJIJ3-Dx7XPLms.js            129.44 kB
+@repo/desktop:build: .output/app/renderer/assets/graphlib-u_DIv6hk.js                         133.60 kB
+@repo/desktop:build: .output/app/renderer/assets/asciidoc-Dsw6zvwf.js                         146.13 kB
+@repo/desktop:build: .output/app/renderer/assets/mdx-BK9ZufRc.js                              146.32 kB
+@repo/desktop:build: .output/app/renderer/assets/cose-bilkent-JH36ORCC-DG8EG0eT.js            165.81 kB
+@repo/desktop:build: .output/app/renderer/assets/objective-cpp-_ooRQ-PY.js                    184.45 kB
+@repo/desktop:build: .output/app/renderer/assets/javascript-B2h9Dq8-.js                       185.18 kB
+@repo/desktop:build: .output/app/renderer/assets/tsx-ALgBvjuf.js                              185.84 kB
+@repo/desktop:build: .output/app/renderer/assets/jsx-BiOzw8Le.js                              188.10 kB
+@repo/desktop:build: .output/app/renderer/assets/sequenceDiagram-DBY2YBRQ-DX6daoqr.js         190.01 kB
+@repo/desktop:build: .output/app/renderer/assets/typescript-BpcZuW2F.js                       190.99 kB
+@repo/desktop:build: .output/app/renderer/assets/angular-ts-38eZTRz_.js                       194.58 kB
+@repo/desktop:build: .output/app/renderer/assets/vue-vine-Cesv_7VA.js                         201.20 kB
+@repo/desktop:build: .output/app/renderer/assets/calendar-BgDj4o5v.js                         259.87 kB
+@repo/desktop:build: .output/app/renderer/assets/wolfram-CcZPfnLd.js                          266.98 kB
+@repo/desktop:build: .output/app/renderer/assets/swimlanes-5IMT3BWC-C3TrKnhc.js               270.27 kB
+@repo/desktop:build: .output/app/renderer/assets/architectureDiagram-ZJ3FMSHR-CTwaAEbA.js     316.57 kB
+@repo/desktop:build: .output/app/renderer/assets/native-DR3Zz-pu.js                           515.12 kB
+@repo/desktop:build: .output/app/renderer/assets/wasm-CKO9kI9N.js                             622.55 kB
+@repo/desktop:build: .output/app/renderer/assets/cpp-DZNfdFFX.js                              669.05 kB
+@repo/desktop:build: .output/app/renderer/assets/pdf-IGXeWzHT.js                              754.92 kB
+@repo/desktop:build: .output/app/renderer/assets/emacs-lisp-CnKcSCGS.js                       782.37 kB
+@repo/desktop:build: .output/app/renderer/assets/cytoscape.esm-Dsw3a50q.js                    866.69 kB
+@repo/desktop:build: .output/app/renderer/assets/mermaid-parser.core-B27RxFzc.js            1,186.34 kB
+@repo/desktop:build: .output/app/renderer/assets/index-BnWt7THU.js                         10,080.09 kB
+@repo/desktop:build: 
+@repo/desktop:build: [33m[INEFFECTIVE_DYNAMIC_IMPORT] [0m../../node_modules/.pnpm/mermaid@11.16.0/node_modules/mermaid/dist/mermaid.core.mjs is dynamically imported by ../app/src/editor/nodes/code-block-mermaid.tsx but also statically imported by ../../node_modules/.pnpm/@streamdown+mermaid@1.0.2_react@19.2.6/node_modules/@streamdown/mermaid/dist/index.js, dynamic import will not move module into another chunk.
+@repo/desktop:build: 
+@repo/desktop:build: ✓ built in 1.34s
+
+ Tasks:    3 successful, 3 total
+Cached:    2 cached, 3 total
+  Time:    2.748s 
+

--- a/packages/app/dev/fixture-bridge.ts
+++ b/packages/app/dev/fixture-bridge.ts
@@ -221,6 +221,33 @@ The hub links here. Backlinks arrive in a later phase.
 `,
 };
 
+// Matches one checkbox line: indent, marker, box state, label. Ordinals count
+// every checkbox (checked or not), mirroring the host's find-task-line.
+const CHECKBOX_RE = /^(\s*)- \[( |x|X)\] (.*)$/;
+
+/** Simulate the background agent's edit: check the `index`-th checkbox off and
+ * append a nested one-line result under it. Returns null when the ordinal
+ * doesn't land on a checkbox. */
+function simulateDelegationEdit(
+  content: string,
+  index: number,
+): { content: string; taskText: string; lineText: string } | null {
+  const lines = content.split("\n");
+  let ordinal = -1;
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i] ?? "";
+    const match = CHECKBOX_RE.exec(line);
+    if (!match) continue;
+    ordinal++;
+    if (ordinal !== index) continue;
+    const [, indent = "", , label = ""] = match;
+    lines[i] = `${indent}- [x] ${label}`;
+    lines.splice(i + 1, 0, `${indent}  - ✅ Done in the dev harness (simulated edit)`);
+    return { content: lines.join("\n"), taskText: label, lineText: line.trim() };
+  }
+  return null;
+}
+
 /** Streams `text` in small chunks via `onDelta`, then calls `onDone`. */
 function streamText(text: string, onDelta: (delta: string) => void, onDone: () => void): void {
   const words = text.split(/(?<= )/);
@@ -265,6 +292,9 @@ export function createFixtureBridge(): Bridge {
   const uiState: Record<string, unknown> = {};
   const history: ChatHistoryEntry[] = [];
   const delegations: Delegation[] = [];
+  // Pre-run copies keyed by delegation id — the in-memory twin of the host's
+  // ~/.inteligir/snapshots store, so "Restore original" is exercisable.
+  const snapshots = new Map<string, { path: string; content: string }>();
   let notifications = { enabled: false };
   let appState: AppState = { phase: "ready", agent: "idle" };
 
@@ -402,28 +432,74 @@ export function createFixtureBridge(): Bridge {
     },
     onVaultChanged: vaultEvents.subscribe,
 
-    // Delegation — no background agent; created delegations fail immediately
-    // so the inline badge + dock plumbing stays exercisable.
+    // Delegation — no background agent, but the run is simulated against the
+    // in-memory vault (running → snapshot → check the box + append a result →
+    // done) so the badge, dock, and "Restore original" plumbing are all
+    // exercisable. The brief "running" beat matters: the dock only tracks
+    // delegations it saw go active this session.
     createDelegation: async ({ sourceFile, index }) => {
       const now = Date.now();
+      const id = `fixture-${now}-${index}`;
+      // Resolve the checkbox up front (as the host does) so the dock card has
+      // a title while the simulated run is still "running".
+      const initial = vault.get(sourceFile);
+      const resolved = initial === undefined ? null : simulateDelegationEdit(initial, index);
       const delegation: Delegation = {
-        id: `fixture-${now}-${index}`,
+        id,
         sourceFile,
-        anchor: { index, text: "", heading: null },
-        lineText: "",
-        status: "failed",
+        anchor: { index, text: resolved?.taskText ?? "", heading: null },
+        lineText: resolved?.lineText ?? "",
+        status: "running",
         createdAt: now,
-        startedAt: null,
-        finishedAt: now,
+        startedAt: now,
+        finishedAt: null,
         resultSummary: null,
-        error: "delegation is not available in the dev harness",
+        error: null,
+        hasSnapshot: false,
+        restoredAt: null,
       };
       delegations.push(delegation);
       delegationEvents.emit({ delegations: [...delegations] });
+      setTimeout(() => {
+        const content = vault.get(delegation.sourceFile);
+        const edited = content === undefined ? null : simulateDelegationEdit(content, index);
+        if (content === undefined || edited === null) {
+          delegation.status = "failed";
+          delegation.error = "That checkbox is no longer in the file.";
+        } else {
+          // Mirror the host's ordering: snapshot the pre-run bytes FIRST, then
+          // let the "agent" edit, then finish done.
+          snapshots.set(id, { path: delegation.sourceFile, content });
+          delegation.hasSnapshot = true;
+          vault.set(delegation.sourceFile, edited.content);
+          vaultEvents.emit({ root: FIXTURE_ROOT });
+          delegation.status = "done";
+          delegation.anchor = { index, text: edited.taskText, heading: null };
+          delegation.lineText = edited.lineText;
+          delegation.resultSummary = "Checked it off in the dev harness (simulated).";
+        }
+        delegation.finishedAt = Date.now();
+        delegationEvents.emit({ delegations: [...delegations] });
+      }, 800);
       return { ok: true, delegation };
     },
     listDelegations: async () => ({ delegations: [...delegations] }),
     cancelDelegation: async () => ({ ok: false }),
+    restoreDelegationSnapshot: async (id) => {
+      const delegation = delegations.find((d) => d.id === id);
+      if (!delegation) return { ok: false, error: "Unknown delegation." };
+      const snapshot = snapshots.get(id);
+      if (!snapshot) return { ok: false, error: "No snapshot exists for this delegation." };
+      // No-op success when the bytes already match; otherwise write + notify,
+      // mirroring the host's restore semantics.
+      if (vault.get(delegation.sourceFile) !== snapshot.content) {
+        vault.set(delegation.sourceFile, snapshot.content);
+        vaultEvents.emit({ root: FIXTURE_ROOT });
+      }
+      delegation.restoredAt = Date.now();
+      delegationEvents.emit({ delegations: [...delegations] });
+      return { ok: true };
+    },
     onDelegationsUpdated: delegationEvents.subscribe,
     onDelegationStreamed: () => () => {},
 

--- a/packages/app/src/delegation/delegation-dock.tsx
+++ b/packages/app/src/delegation/delegation-dock.tsx
@@ -4,14 +4,26 @@ import {
   ClockIcon,
   Loader2Icon,
   SquareIcon,
+  Undo2Icon,
   XCircleIcon,
   XIcon,
 } from "lucide-react";
 
+import {
+  AlertDialog,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@repo/ui/components/alert-dialog";
 import { Response } from "@repo/ui/components/ai-elements/response";
+import { Button } from "@repo/ui/components/button";
+import { toast } from "@repo/ui/components/sonner";
 import { cn } from "@repo/ui/lib/utils";
 
 import { useDelegationStore } from "@repo/app/stores/delegation-store";
+import { useVault } from "@repo/app/workspace/vault-context";
 import type { Delegation } from "@repo/core/delegation";
 
 /**
@@ -26,8 +38,22 @@ export function DelegationDock() {
   const delegations = useDelegationStore((s) => s.delegations);
   const streams = useDelegationStore((s) => s.streams);
   const cancel = useDelegationStore((s) => s.cancel);
+  const restore = useDelegationStore((s) => s.restore);
+  const { entries } = useVault();
   const [tracked, setTracked] = useState<ReadonlySet<string>>(new Set());
   const [dismissed, setDismissed] = useState<ReadonlySet<string>>(new Set());
+  // The delegation awaiting restore confirmation (null = dialog closed).
+  const [confirming, setConfirming] = useState<Delegation | null>(null);
+  const [restoring, setRestoring] = useState(false);
+
+  const confirmRestore = async () => {
+    if (!confirming) return;
+    setRestoring(true);
+    const result = await restore(confirming.id);
+    setRestoring(false);
+    setConfirming(null);
+    if (!result.ok) toast.error(result.error ?? "Couldn't restore the snapshot.");
+  };
 
   // Track any delegation we've seen go active this session.
   useEffect(() => {
@@ -58,7 +84,9 @@ export function DelegationDock() {
           key={d.id}
           delegation={d}
           stream={streams[d.id] ?? null}
+          fileExists={entries.some((entry) => entry.path === d.sourceFile)}
           onStop={() => cancel(d.id)}
+          onRestore={() => setConfirming(d)}
           onDismiss={() =>
             setDismissed((prev) => {
               const next = new Set(prev);
@@ -68,6 +96,30 @@ export function DelegationDock() {
           }
         />
       ))}
+      <AlertDialog
+        open={confirming !== null}
+        onOpenChange={(open) => {
+          if (!open && !restoring) setConfirming(null);
+        }}
+      >
+        <AlertDialogContent size="sm">
+          <AlertDialogHeader>
+            <AlertDialogTitle>Restore original?</AlertDialogTitle>
+          </AlertDialogHeader>
+          <AlertDialogDescription>
+            This overwrites the current content of {confirming?.sourceFile ?? "the file"} with the
+            copy saved before the agent ran.
+          </AlertDialogDescription>
+          <AlertDialogFooter>
+            <Button variant="secondary" disabled={restoring} onClick={() => setConfirming(null)}>
+              Cancel
+            </Button>
+            <Button loading={restoring} onClick={() => void confirmRestore()}>
+              Restore
+            </Button>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
     </div>
   );
 }
@@ -88,18 +140,25 @@ function StatusIcon({ status }: { status: Delegation["status"] }) {
 function DelegationCard({
   delegation,
   stream,
+  fileExists,
   onStop,
+  onRestore,
   onDismiss,
 }: {
   delegation: Delegation;
   stream: string | null;
+  fileExists: boolean;
   onStop: () => void;
+  onRestore: () => void;
   onDismiss: () => void;
 }) {
-  const { status, anchor, resultSummary, error } = delegation;
+  const { status, anchor, resultSummary, error, hasSnapshot, restoredAt } = delegation;
   const active = status === "running" || status === "queued";
   // Prefer the live stream while running; fall back to the persisted summary.
   const body = error ?? stream ?? resultSummary ?? "";
+  // Undo affordance: only once the run is over (restoring under a live run
+  // would race the agent) and only when a pre-run snapshot was captured.
+  const restorable = !active && hasSnapshot;
 
   return (
     <div className="pointer-events-auto flex max-h-72 flex-col overflow-hidden rounded-xl border border-border bg-popover text-popover-foreground shadow-lg">
@@ -135,6 +194,27 @@ function DelegationCard({
             <span className="text-destructive">{body}</span>
           ) : (
             <Response className={cn("prose-sm")}>{body}</Response>
+          )}
+        </div>
+      )}
+      {restorable && (
+        <div className="flex items-center gap-2 border-t border-border px-3 py-1.5">
+          <button
+            type="button"
+            onClick={onRestore}
+            disabled={!fileExists}
+            title={
+              fileExists
+                ? `Overwrite ${delegation.sourceFile} with its pre-run content`
+                : `${delegation.sourceFile} no longer exists`
+            }
+            className="flex items-center gap-1 rounded px-1.5 py-0.5 text-[10px] font-medium text-muted-foreground hover:bg-muted hover:text-foreground disabled:cursor-not-allowed disabled:opacity-50 disabled:hover:bg-transparent disabled:hover:text-muted-foreground"
+          >
+            <Undo2Icon className="size-3" />
+            Restore original
+          </button>
+          {restoredAt !== null && (
+            <span className="text-[10px] text-muted-foreground">Restored</span>
           )}
         </div>
       )}

--- a/packages/app/src/stores/delegation-store.ts
+++ b/packages/app/src/stores/delegation-store.ts
@@ -13,6 +13,9 @@ type DelegationStore = {
    * in the document). */
   delegate: (sourceFile: string, index: number) => Promise<{ ok: boolean; error?: string }>;
   cancel: (id: string) => void;
+  /** Overwrite the delegation's file with its pre-run snapshot (cheap undo of
+   * the agent's edit). The vault watcher refreshes the open editor. */
+  restore: (id: string) => Promise<{ ok: boolean; error?: string }>;
 };
 
 export const useDelegationStore = create<DelegationStore>((set) => ({
@@ -57,6 +60,14 @@ export const useDelegationStore = create<DelegationStore>((set) => ({
     getBridge()
       ?.cancelDelegation(id)
       .catch(() => {});
+  },
+
+  restore: async (id) => {
+    const bridge = getBridge();
+    if (!bridge) return { ok: false, error: "Unavailable" };
+    const result = await bridge.restoreDelegationSnapshot(id).catch(() => null);
+    if (!result) return { ok: false, error: "Couldn't restore the snapshot." };
+    return result.ok ? { ok: true } : { ok: false, error: result.error };
   },
 }));
 

--- a/packages/core/src/bridge-ws-client.ts
+++ b/packages/core/src/bridge-ws-client.ts
@@ -294,6 +294,7 @@ export function createWsBridge(url: string, options: WsBridgeOptions = {}): Brid
     createDelegation: rpc("createDelegation"),
     listDelegations: rpc("listDelegations"),
     cancelDelegation: rpc("cancelDelegation"),
+    restoreDelegationSnapshot: rpc("restoreDelegationSnapshot"),
     onDelegationsUpdated: sub("onDelegationsUpdated"),
     onDelegationStreamed: sub("onDelegationStreamed"),
 

--- a/packages/core/src/delegation.ts
+++ b/packages/core/src/delegation.ts
@@ -45,6 +45,11 @@ export const DelegationSchema = Type.Object(
     resultSummary: Type.Union([Type.String(), Type.Null()]),
     /** Failure reason (status "failed"). */
     error: Type.Union([Type.String(), Type.Null()]),
+    /** True once the host captured the file's pre-run bytes — the undo point
+     * "Restore original" writes back. */
+    hasSnapshot: Type.Boolean(),
+    /** When the user last restored this delegation's snapshot (null = never). */
+    restoredAt: Type.Union([Type.Number(), Type.Null()]),
   },
   { additionalProperties: false },
 );
@@ -72,3 +77,7 @@ export type CreateDelegationResult =
   | { ok: false; error: string };
 
 export type ListDelegationsResult = { delegations: Delegation[] };
+
+/** Result of restoring a delegation's pre-run snapshot. A restore whose target
+ * file already matches the snapshot bytes is a no-op success. */
+export type RestoreSnapshotResult = { ok: true } | { ok: false; error: string };

--- a/packages/core/src/ipc-registry.ts
+++ b/packages/core/src/ipc-registry.ts
@@ -37,6 +37,7 @@ import {
   CreateDelegationParamsSchema,
   type CreateDelegationResult,
   type ListDelegationsResult,
+  type RestoreSnapshotResult,
 } from "./delegation";
 import { AiGenerateParamsSchema, type AiGenerateResult } from "./inline-ai";
 import { UiStateSetSchema } from "./ui-state";
@@ -298,6 +299,14 @@ export const IPC = {
   listDelegations: invokeVoid<ListDelegationsResult>("delegation:list"),
   cancelDelegation: invoke<ReturnType<typeof Type.String>, { ok: boolean }>(
     "delegation:cancel",
+    Type.String({ minLength: 1 }),
+  ),
+  /** Restore the target file's pre-run bytes (captured before the background
+   * agent dispatched). Writes atomically through the vault, so the watcher's
+   * standard onVaultChanged refreshes editors; no-op success when the file
+   * already matches the snapshot. Records `restoredAt` on the delegation. */
+  restoreDelegationSnapshot: invoke<ReturnType<typeof Type.String>, RestoreSnapshotResult>(
+    "delegation:restore-snapshot",
     Type.String({ minLength: 1 }),
   ),
   /** Fired on every delegation status change so the editor's inline badges

--- a/packages/host/src/__tests__/delegation-manager.test.ts
+++ b/packages/host/src/__tests__/delegation-manager.test.ts
@@ -588,11 +588,9 @@ describe("DelegationManager.restoreSnapshot", () => {
     if (!result.ok) expect(result.error).toContain("No snapshot");
     expect(rig.writes).toEqual([]);
     expect(rig.mgr.getDelegations()[0]?.restoredAt).toBeNull();
-    // The record's hasSnapshot flag stays true (prune doesn't rewrite records).
-    // That stale flag is unreachable from the UI: prune runs only at host
-    // start, and the dock only shows delegations seen active this session — a
-    // new surface listing ALL delegations would need to revalidate it.
-    expect(rig.mgr.getDelegations()[0]?.hasSnapshot).toBe(true);
+    // Prune flips hasSnapshot at the data level, so no surface — present or
+    // future — can offer a restore whose bytes are gone.
+    expect(rig.mgr.getDelegations()[0]?.hasSnapshot).toBe(false);
   });
 });
 

--- a/packages/host/src/__tests__/delegation-manager.test.ts
+++ b/packages/host/src/__tests__/delegation-manager.test.ts
@@ -1,8 +1,9 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { DelegationManager, type DelegationAgent } from "../delegation/delegation-manager";
-import { DelegationSnapshotStore } from "../delegation/delegation-snapshots";
+import { DelegationSnapshotStore, SNAPSHOT_RETENTION } from "../delegation/delegation-snapshots";
 import type { FsAdapter } from "../lib/json-store";
+import { isRecord } from "@repo/core/ipc";
 
 function memoryFs(): FsAdapter {
   const files = new Map<string, string>();
@@ -34,7 +35,9 @@ function memorySnapshots(): DelegationSnapshotStore {
         files.delete(p);
       },
       list: (dir) =>
-        [...files.keys()].filter((p) => p.startsWith(`${dir}/`)).map((p) => p.slice(dir.length + 1)),
+        [...files.keys()]
+          .filter((p) => p.startsWith(`${dir}/`))
+          .map((p) => p.slice(dir.length + 1)),
     },
     dir: "/snaps",
     indexPath: "/snapshots.json",
@@ -552,5 +555,92 @@ describe("DelegationManager.restoreSnapshot", () => {
 
     expect(rig.mgr.restoreSnapshot(firstId)).toEqual({ ok: true });
     expect(rig.state.live).toBe(DOC); // back to the original document
+  });
+
+  it("round-trips nasty bytes exactly — CRLF, lone CR, trailing whitespace, unicode, no final newline", async () => {
+    const nasty =
+      "## Tödāy 👩‍🚀\r\n\r\n- [ ] tâsk one\r\n\r\ntrailing spaces  \r\nzero​width, combining é, 日本語\rlone-CR line\nmixed LF, no final newline";
+    const rig = makeRestoreRig(nasty);
+    const id = await runOne(rig);
+
+    // The "agent" checks the box and appends a result on its own line endings.
+    rig.state.live = `${nasty.replace("- [ ]", "- [x]")}\n  - ✅ done\n`;
+
+    expect(rig.mgr.restoreSnapshot(id)).toEqual({ ok: true });
+    expect(rig.state.live).toBe(nasty); // byte-identical, not merely equivalent
+  });
+
+  it("fails gracefully (no write) when the snapshot was pruned by retention", async () => {
+    const rig = makeRestoreRig();
+    const id = await runOne(rig);
+
+    // Push the real snapshot past the retention horizon with strictly newer
+    // captures, then run the host-start sweep.
+    let now = Date.now();
+    vi.spyOn(Date, "now").mockImplementation(() => ++now);
+    for (let i = 0; i < SNAPSHOT_RETENTION; i++) {
+      rig.snapshots.capture(`filler-${i}`, "x.md", `filler ${i}`);
+    }
+    rig.mgr.pruneSnapshots();
+
+    const result = rig.mgr.restoreSnapshot(id);
+    expect(result).toMatchObject({ ok: false });
+    if (!result.ok) expect(result.error).toContain("No snapshot");
+    expect(rig.writes).toEqual([]);
+    expect(rig.mgr.getDelegations()[0]?.restoredAt).toBeNull();
+    // The record's hasSnapshot flag stays true (prune doesn't rewrite records).
+    // That stale flag is unreachable from the UI: prune runs only at host
+    // start, and the dock only shows delegations seen active this session — a
+    // new surface listing ALL delegations would need to revalidate it.
+    expect(rig.mgr.getDelegations()[0]?.hasSnapshot).toBe(true);
+  });
+});
+
+describe("delegations store v2 → v3 migration", () => {
+  // A record exactly as a v2 build persisted it — no hasSnapshot/restoredAt.
+  const V2_RECORD = {
+    id: "3f6b2c1a-0000-4000-8000-000000000001",
+    sourceFile: "notes/today.md",
+    anchor: { index: 1, text: "task two", heading: "Today" },
+    lineText: "- [ ] task two",
+    status: "done",
+    createdAt: 1700000000000,
+    startedAt: 1700000001000,
+    finishedAt: 1700000002000,
+    resultSummary: "did it",
+    error: null,
+  };
+
+  it("loads a real v2 blob, adds snapshot fields with safe defaults, and never quarantines", () => {
+    const files = new Map<string, string>([
+      ["/delegations.json", JSON.stringify({ version: 2, delegations: [V2_RECORD] }, null, 2)],
+    ]);
+    const fs: FsAdapter = {
+      read: (p) => files.get(p) ?? null,
+      write: (p, content) => {
+        files.set(p, content);
+      },
+      rename: (from, to) => {
+        const content = files.get(from);
+        if (content === undefined) throw new Error(`rename: missing ${from}`);
+        files.delete(from);
+        files.set(to, content);
+      },
+    };
+    const mgr = new DelegationManager({
+      fs,
+      path: "/delegations.json",
+      readVault: () => DOC,
+      snapshots: memorySnapshots(),
+    });
+
+    // The record survives intact and gains the v3 fields with their only sane
+    // defaults: a pre-snapshot record has no snapshot and was never restored.
+    expect(mgr.getDelegations()).toEqual([{ ...V2_RECORD, hasSnapshot: false, restoredAt: null }]);
+    // Migration path, not the corrupt-recovery path — nothing was set aside…
+    expect([...files.keys()].filter((k) => k !== "/delegations.json")).toEqual([]);
+    // …and the upgraded shape was re-persisted as v3 so the chain doesn't re-run.
+    const persisted: unknown = JSON.parse(files.get("/delegations.json") ?? "null");
+    expect(isRecord(persisted) ? persisted["version"] : null).toBe(3);
   });
 });

--- a/packages/host/src/__tests__/delegation-manager.test.ts
+++ b/packages/host/src/__tests__/delegation-manager.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { DelegationManager, type DelegationAgent } from "../delegation/delegation-manager";
+import { DelegationSnapshotStore } from "../delegation/delegation-snapshots";
 import type { FsAdapter } from "../lib/json-store";
 
 function memoryFs(): FsAdapter {
@@ -17,6 +18,27 @@ function memoryFs(): FsAdapter {
       files.set(to, content);
     },
   };
+}
+
+/** A snapshot store over an in-memory map — no ~/.inteligir writes in tests. */
+function memorySnapshots(): DelegationSnapshotStore {
+  const files = new Map<string, string>();
+  return new DelegationSnapshotStore({
+    fs: memoryFs(),
+    files: {
+      read: (p) => files.get(p) ?? null,
+      write: (p, content) => {
+        files.set(p, content);
+      },
+      remove: (p) => {
+        files.delete(p);
+      },
+      list: (dir) =>
+        [...files.keys()].filter((p) => p.startsWith(`${dir}/`)).map((p) => p.slice(dir.length + 1)),
+    },
+    dir: "/snaps",
+    indexPath: "/snapshots.json",
+  });
 }
 
 // A controllable stand-in for the background Agent: drive idle resolution and
@@ -72,7 +94,34 @@ const flush = () => new Promise((r) => setTimeout(r, 0));
 const DOC = "## Today\n\n- [ ] task one\n- [ ] task two\n";
 
 function makeManager(doc = DOC) {
-  return new DelegationManager({ fs: memoryFs(), path: "/delegations.json", readVault: () => doc });
+  return new DelegationManager({
+    fs: memoryFs(),
+    path: "/delegations.json",
+    readVault: () => doc,
+    snapshots: memorySnapshots(),
+  });
+}
+
+/** Manager over a mutable `live` document, recording vault writes — the rig
+ * for snapshot/restore tests. */
+function makeRestoreRig(initial = DOC) {
+  const state: { live: string | null } = { live: initial };
+  const writes: Array<{ path: string; content: string }> = [];
+  const snapshots = memorySnapshots();
+  const mgr = new DelegationManager({
+    fs: memoryFs(),
+    path: "/delegations.json",
+    readVault: () => {
+      if (state.live === null) throw new Error("ENOENT: no such file");
+      return state.live;
+    },
+    writeVault: (path, content) => {
+      writes.push({ path, content });
+      state.live = content;
+    },
+    snapshots,
+  });
+  return { mgr, state, writes, snapshots };
 }
 
 afterEach(() => vi.restoreAllMocks());
@@ -157,7 +206,12 @@ describe("DelegationManager run lifecycle", () => {
 
   it("re-runs against current bytes when the task is unchanged but the doc shifted around it", async () => {
     let live = "## Today\n\n- [ ] task one\n- [ ] task two\n";
-    const mgr = new DelegationManager({ fs: memoryFs(), path: "/d.json", readVault: () => live });
+    const mgr = new DelegationManager({
+      fs: memoryFs(),
+      path: "/d.json",
+      readVault: () => live,
+      snapshots: memorySnapshots(),
+    });
     mgr.createDelegation({ sourceFile: "n.md", index: 0 }); // anchor = "task one"
 
     // A non-checkbox paragraph is inserted above: the ordinal is unchanged and
@@ -173,7 +227,12 @@ describe("DelegationManager run lifecycle", () => {
 
   it("fails safe (never dispatches) when the ordinal would retarget to a different task", async () => {
     let live = "## Today\n\n- [ ] task one\n- [ ] task two\n";
-    const mgr = new DelegationManager({ fs: memoryFs(), path: "/d.json", readVault: () => live });
+    const mgr = new DelegationManager({
+      fs: memoryFs(),
+      path: "/d.json",
+      readVault: () => live,
+      snapshots: memorySnapshots(),
+    });
     mgr.createDelegation({ sourceFile: "n.md", index: 1 }); // anchor = "task two"
     expect(mgr.getDelegations()[0]?.anchor.text).toBe("task two");
 
@@ -192,7 +251,12 @@ describe("DelegationManager run lifecycle", () => {
 
   it("fails (and never dispatches) a delegation whose checkbox vanished while queued", async () => {
     let live = "## Today\n\n- [ ] task one\n";
-    const mgr = new DelegationManager({ fs: memoryFs(), path: "/d.json", readVault: () => live });
+    const mgr = new DelegationManager({
+      fs: memoryFs(),
+      path: "/d.json",
+      readVault: () => live,
+      snapshots: memorySnapshots(),
+    });
     mgr.createDelegation({ sourceFile: "n.md", index: 0 });
 
     live = "## Today\n\n(all tasks removed)\n";
@@ -342,5 +406,151 @@ describe("DelegationManager run lifecycle", () => {
     expect(mgr.cancelDelegation(firstId).ok).toBe(true);
     expect(mgr.cancelDelegation(secondId).ok).toBe(true);
     expect(mgr.getDelegations().map((d) => d.anchor.text)).toEqual(["task one"]);
+  });
+
+  it("snapshots the file BEFORE dispatching the agent (never an unsnapshotted run)", async () => {
+    const { mgr, snapshots } = makeRestoreRig();
+    const order: string[] = [];
+    const realCapture = snapshots.capture.bind(snapshots);
+    vi.spyOn(snapshots, "capture").mockImplementation((...args) => {
+      order.push("capture");
+      realCapture(...args);
+    });
+    const fake = fakeAgent();
+    const realSend = fake.agent.sendMessage;
+    fake.agent.sendMessage = async (message) => {
+      order.push("dispatch");
+      await realSend(message);
+    };
+    mgr.setRunner(() => fake.agent);
+
+    const created = mgr.createDelegation({ sourceFile: "n.md", index: 0 });
+    await flush();
+
+    expect(order).toEqual(["capture", "dispatch"]);
+    const id = created.ok ? created.delegation.id : "";
+    expect(mgr.getDelegations()[0]?.hasSnapshot).toBe(true);
+    const snap = snapshots.read(id);
+    expect(snap).toMatchObject({ ok: true, content: DOC });
+  });
+
+  it("aborts the run (agent never dispatched) when the snapshot can't be captured", async () => {
+    const { mgr, snapshots } = makeRestoreRig();
+    vi.spyOn(snapshots, "capture").mockImplementation(() => {
+      throw new Error("disk full");
+    });
+    const fake = fakeAgent();
+    mgr.setRunner(() => fake.agent);
+
+    mgr.createDelegation({ sourceFile: "n.md", index: 0 });
+    await flush();
+
+    const d = mgr.getDelegations()[0];
+    expect(d?.status).toBe("failed");
+    expect(d?.error).toContain("snapshot");
+    expect(d?.hasSnapshot).toBe(false);
+    expect(fake.prompts.length).toBe(0);
+  });
+});
+
+describe("DelegationManager.restoreSnapshot", () => {
+  /** Run one delegation to completion and return its id. */
+  async function runOne(rig: ReturnType<typeof makeRestoreRig>, index = 0): Promise<string> {
+    const fake = fakeAgent();
+    rig.mgr.setRunner(() => fake.agent);
+    const created = rig.mgr.createDelegation({ sourceFile: "n.md", index });
+    await flush();
+    fake.finish();
+    await flush();
+    return created.ok ? created.delegation.id : "";
+  }
+
+  it("restores the pre-run bytes through the vault write and records restoredAt", async () => {
+    const rig = makeRestoreRig();
+    const id = await runOne(rig);
+
+    // The agent edited the file after the snapshot was taken.
+    rig.state.live = "## Today\n\n- [x] task one\n  - ✅ did it\n- [ ] task two\n";
+
+    expect(rig.mgr.restoreSnapshot(id)).toEqual({ ok: true });
+    expect(rig.writes).toEqual([{ path: "n.md", content: DOC }]);
+    expect(rig.state.live).toBe(DOC); // byte-identical to the pre-run copy
+    expect(rig.mgr.getDelegations()[0]?.restoredAt).not.toBeNull();
+  });
+
+  it("is a no-op success (no write) when the file already matches the snapshot", async () => {
+    const rig = makeRestoreRig();
+    const id = await runOne(rig);
+
+    expect(rig.mgr.restoreSnapshot(id)).toEqual({ ok: true });
+    expect(rig.writes).toEqual([]); // no write → no watcher churn
+    expect(rig.mgr.getDelegations()[0]?.restoredAt).not.toBeNull();
+  });
+
+  it("recreates the file when it was deleted after the run", async () => {
+    const rig = makeRestoreRig();
+    const id = await runOne(rig);
+
+    rig.state.live = null; // file deleted — readVault now throws
+
+    expect(rig.mgr.restoreSnapshot(id)).toEqual({ ok: true });
+    expect(rig.writes).toEqual([{ path: "n.md", content: DOC }]);
+  });
+
+  it("rejects a restore while the delegation is still queued or running", async () => {
+    const rig = makeRestoreRig();
+    const fake = fakeAgent();
+    rig.mgr.setRunner(() => fake.agent);
+    const created = rig.mgr.createDelegation({ sourceFile: "n.md", index: 0 });
+    const id = created.ok ? created.delegation.id : "";
+    await flush();
+    expect(rig.mgr.getDelegations()[0]?.status).toBe("running");
+
+    const result = rig.mgr.restoreSnapshot(id);
+    expect(result.ok).toBe(false);
+    expect(rig.writes).toEqual([]);
+  });
+
+  it("rejects an unknown delegation and a delegation that never snapshotted", () => {
+    const rig = makeRestoreRig();
+    expect(rig.mgr.restoreSnapshot("nope").ok).toBe(false);
+
+    // Queued (no runner) → never ran, no snapshot, and also not terminal.
+    const created = rig.mgr.createDelegation({ sourceFile: "n.md", index: 0 });
+    const id = created.ok ? created.delegation.id : "";
+    expect(rig.mgr.restoreSnapshot(id).ok).toBe(false);
+    expect(rig.writes).toEqual([]);
+  });
+
+  it("keeps per-delegation pre-states on the same file — the second snapshot never clobbers the first", async () => {
+    // Two delegations against one file run back-to-back. Each snapshot is keyed
+    // by delegation id and captures the bytes immediately before THAT run, so:
+    // restore(first) = the original document (undoes both edits), and
+    // restore(second) = the state after the first agent edit.
+    const rig = makeRestoreRig();
+    const fake = fakeAgent();
+    rig.mgr.setRunner(() => fake.agent);
+    const first = rig.mgr.createDelegation({ sourceFile: "n.md", index: 0 });
+    const second = rig.mgr.createDelegation({ sourceFile: "n.md", index: 1 });
+    const firstId = first.ok ? first.delegation.id : "";
+    const secondId = second.ok ? second.delegation.id : "";
+    await flush();
+
+    // First runs against the original doc, then "edits" it (checks task one).
+    const afterFirst = "## Today\n\n- [x] task one\n  - ✅ done\n- [ ] task two\n";
+    rig.state.live = afterFirst;
+    fake.finish();
+    await flush(); // second resolves + snapshots against afterFirst
+    const afterSecond = "## Today\n\n- [x] task one\n  - ✅ done\n- [x] task two\n  - ✅ done\n";
+    rig.state.live = afterSecond;
+    fake.finish();
+    await flush();
+    expect(rig.mgr.getDelegations().map((d) => d.status)).toEqual(["done", "done"]);
+
+    expect(rig.mgr.restoreSnapshot(secondId)).toEqual({ ok: true });
+    expect(rig.state.live).toBe(afterFirst); // undo just the second edit
+
+    expect(rig.mgr.restoreSnapshot(firstId)).toEqual({ ok: true });
+    expect(rig.state.live).toBe(DOC); // back to the original document
   });
 });

--- a/packages/host/src/__tests__/delegation-snapshots.test.ts
+++ b/packages/host/src/__tests__/delegation-snapshots.test.ts
@@ -1,0 +1,134 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import {
+  DelegationSnapshotStore,
+  SNAPSHOT_RETENTION,
+} from "../delegation/delegation-snapshots";
+import type { FsAdapter } from "../lib/json-store";
+
+const DIR = "/snaps";
+
+/** One in-memory file map backing both the JsonStore index and the content
+ * files, plus direct access for tamper/orphan setups. */
+function makeStore() {
+  const files = new Map<string, string>();
+  const fs: FsAdapter = {
+    read: (p) => files.get(p) ?? null,
+    write: (p, content) => {
+      files.set(p, content);
+    },
+    rename: (from, to) => {
+      const content = files.get(from);
+      if (content === undefined) throw new Error(`rename: missing ${from}`);
+      files.delete(from);
+      files.set(to, content);
+    },
+  };
+  const store = new DelegationSnapshotStore({
+    fs,
+    files: {
+      read: (p) => files.get(p) ?? null,
+      write: (p, content) => {
+        files.set(p, content);
+      },
+      remove: (p) => {
+        files.delete(p);
+      },
+      list: (dir) =>
+        [...files.keys()]
+          .filter((p) => p.startsWith(`${dir}/`))
+          .map((p) => p.slice(dir.length + 1))
+          .filter((name) => !name.includes("/")),
+    },
+    dir: DIR,
+    indexPath: "/snapshots.json",
+  });
+  return { store, files };
+}
+
+afterEach(() => vi.restoreAllMocks());
+
+describe("DelegationSnapshotStore", () => {
+  it("capture + read round-trips the exact bytes and the capture-time path", () => {
+    const { store } = makeStore();
+    store.capture("d1", "notes/a.md", "# A\n\n- [ ] task\n");
+    expect(store.read("d1")).toEqual({
+      ok: true,
+      path: "notes/a.md",
+      content: "# A\n\n- [ ] task\n",
+    });
+  });
+
+  it("read of an unknown delegation reports no snapshot", () => {
+    const { store } = makeStore();
+    const result = store.read("nope");
+    expect(result.ok).toBe(false);
+  });
+
+  it("refuses to hand back bytes that fail the recorded hash (tampered/torn file)", () => {
+    const { store, files } = makeStore();
+    store.capture("d1", "a.md", "original");
+    files.set(`${DIR}/d1`, "tampered");
+    const result = store.read("d1");
+    expect(result).toMatchObject({ ok: false });
+    if (!result.ok) expect(result.error).toContain("corrupt");
+  });
+
+  it("reports a missing bytes file distinctly from a missing entry", () => {
+    const { store, files } = makeStore();
+    store.capture("d1", "a.md", "original");
+    files.delete(`${DIR}/d1`);
+    const result = store.read("d1");
+    expect(result).toMatchObject({ ok: false });
+    if (!result.ok) expect(result.error).toContain("missing");
+  });
+
+  it("prune keeps the newest SNAPSHOT_RETENTION snapshots and deletes older bytes", () => {
+    const { store } = makeStore();
+    // Distinct capturedAt per snapshot — real captures are never same-ms bursts.
+    let now = 1000;
+    vi.spyOn(Date, "now").mockImplementation(() => ++now);
+    const total = SNAPSHOT_RETENTION + 5;
+    for (let i = 0; i < total; i++) store.capture(`d${i}`, "a.md", `content ${i}`);
+
+    store.prune();
+
+    // The 5 oldest are gone — index entry and bytes both.
+    for (let i = 0; i < 5; i++) expect(store.read(`d${i}`).ok).toBe(false);
+    // The newest SNAPSHOT_RETENTION survive intact.
+    for (let i = 5; i < total; i++) {
+      expect(store.read(`d${i}`)).toMatchObject({ ok: true, content: `content ${i}` });
+    }
+  });
+
+  it("prune sweeps orphan files in the content dir (crash leftovers)", () => {
+    const { store, files } = makeStore();
+    store.capture("d1", "a.md", "keep me");
+    files.set(`${DIR}/orphan`, "bytes with no index entry");
+    files.set(`${DIR}/d9.tmp`, "torn atomic write");
+
+    store.prune();
+
+    expect(files.has(`${DIR}/orphan`)).toBe(false);
+    expect(files.has(`${DIR}/d9.tmp`)).toBe(false);
+    expect(store.read("d1")).toMatchObject({ ok: true, content: "keep me" });
+  });
+
+  it("prune under the cap is a no-op for the index", () => {
+    const { store } = makeStore();
+    store.capture("d1", "a.md", "one");
+    store.capture("d2", "b.md", "two");
+    store.prune();
+    expect(store.read("d1").ok).toBe(true);
+    expect(store.read("d2").ok).toBe(true);
+  });
+
+  it("re-capturing the same delegation id overwrites (idempotent, no duplicate entries)", () => {
+    const { store } = makeStore();
+    store.capture("d1", "a.md", "first");
+    store.capture("d1", "a.md", "second");
+    expect(store.read("d1")).toMatchObject({ ok: true, content: "second" });
+    store.prune(); // must not treat the overwrite as an orphan
+    expect(store.read("d1")).toMatchObject({ ok: true, content: "second" });
+  });
+});

--- a/packages/host/src/__tests__/delegation-snapshots.test.ts
+++ b/packages/host/src/__tests__/delegation-snapshots.test.ts
@@ -1,9 +1,6 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 
-import {
-  DelegationSnapshotStore,
-  SNAPSHOT_RETENTION,
-} from "../delegation/delegation-snapshots";
+import { DelegationSnapshotStore, SNAPSHOT_RETENTION } from "../delegation/delegation-snapshots";
 import type { FsAdapter } from "../lib/json-store";
 
 const DIR = "/snaps";

--- a/packages/host/src/create-host.ts
+++ b/packages/host/src/create-host.ts
@@ -9,6 +9,7 @@ import path from "node:path";
 
 import { configurePaths } from "./agent/paths";
 import { initMachine, shutdown } from "./app/app-machine";
+import { getDelegationManager } from "./delegation/delegation-manager";
 import { emitEvent, subscribeEvents } from "./events";
 import { initAgentLog } from "./lib/agent-log";
 import { acquireHostLock, releaseHostLock } from "./lib/host-lock";
@@ -108,6 +109,14 @@ export function createHost(platform: HostPlatform, options: HostOptions = {}): H
       // module-scoped, so it survives a logout/login reset.
       getVaultManager().ensureReady();
       setVaultChangeNotifier((root) => emitEvent("onVaultChanged", { root }));
+
+      // Snapshot retention sweep (keep the newest SNAPSHOT_RETENTION pre-run
+      // copies). Best-effort — a prune failure must never block boot.
+      try {
+        getDelegationManager().pruneSnapshots();
+      } catch (err) {
+        console.warn("[host] delegation snapshot prune failed:", err);
+      }
 
       initMachine();
     },

--- a/packages/host/src/delegation/delegation-manager.ts
+++ b/packages/host/src/delegation/delegation-manager.ts
@@ -13,6 +13,7 @@ import crypto from "node:crypto";
 import { Type } from "@sinclair/typebox";
 import { Value } from "@sinclair/typebox/value";
 
+import { DelegationSnapshotStore } from "./delegation-snapshots";
 import { findTaskLine } from "./find-task-line";
 import { JsonStore, inteligirPath, type FsAdapter } from "../lib/json-store";
 import { getVaultManager } from "../vault/vault";
@@ -22,11 +23,13 @@ import {
   type CreateDelegationParams,
   type CreateDelegationResult,
   type Delegation,
+  type RestoreSnapshotResult,
 } from "@repo/core/delegation";
-import { toErrorMessage } from "@repo/core/ipc";
+import { isRecord, toErrorMessage } from "@repo/core/ipc";
 
 // v2: anchor moved from text/heading matching to a positional `index`.
-const DELEGATIONS_VERSION = 2;
+// v3: pre-run snapshots — records gained `hasSnapshot` + `restoredAt`.
+const DELEGATIONS_VERSION = 3;
 const RUN_TIMEOUT_MS = 10 * 60 * 1000;
 const MAX_DELEGATIONS = 200;
 const SUMMARY_LEN = 200;
@@ -74,11 +77,19 @@ export type DelegationManagerOptions = {
   path?: string;
   /** Read a vault file's raw text. Defaults to the live VaultManager. */
   readVault?: (rel: string) => string;
+  /** Write a vault file (atomic; the watcher broadcasts the change). Defaults
+   * to the live VaultManager. Restore goes through here so editors refresh via
+   * the standard onVaultChanged path. */
+  writeVault?: (rel: string, content: string) => void;
+  /** Pre-run snapshot store. Defaults to the real ~/.inteligir-backed one. */
+  snapshots?: DelegationSnapshotStore;
 };
 
 export class DelegationManager {
   private readonly store: JsonStore<Delegation[]>;
   private readonly readVault: (rel: string) => string;
+  private readonly writeVault: (rel: string, content: string) => void;
+  private readonly snapshots: DelegationSnapshotStore;
   private getAgent: (() => DelegationAgent | null) | null = null;
   private running = false;
   // Id of a running delegation the user asked to stop — the run marks it stopped
@@ -96,6 +107,9 @@ export class DelegationManager {
 
   constructor(opts?: DelegationManagerOptions) {
     this.readVault = opts?.readVault ?? ((rel) => getVaultManager().readText(rel));
+    this.writeVault =
+      opts?.writeVault ?? ((rel, content) => getVaultManager().writeText(rel, content));
+    this.snapshots = opts?.snapshots ?? new DelegationSnapshotStore();
     this.store = new JsonStore<Delegation[]>(
       opts?.path ?? inteligirPath("delegations.json"),
       DelegationsFileSchema,
@@ -111,7 +125,22 @@ export class DelegationManager {
           // quarantine path — delegations are transient, so dropping them is fine,
           // but firing a scary "corrupt file" recovery notice for a known prior
           // version is not.
-          migrations: { 1: () => ({ version: DELEGATIONS_VERSION, delegations: [] }) },
+          migrations: {
+            1: () => ({ version: DELEGATIONS_VERSION, delegations: [] }),
+            // v2 → v3: records gained snapshot bookkeeping. A pre-snapshot
+            // record has no snapshot by definition and was never restored.
+            2: (raw) => {
+              if (!isRecord(raw) || !Array.isArray(raw["delegations"])) {
+                throw new Error("v2 delegations shape rejected");
+              }
+              return {
+                version: DELEGATIONS_VERSION,
+                delegations: raw["delegations"].map((d: unknown) =>
+                  isRecord(d) ? { ...d, hasSnapshot: false, restoredAt: null } : d,
+                ),
+              };
+            },
+          },
         },
         decode: (raw) => {
           if (!Value.Check(DelegationsFileSchema, raw))
@@ -214,6 +243,8 @@ export class DelegationManager {
       finishedAt: null,
       resultSummary: null,
       error: null,
+      hasSnapshot: false,
+      restoredAt: null,
     };
     this.store.update((all) => {
       const next = [...all, delegation];
@@ -279,6 +310,50 @@ export class DelegationManager {
     return { ok: changed };
   }
 
+  /** Restore the file bytes captured before this delegation ran. The write
+   * targets the delegation's CURRENT sourceFile (renameSource keeps it pointing
+   * at the moved file), goes through the vault's atomic write (the watcher
+   * refreshes editors naturally), and recreates the file if it was deleted
+   * since. Restoring while the delegation is still queued/running is rejected —
+   * it would race the agent's own edits. When the file already matches the
+   * snapshot the restore is a no-op success (no write, no watcher churn);
+   * `restoredAt` is recorded either way, since the user's intent succeeded. */
+  restoreSnapshot(id: string): RestoreSnapshotResult {
+    const delegation = this.getDelegations().find((d) => d.id === id);
+    if (!delegation) return { ok: false, error: "Unknown delegation." };
+    if (delegation.status === "queued" || delegation.status === "running") {
+      return { ok: false, error: "Wait for the delegation to finish before restoring." };
+    }
+    const snapshot = this.snapshots.read(id);
+    if (!snapshot.ok) return { ok: false, error: snapshot.error };
+
+    // Byte-equality IS hash-equality here — the snapshot's recorded hash was
+    // already verified against its content in read().
+    let current: string | null;
+    try {
+      current = this.readVault(delegation.sourceFile);
+    } catch {
+      current = null; // deleted (or unreadable) — the write below recreates it
+    }
+    if (current !== snapshot.content) {
+      try {
+        this.writeVault(delegation.sourceFile, snapshot.content);
+      } catch (err) {
+        return {
+          ok: false,
+          error: `Couldn't restore ${delegation.sourceFile}: ${toErrorMessage(err)}`,
+        };
+      }
+    }
+    this.patch(id, { restoredAt: Date.now() });
+    return { ok: true };
+  }
+
+  /** Retention sweep for the snapshot store — run once at host start. */
+  pruneSnapshots(): void {
+    this.snapshots.prune();
+  }
+
   private patch(id: string, patch: Partial<Delegation>): void {
     this.store.update((all) => all.map((d) => (d.id === id ? { ...d, ...patch } : d)));
     this.notify();
@@ -341,11 +416,13 @@ export class DelegationManager {
   }
 
   /** Re-resolve a delegation's checkbox against the file's current bytes and
-   * refresh its line/anchor so the prompt is never stale. Synchronous (no await
-   * before the first agent call), so stop() can't interleave here. */
+   * refresh its line/anchor so the prompt is never stale. Returns those exact
+   * bytes (`raw`) so the pre-run snapshot captures precisely the content the
+   * run was resolved against. Synchronous (no await before the first agent
+   * call), so stop() can't interleave here. */
   private resolveForRun(
     delegation: Delegation,
-  ): { ok: true; delegation: Delegation } | { ok: false; error: string } {
+  ): { ok: true; delegation: Delegation; raw: string } | { ok: false; error: string } {
     let raw: string;
     try {
       raw = this.readVault(delegation.sourceFile);
@@ -379,7 +456,7 @@ export class DelegationManager {
     ) {
       this.patch(delegation.id, { lineText: fresh.lineText, anchor: fresh.anchor });
     }
-    return { ok: true, delegation: fresh };
+    return { ok: true, delegation: fresh, raw };
   }
 
   private async run(agent: DelegationAgent, delegation: Delegation): Promise<void> {
@@ -394,6 +471,22 @@ export class DelegationManager {
       return;
     }
     const fresh = resolved.delegation;
+
+    // Snapshot the file's pre-run bytes — the undo point "Restore original"
+    // writes back. This MUST land before the agent is dispatched: the agent
+    // edits the file with its own tools through ./vault, so the host can't
+    // intercept the write itself, and an agent edit with no snapshot is an
+    // edit the user can't revert. A capture failure therefore aborts the run.
+    try {
+      this.snapshots.capture(delegation.id, fresh.sourceFile, resolved.raw);
+    } catch (err) {
+      this.finishRun(
+        delegation.id,
+        failedPatch(`Couldn't snapshot ${fresh.sourceFile} before running: ${toErrorMessage(err)}`),
+      );
+      return;
+    }
+    this.patch(delegation.id, { hasSnapshot: true });
 
     const captured: { text: string | null } = { text: null };
     let streamed = "";

--- a/packages/host/src/delegation/delegation-manager.ts
+++ b/packages/host/src/delegation/delegation-manager.ts
@@ -349,9 +349,15 @@ export class DelegationManager {
     return { ok: true };
   }
 
-  /** Retention sweep for the snapshot store — run once at host start. */
+  /** Retention sweep for the snapshot store — run once at host start. Pruned
+   * records lose `hasSnapshot` at the data level so no surface (present or
+   * future) can offer a restore whose bytes are gone. */
   pruneSnapshots(): void {
-    this.snapshots.prune();
+    const prunedIds = new Set(this.snapshots.prune());
+    if (prunedIds.size === 0) return;
+    this.store.update((all) =>
+      all.map((d) => (prunedIds.has(d.id) && d.hasSnapshot ? { ...d, hasSnapshot: false } : d)),
+    );
   }
 
   private patch(id: string, patch: Partial<Delegation>): void {

--- a/packages/host/src/delegation/delegation-snapshots.ts
+++ b/packages/host/src/delegation/delegation-snapshots.ts
@@ -1,0 +1,210 @@
+// ---------------------------------------------------------------------------
+// DelegationSnapshotStore — the pre-run copy behind "Restore original".
+//
+// The background agent edits vault files with its own file tools through the
+// ./vault symlink, so the host can't intercept the write itself. Instead the
+// delegation-manager captures the target file's bytes here at delegation START
+// (after the checkbox is re-resolved, before the agent is dispatched) — a
+// cheap, restorable undo point without a full history feature.
+//
+// Layout under ~/.inteligir: content bytes live as one file per delegation id
+// in `snapshots/` (bytes don't belong inside a JSON blob), and a small
+// versioned JsonStore index (`snapshots.json`) maps delegation id →
+// {path, snapshotFile, capturedAt, hash}. The bytes file is written before the
+// index entry, so a crash between the two leaves only an orphan file — swept
+// by prune() — never an index entry whose bytes are missing.
+// ---------------------------------------------------------------------------
+
+import crypto from "node:crypto";
+import fs from "node:fs";
+import path from "node:path";
+import { Type, type Static } from "@sinclair/typebox";
+import { Value } from "@sinclair/typebox/value";
+
+import { JsonStore, inteligirPath, type FsAdapter } from "../lib/json-store";
+
+// Retention: keep the newest 50 snapshots, pruned on host start. A count cap
+// (not an age window) keeps disk usage proportional to actual delegation use —
+// snapshots are whole-file copies, so "50 × typical note size" is a bounded,
+// predictable footprint, while an idle vault never loses its recent undo
+// points to a calendar. 50 comfortably outlasts the delegation dock's recall
+// horizon (delegation records themselves cap at 200 and snapshots are only
+// actionable while their record survives), and this is a cheap-undo feature,
+// not history — usefulness decays fast once the user has edited on top.
+export const SNAPSHOT_RETENTION = 50;
+
+const SNAPSHOTS_VERSION = 1;
+
+const SnapshotEntrySchema = Type.Object(
+  {
+    delegationId: Type.String(),
+    /** Vault-relative path of the target file AT CAPTURE TIME. Diagnostic —
+     * restore targets the delegation record's current sourceFile, which the
+     * manager remaps across renames. */
+    path: Type.String(),
+    /** Bytes file name under the snapshots dir (relative, so ~/.inteligir can
+     * move without breaking the index). */
+    snapshotFile: Type.String(),
+    capturedAt: Type.Number(),
+    /** sha256 hex of the snapshot bytes — integrity check at read time so a
+     * torn/tampered bytes file can never be written back into the vault. */
+    hash: Type.String(),
+  },
+  { additionalProperties: false },
+);
+
+type SnapshotEntry = Static<typeof SnapshotEntrySchema>;
+
+const SnapshotsFileSchema = Type.Object(
+  { version: Type.Literal(SNAPSHOTS_VERSION), snapshots: Type.Array(SnapshotEntrySchema) },
+  { additionalProperties: false },
+);
+
+/** The few content-file operations the store needs, injectable for tests.
+ * Kept separate from FsAdapter (which is JSON-store-shaped): pruning needs
+ * remove + directory listing, which no JsonStore ever needs. */
+export type SnapshotFileAdapter = {
+  read: (filePath: string) => string | null;
+  write: (filePath: string, content: string) => void;
+  remove: (filePath: string) => void;
+  /** File names directly inside `dir`; [] when the dir doesn't exist. */
+  list: (dir: string) => string[];
+};
+
+// Content files get the same tmp+rename atomic write as everything else under
+// ~/.inteligir — a crash mid-write must not leave a half snapshot that the
+// hash check would then reject at restore time.
+const realFiles: SnapshotFileAdapter = {
+  read: (filePath) => {
+    try {
+      return fs.readFileSync(filePath, "utf8");
+    } catch {
+      return null;
+    }
+  },
+  write: (filePath, content) => {
+    fs.mkdirSync(path.dirname(filePath), { recursive: true, mode: 0o700 });
+    const tmp = `${filePath}.tmp`;
+    fs.writeFileSync(tmp, content, "utf8");
+    fs.renameSync(tmp, filePath);
+  },
+  remove: (filePath) => {
+    fs.rmSync(filePath, { force: true });
+  },
+  list: (dir) => {
+    try {
+      return fs
+        .readdirSync(dir, { withFileTypes: true })
+        .filter((entry) => entry.isFile())
+        .map((entry) => entry.name);
+    } catch {
+      return [];
+    }
+  },
+};
+
+function sha256(content: string): string {
+  return crypto.createHash("sha256").update(content, "utf8").digest("hex");
+}
+
+export type SnapshotReadResult =
+  | { ok: true; path: string; content: string }
+  | { ok: false; error: string };
+
+export type DelegationSnapshotStoreOptions = {
+  /** JsonStore adapter for the index (tests). */
+  fs?: FsAdapter;
+  /** Content-file adapter (tests). */
+  files?: SnapshotFileAdapter;
+  /** Content directory. Defaults to ~/.inteligir/snapshots. */
+  dir?: string;
+  /** Index path. Defaults to ~/.inteligir/snapshots.json — a SIBLING of the
+   * content dir, so prune's orphan sweep can treat every file in the dir as a
+   * snapshot without special-casing the index (or its .tmp/.corrupt kin). */
+  indexPath?: string;
+};
+
+export class DelegationSnapshotStore {
+  private readonly index: JsonStore<SnapshotEntry[]>;
+  private readonly files: SnapshotFileAdapter;
+  private readonly dir: string;
+
+  constructor(opts: DelegationSnapshotStoreOptions = {}) {
+    this.files = opts.files ?? realFiles;
+    this.dir = opts.dir ?? inteligirPath("snapshots");
+    this.index = new JsonStore<SnapshotEntry[]>(
+      opts.indexPath ?? inteligirPath("snapshots.json"),
+      SnapshotsFileSchema,
+      [],
+      {
+        fs: opts.fs,
+        versioning: {
+          current: SNAPSHOTS_VERSION,
+          // No unversioned era — snapshots.json is new with this store.
+          fromLegacy: () => {
+            throw new Error("snapshots.json has no version field");
+          },
+        },
+        decode: (raw) => {
+          if (!Value.Check(SnapshotsFileSchema, raw)) throw new Error("snapshots shape rejected");
+          return raw.snapshots;
+        },
+        encode: (snapshots) => ({ version: SNAPSHOTS_VERSION, snapshots }),
+      },
+    );
+  }
+
+  /** Persist `content` as delegation `delegationId`'s pre-run copy of `path`.
+   * Throws on any failure — the caller must treat an uncaptured snapshot as
+   * fatal to the run (an agent edit with no undo point must never happen).
+   * Re-capturing the same id overwrites (each delegation runs at most once, so
+   * this only makes the operation idempotent). */
+  capture(delegationId: string, filePath: string, content: string): void {
+    const snapshotFile = delegationId;
+    // Bytes first, index second — see the crash-ordering note in the header.
+    this.files.write(path.join(this.dir, snapshotFile), content);
+    const entry: SnapshotEntry = {
+      delegationId,
+      path: filePath,
+      snapshotFile,
+      capturedAt: Date.now(),
+      hash: sha256(content),
+    };
+    this.index.update((all) => [...all.filter((e) => e.delegationId !== delegationId), entry]);
+  }
+
+  /** Read a snapshot's bytes, verifying them against the recorded hash so a
+   * torn or tampered content file is surfaced instead of restored. */
+  read(delegationId: string): SnapshotReadResult {
+    const entry = this.index.read().find((e) => e.delegationId === delegationId);
+    if (!entry) return { ok: false, error: "No snapshot exists for this delegation." };
+    const content = this.files.read(path.join(this.dir, entry.snapshotFile));
+    if (content === null) return { ok: false, error: "The snapshot file is missing." };
+    if (sha256(content) !== entry.hash) {
+      return { ok: false, error: "The snapshot file is corrupt and can't be restored." };
+    }
+    return { ok: true, path: entry.path, content };
+  }
+
+  /** Retention sweep, run on host start: keep the newest SNAPSHOT_RETENTION
+   * entries, delete the bytes of everything older, and remove orphan files in
+   * the content dir that no surviving entry references (crash leftovers).
+   * Best-effort on the file operations — the index is the source of truth. */
+  prune(): void {
+    const all = this.index.read();
+    const byNewest = all.toSorted((a, b) => b.capturedAt - a.capturedAt);
+    const kept = byNewest.slice(0, SNAPSHOT_RETENTION);
+    if (kept.length !== all.length) {
+      this.index.write(kept);
+    }
+    const referenced = new Set(kept.map((e) => e.snapshotFile));
+    for (const name of this.files.list(this.dir)) {
+      if (referenced.has(name)) continue;
+      try {
+        this.files.remove(path.join(this.dir, name));
+      } catch (err) {
+        console.warn(`[snapshots] could not remove ${name}:`, err);
+      }
+    }
+  }
+}

--- a/packages/host/src/delegation/delegation-snapshots.ts
+++ b/packages/host/src/delegation/delegation-snapshots.ts
@@ -190,13 +190,14 @@ export class DelegationSnapshotStore {
    * entries, delete the bytes of everything older, and remove orphan files in
    * the content dir that no surviving entry references (crash leftovers).
    * Best-effort on the file operations — the index is the source of truth. */
-  prune(): void {
+  prune(): string[] {
     const all = this.index.read();
     const byNewest = all.toSorted((a, b) => b.capturedAt - a.capturedAt);
     const kept = byNewest.slice(0, SNAPSHOT_RETENTION);
     if (kept.length !== all.length) {
       this.index.write(kept);
     }
+    const prunedIds = byNewest.slice(SNAPSHOT_RETENTION).map((e) => e.delegationId);
     const referenced = new Set(kept.map((e) => e.snapshotFile));
     for (const name of this.files.list(this.dir)) {
       if (referenced.has(name)) continue;
@@ -206,5 +207,6 @@ export class DelegationSnapshotStore {
         console.warn(`[snapshots] could not remove ${name}:`, err);
       }
     }
+    return prunedIds;
   }
 }

--- a/packages/host/src/handlers/delegation-handlers.ts
+++ b/packages/host/src/handlers/delegation-handlers.ts
@@ -6,5 +6,6 @@ export function registerDelegationHandlers(handle: HandlerRegistrar): void {
   handle("createDelegation", (params) => getDelegationManager().createDelegation(params));
   handle("listDelegations", () => ({ delegations: getDelegationManager().getDelegations() }));
   handle("cancelDelegation", (id) => getDelegationManager().cancelDelegation(id));
+  handle("restoreDelegationSnapshot", (id) => getDelegationManager().restoreSnapshot(id));
   handle("generateInlineAi", (params) => generateInline(params.prompt, params.requestId));
 }

--- a/packages/ui/src/components/alert-dialog.tsx
+++ b/packages/ui/src/components/alert-dialog.tsx
@@ -176,6 +176,17 @@ const alertDialog = {
   },
 };
 
+// Composable primitives for feature-owned confirms (mirrors dialog.tsx's
+// export surface) — GlobalAlertDialog below stays the imperative root.
+export {
+  AlertDialog,
+  AlertDialogContent,
+  AlertDialogHeader,
+  AlertDialogFooter,
+  AlertDialogTitle,
+  AlertDialogDescription,
+};
+
 export const GlobalAlertDialog = () => {
   const [pendingAction, setPendingAction] = React.useState(false);
   const [pendingCancel, setPendingCancel] = React.useState(false);


### PR DESCRIPTION
Locked decision from docs/replatform-plan.md: the host snapshots a file before any background-agent write (under ~/.inteligir), restorable — cheap undo for agent edits without a history feature.

## What

- **Capture seam**: inside `DelegationManager.run()`, synchronously between `resolveForRun()` (snapshot = the exact bytes the run validated against — no TOCTOU) and agent dispatch. Snapshot failure aborts the delegation; the agent can never run against an unsnapshotted file (proven by walking every dispatch path).
- **Storage**: bytes-first atomic writes (tmp+rename) under `~/.inteligir`, sha256-verified at read, index written after bytes; orphans swept on host start.
- **Restore**: `restoreDelegationSnapshot` channel — byte-exact (CRLF/ZWJ/combining-marks/no-final-newline tested), rejected while queued/running, no-op on unchanged content, recreates deleted files. Queue-serialized same-file semantics: restore(first) = pre-both state.
- **Retention**: newest 50, pruned on host start; **prune flips `hasSnapshot` at the data level** so no surface can ever offer a restore whose bytes are gone.
- **UI**: "Restore original" on completed delegations in the dock, confirm dialog, disabled when the file is deleted. Delegations JsonStore v2→v3 with a real field-adding migration (v2-blob test — no quarantine).

## Verification

Implement + independent review (rebased onto post-#362 main): full gates green incl. format; 226 host / 254 app tests; harness drive end-to-end (delegate → restore → byte-revert → deleted-file disabled state). Reviewer added migration/fidelity/pruned-restore tests; hardening applied post-review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Restore overwrites live vault content and runs on the delegation/vault path, but guards (snapshot-before-run, hash checks, no restore while running) and extensive tests limit blast radius; accidental `gates2.log` is low impact.
> 
> **Overview**
> Adds **cheap undo** for background-agent checkbox delegations by snapshotting the target vault file **after** re-resolving the task and **before** the agent is dispatched; capture failure **aborts** the run so edits are never unsnapshotted.
> 
> **Host:** New `DelegationSnapshotStore` under `~/.inteligir` (bytes on disk + indexed metadata with sha256 verification, atomic writes, retention of newest 50 with orphan cleanup on boot). `DelegationManager` gains `restoreSnapshot`, `pruneSnapshots`, delegations store **v2→v3** (`hasSnapshot`, `restoredAt`), and restore writes through the vault (no-op when bytes already match; blocked while queued/running). **IPC:** `restoreDelegationSnapshot` wired through registry, WS bridge, and handlers.
> 
> **App:** Delegation dock shows **Restore original** with confirm dialog (disabled if the file was deleted); store calls the new bridge method. Dev **fixture bridge** simulates snapshot + restore for harness testing.
> 
> **Tests:** Coverage for snapshot store, restore semantics, capture-before-dispatch ordering, migration, and pruned snapshots clearing `hasSnapshot`.
> 
> **Note:** The diff also adds `gates2.log` (CI output) — likely accidental and worth dropping from the PR.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f069e1efaa6fe6b7fe27ee42958a049f422c40f5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add pre-run delegation snapshots and a “Restore original” action to quickly undo agent edits. Snapshots are saved under ~/.inteligir with integrity checks and retention; restore writes back atomically through the vault.

- **New Features**
  - Host snapshots the target file after re-resolve and before agent dispatch; failures abort the run.
  - Snapshots live under ~/.inteligir/snapshots with atomic writes and sha256 verification; host start prunes to the newest 50 and clears stale restore offers.
  - New restore API restores exact bytes, recreates deleted files, is a no-op if unchanged, and is rejected while queued/running; records when a restore occurs.
  - Delegation dock adds “Restore original” with a confirm dialog; disabled if the file was deleted; dev fixture simulates runs to exercise restore end-to-end.
  - IPC/bridge adds restore channel so the app can trigger a restore.

- **Migration**
  - Delegations store auto-migrates v2→v3; no action needed.

<sup>Written for commit f069e1efaa6fe6b7fe27ee42958a049f422c40f5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kyh/inteligir/pull/363?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

