### PR TITLE
Phase 6: knowledge UI — tabs, wiki navigation, transclusion, backlinks, graph, palette search

### DIFF
--- a/packages/app/dev/fixture-bridge.ts
+++ b/packages/app/dev/fixture-bridge.ts
@@ -223,6 +223,35 @@ Embed placeholder: ![[target note]]
 
 The hub links here. Backlinks arrive in a later phase.
 `,
+  // Phase F knowledge notes — an interlinked cluster so tabs, chips,
+  // backlinks, transclusion (incl. guards), graph, and search all demo well.
+  "wiki/ideas.md": `# Ideas
+
+Seeds worth growing, linked from the [[hub]].
+
+- Build a [[target note|target]] deep-dive
+- Cross-link with [[wiki/projects|projects]]
+- Chase the [[missing note]] ghost
+
+Embedded reference: ![[target note]]
+`,
+  "wiki/projects.md": `# Projects
+
+Active work, paired with [[ideas]].
+
+1. Ship the knowledge UI (see [[hub]])
+2. Write the [[target note#Section|section notes]]
+`,
+  "wiki/digest.md": `# Digest
+
+A transclusion sampler over the wiki cluster.
+
+Full embed: ![[ideas]]
+
+Missing embed: ![[missing note]]
+
+Self embed (cycle guard): ![[digest]]
+`,
 };
 
 // Matches one checkbox line: indent, marker, box state, label. Ordinals count

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -38,6 +38,7 @@
     "@repo/ui": "workspace:^",
     "@sinclair/typebox": "catalog:",
     "ai": "^6.0.191",
+    "d3-force": "^3.0.0",
     "katex": "^0.16.22",
     "lowlight": "^3.3.0",
     "lucide-react": "catalog:",
@@ -62,6 +63,7 @@
   },
   "devDependencies": {
     "@tailwindcss/vite": "catalog:",
+    "@types/d3-force": "^3.0.10",
     "@types/mdast": "^4.0.4",
     "@types/node": "catalog:",
     "@types/react": "catalog:",

--- a/packages/app/src/__tests__/editor-kits.test.ts
+++ b/packages/app/src/__tests__/editor-kits.test.ts
@@ -121,11 +121,17 @@ function type(editor: ReturnType<typeof makeEditor>, text: string) {
   for (const char of text) editor.tf.insertText(char);
 }
 
+// Since Phase F, char-by-char typing of `[[` opens the autocomplete picker
+// (wiki-autocomplete.test.ts pins that flow). The `]]` rule remains the
+// completion path for bodies already present as TEXT — a paste, or the
+// picker's cancel-restore — so these drive it with a bulk insert (the trigger
+// only fires on a single typed `[`) followed by typed closing brackets.
 describe("wiki `]]` completion rule", () => {
   it("completes [[Note]] into a wikiLink chip whose bytes round-trip", () => {
     const editor = makeEditor("x\n");
     editor.tf.select(editor.api.end([0]));
-    type(editor, " see [[Some Note]]");
+    editor.tf.insertText(" see [[Some Note");
+    type(editor, "]]");
     const wiki = el(editor.children[0]).children.find(
       (child) => ElementApi.isElement(child) && child.type === "wikiLink",
     );
@@ -135,10 +141,18 @@ describe("wiki `]]` completion rule", () => {
     expect(roundTrip(output)).toBe(output);
   });
 
+  it("typing [[ char-by-char opens the autocomplete picker instead", () => {
+    const editor = makeEditor("x\n");
+    editor.tf.select(editor.api.end([0]));
+    type(editor, " [[");
+    expect(JSON.stringify(editor.children).includes("wiki_input")).toBe(true);
+  });
+
   it("completes ![[img.png]] into a wikiEmbed chip", () => {
     const editor = makeEditor("x\n");
     editor.tf.select(editor.api.end([0]));
-    type(editor, " ![[img.png]]");
+    editor.tf.insertText(" ![[img.png");
+    type(editor, "]]");
     expect(out(editor)).toContain("![[img.png]]");
     expect(
       el(editor.children[0]).children.some(
@@ -150,7 +164,8 @@ describe("wiki `]]` completion rule", () => {
   it("keeps alias/anchor bodies verbatim", () => {
     const editor = makeEditor("x\n");
     editor.tf.select(editor.api.end([0]));
-    type(editor, " [[target#sec|alias]]");
+    editor.tf.insertText(" [[target#sec|alias");
+    type(editor, "]]");
     expect(out(editor)).toContain("[[target#sec|alias]]");
   });
 
@@ -177,7 +192,11 @@ describe("wiki `]]` completion rule", () => {
     // swallow the rest of the line.
     const editor = makeEditor("x\n");
     editor.tf.select(editor.api.end([0]));
-    type(editor, " [[a]]![[b]] tail");
+    editor.tf.insertText(" [[a");
+    type(editor, "]]");
+    editor.tf.insertText("![[b");
+    type(editor, "]]");
+    type(editor, " tail");
     const output = out(editor);
     expect(output).toBe("x [[a]]![[b]] tail\n");
     expect(output).not.toContain("​");

--- a/packages/app/src/__tests__/kit-parity.test.ts
+++ b/packages/app/src/__tests__/kit-parity.test.ts
@@ -58,7 +58,7 @@ describe("kit parity (Base half)", () => {
     expect(optionsB.rules).toBe(MD_RULES);
     expect(optionsA.remarkPlugins).toBe(MD_REMARK_PLUGINS);
     expect(optionsB.remarkPlugins).toBe(MD_REMARK_PLUGINS);
-    expect(optionsA.disallowedNodes).toEqual(["ai", "slash_input", "emoji_input"]);
+    expect(optionsA.disallowedNodes).toEqual(["ai", "slash_input", "emoji_input", "wiki_input"]);
     // Suggestion marks are transient via allowNode + plainMarks (a blanket
     // disallow would drop deletion-marked ORIGINAL text): see ai/transient.ts.
     expect(optionsA.allowNode?.serialize).toBe(shouldSerializeNode);
@@ -102,7 +102,7 @@ describe("kit parity (live editor mirror)", () => {
     const options = live.getOptions(MarkdownPlugin);
     expect(options.rules).toBe(MD_RULES);
     expect(options.remarkPlugins).toBe(MD_REMARK_PLUGINS);
-    expect(options.disallowedNodes).toEqual(["ai", "slash_input", "emoji_input"]);
+    expect(options.disallowedNodes).toEqual(["ai", "slash_input", "emoji_input", "wiki_input"]);
     expect(options.allowNode?.serialize).toBe(shouldSerializeNode);
     expect(options.plainMarks).toEqual(["suggestion"]);
   });

--- a/packages/app/src/__tests__/markdown-corpus.test.ts
+++ b/packages/app/src/__tests__/markdown-corpus.test.ts
@@ -54,6 +54,11 @@ const EXPECTED: Record<string, Classification> = {
   "math-and-diagrams.md": "canonical",
   "wiki/hub.md": "canonical",
   "wiki/target note.md": "canonical",
+  // Phase F knowledge notes — the interlinked wiki cluster + transclusion
+  // sampler; canonical so knowledge surfaces demo on Rich-mode files.
+  "wiki/ideas.md": "canonical",
+  "wiki/projects.md": "canonical",
+  "wiki/digest.md": "canonical",
 };
 
 const CORPUS: Record<string, string> = { ...REPO_DOCS, ...SAMPLE_NOTES };

--- a/packages/app/src/__tests__/tab-session.test.ts
+++ b/packages/app/src/__tests__/tab-session.test.ts
@@ -90,6 +90,11 @@ describe("renameTab", () => {
     expect(renameTab(s, "a.md", "b.md")).toEqual(session(["b.md"], "b.md"));
   });
 
+  it("collapsing a BACKGROUND tab into an open destination keeps the active tab", () => {
+    const s = session(["a.md", "b.md", "c.md"], "c.md");
+    expect(renameTab(s, "a.md", "b.md")).toEqual(session(["b.md", "c.md"], "c.md"));
+  });
+
   it("ignores unknown sources", () => {
     const s = session(["a.md"], "a.md");
     expect(renameTab(s, "x.md", "y.md")).toBe(s);
@@ -120,6 +125,9 @@ describe("parseSession", () => {
       session(["a.md", "b.md"], "a.md"),
     );
     expect(parseSession({ tabs: ["a.md"] })).toEqual(session(["a.md"], "a.md"));
+    expect(parseSession({ active: 7, tabs: ["a.md", "b.md"] })).toEqual(
+      session(["a.md", "b.md"], "a.md"),
+    );
   });
 
   it("rejects malformed shapes and duplicates", () => {

--- a/packages/app/src/__tests__/tab-session.test.ts
+++ b/packages/app/src/__tests__/tab-session.test.ts
@@ -1,0 +1,132 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  EMPTY_SESSION,
+  activateTab,
+  closeTab,
+  cycleTab,
+  moveTab,
+  openTab,
+  parseSession,
+  renameTab,
+  type TabSession,
+} from "@repo/app/workspace/tab-session";
+
+const session = (tabs: string[], active: string | null): TabSession => ({ tabs, active });
+
+describe("openTab", () => {
+  it("opens the first tab from empty", () => {
+    expect(openTab(EMPTY_SESSION, "a.md", "replace")).toEqual(session(["a.md"], "a.md"));
+    expect(openTab(EMPTY_SESSION, "a.md", "new")).toEqual(session(["a.md"], "a.md"));
+  });
+
+  it("replace swaps the path into the active slot", () => {
+    const s = session(["a.md", "b.md", "c.md"], "b.md");
+    expect(openTab(s, "x.md", "replace")).toEqual(session(["a.md", "x.md", "c.md"], "x.md"));
+  });
+
+  it("new inserts after the active tab", () => {
+    const s = session(["a.md", "b.md", "c.md"], "a.md");
+    expect(openTab(s, "x.md", "new")).toEqual(session(["a.md", "x.md", "b.md", "c.md"], "x.md"));
+  });
+
+  it("an already-open path just activates its tab — no duplicates", () => {
+    const s = session(["a.md", "b.md"], "a.md");
+    expect(openTab(s, "b.md", "replace")).toEqual(session(["a.md", "b.md"], "b.md"));
+    expect(openTab(s, "b.md", "new")).toEqual(session(["a.md", "b.md"], "b.md"));
+  });
+});
+
+describe("closeTab", () => {
+  it("closing the active tab activates the right neighbor", () => {
+    const s = session(["a.md", "b.md", "c.md"], "b.md");
+    expect(closeTab(s, "b.md")).toEqual(session(["a.md", "c.md"], "c.md"));
+  });
+
+  it("closing the last (rightmost) active tab falls back left", () => {
+    const s = session(["a.md", "b.md"], "b.md");
+    expect(closeTab(s, "b.md")).toEqual(session(["a.md"], "a.md"));
+  });
+
+  it("closing a background tab keeps the active tab", () => {
+    const s = session(["a.md", "b.md", "c.md"], "a.md");
+    expect(closeTab(s, "c.md")).toEqual(session(["a.md", "b.md"], "a.md"));
+  });
+
+  it("closing the only tab empties the session", () => {
+    expect(closeTab(session(["a.md"], "a.md"), "a.md")).toEqual(EMPTY_SESSION);
+  });
+
+  it("closing an unknown path is a no-op", () => {
+    const s = session(["a.md"], "a.md");
+    expect(closeTab(s, "x.md")).toBe(s);
+  });
+});
+
+describe("activateTab / cycleTab", () => {
+  it("activates a member tab and ignores strangers", () => {
+    const s = session(["a.md", "b.md"], "a.md");
+    expect(activateTab(s, "b.md").active).toBe("b.md");
+    expect(activateTab(s, "x.md")).toBe(s);
+  });
+
+  it("cycles forward and backward with wrap-around", () => {
+    const s = session(["a.md", "b.md", "c.md"], "c.md");
+    expect(cycleTab(s, 1).active).toBe("a.md");
+    expect(cycleTab(s, -1).active).toBe("b.md");
+    expect(cycleTab(session(["a.md"], "a.md"), 1).active).toBe("a.md");
+  });
+});
+
+describe("renameTab", () => {
+  it("re-keys the tab in place, carrying active state", () => {
+    const s = session(["a.md", "b.md"], "b.md");
+    expect(renameTab(s, "b.md", "z.md")).toEqual(session(["a.md", "z.md"], "z.md"));
+    expect(renameTab(s, "a.md", "z.md")).toEqual(session(["z.md", "b.md"], "b.md"));
+  });
+
+  it("collapses into an existing destination tab instead of duplicating", () => {
+    const s = session(["a.md", "b.md"], "a.md");
+    expect(renameTab(s, "a.md", "b.md")).toEqual(session(["b.md"], "b.md"));
+  });
+
+  it("ignores unknown sources", () => {
+    const s = session(["a.md"], "a.md");
+    expect(renameTab(s, "x.md", "y.md")).toBe(s);
+  });
+});
+
+describe("moveTab", () => {
+  it("moves a tab to a new index, keeping active by path", () => {
+    const s = session(["a.md", "b.md", "c.md"], "a.md");
+    expect(moveTab(s, 0, 2)).toEqual(session(["b.md", "c.md", "a.md"], "a.md"));
+  });
+
+  it("rejects out-of-range moves", () => {
+    const s = session(["a.md", "b.md"], "a.md");
+    expect(moveTab(s, 0, 5)).toBe(s);
+    expect(moveTab(s, 5, 0)).toBe(s);
+  });
+});
+
+describe("parseSession", () => {
+  it("round-trips a valid session", () => {
+    const s = session(["a.md", "b.md"], "b.md");
+    expect(parseSession(JSON.parse(JSON.stringify(s)))).toEqual(s);
+  });
+
+  it("repairs a missing/foreign active to the first tab", () => {
+    expect(parseSession({ tabs: ["a.md", "b.md"], active: "x.md" })).toEqual(
+      session(["a.md", "b.md"], "a.md"),
+    );
+    expect(parseSession({ tabs: ["a.md"] })).toEqual(session(["a.md"], "a.md"));
+  });
+
+  it("rejects malformed shapes and duplicates", () => {
+    expect(parseSession(null)).toBeUndefined();
+    expect(parseSession({ tabs: "a.md" })).toBeUndefined();
+    expect(parseSession({ tabs: ["a.md", "a.md"] })).toBeUndefined();
+    expect(parseSession({ tabs: [1] })).toBeUndefined();
+    expect(parseSession({ tabs: [] })).toEqual(EMPTY_SESSION);
+  });
+});

--- a/packages/app/src/__tests__/transclusion-guard.test.ts
+++ b/packages/app/src/__tests__/transclusion-guard.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+
+import { decideTransclusion, nestedScope } from "@repo/app/editor/transclusion-guard";
+
+const root = (path: string) => ({ depth: 0, chain: [path] });
+
+describe("decideTransclusion", () => {
+  it("renders a resolved top-level embed", () => {
+    expect(decideTransclusion(root("hub.md"), "target.md")).toEqual({
+      kind: "render",
+      path: "target.md",
+    });
+  });
+
+  it("chips an unresolved target", () => {
+    expect(decideTransclusion(root("hub.md"), null)).toEqual({
+      kind: "chip",
+      reason: "unresolved",
+    });
+  });
+
+  it("chips a self-embed as a cycle", () => {
+    expect(decideTransclusion(root("hub.md"), "hub.md")).toEqual({ kind: "chip", reason: "cycle" });
+  });
+
+  it("chips embeds inside embedded content (depth guard)", () => {
+    const inner = nestedScope(root("hub.md"), "target.md");
+    expect(decideTransclusion(inner, "other.md")).toEqual({ kind: "chip", reason: "depth" });
+    // Even a would-be cycle at depth is reported as depth — it never renders.
+    expect(decideTransclusion(inner, "hub.md")).toEqual({ kind: "chip", reason: "depth" });
+  });
+
+  it("nestedScope extends the ancestor chain", () => {
+    const inner = nestedScope(root("a.md"), "b.md");
+    expect(inner).toEqual({ depth: 1, chain: ["a.md", "b.md"] });
+  });
+});

--- a/packages/app/src/__tests__/wiki-autocomplete.test.ts
+++ b/packages/app/src/__tests__/wiki-autocomplete.test.ts
@@ -1,0 +1,141 @@
+// The `[[` picker's editor semantics, headless: the second `[` swaps in the
+// trigger element, completion consumes the literal first `[` (and a `!` for
+// embeds) and inserts the chip, cancel restores plain text, and a mid-picker
+// autosave serializes cleanly (wiki_input is structurally excluded).
+
+import { describe, expect, it } from "vitest";
+import { ElementApi, createSlateEditor, type TElement } from "platejs";
+import { serializeMd } from "@platejs/markdown";
+
+import { cancelComboboxInput, commitComboboxInput } from "@repo/app/editor/combobox-input";
+import { EDITOR_KIT } from "@repo/app/editor/kits/editor-kit";
+import { MD_STRINGIFY } from "@repo/app/editor/markdown/markdown-doc";
+import { insertWikiChipFromPicker } from "@repo/app/editor/wiki-insert";
+import { WIKI_INPUT_KEY } from "@repo/app/editor/wiki-input-key";
+import { composeWikiBody, wikiBodyForPath } from "@repo/app/editor/wiki-target";
+import { buildResolver } from "@repo/core/knowledge/link-resolve";
+
+function makeEditor(text: string) {
+  return createSlateEditor({
+    plugins: EDITOR_KIT,
+    value: [{ children: [{ text }], type: "p" }],
+  });
+}
+
+type Editor = ReturnType<typeof makeEditor>;
+
+function out(editor: Editor): string {
+  return serializeMd(editor, { remarkStringifyOptions: MD_STRINGIFY });
+}
+
+function findByType(editor: Editor, type: string): TElement | null {
+  for (const [node] of editor.api.nodes({ at: [], match: { type } })) {
+    if (ElementApi.isElement(node)) return node;
+  }
+  return null;
+}
+
+/** Type `[[` at the end of block 0, returning the trigger element. */
+function openWikiPicker(editor: Editor): TElement {
+  const end = editor.api.end([0]);
+  if (!end) throw new Error("no end point");
+  editor.tf.select(end);
+  editor.tf.insertText("[");
+  editor.tf.insertText("[");
+  const element = findByType(editor, WIKI_INPUT_KEY);
+  if (!element) throw new Error("[[ did not insert the wiki input element");
+  return element;
+}
+
+describe("[[ trigger", () => {
+  it("a single [ stays plain text — no picker", () => {
+    const editor = makeEditor("see ");
+    const end = editor.api.end([0]);
+    if (end) editor.tf.select(end);
+    editor.tf.insertText("[");
+    expect(findByType(editor, WIKI_INPUT_KEY)).toBeNull();
+    expect(out(editor)).toBe("see \\[\n");
+  });
+
+  it("[[ inserts the trigger element after the literal first [", () => {
+    const editor = makeEditor("see ");
+    openWikiPicker(editor);
+    expect(editor.api.string([0])).toContain("see [");
+  });
+
+  it("a mid-picker autosave serializes without the trigger element", () => {
+    const editor = makeEditor("see ");
+    openWikiPicker(editor);
+    // The literal first `[` serializes escaped; the element contributes nothing.
+    expect(out(editor)).toBe("see \\[\n");
+  });
+});
+
+describe("picker completion", () => {
+  it("completes a wikiLink chip, consuming the literal [", () => {
+    const editor = makeEditor("see ");
+    const element = openWikiPicker(editor);
+    commitComboboxInput(editor, element, false);
+    insertWikiChipFromPicker(editor, "target note");
+    expect(findByType(editor, "wikiLink")?.body).toBe("target note");
+    expect(out(editor)).toBe("see [[target note]]\n");
+  });
+
+  it("upgrades ![[ to a wikiEmbed chip, consuming the bang", () => {
+    const editor = makeEditor("see !");
+    const element = openWikiPicker(editor);
+    commitComboboxInput(editor, element, false);
+    insertWikiChipFromPicker(editor, "target note");
+    expect(findByType(editor, "wikiEmbed")?.body).toBe("target note");
+    expect(findByType(editor, "wikiLink")).toBeNull();
+    expect(out(editor)).toBe("see ![[target note]]\n");
+  });
+
+  it("keeps typing after completion in the text flow (caret escaped the void)", () => {
+    const editor = makeEditor("");
+    const element = openWikiPicker(editor);
+    commitComboboxInput(editor, element, false);
+    insertWikiChipFromPicker(editor, "note");
+    editor.tf.insertText(" after");
+    expect(out(editor)).toBe("[[note]] after\n");
+  });
+
+  it("cancel restores the typed query as plain text", () => {
+    const editor = makeEditor("see ");
+    const element = openWikiPicker(editor);
+    cancelComboboxInput(editor, element, { cause: "escape", restoreText: "[quer" });
+    expect(findByType(editor, WIKI_INPUT_KEY)).toBeNull();
+    expect(editor.api.string([0])).toBe("see [[quer");
+  });
+});
+
+describe("body composition", () => {
+  const resolver = buildResolver([
+    "wiki/target note.md",
+    "wiki/hub.md",
+    "notes/hub.md",
+    "diagram.png",
+  ]);
+  const resolve = (target: string) => resolver.resolveWiki(target);
+
+  it("uses the bare stem when it round-trips to the path", () => {
+    expect(wikiBodyForPath("wiki/target note.md", resolve)).toBe("target note");
+    expect(wikiBodyForPath("diagram.png", resolve)).toBe("diagram.png");
+  });
+
+  it("falls back to the full (extension-less) path on ambiguity", () => {
+    // Two hub.md files: the bare stem resolves to exactly one of them
+    // (shortest path wins the tie), so the OTHER file must link by path.
+    expect(resolve("hub")).toBe("wiki/hub.md");
+    expect(wikiBodyForPath("wiki/hub.md", resolve)).toBe("hub");
+    expect(wikiBodyForPath("notes/hub.md", resolve)).toBe("notes/hub");
+    expect(resolve("notes/hub")).toBe("notes/hub.md");
+  });
+
+  it("passes typed anchor/alias through", () => {
+    expect(composeWikiBody("note", {})).toBe("note");
+    expect(composeWikiBody("note", { anchor: "sec" })).toBe("note#sec");
+    expect(composeWikiBody("note", { alias: "nice" })).toBe("note|nice");
+    expect(composeWikiBody("note", { anchor: "sec", alias: "nice" })).toBe("note#sec|nice");
+  });
+});

--- a/packages/app/src/command/command-palette.tsx
+++ b/packages/app/src/command/command-palette.tsx
@@ -1,5 +1,12 @@
 import { useCallback, useEffect, useRef, useState } from "react";
-import { FilePlusIcon, FileTextIcon, FolderIcon, MoonIcon, SunIcon } from "lucide-react";
+import {
+  FilePlusIcon,
+  FileTextIcon,
+  FolderIcon,
+  MoonIcon,
+  SunIcon,
+  WaypointsIcon,
+} from "lucide-react";
 
 import {
   CommandDialog,
@@ -10,12 +17,32 @@ import {
   CommandList,
 } from "@repo/ui/components/command";
 
+import { getBridge } from "@repo/app/lib/bridge";
 import { useTheme } from "@repo/app/lib/use-theme";
+import { useViewStore } from "@repo/app/stores/view-store";
 import { useVault } from "@repo/app/workspace/vault-context";
+import type { SearchResult } from "@repo/core/knowledge/knowledge-index";
+
+const SEARCH_DEBOUNCE_MS = 150;
+const SEARCH_LIMIT = 8;
+
+/** Every whitespace-separated term must appear somewhere in the haystack —
+ * the filename filter (filtering is ours: cmdk's scorer can't see the
+ * host-ranked full-text results, so `shouldFilter` is off and both entry
+ * kinds go through app-side matching). */
+function matchesQuery(haystack: string, query: string): boolean {
+  const lower = haystack.toLowerCase();
+  return query
+    .toLowerCase()
+    .split(/\s+/)
+    .filter((term) => term !== "")
+    .every((term) => lower.includes(term));
+}
 
 /**
- * The ⌘K command palette: fuzzy-search notes to jump to them, create a note
- * from the typed name, and run a handful of workspace commands. Opened by ⌘K
+ * The ⌘K command palette: fuzzy-search notes by filename, full-text search
+ * their contents (searchVault, debounced as-you-type), create a note from the
+ * typed name, and run a handful of workspace commands. Opened by ⌘K
  * (WorkspacePage) and the sidebar's "Quick actions" pill.
  */
 export function CommandPalette({
@@ -26,16 +53,43 @@ export function CommandPalette({
   onOpenChange: (open: boolean) => void;
 }) {
   const { entries, openFile, createFile, changeFolder } = useVault();
+  const setSurface = useViewStore((s) => s.setSurface);
   const { resolved, setTheme } = useTheme();
   const [query, setQuery] = useState("");
+  const [hits, setHits] = useState<SearchResult[]>([]);
   const inputRef = useRef<HTMLInputElement>(null);
 
   // Clear the filter on every close, no matter the path — Esc / select run
   // `close()`, but ⌘K-to-dismiss toggles `open` in WorkspacePage and bypasses
   // it, so reopening would otherwise show stale query text.
   useEffect(() => {
-    if (!open) setQuery("");
+    if (!open) {
+      setQuery("");
+      setHits([]);
+    }
   }, [open]);
+
+  // Debounced full-text search; a stale response never lands over a newer
+  // query (sequence check).
+  const searchSeq = useRef(0);
+  useEffect(() => {
+    const trimmedQuery = query.trim();
+    const seq = ++searchSeq.current;
+    if (!open || trimmedQuery === "") {
+      setHits([]);
+      return;
+    }
+    const timer = setTimeout(() => {
+      getBridge()
+        ?.searchVault({ query: trimmedQuery, limit: SEARCH_LIMIT })
+        .then((results) => {
+          if (seq === searchSeq.current) setHits(results);
+          return undefined;
+        })
+        .catch(() => {});
+    }, SEARCH_DEBOUNCE_MS);
+    return () => clearTimeout(timer);
+  }, [query, open]);
 
   const close = useCallback(() => onOpenChange(false), [onOpenChange]);
 
@@ -54,12 +108,47 @@ export function CommandPalette({
     (e) => e.path.toLowerCase() === lower || e.path.toLowerCase() === `${lower}.md`,
   );
 
+  // Notes = filename matches, then full-text hits that the filename filter
+  // missed (deduped by path, host ranking preserved).
+  const nameMatches =
+    trimmed === "" ? entries : entries.filter((e) => matchesQuery(e.path, trimmed));
+  const namePaths = new Set(nameMatches.map((e) => e.path));
+  const contentHits = hits.filter((hit) => !namePaths.has(hit.path));
+
+  const actions = [
+    {
+      value: "graph",
+      keywords: "open graph view links map",
+      icon: <WaypointsIcon />,
+      label: "Open graph view",
+      onSelect: () => setSurface("graph"),
+    },
+    {
+      value: "theme",
+      keywords: "toggle theme dark light appearance",
+      icon: resolved === "dark" ? <SunIcon /> : <MoonIcon />,
+      label: `Switch to ${resolved === "dark" ? "light" : "dark"} theme`,
+      onSelect: () => setTheme(resolved === "dark" ? "light" : "dark"),
+    },
+    {
+      value: "vault",
+      keywords: "switch vault folder change directory",
+      icon: <FolderIcon />,
+      label: "Switch vault folder…",
+      onSelect: () => void changeFolder(),
+    },
+  ].filter(
+    (action) => trimmed === "" || matchesQuery(`${action.label} ${action.keywords}`, trimmed),
+  );
+
   return (
     <CommandDialog
       open={open}
       onOpenChange={(next) => (next ? onOpenChange(true) : close())}
       initialFocus={inputRef}
+      shouldFilter={false}
     >
+      {/* Filtering is app-side (filename terms + host-ranked full text). */}
       <CommandInput
         ref={inputRef}
         value={query}
@@ -69,12 +158,25 @@ export function CommandPalette({
       <CommandList>
         <CommandEmpty>No results.</CommandEmpty>
 
-        {entries.length > 0 && (
+        {(nameMatches.length > 0 || contentHits.length > 0) && (
           <CommandGroup heading="Notes">
-            {entries.map((e) => (
+            {nameMatches.map((e) => (
               <CommandItem key={e.path} value={e.path} onSelect={() => run(() => openFile(e.path))}>
                 <FileTextIcon />
                 <span className="truncate">{e.path}</span>
+              </CommandItem>
+            ))}
+            {contentHits.map((hit) => (
+              <CommandItem
+                key={`hit:${hit.path}`}
+                value={`hit:${hit.path}`}
+                onSelect={() => run(() => openFile(hit.path))}
+              >
+                <FileTextIcon />
+                <span className="flex min-w-0 flex-1 flex-col">
+                  <span className="truncate">{hit.title}</span>
+                  <span className="truncate text-xs text-muted-foreground">{hit.snippet}</span>
+                </span>
               </CommandItem>
             ))}
           </CommandGroup>
@@ -94,22 +196,20 @@ export function CommandPalette({
           </CommandGroup>
         )}
 
-        <CommandGroup heading="Actions">
-          <CommandItem
-            value="toggle theme dark light appearance"
-            onSelect={() => run(() => setTheme(resolved === "dark" ? "light" : "dark"))}
-          >
-            {resolved === "dark" ? <SunIcon /> : <MoonIcon />}
-            <span>Switch to {resolved === "dark" ? "light" : "dark"} theme</span>
-          </CommandItem>
-          <CommandItem
-            value="switch vault folder change directory"
-            onSelect={() => run(() => void changeFolder())}
-          >
-            <FolderIcon />
-            <span>Switch vault folder…</span>
-          </CommandItem>
-        </CommandGroup>
+        {actions.length > 0 && (
+          <CommandGroup heading="Actions">
+            {actions.map((action) => (
+              <CommandItem
+                key={action.value}
+                value={action.value}
+                onSelect={() => run(action.onSelect)}
+              >
+                {action.icon}
+                <span>{action.label}</span>
+              </CommandItem>
+            ))}
+          </CommandGroup>
+        )}
       </CommandList>
     </CommandDialog>
   );

--- a/packages/app/src/editor/editor-pane.tsx
+++ b/packages/app/src/editor/editor-pane.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef, type KeyboardEvent } from "react";
 
 import { MarkdownEditor } from "@repo/app/editor/markdown-editor";
+import { BacklinksPanel } from "@repo/app/workspace/backlinks-panel";
 import { useVault } from "@repo/app/workspace/vault-context";
 
 /**
@@ -109,6 +110,8 @@ export function EditorPane() {
           placeholder="Empty note"
         />
       )}
+      {/* Linked mentions live in the same centered column, below the doc. */}
+      <BacklinksPanel />
     </div>
   );
 }

--- a/packages/app/src/editor/inline-combobox.tsx
+++ b/packages/app/src/editor/inline-combobox.tsx
@@ -40,7 +40,7 @@ type FilterItem = {
   keywords?: string[] | undefined;
   label?: string | undefined;
 };
-type FilterFn = (item: FilterItem, search: string) => boolean;
+export type FilterFn = (item: FilterItem, search: string) => boolean;
 
 type InlineComboboxContextValue = {
   commit: (focusEditor: boolean) => void;

--- a/packages/app/src/editor/kits/editor-kit.ts
+++ b/packages/app/src/editor/kits/editor-kit.ts
@@ -27,6 +27,7 @@ import { TableKit } from "@repo/app/editor/kits/table-kit";
 import { ToggleKit } from "@repo/app/editor/kits/toggle-kit";
 import { WikiLinkKit } from "@repo/app/editor/kits/wiki-link-kit";
 import { SlashKit } from "@repo/app/editor/slash-menu";
+import { WikiAutocompleteKit } from "@repo/app/editor/wiki-autocomplete";
 
 export const EDITOR_KIT = [
   ...BasicMarksKit,
@@ -43,6 +44,7 @@ export const EDITOR_KIT = [
   ...CalloutKit,
   ...FrontmatterKit,
   ...WikiLinkKit,
+  ...WikiAutocompleteKit,
   ...EmojiKit,
   ...SlashKit,
   ...DragKit,

--- a/packages/app/src/editor/kits/markdown-kit.ts
+++ b/packages/app/src/editor/kits/markdown-kit.ts
@@ -10,15 +10,16 @@ import { AI_MARK } from "@repo/app/editor/ai/ai-mark";
 import { shouldSerializeNode } from "@repo/app/editor/ai/transient";
 import { MD_REMARK_PLUGINS } from "@repo/app/editor/markdown/md-plugins";
 import { MD_RULES } from "@repo/app/editor/markdown/md-rules";
+import { WIKI_INPUT_KEY } from "@repo/app/editor/wiki-input-key";
 
 export const MarkdownKit = [
   MarkdownPlugin.configure({
     options: {
       // Transient nodes never serialize. Two mechanisms:
       // - disallowedNodes drops WHOLE nodes: the inline-AI streaming mark and
-      //   the combobox trigger elements (`/` and `:` inputs are UI state — an
-      //   autosave firing mid-combobox must skip them structurally, never hit
-      //   the serializer's "Unreachable code" fallback).
+      //   the combobox trigger elements (`/`, `:`, and `[[` inputs are UI
+      //   state — an autosave firing mid-combobox must skip them structurally,
+      //   never hit the serializer's "Unreachable code" fallback).
       // - allowNode.serialize handles suggestion (track-changes) marks, which
       //   need per-TYPE treatment: pending INSERTIONS are dropped, but
       //   deletion-marked text is the user's ORIGINAL content and must stay
@@ -26,7 +27,7 @@ export const MarkdownKit = [
       // - plainMarks strips the default `suggestion` mark rule's
       //   <suggestion> JSX wrapper from the kept (remove/update) text — the
       //   bytes are the plain original text.
-      disallowedNodes: [AI_MARK, KEYS.slashInput, KEYS.emojiInput],
+      disallowedNodes: [AI_MARK, KEYS.slashInput, KEYS.emojiInput, WIKI_INPUT_KEY],
       allowNode: { serialize: shouldSerializeNode },
       plainMarks: [KEYS.suggestion],
       remarkPlugins: MD_REMARK_PLUGINS,

--- a/packages/app/src/editor/kits/wiki-link-kit.tsx
+++ b/packages/app/src/editor/kits/wiki-link-kit.tsx
@@ -1,18 +1,23 @@
 // Wiki-link kit: inline-void nodes for [[target]] / [[target|alias]] /
 // ![[embed]]. Node shape: { type, body, children:[{text:""}] } with `body`
-// verbatim (round-trip contract lives in @repo/core/markdown/remark-wiki-link). The
-// React half renders non-navigating chips (resolution/backlinks/autocomplete
-// are Phase F) and adds the `]]` input rule: without it, typed `[[Note]]`
-// would stay plain text and the serializer would escape it to `\[\[Note]]`
-// on save — the flagship syntax would self-destruct.
+// verbatim (round-trip contract lives in @repo/core/markdown/remark-wiki-link).
+// The React half renders navigating chips (wiki-chip.tsx) and transclusion
+// cards (transclusion.tsx) — both behind React.lazy, because they reach into
+// vault-context and an eager import from this file (which base-kit composes)
+// would close an import cycle around the kit files. It also adds the `]]`
+// input rule: without it, typed `[[Note]]` would stay plain text and the
+// serializer would escape it to `\[\[Note]]` on save — the flagship syntax
+// would self-destruct.
 
+import { Suspense, lazy } from "react";
 import { KEYS, NodeApi, TextApi, createSlatePlugin, type SlateEditor } from "platejs";
 import { PlateElement, type PlateElementProps } from "platejs/react";
 
-import { cn } from "@repo/ui/lib/utils";
-
 import { insertVoidAndEscape } from "@repo/app/editor/insert-void";
 import { parseWikiBody } from "@repo/core/markdown/remark-wiki-link";
+
+const WikiChip = lazy(() => import("@repo/app/editor/wiki-chip"));
+const Transclusion = lazy(() => import("@repo/app/editor/transclusion"));
 
 const wikiLinkBasePlugin = createSlatePlugin({
   key: "wikiLink",
@@ -37,15 +42,33 @@ function chipLabel(body: unknown): string {
   return parsed.anchor ? `${parsed.target}#${parsed.anchor}` : parsed.target;
 }
 
+// The pre-hydration fallback chip (also what a chip looks like while the lazy
+// module streams in) — inert, but visually identical to a resolved chip.
+function FallbackChip({ body, embed }: { body: unknown; embed?: boolean }) {
+  return (
+    <span
+      contentEditable={false}
+      className="cursor-default rounded-sm bg-primary/10 px-1 text-primary/80"
+    >
+      {embed === true && (
+        <span className="mr-0.5 font-semibold text-primary/50 select-none">!</span>
+      )}
+      {chipLabel(body)}
+    </span>
+  );
+}
+
+function elementBody(element: PlateElementProps["element"]): string {
+  return typeof element.body === "string" ? element.body : "";
+}
+
 function WikiLinkElement(props: PlateElementProps) {
   return (
     <PlateElement {...props} as="span" className="inline-block">
-      <span
-        contentEditable={false}
-        title="Links resolve in a later phase"
-        className="cursor-default rounded-sm bg-primary/10 px-1 text-primary/80"
-      >
-        {chipLabel(props.element.body)}
+      <span contentEditable={false}>
+        <Suspense fallback={<FallbackChip body={props.element.body} />}>
+          <WikiChip body={elementBody(props.element)} />
+        </Suspense>
       </span>
       {props.children}
     </PlateElement>
@@ -54,14 +77,11 @@ function WikiLinkElement(props: PlateElementProps) {
 
 function WikiEmbedElement(props: PlateElementProps) {
   return (
-    <PlateElement {...props} as="span" className="inline-block">
-      <span
-        contentEditable={false}
-        title="Embeds resolve in a later phase"
-        className="cursor-default rounded-sm bg-primary/10 px-1 text-primary/80"
-      >
-        <span className={cn("mr-0.5 font-semibold select-none", "text-primary/50")}>!</span>
-        {chipLabel(props.element.body)}
+    <PlateElement {...props} as="span" className="inline-block w-full">
+      <span contentEditable={false} className="block w-full">
+        <Suspense fallback={<FallbackChip body={props.element.body} embed />}>
+          <Transclusion body={elementBody(props.element)} />
+        </Suspense>
       </span>
       {props.children}
     </PlateElement>

--- a/packages/app/src/editor/transclusion-guard.ts
+++ b/packages/app/src/editor/transclusion-guard.ts
@@ -1,0 +1,25 @@
+// Pure guard policy for ![[transclusion]] rendering — React-free so the
+// depth/cycle semantics are pinned by unit tests. The editor root renders at
+// depth 0 (embeds expand); content rendered INSIDE a transclusion carries
+// depth 1+, where embeds stay chips. `chain` is the ancestor path list.
+
+export type TransclusionScope = { depth: number; chain: readonly string[] };
+
+export type TransclusionDecision =
+  | { kind: "chip"; reason: "unresolved" | "depth" | "cycle" }
+  | { kind: "render"; path: string };
+
+export function decideTransclusion(
+  scope: TransclusionScope,
+  resolved: string | null,
+): TransclusionDecision {
+  if (resolved === null) return { kind: "chip", reason: "unresolved" };
+  if (scope.depth >= 1) return { kind: "chip", reason: "depth" };
+  if (scope.chain.includes(resolved)) return { kind: "chip", reason: "cycle" };
+  return { kind: "render", path: resolved };
+}
+
+/** The scope the rendered target's own content is evaluated under. */
+export function nestedScope(scope: TransclusionScope, resolved: string): TransclusionScope {
+  return { depth: scope.depth + 1, chain: [...scope.chain, resolved] };
+}

--- a/packages/app/src/editor/transclusion.tsx
+++ b/packages/app/src/editor/transclusion.tsx
@@ -1,0 +1,308 @@
+// ![[transclusion]] rendering: the embed chip expands into the target note's
+// content, rendered READ-ONLY through Plate's static path over the SAME
+// BASE_KIT the byte-stability gate uses — no nested live editor. Guards:
+// unresolved targets render the unresolved chip, self/circular embeds render
+// a chip + note, and embeds inside embedded content (depth > 1) render as
+// chips. Content re-reads on every onVaultChanged so an edit to the target
+// (agent or user) refreshes the card.
+//
+// Loaded via React.lazy from wiki-link-kit — this module reaches into
+// vault-context, so an eager import from the kit file (which base-kit
+// composes) would close an import cycle around the kit files.
+
+import {
+  createContext,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+  type MouseEvent,
+  type ReactNode,
+} from "react";
+import { createSlateEditor } from "platejs";
+import { PlateStatic, SlateElement, type SlateElementProps } from "platejs/static";
+
+import { cn } from "@repo/ui/lib/utils";
+
+import { getBridge } from "@repo/app/lib/bridge";
+import { BASE_KIT } from "@repo/app/editor/kits/base-kit";
+import { parseMarkdown } from "@repo/app/editor/markdown/markdown-doc";
+import {
+  decideTransclusion,
+  nestedScope,
+  type TransclusionScope,
+} from "@repo/app/editor/transclusion-guard";
+import WikiChip, { wikiChipLabel } from "@repo/app/editor/wiki-chip";
+import { useVault } from "@repo/app/workspace/vault-context";
+import { parseWikiBody } from "@repo/core/markdown/remark-wiki-link";
+
+// Depth/cycle scope context — the policy itself lives in transclusion-guard.ts.
+const TransclusionScopeContext = createContext<TransclusionScope | null>(null);
+
+// ---------------------------------------------------------------------------
+// Static components for the read-only render. The default static renderers
+// already produce solid markup (headings, marks, lists, quotes, code); these
+// cover the nodes that would otherwise render empty or unstyled voids.
+// ---------------------------------------------------------------------------
+
+function LinkStatic(props: SlateElementProps) {
+  const url = typeof props.element.url === "string" ? props.element.url : "";
+  return (
+    <SlateElement
+      {...props}
+      as="a"
+      className="text-primary underline decoration-primary/40 underline-offset-2"
+      attributes={{ ...props.attributes, href: url, rel: "noreferrer", target: "_blank" }}
+    >
+      {props.children}
+    </SlateElement>
+  );
+}
+
+function WikiLinkStatic(props: SlateElementProps) {
+  const body = typeof props.element.body === "string" ? props.element.body : "";
+  return (
+    <SlateElement {...props} as="span">
+      <WikiChip body={body} />
+      {props.children}
+    </SlateElement>
+  );
+}
+
+/** Embeds inside embedded content: always a chip (depth guard) — but still a
+ * navigable one. */
+function WikiEmbedStatic(props: SlateElementProps) {
+  const body = typeof props.element.body === "string" ? props.element.body : "";
+  return (
+    <SlateElement {...props} as="span">
+      <EmbedChip body={body} />
+      {props.children}
+    </SlateElement>
+  );
+}
+
+function DateStatic(props: SlateElementProps) {
+  const date = typeof props.element.date === "string" ? props.element.date : "";
+  return (
+    <SlateElement {...props} as="span" className="rounded-sm bg-muted px-1 text-muted-foreground">
+      {date || "date"}
+      {props.children}
+    </SlateElement>
+  );
+}
+
+function EquationStatic(props: SlateElementProps) {
+  const tex = typeof props.element.texExpression === "string" ? props.element.texExpression : "";
+  return (
+    <SlateElement {...props} className="my-1">
+      <code className="rounded-sm bg-muted px-1 py-0.5 font-mono text-sm">{tex}</code>
+      {props.children}
+    </SlateElement>
+  );
+}
+
+function InlineEquationStatic(props: SlateElementProps) {
+  const tex = typeof props.element.texExpression === "string" ? props.element.texExpression : "";
+  return (
+    <SlateElement {...props} as="span">
+      <code className="rounded-sm bg-muted px-1 font-mono text-sm">{tex}</code>
+      {props.children}
+    </SlateElement>
+  );
+}
+
+/** Media voids (video / tweet / pdf) compact to a link — a full player inside
+ * a read-only digest is noise. */
+function MediaStatic(props: SlateElementProps) {
+  const url = typeof props.element.url === "string" ? props.element.url : "";
+  return (
+    <SlateElement {...props} className="my-1">
+      <a
+        href={url}
+        target="_blank"
+        rel="noreferrer"
+        className="text-sm text-primary underline underline-offset-2"
+      >
+        {url}
+      </a>
+      {props.children}
+    </SlateElement>
+  );
+}
+
+function FrontmatterStatic(props: SlateElementProps) {
+  return (
+    <SlateElement {...props} className="hidden">
+      {props.children}
+    </SlateElement>
+  );
+}
+
+const STATIC_COMPONENTS: Record<string, (props: SlateElementProps) => ReactNode> = {
+  a: LinkStatic,
+  date: DateStatic,
+  equation: EquationStatic,
+  inline_equation: InlineEquationStatic,
+  video: MediaStatic,
+  media_embed: MediaStatic,
+  file: MediaStatic,
+  frontmatter: FrontmatterStatic,
+  wikiLink: WikiLinkStatic,
+  wikiEmbed: WikiEmbedStatic,
+};
+
+// withComponent returns extended copies — BASE_KIT itself (the serialization
+// mirror) is never mutated.
+const TRANSCLUSION_KIT = BASE_KIT.map((plugin) => {
+  const component = STATIC_COMPONENTS[plugin.key];
+  return component ? plugin.withComponent(component) : plugin;
+});
+
+// ---------------------------------------------------------------------------
+// Target content, read through the bridge and refreshed on vault changes.
+// ---------------------------------------------------------------------------
+
+type TargetContent =
+  | { status: "loading" }
+  | { status: "missing" }
+  | { status: "ready"; content: string };
+
+function useTargetContent(path: string | null): TargetContent {
+  const [state, setState] = useState<TargetContent>({ status: "loading" });
+  useEffect(() => {
+    if (path === null) return;
+    const bridge = getBridge();
+    if (!bridge) return;
+    let live = true;
+    const read = () => {
+      bridge
+        .readVaultDoc({ path })
+        .then((content) => {
+          if (!live) return;
+          setState((prev) =>
+            prev.status === "ready" && prev.content === content
+              ? prev
+              : { status: "ready", content },
+          );
+          return undefined;
+        })
+        .catch(() => {
+          if (live) setState({ status: "missing" });
+        });
+    };
+    read();
+    // The vault event carries no path — re-read unconditionally (a cheap
+    // index-map/disk read) rather than tracking per-file freshness here.
+    const unsubscribe = bridge.onVaultChanged(read);
+    return () => {
+      live = false;
+      unsubscribe();
+    };
+  }, [path]);
+  return state;
+}
+
+// ---------------------------------------------------------------------------
+// Chip fallbacks + the expanded card
+// ---------------------------------------------------------------------------
+
+/** The `!`-prefixed embed chip (unresolved / cycle / depth-guarded). */
+function EmbedChip({ body, note }: { body: string; note?: string | undefined }) {
+  return (
+    <span className="inline-flex items-baseline gap-0.5">
+      <span className="font-semibold text-primary/50 select-none" contentEditable={false}>
+        !
+      </span>
+      <WikiChip body={body} />
+      {note !== undefined && (
+        <span className="ml-1 text-xs text-muted-foreground italic" contentEditable={false}>
+          ({note})
+        </span>
+      )}
+    </span>
+  );
+}
+
+function TransclusionBody({ content }: { content: string }) {
+  const parsed = useMemo(() => parseMarkdown(content), [content]);
+  const editor = useMemo(
+    () =>
+      parsed.ok ? createSlateEditor({ plugins: TRANSCLUSION_KIT, value: parsed.value }) : null,
+    [parsed],
+  );
+  if (content.trim() === "") {
+    return <span className="text-sm text-muted-foreground italic">This note is empty.</span>;
+  }
+  if (!editor) {
+    // Out-of-vocabulary / unparseable target — show the bytes rather than
+    // nothing (the same honesty rule as the Raw editor mode).
+    return <pre className="overflow-x-auto font-mono text-xs whitespace-pre-wrap">{content}</pre>;
+  }
+  return <PlateStatic editor={editor} />;
+}
+
+export default function Transclusion({ body }: { body: string }) {
+  const { resolveWikiTarget, openFile } = useVault();
+  const vaultEditorPath = useVault().editor.path;
+  const scope = useContext(TransclusionScopeContext);
+  const parsed = parseWikiBody(body);
+  const resolved = parsed.target === "" ? null : resolveWikiTarget(parsed.target);
+  const content = useTargetContent(resolved);
+
+  const effectiveScope: TransclusionScope = useMemo(
+    () =>
+      scope ?? {
+        depth: 0,
+        chain: vaultEditorPath !== null ? [vaultEditorPath] : [],
+      },
+    [scope, vaultEditorPath],
+  );
+  const innerScope = useMemo(
+    () => (resolved !== null ? nestedScope(effectiveScope, resolved) : null),
+    [effectiveScope, resolved],
+  );
+
+  // Guards, in order: unresolved → chip; nested-in-embed → chip; cycle →
+  // chip + note; missing on read → chip.
+  const decision = decideTransclusion(effectiveScope, resolved);
+  if (decision.kind === "chip") {
+    return <EmbedChip body={body} note={decision.reason === "cycle" ? "circular" : undefined} />;
+  }
+  if (content.status === "missing") return <EmbedChip body={body} />;
+
+  const target = decision.path;
+  const title = wikiChipLabel(body);
+  const onOpen = (e: MouseEvent) => {
+    e.preventDefault();
+    openFile(target, { newTab: e.metaKey || e.ctrlKey });
+  };
+
+  return (
+    <span
+      contentEditable={false}
+      className={cn(
+        "my-1 inline-block w-full rounded-md border border-border bg-muted/30 align-top",
+      )}
+    >
+      <span className="flex items-center border-b border-border/60 px-3 py-1">
+        <button
+          type="button"
+          onClick={onOpen}
+          title={target}
+          className="cursor-pointer truncate text-xs font-medium text-muted-foreground transition-colors hover:text-primary"
+        >
+          {title}
+        </button>
+      </span>
+      <span className="block px-3 py-2 text-sm">
+        {content.status === "loading" || innerScope === null ? (
+          <span className="text-muted-foreground italic">Loading…</span>
+        ) : (
+          <TransclusionScopeContext.Provider value={innerScope}>
+            <TransclusionBody content={content.content} />
+          </TransclusionScopeContext.Provider>
+        )}
+      </span>
+    </span>
+  );
+}

--- a/packages/app/src/editor/wiki-autocomplete.tsx
+++ b/packages/app/src/editor/wiki-autocomplete.tsx
@@ -1,0 +1,164 @@
+// `[[` wiki autocomplete — the third inline-combobox consumer (after slash
+// and emoji). Typing `[` after `[` swaps in a trigger element listing every
+// linkable note (listWikiTargets, fuzzy-filtered); Enter/click completes the
+// chip and the closing brackets. `|alias` and `#anchor` typed into the query
+// pass straight through into the chip body, typing `]]` completes verbatim
+// (fluent-typing parity with the kit's `]]` input rule), and an unresolved
+// query offers a create-note entry that also inserts the (now-resolving) chip.
+
+import { useCallback, useEffect, useState } from "react";
+import { FilePlusIcon, FileTextIcon } from "lucide-react";
+import { KEYS, createTSlatePlugin, type PluginConfig } from "platejs";
+import { PlateElement, createPlatePlugin, type PlateElementProps } from "platejs/react";
+import {
+  withTriggerCombobox,
+  filterWords,
+  type TriggerComboboxPluginOptions,
+} from "@platejs/combobox";
+
+import { getBridge } from "@repo/app/lib/bridge";
+import { commitComboboxInput } from "@repo/app/editor/combobox-input";
+import {
+  InlineCombobox,
+  InlineComboboxContent,
+  InlineComboboxEmpty,
+  InlineComboboxGroup,
+  InlineComboboxItem,
+  InlineComboboxInput,
+  type FilterFn,
+} from "@repo/app/editor/inline-combobox";
+import { insertWikiChipFromPicker } from "@repo/app/editor/wiki-insert";
+import { WIKI_INPUT_KEY } from "@repo/app/editor/wiki-input-key";
+import { composeWikiBody, wikiBodyForPath } from "@repo/app/editor/wiki-target";
+import { useVault } from "@repo/app/workspace/vault-context";
+import type { WikiTarget } from "@repo/core/knowledge/knowledge-index";
+import { parseWikiBody } from "@repo/core/markdown/remark-wiki-link";
+
+const CREATE_VALUE = "__create__";
+
+// The query's alias/anchor tails are passthrough, not search terms — filter
+// on the target part only. The create entry self-manages its visibility.
+const wikiFilter: FilterFn = (item, search) => {
+  if (item.value === CREATE_VALUE) return true;
+  const target = parseWikiBody(search).target;
+  if (target === "") return true;
+  const terms = [item.value, ...(item.keywords ?? []), item.label].filter(
+    (k): k is string => typeof k === "string" && k !== "",
+  );
+  return terms.some((keyword) => filterWords(keyword, target));
+};
+
+function WikiInputElement(props: PlateElementProps) {
+  const { children, editor, element } = props;
+  const { resolveWikiTarget, createFileAt } = useVault();
+  const [value, setValue] = useState("");
+  const [targets, setTargets] = useState<WikiTarget[]>([]);
+
+  useEffect(() => {
+    let cancelled = false;
+    getBridge()
+      ?.listWikiTargets()
+      .then((list) => {
+        if (!cancelled) setTargets(list);
+        return undefined;
+      })
+      .catch(() => {});
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const typed = parseWikiBody(value);
+
+  const complete = useCallback((body: string) => insertWikiChipFromPicker(editor, body), [editor]);
+
+  // Typing the closing `]]` completes the chip verbatim, exactly like the
+  // editor-level input rule would have without the picker in the way.
+  const onValueChange = useCallback(
+    (next: string) => {
+      if (next.endsWith("]]") && next.slice(0, -2) !== "") {
+        commitComboboxInput(editor, element, true);
+        complete(next.slice(0, -2));
+        return;
+      }
+      setValue(next);
+    },
+    [editor, element, complete],
+  );
+
+  const showCreate = typed.target !== "" && resolveWikiTarget(typed.target) === null;
+
+  return (
+    <PlateElement {...props} as="span">
+      <InlineCombobox
+        element={element}
+        trigger="["
+        value={value}
+        setValue={onValueChange}
+        filter={wikiFilter}
+      >
+        <InlineComboboxInput />
+        <InlineComboboxContent>
+          <InlineComboboxEmpty>No notes found</InlineComboboxEmpty>
+          <InlineComboboxGroup>
+            {targets.map((target) => (
+              <InlineComboboxItem
+                key={target.path}
+                value={target.path}
+                label={target.title}
+                keywords={[target.title]}
+                onClick={() =>
+                  complete(composeWikiBody(wikiBodyForPath(target.path, resolveWikiTarget), typed))
+                }
+              >
+                <FileTextIcon className="mr-2 text-muted-foreground" />
+                <span className="flex min-w-0 flex-1 items-baseline gap-2">
+                  <span className="truncate">{target.title}</span>
+                  <span className="truncate text-xs text-muted-foreground">{target.path}</span>
+                </span>
+              </InlineComboboxItem>
+            ))}
+            {showCreate && (
+              <InlineComboboxItem
+                value={CREATE_VALUE}
+                onClick={() => {
+                  // Create the note in the background (no navigation) so the
+                  // inserted chip resolves immediately.
+                  void createFileAt(typed.target);
+                  complete(composeWikiBody(typed.target, typed));
+                }}
+              >
+                <FilePlusIcon className="mr-2 text-muted-foreground" />
+                <span>
+                  Create <span className="font-medium">{typed.target}</span>
+                </span>
+              </InlineComboboxItem>
+            )}
+          </InlineComboboxGroup>
+        </InlineComboboxContent>
+      </InlineCombobox>
+      {children}
+    </PlateElement>
+  );
+}
+
+type WikiTriggerConfig = PluginConfig<"wiki_trigger", TriggerComboboxPluginOptions>;
+
+export const WikiAutocompleteKit = [
+  createTSlatePlugin<WikiTriggerConfig>({
+    key: "wiki_trigger",
+    options: {
+      trigger: "[",
+      // Only a `[` immediately before the typed `[` opens the picker — plain
+      // brackets elsewhere stay plain text.
+      triggerPreviousCharPattern: /^\[$/,
+      triggerQuery: (editor) =>
+        !editor.api.some({ match: { type: editor.getType(KEYS.codeBlock) } }),
+      createComboboxInput: () => ({ children: [{ text: "" }], type: WIKI_INPUT_KEY }),
+    },
+  }).overrideEditor(withTriggerCombobox),
+  createPlatePlugin({
+    key: WIKI_INPUT_KEY,
+    node: { isElement: true, isInline: true, isVoid: true },
+  }).withComponent(WikiInputElement),
+];

--- a/packages/app/src/editor/wiki-chip.tsx
+++ b/packages/app/src/editor/wiki-chip.tsx
@@ -1,0 +1,89 @@
+// The live wiki-link chip: resolves its target against the vault listing and
+// navigates on click (Cmd/Ctrl-click opens a new tab). Unresolved targets are
+// visually distinct (dashed) and clicking offers to create the note.
+//
+// Loaded via React.lazy from wiki-link-kit: this module reaches into
+// vault-context (and through it the markdown pipeline and base-kit), so an
+// eager import from the kit file — which base-kit composes — would close an
+// import cycle around the kit files. Same seam as block-list → todo-delegation.
+
+import { useRef, useState, type MouseEvent } from "react";
+import { FilePlusIcon } from "lucide-react";
+
+import { Popover, PopoverContent } from "@repo/ui/components/popover";
+import { cn } from "@repo/ui/lib/utils";
+
+import { useVault } from "@repo/app/workspace/vault-context";
+import { parseWikiBody } from "@repo/core/markdown/remark-wiki-link";
+
+/** Shared chip label: alias wins, else target(+anchor) as written. */
+export function wikiChipLabel(body: string): string {
+  const parsed = parseWikiBody(body);
+  if (parsed.alias) return parsed.alias;
+  return parsed.anchor ? `${parsed.target}#${parsed.anchor}` : parsed.target;
+}
+
+export const RESOLVED_CHIP_CLASS =
+  "cursor-pointer rounded-sm bg-primary/10 px-1 text-primary transition-colors hover:bg-primary/20";
+export const UNRESOLVED_CHIP_CLASS =
+  "cursor-pointer rounded-sm px-1 text-muted-foreground underline decoration-dashed decoration-muted-foreground/60 underline-offset-2 transition-colors hover:bg-muted";
+
+export default function WikiChip({ body }: { body: string }) {
+  const { resolveWikiTarget, openFile, createFile } = useVault();
+  const [createOpen, setCreateOpen] = useState(false);
+  const chipRef = useRef<HTMLButtonElement>(null);
+
+  const parsed = parseWikiBody(body);
+  const label = wikiChipLabel(body);
+  // A pure-anchor link (`[[#sec]]`) points at the open note — nothing to
+  // resolve or create; render an inert chip.
+  const resolved = parsed.target === "" ? null : resolveWikiTarget(parsed.target);
+
+  const onClick = (e: MouseEvent) => {
+    e.preventDefault();
+    if (parsed.target === "") return;
+    if (resolved !== null) {
+      openFile(resolved, { newTab: e.metaKey || e.ctrlKey });
+      return;
+    }
+    setCreateOpen(true);
+  };
+
+  return (
+    <>
+      <button
+        ref={chipRef}
+        type="button"
+        contentEditable={false}
+        title={
+          parsed.target === ""
+            ? label
+            : (resolved ?? `${parsed.target} — not created yet (click to create)`)
+        }
+        onClick={onClick}
+        className={cn(resolved !== null ? RESOLVED_CHIP_CLASS : UNRESOLVED_CHIP_CLASS)}
+      >
+        {label}
+      </button>
+      {resolved === null && parsed.target !== "" && (
+        <Popover open={createOpen} onOpenChange={setCreateOpen}>
+          <PopoverContent anchor={chipRef} className="p-1">
+            <button
+              type="button"
+              onClick={() => {
+                setCreateOpen(false);
+                void createFile(parsed.target);
+              }}
+              className="flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-sm hover:bg-accent hover:text-accent-foreground"
+            >
+              <FilePlusIcon className="size-4 text-muted-foreground" />
+              <span>
+                Create <span className="font-medium">{parsed.target}.md</span>
+              </span>
+            </button>
+          </PopoverContent>
+        </Popover>
+      )}
+    </>
+  );
+}

--- a/packages/app/src/editor/wiki-input-key.ts
+++ b/packages/app/src/editor/wiki-input-key.ts
@@ -1,0 +1,6 @@
+// The `[[` autocomplete's trigger-element key, alone in a dependency-free
+// module: markdown-kit (composed into BASE_KIT) needs it for disallowedNodes,
+// while the kit itself (wiki-autocomplete.tsx) reaches into vault-context —
+// importing the key from there would close an import cycle around the kits.
+
+export const WIKI_INPUT_KEY = "wiki_input";

--- a/packages/app/src/editor/wiki-insert.ts
+++ b/packages/app/src/editor/wiki-insert.ts
@@ -1,0 +1,31 @@
+// The `[[` picker's editor-mutation core, React-free so the completion
+// behavior (consume the literal "[" the trigger left behind, upgrade a
+// preceding "!" into an embed) is pinned by headless regression tests —
+// the same split as combobox-input.ts.
+
+import type { SlateEditor } from "platejs";
+
+import { insertVoidAndEscape } from "@repo/app/editor/insert-void";
+
+/**
+ * Insert a wiki chip after the picker's commit removed the trigger element.
+ * At that point the caret sits right after the literal `[` that preceded the
+ * trigger (the FIRST bracket of `[[` — withTriggerCombobox swallowed the
+ * second). Consume it, and when a `!` precedes it (`![[`), consume that too
+ * and insert a wikiEmbed instead of a wikiLink.
+ */
+export function insertWikiChipFromPicker(editor: SlateEditor, body: string): void {
+  editor.tf.deleteBackward("character"); // the "[" the trigger left in the text
+  let type = "wikiLink";
+  const selection = editor.selection;
+  if (selection && editor.api.isCollapsed()) {
+    const before = editor.api.before(selection.anchor);
+    if (before && editor.api.string({ anchor: before, focus: selection.anchor }) === "!") {
+      editor.tf.deleteBackward("character");
+      type = "wikiEmbed";
+    }
+  }
+  // insertVoidAndEscape moves the caret past the chip — Slate would otherwise
+  // park it inside the void's empty text and swallow subsequent keystrokes.
+  insertVoidAndEscape(editor, { body, children: [{ text: "" }], type });
+}

--- a/packages/app/src/editor/wiki-target.ts
+++ b/packages/app/src/editor/wiki-target.ts
@@ -1,0 +1,27 @@
+// Pure helpers for composing wiki-link bodies from picker selections —
+// React-free so the completion semantics are pinned by unit tests.
+
+/** The target text to write into `[[...]]` for a vault path: the bare
+ * filename stem when it uniquely resolves back to the path (the short,
+ * Obsidian-style form), else the full path (extension-less for `.md`), which
+ * resolves exactly by construction. */
+export function wikiBodyForPath(
+  path: string,
+  resolveWiki: (target: string) => string | null,
+): string {
+  const stem = path.replace(/\.md$/i, "");
+  const base = stem.split("/").pop() ?? stem;
+  if (resolveWiki(base) === path) return base;
+  return stem;
+}
+
+/** Compose a full wiki body from a target plus the anchor/alias the user
+ * already typed into the picker query (`target#anchor|alias`). */
+export function composeWikiBody(
+  target: string,
+  parts: { anchor?: string | undefined; alias?: string | undefined },
+): string {
+  const anchor = parts.anchor !== undefined && parts.anchor !== "" ? `#${parts.anchor}` : "";
+  const alias = parts.alias !== undefined && parts.alias !== "" ? `|${parts.alias}` : "";
+  return `${target}${anchor}${alias}`;
+}

--- a/packages/app/src/sidebar/app-sidebar.tsx
+++ b/packages/app/src/sidebar/app-sidebar.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, useState } from "react";
+import { useCallback, useMemo, useState, type MouseEvent } from "react";
 import {
   ChevronRightIcon,
   ChevronsUpDownIcon,
@@ -9,6 +9,7 @@ import {
   PencilIcon,
   SearchIcon,
   Trash2Icon,
+  WaypointsIcon,
 } from "lucide-react";
 
 import { Button } from "@repo/ui/components/button";
@@ -37,6 +38,7 @@ import { ThemeToggle } from "@repo/app/components/theme-toggle";
 import { SettingsDialog } from "@repo/app/settings/settings-dialog";
 import { useResizableSidebar } from "@repo/app/sidebar/use-resizable-sidebar";
 import { buildVaultTree, type VaultTreeNode } from "@repo/app/sidebar/vault-tree";
+import { useViewStore } from "@repo/app/stores/view-store";
 import { useVault } from "@repo/app/workspace/vault-context";
 
 function withName(path: string, name: string): string {
@@ -70,10 +72,15 @@ export function AppSidebar({ onOpenPalette }: { onOpenPalette: () => void }) {
     void createFile(name);
   }, [newName, createFile]);
 
+  const surface = useViewStore((s) => s.surface);
+  const setSurface = useViewStore((s) => s.setSurface);
+
   const rowProps = {
     selectedPath: editor.path,
     renaming,
-    onOpen: openFile,
+    // Cmd/Ctrl-click opens a new tab; a plain click replaces the active one.
+    onOpen: (path: string, e?: MouseEvent) =>
+      openFile(path, { newTab: e ? e.metaKey || e.ctrlKey : false }),
     onStartRename: setRenaming,
     onCommitRename: (from: string, to: string) => {
       setRenaming(null);
@@ -115,6 +122,23 @@ export function AppSidebar({ onOpenPalette }: { onOpenPalette: () => void }) {
       </SidebarHeader>
 
       <SidebarContent className="px-2">
+        <SidebarGroup className="gap-1 p-0">
+          <SidebarMenu>
+            <SidebarMenuItem>
+              <SidebarMenuButton
+                size="sm"
+                isActive={surface === "graph"}
+                onClick={() => setSurface("graph")}
+                className={cn(
+                  surface === "graph" && "bg-sidebar-accent text-sidebar-accent-foreground",
+                )}
+              >
+                <WaypointsIcon />
+                <span>Graph</span>
+              </SidebarMenuButton>
+            </SidebarMenuItem>
+          </SidebarMenu>
+        </SidebarGroup>
         <SidebarGroup className="gap-1 p-0">
           <div className="flex items-center justify-between pr-1">
             <SidebarGroupLabel>Notes</SidebarGroupLabel>
@@ -181,7 +205,7 @@ export function AppSidebar({ onOpenPalette }: { onOpenPalette: () => void }) {
 type RowHandlers = {
   selectedPath: string | null;
   renaming: string | null;
-  onOpen: (path: string) => void;
+  onOpen: (path: string, e?: MouseEvent) => void;
   onStartRename: (path: string) => void;
   onCommitRename: (from: string, to: string) => void;
   onCancelRename: () => void;
@@ -262,7 +286,7 @@ function FileRow({
       <SidebarMenuButton
         size="sm"
         isActive={selectedPath === path}
-        onClick={() => onOpen(path)}
+        onClick={(e) => onOpen(path, e)}
         className={cn(selectedPath === path && "bg-sidebar-accent text-sidebar-accent-foreground")}
       >
         {kind === "doc" ? <FileTextIcon /> : <FileIcon />}

--- a/packages/app/src/stores/view-store.ts
+++ b/packages/app/src/stores/view-store.ts
@@ -1,16 +1,26 @@
 import { create } from "zustand";
 
 // Transient UI/view state for the shell (not persisted): whether the user has
-// pinned the agent response popover open. Everything else about the popover's
-// visibility is derived from live agent activity in the bottom composer.
+// pinned the agent response popover open, and which main surface fills the
+// workspace (the editor panes, or the link-graph view). Everything else about
+// the popover's visibility is derived from live agent activity in the bottom
+// composer.
+
+/** The workspace's main surface: the note editor, or the link graph. */
+type WorkspaceSurface = "editor" | "graph";
+
 type ViewStore = {
   responsePinned: boolean;
   togglePinned: () => void;
   setPinned: (pinned: boolean) => void;
+  surface: WorkspaceSurface;
+  setSurface: (surface: WorkspaceSurface) => void;
 };
 
 export const useViewStore = create<ViewStore>((set) => ({
   responsePinned: false,
   togglePinned: () => set((s) => ({ responsePinned: !s.responsePinned })),
   setPinned: (responsePinned) => set({ responsePinned }),
+  surface: "editor",
+  setSurface: (surface) => set({ surface }),
 }));

--- a/packages/app/src/workspace/backlinks-panel.tsx
+++ b/packages/app/src/workspace/backlinks-panel.tsx
@@ -1,0 +1,107 @@
+// Backlinks for the open note — a collapsible section at the bottom of the
+// editor column (below the document, sharing its geometry) rather than a
+// right rail: the workspace is a single centered text column with the
+// composer pinned bottom, so a rail would fight both the 700px measure and
+// the chat popover. Entries group by source note with the linking line as a
+// snippet; click navigates (Cmd/Ctrl-click opens a new tab). Refreshes on
+// onKnowledgeUpdated (the index lags saves by ~200-300ms, which is fine for
+// a reference panel) plus on note switch.
+
+import { useCallback, useEffect, useState, type MouseEvent } from "react";
+import { ChevronRightIcon } from "lucide-react";
+
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from "@repo/ui/components/collapsible";
+
+import { getBridge } from "@repo/app/lib/bridge";
+import { useVault } from "@repo/app/workspace/vault-context";
+import type { BacklinkEntry } from "@repo/core/knowledge/knowledge-index";
+
+function noteTitle(path: string): string {
+  const name = path.split("/").pop() ?? path;
+  const dot = name.lastIndexOf(".");
+  return dot > 0 ? name.slice(0, dot) : name;
+}
+
+export function BacklinksPanel() {
+  const { editor, openFile } = useVault();
+  const path = editor.path;
+  const [backlinks, setBacklinks] = useState<BacklinkEntry[]>([]);
+
+  const refresh = useCallback((notePath: string) => {
+    const bridge = getBridge();
+    if (!bridge) return;
+    bridge
+      .getBacklinks({ path: notePath })
+      .then((entries) => setBacklinks(entries))
+      .catch(() => {});
+  }, []);
+
+  useEffect(() => {
+    if (path === null) {
+      setBacklinks([]);
+      return;
+    }
+    refresh(path);
+    const bridge = getBridge();
+    return bridge?.onKnowledgeUpdated(() => refresh(path));
+  }, [path, refresh]);
+
+  if (path === null || backlinks.length === 0) return null;
+
+  // Group occurrences by source note (index order preserved), one row per
+  // source LINE — two links on the same line share a snippet and a target.
+  const groups = new Map<string, Map<number, BacklinkEntry>>();
+  for (const entry of backlinks) {
+    const lines = groups.get(entry.sourcePath) ?? new Map<number, BacklinkEntry>();
+    if (!lines.has(entry.line)) lines.set(entry.line, entry);
+    groups.set(entry.sourcePath, lines);
+  }
+
+  const open = (source: string) => (e: MouseEvent) => {
+    openFile(source, { newTab: e.metaKey || e.ctrlKey });
+  };
+
+  return (
+    <Collapsible defaultOpen className="group/backlinks mt-10 border-t border-border pt-3">
+      <CollapsibleTrigger className="flex w-full cursor-pointer items-center gap-1.5 text-xs font-medium text-muted-foreground transition-colors hover:text-foreground">
+        <ChevronRightIcon className="size-3.5 transition-transform group-data-[panel-open]/backlinks:rotate-90" />
+        <span>Backlinks</span>
+        <span className="rounded-full bg-muted px-1.5 py-px text-[10px] tabular-nums">
+          {backlinks.length}
+        </span>
+      </CollapsibleTrigger>
+      <CollapsibleContent>
+        <div className="mt-2 flex flex-col gap-3 pb-2">
+          {[...groups.entries()].map(([source, entries]) => (
+            <div key={source}>
+              <button
+                type="button"
+                onClick={open(source)}
+                title={source}
+                className="cursor-pointer text-sm font-medium text-foreground transition-colors hover:text-primary"
+              >
+                {noteTitle(source)}
+              </button>
+              <div className="mt-1 flex flex-col gap-1">
+                {[...entries.values()].map((entry) => (
+                  <button
+                    key={entry.line}
+                    type="button"
+                    onClick={open(source)}
+                    className="cursor-pointer rounded-md bg-muted/40 px-2 py-1 text-left text-xs text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+                  >
+                    <span className="line-clamp-2">{entry.snippet}</span>
+                  </button>
+                ))}
+              </div>
+            </div>
+          ))}
+        </div>
+      </CollapsibleContent>
+    </Collapsible>
+  );
+}

--- a/packages/app/src/workspace/graph-view.tsx
+++ b/packages/app/src/workspace/graph-view.tsx
@@ -1,0 +1,427 @@
+// The vault link graph — an alternate workspace surface rendering
+// getLinkGraph on a hand-rolled canvas over a d3-force simulation. Chosen over
+// react-force-graph-2d deliberately: d3-force is the only dependency (~15KB in
+// this lazy chunk vs ~100KB+ for the wrapper stack), and owning the draw loop
+// keeps node styling on the app's own CSS tokens (dark-mode aware for free).
+//
+// Interactions: wheel zooms about the cursor, drag pans, click opens the node
+// (phantom nodes offer to create the note), Esc returns to the editor. Nodes
+// are sized by degree; phantoms draw dashed; the active tab's note gets a
+// highlight ring. Data refreshes on onKnowledgeUpdated, preserving layout
+// positions by node id.
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import {
+  forceCenter,
+  forceCollide,
+  forceLink,
+  forceManyBody,
+  forceSimulation,
+  type Simulation,
+  type SimulationLinkDatum,
+  type SimulationNodeDatum,
+} from "d3-force";
+
+import { getBridge } from "@repo/app/lib/bridge";
+import { useTheme } from "@repo/app/lib/use-theme";
+import { useViewStore } from "@repo/app/stores/view-store";
+import { useVault } from "@repo/app/workspace/vault-context";
+import type { LinkGraph } from "@repo/core/knowledge/knowledge-index";
+
+type SimNode = SimulationNodeDatum & {
+  id: string;
+  title: string;
+  path?: string;
+  phantom: boolean;
+  degree: number;
+};
+
+/** Edges keep plain string endpoints for drawing/hit-work; d3's link force
+ * gets its own throwaway array to mutate. */
+type DrawEdge = { source: string; target: string; count: number };
+
+type GraphData = {
+  nodes: SimNode[];
+  byId: Map<string, SimNode>;
+  edges: DrawEdge[];
+};
+
+type Transform = { x: number; y: number; k: number };
+
+const MIN_ZOOM = 0.2;
+const MAX_ZOOM = 6;
+/** Zoom level above which every node gets a label (below it: hover/active only). */
+const LABEL_ZOOM = 0.8;
+
+function nodeRadius(node: SimNode): number {
+  return 4 + Math.min(10, Math.sqrt(node.degree) * 2);
+}
+
+function toGraphData(graph: LinkGraph, previous: GraphData | null): GraphData {
+  const byId = new Map<string, SimNode>();
+  const nodes = graph.nodes.map((node): SimNode => {
+    const prior = previous?.byId.get(node.id);
+    const sim: SimNode = { ...node };
+    // Carry the settled layout across refreshes so an index update nudges the
+    // graph instead of re-rolling it.
+    if (prior) {
+      sim.x = prior.x;
+      sim.y = prior.y;
+      sim.vx = prior.vx;
+      sim.vy = prior.vy;
+    }
+    byId.set(node.id, sim);
+    return sim;
+  });
+  const edges = graph.edges.map((edge): DrawEdge => {
+    return { source: edge.source, target: edge.target, count: edge.count };
+  });
+  return { nodes, byId, edges };
+}
+
+/** CSS token colors read off the canvas element, so the graph re-skins itself
+ * with the theme. */
+type Palette = {
+  node: string;
+  phantom: string;
+  edge: string;
+  label: string;
+  halo: string;
+  font: string;
+};
+
+function readPalette(canvas: HTMLCanvasElement): Palette {
+  const style = getComputedStyle(canvas);
+  const token = (name: string) => style.getPropertyValue(name).trim();
+  return {
+    node: token("--primary"),
+    phantom: token("--muted-foreground"),
+    edge: token("--border"),
+    label: token("--muted-foreground"),
+    halo: token("--ring"),
+    font: `11px ${style.fontFamily}`,
+  };
+}
+
+export default function GraphView() {
+  const { openFile, createFile, activeTab } = useVault();
+  const setSurface = useViewStore((s) => s.setSurface);
+  const { resolved: resolvedTheme } = useTheme();
+  const [empty, setEmpty] = useState(false);
+
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+  const dataRef = useRef<GraphData | null>(null);
+  const simRef = useRef<Simulation<SimNode, SimulationLinkDatum<SimNode>> | null>(null);
+  const transformRef = useRef<Transform>({ x: 0, y: 0, k: 1 });
+  const hoveredRef = useRef<SimNode | null>(null);
+  const activePathRef = useRef<string | null>(activeTab);
+  activePathRef.current = activeTab;
+  const frameRef = useRef<number | null>(null);
+
+  const draw = useCallback(() => {
+    const canvas = canvasRef.current;
+    const data = dataRef.current;
+    if (!canvas || !data) return;
+    const ctx = canvas.getContext("2d");
+    if (!ctx) return;
+    const dpr = window.devicePixelRatio || 1;
+    const width = canvas.clientWidth;
+    const height = canvas.clientHeight;
+    const palette = readPalette(canvas);
+    const { x, y, k } = transformRef.current;
+
+    ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+    ctx.clearRect(0, 0, width, height);
+    ctx.translate(width / 2 + x, height / 2 + y);
+    ctx.scale(k, k);
+
+    // Edges under nodes.
+    ctx.strokeStyle = palette.edge;
+    for (const edge of data.edges) {
+      const source = data.byId.get(edge.source);
+      const target = data.byId.get(edge.target);
+      if (!source || !target) continue;
+      if (
+        source.x === undefined ||
+        source.y === undefined ||
+        target.x === undefined ||
+        target.y === undefined
+      )
+        continue;
+      ctx.lineWidth = Math.min(3, 0.75 + Math.log2(edge.count)) / k;
+      ctx.beginPath();
+      ctx.moveTo(source.x, source.y);
+      ctx.lineTo(target.x, target.y);
+      ctx.stroke();
+    }
+
+    const hovered = hoveredRef.current;
+    const activePath = activePathRef.current;
+    ctx.font = palette.font;
+    ctx.textAlign = "center";
+    ctx.textBaseline = "top";
+    for (const node of data.nodes) {
+      if (node.x === undefined || node.y === undefined) continue;
+      const r = nodeRadius(node);
+      const isActive = node.path !== undefined && node.path === activePath;
+      const isHovered = node === hovered;
+
+      if (isActive || isHovered) {
+        ctx.beginPath();
+        ctx.arc(node.x, node.y, r + 3 / k, 0, Math.PI * 2);
+        ctx.strokeStyle = palette.halo;
+        ctx.lineWidth = 2 / k;
+        ctx.setLineDash([]);
+        ctx.stroke();
+      }
+
+      ctx.beginPath();
+      ctx.arc(node.x, node.y, r, 0, Math.PI * 2);
+      if (node.phantom) {
+        // Phantom (unresolved target): a dashed ghost outline, no fill.
+        ctx.setLineDash([3 / k, 2 / k]);
+        ctx.strokeStyle = palette.phantom;
+        ctx.lineWidth = 1.25 / k;
+        ctx.stroke();
+        ctx.setLineDash([]);
+      } else {
+        ctx.fillStyle = palette.node;
+        ctx.fill();
+      }
+
+      if (k >= LABEL_ZOOM || isHovered || isActive) {
+        ctx.fillStyle = palette.label;
+        ctx.globalAlpha = node.phantom ? 0.7 : 1;
+        ctx.fillText(node.title, node.x, node.y + r + 4 / k);
+        ctx.globalAlpha = 1;
+      }
+    }
+  }, []);
+
+  const scheduleDraw = useCallback(() => {
+    if (frameRef.current !== null) return;
+    frameRef.current = requestAnimationFrame(() => {
+      frameRef.current = null;
+      draw();
+    });
+  }, [draw]);
+
+  // Load + live-refresh the graph data, feeding one persistent simulation.
+  useEffect(() => {
+    const bridge = getBridge();
+    if (!bridge) return;
+    let disposed = false;
+
+    const apply = (graph: LinkGraph) => {
+      if (disposed) return;
+      const data = toGraphData(graph, dataRef.current);
+      dataRef.current = data;
+      setEmpty(data.nodes.length === 0);
+      const links: SimulationLinkDatum<SimNode>[] = data.edges.map((edge) => ({
+        source: edge.source,
+        target: edge.target,
+      }));
+      const existing = simRef.current;
+      if (existing) {
+        existing.nodes(data.nodes);
+        const linkForce =
+          existing.force<ReturnType<typeof forceLink<SimNode, SimulationLinkDatum<SimNode>>>>(
+            "link",
+          );
+        linkForce?.links(links);
+        existing.alpha(0.3).restart();
+        return;
+      }
+      const sim = forceSimulation<SimNode>(data.nodes)
+        .force(
+          "link",
+          forceLink<SimNode, SimulationLinkDatum<SimNode>>(links)
+            .id((node) => node.id)
+            .distance(70)
+            .strength(0.5),
+        )
+        .force("charge", forceManyBody().strength(-220))
+        .force("center", forceCenter(0, 0))
+        .force(
+          "collide",
+          forceCollide<SimNode>().radius((node) => nodeRadius(node) + 6),
+        );
+      sim.on("tick", scheduleDraw);
+      simRef.current = sim;
+    };
+
+    const refresh = () => {
+      bridge
+        .getLinkGraph()
+        .then(apply)
+        .catch(() => {});
+    };
+    refresh();
+    const unsubscribe = bridge.onKnowledgeUpdated(refresh);
+    return () => {
+      disposed = true;
+      unsubscribe();
+      simRef.current?.stop();
+      simRef.current = null;
+      if (frameRef.current !== null) cancelAnimationFrame(frameRef.current);
+      frameRef.current = null;
+    };
+  }, [scheduleDraw]);
+
+  // Size the canvas buffer to its CSS box (DPR-aware) and redraw on resize.
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+    const resize = () => {
+      const dpr = window.devicePixelRatio || 1;
+      canvas.width = Math.max(1, Math.round(canvas.clientWidth * dpr));
+      canvas.height = Math.max(1, Math.round(canvas.clientHeight * dpr));
+      scheduleDraw();
+    };
+    resize();
+    const observer = new ResizeObserver(resize);
+    observer.observe(canvas);
+    return () => observer.disconnect();
+  }, [scheduleDraw]);
+
+  // Redraw on theme flips (colors are read at draw time) and active-note moves.
+  useEffect(() => {
+    scheduleDraw();
+  }, [scheduleDraw, resolvedTheme, activeTab]);
+
+  // Esc returns to the editor surface.
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") setSurface("editor");
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [setSurface]);
+
+  /** Canvas-pixel position → the node under it, hit-testing in world space. */
+  const nodeAt = useCallback((clientX: number, clientY: number): SimNode | null => {
+    const canvas = canvasRef.current;
+    const data = dataRef.current;
+    if (!canvas || !data) return null;
+    const rect = canvas.getBoundingClientRect();
+    const { x, y, k } = transformRef.current;
+    const wx = (clientX - rect.left - rect.width / 2 - x) / k;
+    const wy = (clientY - rect.top - rect.height / 2 - y) / k;
+    let best: SimNode | null = null;
+    let bestDist = Number.POSITIVE_INFINITY;
+    for (const node of data.nodes) {
+      if (node.x === undefined || node.y === undefined) continue;
+      const dx = node.x - wx;
+      const dy = node.y - wy;
+      const dist = Math.hypot(dx, dy);
+      if (dist <= Math.max(nodeRadius(node) + 2, 8 / k) && dist < bestDist) {
+        best = node;
+        bestDist = dist;
+      }
+    }
+    return best;
+  }, []);
+
+  // Pointer interactions: drag pans, click (sub-threshold movement) opens.
+  const dragRef = useRef<{ id: number; startX: number; startY: number; moved: boolean } | null>(
+    null,
+  );
+
+  const onPointerDown = useCallback((e: React.PointerEvent<HTMLCanvasElement>) => {
+    e.currentTarget.setPointerCapture(e.pointerId);
+    dragRef.current = { id: e.pointerId, startX: e.clientX, startY: e.clientY, moved: false };
+  }, []);
+
+  const onPointerMove = useCallback(
+    (e: React.PointerEvent<HTMLCanvasElement>) => {
+      const drag = dragRef.current;
+      if (drag && drag.id === e.pointerId) {
+        const dx = e.clientX - drag.startX;
+        const dy = e.clientY - drag.startY;
+        if (drag.moved || Math.hypot(dx, dy) > 4) {
+          drag.moved = true;
+          transformRef.current = {
+            ...transformRef.current,
+            x: transformRef.current.x + e.movementX,
+            y: transformRef.current.y + e.movementY,
+          };
+          scheduleDraw();
+        }
+        return;
+      }
+      const hovered = nodeAt(e.clientX, e.clientY);
+      if (hovered !== hoveredRef.current) {
+        hoveredRef.current = hovered;
+        e.currentTarget.style.cursor = hovered ? "pointer" : "grab";
+        e.currentTarget.title = hovered
+          ? hovered.phantom
+            ? `${hovered.title} — not created yet`
+            : (hovered.path ?? hovered.title)
+          : "";
+        scheduleDraw();
+      }
+    },
+    [nodeAt, scheduleDraw],
+  );
+
+  const onPointerUp = useCallback(
+    (e: React.PointerEvent<HTMLCanvasElement>) => {
+      const drag = dragRef.current;
+      dragRef.current = null;
+      if (!drag || drag.moved) return;
+      const node = nodeAt(e.clientX, e.clientY);
+      if (!node) return;
+      if (node.phantom) {
+        // Phantom → offer to create the missing note (created at the vault
+        // root, matching wiki resolution for a bare target).
+        if (window.confirm(`Create "${node.title}.md"?`)) void createFile(node.title);
+        return;
+      }
+      if (node.path !== undefined) openFile(node.path, { newTab: e.metaKey || e.ctrlKey });
+    },
+    [createFile, nodeAt, openFile],
+  );
+
+  const onWheel = useCallback(
+    (e: React.WheelEvent<HTMLCanvasElement>) => {
+      const canvas = canvasRef.current;
+      if (!canvas) return;
+      const rect = canvas.getBoundingClientRect();
+      const { x, y, k } = transformRef.current;
+      const nextK = Math.min(MAX_ZOOM, Math.max(MIN_ZOOM, k * Math.exp(-e.deltaY * 0.002)));
+      if (nextK === k) return;
+      // Zoom about the cursor: keep the world point under it fixed.
+      const mx = e.clientX - rect.left - rect.width / 2;
+      const my = e.clientY - rect.top - rect.height / 2;
+      transformRef.current = {
+        x: mx - ((mx - x) / k) * nextK,
+        y: my - ((my - y) / k) * nextK,
+        k: nextK,
+      };
+      scheduleDraw();
+    },
+    [scheduleDraw],
+  );
+
+  return (
+    <div className="relative h-full w-full">
+      <canvas
+        ref={canvasRef}
+        aria-label="Vault link graph"
+        onPointerDown={onPointerDown}
+        onPointerMove={onPointerMove}
+        onPointerUp={onPointerUp}
+        onWheel={onWheel}
+        className="h-full w-full cursor-grab touch-none"
+      />
+      {empty && (
+        <div className="pointer-events-none absolute inset-0 flex items-center justify-center text-sm text-muted-foreground">
+          Nothing to graph yet — link notes with [[wiki links]].
+        </div>
+      )}
+      <div className="pointer-events-none absolute bottom-3 left-1/2 -translate-x-1/2 text-xs text-muted-foreground/70">
+        Scroll to zoom · drag to pan · click a note to open · Esc to close
+      </div>
+    </div>
+  );
+}

--- a/packages/app/src/workspace/tab-session.ts
+++ b/packages/app/src/workspace/tab-session.ts
@@ -1,0 +1,98 @@
+// Pure tab-session semantics for the workspace tab strip — every transition
+// the VaultProvider applies to its open-tab list lives here so the VS Code
+// conventions (replace-active vs new-tab, close activates the right
+// neighbor, cycle wraps) are unit-testable without React or controllers.
+//
+// Invariants every operation preserves:
+// - `tabs` has no duplicate paths (a path is open in at most one tab).
+// - `active` is a member of `tabs`, or null exactly when `tabs` is empty.
+
+export type TabSession = {
+  readonly tabs: readonly string[];
+  readonly active: string | null;
+};
+
+export const EMPTY_SESSION: TabSession = { tabs: [], active: null };
+
+/** How `openTab` places the path: `replace` swaps it into the active tab
+ * slot (plain click — VS Code's open-in-current-tab), `new` appends a tab
+ * after the active one (Cmd/Ctrl-click). Either way, a path that is already
+ * open just activates its existing tab. */
+export type OpenMode = "replace" | "new";
+
+export function openTab(session: TabSession, path: string, mode: OpenMode): TabSession {
+  if (session.tabs.includes(path)) return { tabs: session.tabs, active: path };
+  if (mode === "replace" && session.active !== null) {
+    const tabs = session.tabs.map((tab) => (tab === session.active ? path : tab));
+    return { tabs, active: path };
+  }
+  const at =
+    session.active === null ? session.tabs.length : session.tabs.indexOf(session.active) + 1;
+  const tabs = [...session.tabs.slice(0, at), path, ...session.tabs.slice(at)];
+  return { tabs, active: path };
+}
+
+/** Close a tab. Closing the active tab activates its right neighbor, falling
+ * back to the left one (VS Code). Closing a background tab keeps the active. */
+export function closeTab(session: TabSession, path: string): TabSession {
+  const at = session.tabs.indexOf(path);
+  if (at === -1) return session;
+  const tabs = session.tabs.filter((tab) => tab !== path);
+  if (tabs.length === 0) return EMPTY_SESSION;
+  if (session.active !== path) return { tabs, active: session.active };
+  const next = tabs[Math.min(at, tabs.length - 1)] ?? null;
+  return { tabs, active: next };
+}
+
+export function activateTab(session: TabSession, path: string): TabSession {
+  if (!session.tabs.includes(path) || session.active === path) return session;
+  return { tabs: session.tabs, active: path };
+}
+
+/** Ctrl+Tab / Ctrl+Shift+Tab: cycle the active tab by `delta`, wrapping. */
+export function cycleTab(session: TabSession, delta: 1 | -1): TabSession {
+  if (session.tabs.length < 2 || session.active === null) return session;
+  const at = session.tabs.indexOf(session.active);
+  const next = session.tabs[(at + delta + session.tabs.length) % session.tabs.length];
+  return next === undefined ? session : { tabs: session.tabs, active: next };
+}
+
+/** A file was renamed/moved — carry its tab (and active state) to the new
+ * path in place. If the destination is somehow already open, the stale
+ * source tab closes instead of duplicating. */
+export function renameTab(session: TabSession, from: string, to: string): TabSession {
+  if (!session.tabs.includes(from) || from === to) return session;
+  if (session.tabs.includes(to)) {
+    const closed = closeTab(session, from);
+    return session.active === from ? { tabs: closed.tabs, active: to } : closed;
+  }
+  const tabs = session.tabs.map((tab) => (tab === from ? to : tab));
+  return { tabs, active: session.active === from ? to : session.active };
+}
+
+/** Reorder: move the tab at `from` to index `to` (drag-reorder). */
+export function moveTab(session: TabSession, from: number, to: number): TabSession {
+  const path = session.tabs[from];
+  if (path === undefined || from === to || to < 0 || to >= session.tabs.length) return session;
+  const tabs = session.tabs.filter((_, i) => i !== from);
+  tabs.splice(to, 0, path);
+  return { tabs, active: session.active };
+}
+
+/** Parse a persisted ui-state value back into a session, dropping anything
+ * malformed (unknown shape, duplicates, active not a member). */
+export function parseSession(value: unknown): TabSession | undefined {
+  if (typeof value !== "object" || value === null) return undefined;
+  const record: Record<string, unknown> = { ...value };
+  const rawTabs = record["tabs"];
+  const rawActive = record["active"];
+  if (!Array.isArray(rawTabs)) return undefined;
+  const tabs: string[] = [];
+  for (const tab of rawTabs) {
+    if (typeof tab !== "string" || tab === "" || tabs.includes(tab)) return undefined;
+    tabs.push(tab);
+  }
+  if (tabs.length === 0) return EMPTY_SESSION;
+  const active = typeof rawActive === "string" && tabs.includes(rawActive) ? rawActive : tabs[0];
+  return active === undefined ? EMPTY_SESSION : { tabs, active };
+}

--- a/packages/app/src/workspace/tab-strip.tsx
+++ b/packages/app/src/workspace/tab-strip.tsx
@@ -1,0 +1,97 @@
+// The workspace tab strip — one tab per open note, VS Code conventions:
+// click activates, Cmd/Ctrl-click in the sidebar opens a new tab, middle-click
+// closes, closing a dirty tab flushes first (vault-context owns that), and the
+// dirty dot swaps to an X on hover.
+
+import { useCallback, useSyncExternalStore, type MouseEvent } from "react";
+import { XIcon } from "lucide-react";
+
+import { cn } from "@repo/ui/lib/utils";
+
+import { useVault } from "@repo/app/workspace/vault-context";
+
+function tabLabel(path: string): string {
+  const name = path.split("/").pop() ?? path;
+  const dot = name.lastIndexOf(".");
+  return dot > 0 ? name.slice(0, dot) : name;
+}
+
+function TabItem({ path }: { path: string }) {
+  const { activeTab, activateTab, closeTab, subscribeTab, isTabDirty } = useVault();
+  const subscribe = useCallback(
+    (listener: () => void) => subscribeTab(path, listener),
+    [subscribeTab, path],
+  );
+  const dirty = useSyncExternalStore(subscribe, () => isTabDirty(path));
+  const active = activeTab === path;
+
+  const onAuxClick = (e: MouseEvent) => {
+    if (e.button === 1) {
+      e.preventDefault();
+      closeTab(path);
+    }
+  };
+
+  return (
+    <div
+      role="tab"
+      aria-selected={active}
+      title={path}
+      onClick={() => activateTab(path)}
+      onAuxClick={onAuxClick}
+      className={cn(
+        "group flex h-full min-w-0 max-w-48 shrink-0 cursor-pointer select-none items-center gap-1.5 border-r border-border px-3 text-xs transition-colors",
+        active
+          ? "bg-background text-foreground shadow-[inset_0_-2px_0_0_var(--primary)]"
+          : "bg-sidebar text-muted-foreground hover:bg-accent hover:text-foreground",
+      )}
+    >
+      <span className="truncate">{tabLabel(path)}</span>
+      <button
+        type="button"
+        aria-label={dirty ? `Close ${path} (unsaved changes)` : `Close ${path}`}
+        onClick={(e) => {
+          e.stopPropagation();
+          closeTab(path);
+        }}
+        className={cn(
+          "relative flex size-4 shrink-0 items-center justify-center rounded-sm text-muted-foreground hover:bg-border hover:text-foreground",
+        )}
+      >
+        {/* Dirty dot by default, X on tab hover — VS Code's affordance. A
+         * clean tab reserves the same box so labels don't shift on hover. */}
+        <span
+          className={cn(
+            "size-2 rounded-full bg-foreground/70 group-hover:hidden",
+            dirty ? "block" : "hidden",
+          )}
+        />
+        <XIcon
+          className={cn(
+            "size-3.5",
+            dirty ? "hidden group-hover:block" : "invisible group-hover:visible",
+          )}
+        />
+      </button>
+    </div>
+  );
+}
+
+export function TabStrip() {
+  const { tabs } = useVault();
+  if (tabs.length === 0) return null;
+
+  return (
+    <div
+      role="tablist"
+      aria-label="Open notes"
+      className="flex h-9 shrink-0 items-end overflow-x-auto border-b border-border bg-sidebar"
+    >
+      <div className="flex h-full">
+        {tabs.map((path) => (
+          <TabItem key={path} path={path} />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/packages/app/src/workspace/vault-context.tsx
+++ b/packages/app/src/workspace/vault-context.tsx
@@ -432,16 +432,23 @@ export function VaultProvider({ children }: { children: ReactNode }) {
         toast.error("Couldn't save the file — resolve that before renaming.");
         return false;
       }
+      // Dispose `from`'s runtime BEFORE the bridge call: the rename's
+      // vault-changed broadcast otherwise races the remap below — the old
+      // controller reloads the now-missing source path, lands on path: null,
+      // and the vanish watcher closes the very tab we're carrying over.
+      const wasOpen = sessionRef.current.tabs.includes(from);
+      if (wasOpen) disposeRuntime(from);
       const result = await bridge.renameVaultEntry({ from, to: dest }).catch(() => null);
       if (!result || !result.ok) {
         toast.error(result?.ok === false ? result.error : "Couldn't rename the file.");
+        // The file never moved — re-attach a controller to the still-open tab.
+        if (wasOpen && sessionRef.current.tabs.includes(from)) ensureRuntime(from);
         return false;
       }
       refreshList();
       // Carry the tab to the new path: same strip position, fresh controller
-      // reading the moved file (the old one was flushed above).
+      // reading the moved file (the old one was flushed + disposed above).
       if (sessionRef.current.tabs.includes(from)) {
-        disposeRuntime(from);
         const next = renameTabPure(sessionRef.current, from, dest);
         ensureRuntime(dest);
         applySession(next);

--- a/packages/app/src/workspace/vault-context.tsx
+++ b/packages/app/src/workspace/vault-context.tsx
@@ -24,6 +24,19 @@ import {
   type VaultEditorState,
   type VaultIO,
 } from "@repo/app/editor/vault-editor";
+import {
+  EMPTY_SESSION,
+  activateTab as activateTabPure,
+  closeTab as closeTabPure,
+  cycleTab as cycleTabPure,
+  openTab as openTabPure,
+  parseSession,
+  renameTab as renameTabPure,
+  type TabSession,
+} from "@repo/app/workspace/tab-session";
+import { useUiStateStore } from "@repo/app/stores/ui-state-store";
+import { useViewStore } from "@repo/app/stores/view-store";
+import { buildResolver } from "@repo/core/knowledge/link-resolve";
 
 // Files the rich (Plate) editor can render. `.mdx` is excluded — the Plate
 // markdown pipeline doesn't round-trip MDX.
@@ -32,9 +45,12 @@ import type { VaultEntry } from "@repo/core/ipc-registry";
 
 const AUTOSAVE_DEBOUNCE_MS = 600;
 
-// IO the editor controller acts through — thin wrappers over the bridge so the
-// controller stays bridge-agnostic and unit-testable. A missing bridge throws,
-// which the controller treats like any read/write failure.
+/** ui-state key the open-tab session persists under (restored on boot). */
+const TAB_SESSION_KEY = "workspace.tabs";
+
+// IO the editor controllers act through — thin wrappers over the bridge so the
+// controllers stay bridge-agnostic and unit-testable. A missing bridge throws,
+// which a controller treats like any read/write failure.
 const VAULT_IO: VaultIO = {
   read: (path) => {
     const bridge = getBridge();
@@ -53,29 +69,83 @@ const VAULT_IO: VaultIO = {
   },
 };
 
+// The `editor` snapshot rendered while no tab is open. Root lives at the
+// provider level (state below), so this can be a stable module constant.
+const NO_TAB_STATE: VaultEditorState = {
+  root: "",
+  path: null,
+  content: "",
+  dirty: false,
+  saving: false,
+};
+const noTabSubscribe = () => () => {};
+const getNoTabState = () => NO_TAB_STATE;
+
+/** One open tab's live machinery: its own editor controller (per-doc state),
+ * its own autosave debounce, and the vanish watcher that closes the tab when
+ * the file disappears out from under it. */
+type TabRuntime = {
+  controller: VaultEditorController;
+  saveTimer: ReturnType<typeof setTimeout> | null;
+  /** The controller has successfully loaded its path at least once — gates the
+   * vanish watcher so the initial `path: null` state doesn't close the tab. */
+  opened: boolean;
+  unsubscribe: () => void;
+};
+
+export type OpenFileOptions = {
+  /** Open in a new tab (Cmd/Ctrl-click) instead of replacing the active one. */
+  newTab?: boolean;
+};
+
 type VaultContextValue = {
-  /** Live editor session state (open file, content, dirty, saving). */
+  /** Live editor session state of the ACTIVE tab (open file, content, dirty,
+   * saving). A stable empty snapshot when no tab is open. */
   editor: VaultEditorState;
+  /** Open tabs, in strip order (vault-relative paths). */
+  tabs: readonly string[];
+  /** The active tab's path (=== editor.path once its content is loaded). */
+  activeTab: string | null;
   /** Flat listing of every file in the vault (the tree is derived from it). */
   entries: VaultEntry[];
   /** The vault root folder name (display only). */
   folderName: string;
-  /** Open a file, autosaving any pending edits first. */
-  openFile: (path: string) => void;
-  /** Record an edit to the open buffer (debounced autosave). */
+  /** Open a file: activate its existing tab, else replace the active tab
+   * (VS Code convention) — or append a new tab with `{ newTab: true }`.
+   * Any pending edits on a replaced tab are flushed first. */
+  openFile: (path: string, options?: OpenFileOptions) => void;
+  /** Close a tab, flushing its unsaved edits first (a failed flush keeps the
+   * tab open so nothing is lost). */
+  closeTab: (path: string) => void;
+  /** Make an already-open tab active. */
+  activateTab: (path: string) => void;
+  /** Ctrl+Tab / Ctrl+Shift+Tab — cycle the active tab. */
+  cycleTab: (delta: 1 | -1) => void;
+  /** Subscribe to one tab's controller (dirty-dot rendering). Fires on every
+   * state change of that tab; returns an unsubscribe. */
+  subscribeTab: (path: string, listener: () => void) => () => void;
+  /** Whether a tab has unsaved edits (read inside a subscribeTab store). */
+  isTabDirty: (path: string) => boolean;
+  /** Record an edit to the active tab's buffer (debounced autosave). */
   onEdit: (content: string) => void;
   /** Create a file at `path` (e.g. "folder/note.md") and open it. */
   createFile: (path: string) => Promise<void>;
+  /** Create an empty file WITHOUT opening it (wiki create-on-complete). An
+   * existing file is left untouched and counts as success. */
+  createFileAt: (path: string) => Promise<boolean>;
   /** Rename/move the file at `from` to `to`. Resolves `false` if the rename
    * failed (so callers like the title field can roll back their UI). */
   renameEntry: (from: string, to: string) => Promise<boolean>;
-  /** Delete a file (the open one, or any path). */
+  /** Delete a file (closes its tab if open). */
   deleteEntry: (path: string) => Promise<void>;
   /** Pick a different vault folder. */
   changeFolder: () => Promise<void>;
-  /** Persist any pending edits to disk now (e.g. before delegating a checkbox).
-   * Resolves `true` once the buffer is clean, `false` if the save didn't land. */
+  /** Persist the active tab's pending edits to disk now (e.g. before
+   * delegating a checkbox). Resolves `true` once the buffer is clean. */
   flush: () => Promise<boolean>;
+  /** Resolve a wiki target (`[[target]]`) against the current file listing —
+   * the same Obsidian-style tiers the host's knowledge index uses. */
+  resolveWikiTarget: (target: string) => string | null;
 
   // ---- Editor view (lifted so the header can own the controls) -------------
   /** Whether the open file is a markdown doc the rich editor can render. */
@@ -106,10 +176,187 @@ export function useVault(): VaultContextValue {
 }
 
 export function VaultProvider({ children }: { children: ReactNode }) {
-  const controller = useMemo(() => new VaultEditorController(VAULT_IO), []);
-  const editor = useSyncExternalStore(controller.subscribe, controller.getState);
   const [entries, setEntries] = useState<VaultEntry[]>([]);
-  const saveTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const [root, setRoot] = useState("");
+  const rootRef = useRef("");
+
+  // ---- Tab session ---------------------------------------------------------
+  // The ref is the source of truth every operation reads and writes
+  // SYNCHRONOUSLY; the state is its render mirror. Keeping mutations out of
+  // setState updaters keeps them single-shot under StrictMode's double-invoke.
+  const sessionRef = useRef<TabSession>(EMPTY_SESSION);
+  const [session, setSession] = useState<TabSession>(EMPTY_SESSION);
+  const runtimes = useRef(new Map<string, TabRuntime>());
+  // Per-tab dirty-dot subscribers (keyed by path), fed by controller emits.
+  const tabListeners = useRef(new Map<string, Set<() => void>>());
+  const setUiState = useUiStateStore((s) => s.set);
+  const uiLoaded = useUiStateStore((s) => s.loaded);
+
+  const applySession = useCallback(
+    (next: TabSession) => {
+      if (next === sessionRef.current) return;
+      sessionRef.current = next;
+      setSession(next);
+      setUiState(TAB_SESSION_KEY, { tabs: [...next.tabs], active: next.active });
+    },
+    [setUiState],
+  );
+
+  const notifyTab = useCallback((path: string) => {
+    const listeners = tabListeners.current.get(path);
+    if (listeners) for (const fn of listeners) fn();
+  }, []);
+
+  const disposeRuntime = useCallback((path: string) => {
+    const runtime = runtimes.current.get(path);
+    if (!runtime) return;
+    if (runtime.saveTimer) clearTimeout(runtime.saveTimer);
+    runtime.unsubscribe();
+    runtimes.current.delete(path);
+  }, []);
+
+  /** Drop a tab without flushing — the file is already gone (external delete,
+   * unreadable restore) or explicitly deleted. */
+  const dropTab = useCallback(
+    (path: string) => {
+      disposeRuntime(path);
+      applySession(closeTabPure(sessionRef.current, path));
+    },
+    [applySession, disposeRuntime],
+  );
+  const dropTabRef = useRef(dropTab);
+  dropTabRef.current = dropTab;
+
+  /** Create (if needed) the runtime for a tab and start loading its file. */
+  const ensureRuntime = useCallback(
+    (path: string): TabRuntime => {
+      const existing = runtimes.current.get(path);
+      if (existing) return existing;
+      const controller = new VaultEditorController(VAULT_IO);
+      controller.setRoot(rootRef.current);
+      const runtime: TabRuntime = {
+        controller,
+        saveTimer: null,
+        opened: false,
+        unsubscribe: () => {},
+      };
+      runtime.unsubscribe = controller.subscribe(() => {
+        const st = controller.getState();
+        if (st.path === path) runtime.opened = true;
+        // The file vanished under an open tab (deleted externally / removed) —
+        // its tab closes rather than lingering over nothing.
+        else if (runtime.opened && st.path === null) dropTabRef.current(path);
+        notifyTab(path);
+      });
+      runtimes.current.set(path, runtime);
+      void controller.open(path).then(() => {
+        // Unreadable on first load (e.g. a restored tab whose file is gone) —
+        // the tab never held content, so it silently closes.
+        if (controller.getState().path !== path) dropTabRef.current(path);
+        return undefined;
+      });
+      return runtime;
+    },
+    [notifyTab],
+  );
+
+  /** Flush one tab's pending edits (clearing its debounce). True when clean. */
+  const flushTab = useCallback(async (path: string): Promise<boolean> => {
+    const runtime = runtimes.current.get(path);
+    if (!runtime) return true;
+    if (runtime.saveTimer) {
+      clearTimeout(runtime.saveTimer);
+      runtime.saveTimer = null;
+    }
+    await runtime.controller.flush();
+    return !runtime.controller.getState().dirty;
+  }, []);
+
+  const openFile = useCallback(
+    (path: string, options?: OpenFileOptions) => {
+      void (async () => {
+        // Navigation always lands on the editor surface — opening a note from
+        // the graph, palette, or a wiki chip must show the note, not stay on
+        // whatever surface was up.
+        useViewStore.getState().setSurface("editor");
+        const current = sessionRef.current;
+        if (current.tabs.includes(path)) {
+          applySession(activateTabPure(current, path));
+          return;
+        }
+        const mode = options?.newTab ? "new" : "replace";
+        // A plain open replaces the active tab — flush it first, and refuse to
+        // navigate away from edits that won't save (same contract as before).
+        const leaving = mode === "replace" ? current.active : null;
+        if (leaving !== null && !(await flushTab(leaving))) {
+          toast.error("Couldn't save the current file — resolve that before switching.");
+          return;
+        }
+        const next = openTabPure(sessionRef.current, path, mode);
+        for (const tab of sessionRef.current.tabs) {
+          if (!next.tabs.includes(tab)) disposeRuntime(tab); // replaced (already flushed)
+        }
+        ensureRuntime(path);
+        applySession(next);
+      })();
+    },
+    [applySession, disposeRuntime, ensureRuntime, flushTab],
+  );
+
+  const closeTab = useCallback(
+    (path: string) => {
+      void (async () => {
+        if (!sessionRef.current.tabs.includes(path)) return;
+        // Closing a dirty tab flushes; a failed flush keeps the tab open so
+        // the edits aren't dropped on the floor.
+        if (!(await flushTab(path))) {
+          toast.error("Couldn't save the file — resolve that before closing its tab.");
+          return;
+        }
+        disposeRuntime(path);
+        applySession(closeTabPure(sessionRef.current, path));
+      })();
+    },
+    [applySession, disposeRuntime, flushTab],
+  );
+
+  const activateTab = useCallback(
+    (path: string) => {
+      useViewStore.getState().setSurface("editor");
+      applySession(activateTabPure(sessionRef.current, path));
+    },
+    [applySession],
+  );
+
+  const cycleTab = useCallback(
+    (delta: 1 | -1) => applySession(cycleTabPure(sessionRef.current, delta)),
+    [applySession],
+  );
+
+  const subscribeTab = useCallback((path: string, listener: () => void) => {
+    let set = tabListeners.current.get(path);
+    if (!set) {
+      set = new Set();
+      tabListeners.current.set(path, set);
+    }
+    set.add(listener);
+    return () => {
+      set.delete(listener);
+      if (set.size === 0) tabListeners.current.delete(path);
+    };
+  }, []);
+
+  const isTabDirty = useCallback((path: string): boolean => {
+    return runtimes.current.get(path)?.controller.getState().dirty ?? false;
+  }, []);
+
+  // ---- Active-tab editor state ---------------------------------------------
+  const activeRuntime = session.active !== null ? runtimes.current.get(session.active) : undefined;
+  const activeController = activeRuntime?.controller ?? null;
+  const editor = useSyncExternalStore(
+    activeController ? activeController.subscribe : noTabSubscribe,
+    activeController ? activeController.getState : getNoTabState,
+  );
 
   // Ordering token so overlapping list calls (initial load + onVaultChanged, or
   // rapid vault events) can't land out of order — only the latest applies.
@@ -128,31 +375,40 @@ export function VaultProvider({ children }: { children: ReactNode }) {
     })();
   }, []);
 
-  const cancelTimer = useCallback(() => {
-    if (saveTimer.current) {
-      clearTimeout(saveTimer.current);
-      saveTimer.current = null;
-    }
+  const onEdit = useCallback((next: string) => {
+    const active = sessionRef.current.active;
+    const runtime = active !== null ? runtimes.current.get(active) : undefined;
+    if (!runtime) return;
+    runtime.controller.edit(next);
+    if (runtime.saveTimer) clearTimeout(runtime.saveTimer);
+    runtime.saveTimer = setTimeout(() => {
+      runtime.saveTimer = null;
+      void runtime.controller.flush();
+    }, AUTOSAVE_DEBOUNCE_MS);
   }, []);
 
-  const onEdit = useCallback(
-    (next: string) => {
-      controller.edit(next);
-      cancelTimer();
-      saveTimer.current = setTimeout(() => void controller.flush(), AUTOSAVE_DEBOUNCE_MS);
+  const createFileAt = useCallback(
+    async (rawPath: string): Promise<boolean> => {
+      const trimmed = rawPath.trim();
+      if (!trimmed) return false;
+      const path = /\.[a-z0-9]+$/i.test(trimmed) ? trimmed : `${trimmed}.md`;
+      const bridge = getBridge();
+      if (!bridge) return false;
+      // Don't truncate an existing file — it already satisfies "exists".
+      const exists = await bridge
+        .readVaultDoc({ path })
+        .then(() => true)
+        .catch(() => false);
+      if (exists) return true;
+      const created = await bridge
+        .writeVaultDoc({ path, content: "" })
+        .then(() => true)
+        .catch(() => false);
+      if (created) refreshList();
+      else toast.error(`Couldn't create ${path}.`);
+      return created;
     },
-    [controller, cancelTimer],
-  );
-
-  const openFile = useCallback(
-    (path: string) => {
-      cancelTimer();
-      void controller.open(path).then((opened) => {
-        if (!opened) toast.error("Couldn't save the current file — resolve that before switching.");
-        return undefined;
-      });
-    },
-    [cancelTimer, controller],
+    [refreshList],
   );
 
   const createFile = useCallback(
@@ -160,35 +416,9 @@ export function VaultProvider({ children }: { children: ReactNode }) {
       const trimmed = rawPath.trim();
       if (!trimmed) return;
       const path = /\.[a-z0-9]+$/i.test(trimmed) ? trimmed : `${trimmed}.md`;
-      const bridge = getBridge();
-      if (!bridge) return;
-      cancelTimer();
-      await controller.flush();
-      if (controller.getState().dirty) {
-        toast.error("Couldn't save the current file — resolve that before creating another.");
-        return;
-      }
-      // Don't truncate an existing file — open it instead (disk truth via read).
-      const exists = await bridge
-        .readVaultDoc({ path })
-        .then(() => true)
-        .catch(() => false);
-      if (exists) {
-        openFile(path);
-        return;
-      }
-      const created = await bridge
-        .writeVaultDoc({ path, content: "" })
-        .then(() => true)
-        .catch(() => false);
-      if (!created) {
-        toast.error(`Couldn't create ${path}.`);
-        return;
-      }
-      refreshList();
-      openFile(path);
+      if (await createFileAt(path)) openFile(path);
     },
-    [cancelTimer, controller, openFile, refreshList],
+    [createFileAt, openFile],
   );
 
   const renameEntry = useCallback(
@@ -198,11 +428,8 @@ export function VaultProvider({ children }: { children: ReactNode }) {
       const bridge = getBridge();
       if (!bridge) return false;
       // Flush first so an in-flight write of `from` can't recreate it post-move.
-      cancelTimer();
-      await controller.flush();
-      if (controller.getState().dirty) {
-        // Save failed — don't move a file out from under unsaved edits.
-        toast.error("Couldn't save the current file — resolve that before renaming.");
+      if (!(await flushTab(from))) {
+        toast.error("Couldn't save the file — resolve that before renaming.");
         return false;
       }
       const result = await bridge.renameVaultEntry({ from, to: dest }).catch(() => null);
@@ -211,34 +438,47 @@ export function VaultProvider({ children }: { children: ReactNode }) {
         return false;
       }
       refreshList();
-      // Re-open under the new path if the renamed file was the open one.
-      if (controller.getState().path === from) openFile(dest);
+      // Carry the tab to the new path: same strip position, fresh controller
+      // reading the moved file (the old one was flushed above).
+      if (sessionRef.current.tabs.includes(from)) {
+        disposeRuntime(from);
+        const next = renameTabPure(sessionRef.current, from, dest);
+        ensureRuntime(dest);
+        applySession(next);
+      }
       return true;
     },
-    [cancelTimer, controller, openFile, refreshList],
+    [applySession, disposeRuntime, ensureRuntime, flushTab, refreshList],
   );
 
   const deleteEntry = useCallback(
     async (path: string) => {
-      const bridge = getBridge();
-      if (!bridge) return;
-      if (controller.getState().path === path) {
-        cancelTimer();
-        await controller.remove();
+      const runtime = runtimes.current.get(path);
+      if (runtime) {
+        if (runtime.saveTimer) {
+          clearTimeout(runtime.saveTimer);
+          runtime.saveTimer = null;
+        }
+        // remove() emits path:null, which the vanish watcher turns into a
+        // dropped tab; the explicit drop below is an idempotent backstop.
+        await runtime.controller.remove();
+        dropTab(path);
       } else {
+        const bridge = getBridge();
+        if (!bridge) return;
         await bridge.deleteVaultEntry({ path }).catch(() => undefined);
       }
       refreshList();
     },
-    [cancelTimer, controller, refreshList],
+    [dropTab, refreshList],
   );
 
   const changeFolder = useCallback(async () => {
-    cancelTimer();
-    await controller.flush();
-    if (controller.getState().dirty) {
-      toast.error("Couldn't save the current file — resolve that before switching folders.");
-      return;
+    for (const path of sessionRef.current.tabs) {
+      if (!(await flushTab(path))) {
+        toast.error("Couldn't save every open file — resolve that before switching folders.");
+        return;
+      }
     }
     const bridge = getBridge();
     if (!bridge) return;
@@ -249,61 +489,108 @@ export function VaultProvider({ children }: { children: ReactNode }) {
       return;
     }
     if ("root" in result) {
-      controller.setRoot(result.root);
-      controller.clear();
+      rootRef.current = result.root;
+      setRoot(result.root);
+      // disposeRuntime only deletes the key being visited — safe mid-iteration.
+      for (const path of runtimes.current.keys()) disposeRuntime(path);
+      applySession(EMPTY_SESSION);
       refreshList();
     }
-  }, [cancelTimer, controller, refreshList]);
+  }, [applySession, disposeRuntime, flushTab, refreshList]);
 
   const flush = useCallback(async (): Promise<boolean> => {
-    cancelTimer();
-    await controller.flush();
-    return !controller.getState().dirty;
-  }, [cancelTimer, controller]);
+    const active = sessionRef.current.active;
+    return active === null ? true : flushTab(active);
+  }, [flushTab]);
 
   // Initial load: adopt the root + list files.
   useEffect(() => {
     getBridge()
       ?.getVaultRoot()
-      .then((root) => {
-        controller.setRoot(root);
+      .then((r) => {
+        rootRef.current = r;
+        setRoot(r);
+        for (const runtime of runtimes.current.values()) runtime.controller.setRoot(r);
         return undefined;
       })
       .catch(() => {});
     refreshList();
-  }, [controller, refreshList]);
+  }, [refreshList]);
 
-  // Live updates: hand every vault-changed broadcast to the controller (reload
-  // or drop the open file) and re-list the tree.
+  // Restore the persisted tab session once ui-state has loaded — but never
+  // over tabs the user already opened while it was loading.
+  const restored = useRef(false);
+  useEffect(() => {
+    if (!uiLoaded || restored.current) return;
+    restored.current = true;
+    if (sessionRef.current.tabs.length > 0) return;
+    const stored = parseSession(useUiStateStore.getState().values[TAB_SESSION_KEY]);
+    if (!stored || stored.tabs.length === 0) return;
+    for (const path of stored.tabs) ensureRuntime(path);
+    sessionRef.current = stored;
+    setSession(stored);
+  }, [uiLoaded, ensureRuntime]);
+
+  // Live updates: hand every vault-changed broadcast to every tab's controller
+  // (reload or drop) and re-list the tree. A real root switch drops all tabs —
+  // their relative paths belong to the old vault.
   useEffect(() => {
     const bridge = getBridge();
     if (!bridge) return;
-    return bridge.onVaultChanged(({ root }) => {
-      controller.externalChange(root);
+    return bridge.onVaultChanged(({ root: nextRoot }) => {
+      const switched = rootRef.current !== "" && nextRoot !== rootRef.current;
+      rootRef.current = nextRoot;
+      setRoot(nextRoot);
+      if (switched) {
+        for (const path of runtimes.current.keys()) disposeRuntime(path);
+        applySession(EMPTY_SESSION);
+      } else {
+        for (const runtime of runtimes.current.values()) {
+          runtime.controller.externalChange(nextRoot);
+        }
+      }
       refreshList();
     });
-  }, [controller, refreshList]);
+  }, [applySession, disposeRuntime, refreshList]);
 
   // Persist on unmount so a change within the debounce window isn't lost.
-  useEffect(() => () => void controller.flush(), [controller]);
+  useEffect(
+    () => () => {
+      for (const runtime of runtimes.current.values()) void runtime.controller.flush();
+    },
+    [],
+  );
 
   // Expose the flush + open-note path to non-React callers (the voice transcript
   // path) so a dictated turn persists the open note AND tags the agent with which
   // file "this note" means — same as the typed composer. The path getter reads
-  // the controller live, so it stays correct without re-registering per open.
+  // the live session, so it stays correct without re-registering per open.
   useEffect(() => {
     registerOpenNoteFlush(flush);
-    registerOpenNotePath(() => controller.getState().path);
+    registerOpenNotePath(() => {
+      const active = sessionRef.current.active;
+      return active !== null
+        ? (runtimes.current.get(active)?.controller.getState().path ?? null)
+        : null;
+    });
     return () => {
       registerOpenNoteFlush(null);
       registerOpenNotePath(null);
     };
-  }, [flush, controller]);
+  }, [flush]);
 
   const folderName = useMemo(() => {
-    const root = editor.root.replace(/[/\\]+$/, "");
-    return root.split(/[/\\]/).pop() ?? root;
-  }, [editor.root]);
+    const cleaned = root.replace(/[/\\]+$/, "");
+    return cleaned.split(/[/\\]/).pop() ?? cleaned;
+  }, [root]);
+
+  // Wiki resolution over the live listing — same engine as the host's index,
+  // so chips and the knowledge channels agree on what resolves.
+  const resolver = useMemo(() => buildResolver(entries.map((e) => e.path)), [entries]);
+  const resolveWikiTarget = useCallback(
+    (target: string) => resolver.resolveWiki(target),
+    [resolver],
+  );
 
   // ---- Editor view (mode + canonicality) ----------------------------------
   const isMarkdownOpen = editor.path !== null && MARKDOWN_RE.test(editor.path);
@@ -358,15 +645,24 @@ export function VaultProvider({ children }: { children: ReactNode }) {
   const value = useMemo<VaultContextValue>(
     () => ({
       editor,
+      tabs: session.tabs,
+      activeTab: session.active,
       entries,
       folderName,
       openFile,
+      closeTab,
+      activateTab,
+      cycleTab,
+      subscribeTab,
+      isTabDirty,
       onEdit,
       createFile,
+      createFileAt,
       renameEntry,
       deleteEntry,
       changeFolder,
       flush,
+      resolveWikiTarget,
       isMarkdownOpen,
       canonical: analysis.canonical,
       richSafe: analysis.richSafe,
@@ -377,15 +673,23 @@ export function VaultProvider({ children }: { children: ReactNode }) {
     }),
     [
       editor,
+      session,
       entries,
       folderName,
       openFile,
+      closeTab,
+      activateTab,
+      cycleTab,
+      subscribeTab,
+      isTabDirty,
       onEdit,
       createFile,
+      createFileAt,
       renameEntry,
       deleteEntry,
       changeFolder,
       flush,
+      resolveWikiTarget,
       isMarkdownOpen,
       analysis,
       mode,

--- a/packages/app/src/workspace/workspace-page.tsx
+++ b/packages/app/src/workspace/workspace-page.tsx
@@ -1,7 +1,8 @@
-import { useCallback, useEffect, useState } from "react";
+import { Suspense, lazy, useCallback, useEffect, useState } from "react";
 
 import { Button } from "@repo/ui/components/button";
 import { SidebarProvider } from "@repo/ui/components/sidebar";
+import { Spinner } from "@repo/ui/components/spinner";
 
 import { getBridge } from "@repo/app/lib/bridge";
 import { CommandPalette } from "@repo/app/command/command-palette";
@@ -10,16 +11,49 @@ import { BottomComposer } from "@repo/app/composer/bottom-composer";
 import { EditorPane } from "@repo/app/editor/editor-pane";
 import { Header } from "@repo/app/layout/header";
 import { AppSidebar } from "@repo/app/sidebar/app-sidebar";
-import { VaultProvider } from "@repo/app/workspace/vault-context";
+import { TabStrip } from "@repo/app/workspace/tab-strip";
+import { VaultProvider, useVault } from "@repo/app/workspace/vault-context";
 import { useAgentStore } from "@repo/app/stores/agent-store";
 import { useDelegationStore } from "@repo/app/stores/delegation-store";
+import { useViewStore } from "@repo/app/stores/view-store";
 import { useVoiceStore } from "@repo/app/stores/voice-store";
+
+// The graph view stays out of the main chunk: it (and its d3-force dependency)
+// loads on first open.
+const GraphView = lazy(() => import("@repo/app/workspace/graph-view"));
+
+/** Tab keyboard shortcuts — mounted inside the VaultProvider: Cmd/Ctrl+W
+ * closes the active tab, Ctrl(+Shift)+Tab cycles. (A plain browser reserves
+ * Cmd/Ctrl+W for its own tabs; the Electron shell delivers it.) */
+function TabHotkeys() {
+  const { activeTab, closeTab, cycleTab } = useVault();
+
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if ((e.metaKey || e.ctrlKey) && !e.shiftKey && !e.altKey && e.key.toLowerCase() === "w") {
+        if (activeTab === null) return;
+        e.preventDefault();
+        closeTab(activeTab);
+        return;
+      }
+      if (e.ctrlKey && !e.metaKey && !e.altKey && e.key === "Tab") {
+        e.preventDefault();
+        cycleTab(e.shiftKey ? -1 : 1);
+      }
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [activeTab, closeTab, cycleTab]);
+
+  return null;
+}
 
 /**
  * The workspace — the app's only surface. Two flush Attio-style panes: a
- * collapsible file-tree sidebar and a full-width editor with the AI composer
- * pinned at the bottom. No chat column. Cmd+B toggles the sidebar; Cmd+K opens
- * the command palette.
+ * collapsible file-tree sidebar and a full-width editor (with a tab strip and
+ * the AI composer pinned at the bottom); the link-graph view swaps in as an
+ * alternate main surface. No chat column. Cmd+B toggles the sidebar; Cmd+K
+ * opens the command palette.
  */
 export function WorkspacePage() {
   const initVoice = useVoiceStore((s) => s.init);
@@ -29,6 +63,7 @@ export function WorkspacePage() {
   useEffect(() => initDelegations(), [initDelegations]);
 
   const [paletteOpen, setPaletteOpen] = useState(false);
+  const surface = useViewStore((s) => s.surface);
 
   useEffect(() => {
     const onKey = (e: KeyboardEvent) => {
@@ -75,12 +110,26 @@ export function WorkspacePage() {
             </div>
           )}
 
+          {surface === "editor" && <TabStrip />}
           <main className="min-h-0 flex-1 overflow-auto">
-            <EditorPane />
+            {surface === "graph" ? (
+              <Suspense
+                fallback={
+                  <div className="flex h-full items-center justify-center">
+                    <Spinner className="size-5 text-muted-foreground" />
+                  </div>
+                }
+              >
+                <GraphView />
+              </Suspense>
+            ) : (
+              <EditorPane />
+            )}
           </main>
           <DelegationDock />
           <BottomComposer />
         </div>
+        <TabHotkeys />
       </SidebarProvider>
       <CommandPalette open={paletteOpen} onOpenChange={setPaletteOpen} />
     </VaultProvider>

--- a/packages/ui/src/components/command.tsx
+++ b/packages/ui/src/components/command.tsx
@@ -30,6 +30,7 @@ function CommandDialog({
   onOpenChange,
   title = "Command palette",
   initialFocus,
+  shouldFilter,
   children,
 }: {
   open: boolean;
@@ -38,6 +39,9 @@ function CommandDialog({
   // Focused on open via Base UI's own mechanism — point it at the cmdk input
   // so the user can type immediately (Base UI otherwise focuses the popup).
   initialFocus?: RefObject<HTMLElement | null>;
+  // Forwarded to cmdk — off when the caller does its own matching (e.g. the
+  // palette mixing filename filtering with host-ranked full-text results).
+  shouldFilter?: boolean;
   children: ReactNode;
 }) {
   return (
@@ -50,7 +54,7 @@ function CommandDialog({
           className="fixed left-1/2 top-[18vh] z-50 w-[calc(100%-2rem)] max-w-xl -translate-x-1/2 overflow-hidden rounded-xl border border-border bg-popover shadow-lg outline-none transition-all duration-150 data-[ending-style]:scale-95 data-[ending-style]:opacity-0 data-[starting-style]:scale-95 data-[starting-style]:opacity-0"
         >
           <DialogPrimitive.Title className="sr-only">{title}</DialogPrimitive.Title>
-          <Command>{children}</Command>
+          <Command {...(shouldFilter !== undefined && { shouldFilter })}>{children}</Command>
         </DialogPrimitive.Popup>
       </DialogPrimitive.Portal>
     </DialogPrimitive.Root>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -201,6 +201,9 @@ importers:
       ai:
         specifier: ^6.0.191
         version: 6.0.191(zod@4.4.3)
+      d3-force:
+        specifier: ^3.0.0
+        version: 3.0.0
       katex:
         specifier: ^0.16.22
         version: 0.16.47
@@ -268,6 +271,9 @@ importers:
       '@tailwindcss/vite':
         specifier: 'catalog:'
         version: 4.3.0(vite@8.0.14(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.44.1)(tsx@4.22.3)(yaml@2.9.0))
+      '@types/d3-force':
+        specifier: ^3.0.10
+        version: 3.0.10
       '@types/mdast':
         specifier: ^4.0.4
         version: 4.0.4


### PR DESCRIPTION
The app-side half of the knowledge suite, on #364's channels. Closes the Phase 6 feature list.

## What

- **Tabs**: pure `tab-session.ts` (VS Code semantics) + one editor controller/autosave/vanish-watcher per open note in vault-context; dirty tabs flush on close/replace; session persisted in ui-state and restored on boot; Cmd+W / Ctrl+Tab / middle-click / Cmd-click-new-tab.
- **Wiki navigation**: chips resolve via the same core resolver as the host index; unresolved chips are dashed with a create-note popover; Cmd-click opens in a new tab.
- **`[[` autocomplete**: WP3 combobox + `withTriggerCombobox`; alias/anchor passthrough, `]]`-typed completion, create-new entry. Byte-checked: completions serialize to exactly `[[target note]]`.
- **`![[transclusion]]`**: render-only `PlateStatic` over the base kit (zero editor ops); pure guard module — unresolved/depth>1/cycles degrade to chips, never crash.
- **Backlinks panel**: collapsible under the editor column, grouped with snippets, live count.
- **Graph view**: d3-force + hand-rolled canvas — a **16KB lazy chunk** (vs a react-force-graph dependency), CSS-token theming (dark mode free), degree sizing, dashed phantoms, click-to-open, phantom-click creates the note.
- **Palette**: full-text `searchVault` results with snippets join the existing entries.

## Review catches (fixed + pinned)

- **Renaming an open tab dropped the tab** — the rename broadcast raced the tab remap; the stale controller's vanish-watcher closed it. Fix: dispose the source runtime before the rename call, re-attach on failure. Live re-proven both active and background.

## Verification

Implement + two review passes (the first died mid-run; its rebase was range-diff-audited, not trusted): gates green, **744 tests** (322 app), live CDP drive of every surface, d3-force proven absent from main chunks, byte-safety checks on all wiki writes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Large vault-context refactor (per-tab controllers, flush/rename/tab-drop races) touches save-before-navigate behavior; mitigated by dedicated tab-session/transclusion/wiki tests but still the main data-loss surface area.
> 
> **Overview**
> **Phase 6 knowledge UI** turns placeholder wiki chips into a connected note workspace: open notes in a **VS Code-style tab strip** (replace vs new tab, persisted session, flush-before-close/replace), with **Cmd/Ctrl-click** and palette/sidebar entry points sharing the same navigation rules.
> 
> **Wiki editing & reading** adds **`[[` autocomplete** (`wiki_input` excluded from markdown save), clickable **resolved/unresolved chips** (create-note affordances), and **`![[transclusion]]`** cards rendered read-only via `PlateStatic` with pure **depth/cycle/unresolved** guards. A **backlinks** section sits under the editor column; **⌘K** now merges filename filtering with **debounced `searchVault`** snippets and can jump to the **graph** surface.
> 
> **Graph view** (lazy **`d3-force`** chunk) draws the vault link graph on canvas with theme tokens, live index refresh, and click-to-open/create. **Fixture wiki cluster** notes and corpus expectations exercise tabs, transclusion, and search in the dev harness.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d23c2976e3281763674f9b5273af0a7c98b09938. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ships the knowledge UI: workspace tabs, wiki navigation with `[[` autocomplete and embeds, backlinks, a lazy canvas graph, and palette full‑text search. Improves navigation speed and adds a clear view of relationships across notes.

- **New Features**
  - Workspace tabs with VS Code behavior: replace/new-tab, close activates neighbor, cycle wrapping; session persists and restores; Cmd+W, Ctrl+Tab, middle‑click; dirty tabs flush on close/replace/rename.
  - Wiki navigation: chips resolve and navigate (Cmd/Ctrl‑click opens a new tab); `[[` autocomplete with `|alias` and `#anchor`, create‑note for misses, `]]` completes; `![[...]]` transclusion renders read‑only with guards for unresolved/depth/cycles.
  - Backlinks panel below the editor with grouped snippets and live counts.
  - Link graph view using `d3-force` on a custom canvas, lazy‑loaded (~16 KB); zoom/pan; click to open; dashed phantom nodes can create notes; Esc returns to the editor.
  - Command palette adds full‑text results with snippets and an Open Graph action; app‑side filtering to respect host ranking.

- **Bug Fixes**
  - Renaming an open tab no longer drops it: dispose the source runtime before the rename, and re‑attach on failure.

<sup>Written for commit d23c2976e3281763674f9b5273af0a7c98b09938. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kyh/inteligir/pull/366?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

