### PR TITLE
fix: toggle collapse + inline-combobox first-char caret (acceptance bugs)

### DIFF
--- a/packages/app/src/__tests__/editor-kits.test.ts
+++ b/packages/app/src/__tests__/editor-kits.test.ts
@@ -7,6 +7,7 @@
 import { describe, expect, it } from "vitest";
 import { createSlateEditor, ElementApi, KEYS, type TElement } from "platejs";
 import { serializeMd } from "@platejs/markdown";
+import { TogglePlugin } from "@platejs/toggle/react";
 
 import { insertColumnGroup } from "@repo/app/editor/kits/column-kit";
 import { insertDate } from "@repo/app/editor/kits/date-kit";
@@ -244,6 +245,22 @@ describe("insertToggle", () => {
     const editor = makeEditor("<toggle />\n\ntext\n");
     editor.tf.insertText("!", { at: { offset: 4, path: [1, 0] } });
     expect(out(editor)).toBe("<toggle />\n\ntext!\n");
+  });
+
+  it("collapse state lives in the plugin store — flipping it never dirties bytes", () => {
+    // The chevron (ToggleElement) renders open = openIds.has(id) and hides the
+    // body via CSS; this pins the store mapping it consumes. Live blocks get
+    // ids from NodeIdPlugin; headless parse doesn't, so drive an explicit id.
+    const editor = makeEditor("<toggle>\n  Summary\n\n  body\n</toggle>\n");
+    const before = out(editor);
+    const isOpen = (id: string) => editor.getOptions(TogglePlugin).openIds?.has(id) ?? false;
+    expect(isOpen("t1")).toBe(false); // default: collapsed
+    editor.getApi(TogglePlugin).toggle.toggleIds(["t1"]);
+    expect(isOpen("t1")).toBe(true);
+    editor.getApi(TogglePlugin).toggle.toggleIds(["t1"]);
+    expect(isOpen("t1")).toBe(false);
+    expect(out(editor)).toBe(before); // open state never reaches the document
+    expect(before).toContain("<toggle>\n"); // zero attributes serialized
   });
 });
 

--- a/packages/app/src/__tests__/inline-combobox.test.ts
+++ b/packages/app/src/__tests__/inline-combobox.test.ts
@@ -15,6 +15,7 @@ import {
   cancelComboboxInput,
   commitComboboxInput,
   racedComboboxText,
+  reconcileInsertionCaret,
 } from "@repo/app/editor/combobox-input";
 import { EDITOR_KIT } from "@repo/app/editor/kits/editor-kit";
 import { MD_STRINGIFY } from "@repo/app/editor/markdown/markdown-doc";
@@ -161,6 +162,55 @@ describe("inline combobox cancel safety (the about:blank crash class)", () => {
       for (let i = 0; i < 10; i++) editor.redo();
     }).not.toThrow();
     expect(out(editor)).toBe(":tada\n");
+  });
+});
+
+describe("reconcileInsertionCaret (the #367 first-commit caret quirk)", () => {
+  // Chromium's first IME-style commit into the freshly focused input leaves
+  // the caret BEFORE the inserted text; every later keystroke then lands one
+  // run too early ('deep' → 'eepd', ':tada' → 'adat').
+  it("moves a caret stranded before the first typed char", () => {
+    expect(reconcileInsertionCaret("", "d", 0)).toBe(1); // [[deep — first 'd'
+    expect(reconcileInsertionCaret("", "t", 0)).toBe(1); // :tada — first 't'
+  });
+
+  it("assembles 'deep' and 'tada' across the exact first-char sequence", () => {
+    for (const word of ["deep", "tada"]) {
+      let value = "";
+      let caret = 0;
+      for (const [i, char] of [...word].entries()) {
+        const next = value.slice(0, caret) + char + value.slice(caret);
+        // The browser strands the caret on the first commit, then behaves.
+        const reported = i === 0 ? caret : caret + 1;
+        caret = reconcileInsertionCaret(value, next, reported) ?? reported;
+        value = next;
+      }
+      expect(value).toBe(word);
+      expect(caret).toBe(word.length);
+    }
+  });
+
+  it("moves a stranded caret for multi-char and mid-string commits", () => {
+    expect(reconcileInsertionCaret("", "deep", 0)).toBe(4); // paste-like commit
+    expect(reconcileInsertionCaret("ab", "aXb", 1)).toBe(2); // mid-string
+  });
+
+  it("never fights a consistent native caret", () => {
+    expect(reconcileInsertionCaret("", "d", 1)).toBeNull();
+    expect(reconcileInsertionCaret("de", "dee", 3)).toBeNull();
+    expect(reconcileInsertionCaret("ab", "aXb", 2)).toBeNull();
+  });
+
+  it("repeated characters read both ways — trust the browser", () => {
+    // 'aaa' from 'aa': caret 1 is a valid post-insert position (typed at 0).
+    expect(reconcileInsertionCaret("aa", "aaa", 1)).toBeNull();
+    expect(reconcileInsertionCaret("aa", "aaa", 2)).toBeNull();
+  });
+
+  it("ignores deletions, replacements, and missing carets", () => {
+    expect(reconcileInsertionCaret("de", "d", 1)).toBeNull(); // deletion
+    expect(reconcileInsertionCaret("abc", "aXbYc", 1)).toBeNull(); // two runs
+    expect(reconcileInsertionCaret("", "d", null)).toBeNull();
   });
 });
 

--- a/packages/app/src/editor/combobox-input.ts
+++ b/packages/app/src/editor/combobox-input.ts
@@ -55,6 +55,45 @@ export function absorbRacedComboboxText(editor: SlateEditor, element: TElement):
 }
 
 /**
+ * Chromium leaves the caret BEFORE the text of an IME-style commit
+ * (`Input.insertText` automation, dictation) when it is the first edit after
+ * the input was focused programmatically — the next keystroke then lands at
+ * offset 0 and "deep" assembles as "eepd" (issue #367). Given the input's
+ * previous value, its new value, and the caret the browser reported, return
+ * the caret a native keystroke would have produced — or null when the
+ * browser's caret is already consistent (never fight a correct browser).
+ *
+ * Detection: a value change that is a single inserted run has a (possibly
+ * ambiguous, when the run repeats neighboring characters) interval of valid
+ * insertion positions. A caret that can only be read as an insertion START —
+ * never as an insertion END — is the quirk; anything else is left alone.
+ */
+export function reconcileInsertionCaret(
+  previous: string,
+  next: string,
+  caret: number | null,
+): number | null {
+  if (caret === null) return null;
+  const inserted = next.length - previous.length;
+  if (inserted <= 0) return null; // deletion or no-op — not an insertion
+  let prefix = 0;
+  while (prefix < previous.length && previous[prefix] === next[prefix]) prefix += 1;
+  let suffix = 0;
+  while (
+    suffix < previous.length &&
+    previous[previous.length - 1 - suffix] === next[next.length - 1 - suffix]
+  ) {
+    suffix += 1;
+  }
+  if (prefix + suffix < previous.length) return null; // not a single run
+  const lo = previous.length - suffix;
+  const hi = prefix;
+  if (caret >= lo + inserted && caret <= hi + inserted) return null; // consistent
+  if (caret >= lo && caret <= hi) return caret + inserted; // stranded before the run
+  return null; // unrelated caret — don't touch
+}
+
+/**
  * Commit path: remove the trigger element (the selected item's own action
  * inserts content afterwards). Safe when the element is already gone.
  */

--- a/packages/app/src/editor/inline-combobox.tsx
+++ b/packages/app/src/editor/inline-combobox.tsx
@@ -31,6 +31,7 @@ import {
   cancelComboboxInput,
   commitComboboxInput,
   racedComboboxText,
+  reconcileInsertionCaret,
   type ComboboxCancelCause,
 } from "@repo/app/editor/combobox-input";
 
@@ -171,6 +172,22 @@ function InlineCombobox({
     inputRef.current?.setSelectionRange(pos, pos);
   });
 
+  // Chromium strands the caret at 0 on the first IME-style commit into the
+  // freshly focused input ("deep" → "eepd", issue #367); the pure reconciler
+  // detects that signature and moves the caret where a native keystroke would
+  // have left it, before React commits the controlled value.
+  const onInputValueChange = React.useCallback(
+    (nextValue: string) => {
+      const input = inputRef.current;
+      if (input && document.activeElement === input) {
+        const fixed = reconcileInsertionCaret(valueRef.current, nextValue, input.selectionStart);
+        if (fixed !== null) input.setSelectionRange(fixed, fixed);
+      }
+      setValue(nextValue);
+    },
+    [setValue],
+  );
+
   // Clicking elsewhere in the note moves the Slate selection off the element
   // while it is still mounted — cancel and restore the typed text.
   const selected = useSelected();
@@ -251,7 +268,7 @@ function InlineCombobox({
         filter={null}
         inputValue={value}
         modal={false}
-        onInputValueChange={setValue}
+        onInputValueChange={onInputValueChange}
         // Open state is fully derived; Base UI close requests (escape/outside
         // click) route through cancel paths instead.
         onOpenChange={() => undefined}

--- a/packages/app/src/editor/nodes/toggle-node.tsx
+++ b/packages/app/src/editor/nodes/toggle-node.tsx
@@ -6,22 +6,20 @@
 // row; children 2..n are the collapsible body. Open state lives in the toggle
 // plugin's store (openIds) keyed by node id — never on the node — so
 // collapse/expand cannot dirty the document.
+//
+// Hiding happens in CSS, not by splitting `props.children`: Plate hands the
+// element ALL of its rendered Slate children as a single React child (plus a
+// BelowRootNodes sibling), so a React-level split can't separate summary from
+// body without poking into opaque internals. Instead every Slate block after
+// the first is hidden by the `[data-toggle-collapsed]` rule in styles.css —
+// kept mounted (Slate needs the DOM) but invisible, mirroring the flat-model
+// plugin's hidden style.
 
-import { Children, type ReactNode } from "react";
 import { ChevronRightIcon } from "lucide-react";
 import { PlateElement, useElement, type PlateElementProps } from "platejs/react";
 import { useToggleButton, useToggleButtonState } from "@platejs/toggle/react";
 
 import { cn } from "@repo/ui/lib/utils";
-
-// Mirrors @platejs/toggle's hidden style for closed flat-model toggles: keeps
-// the collapsed children mounted (Slate needs their DOM) but invisible.
-const HIDDEN_STYLE: React.CSSProperties = {
-  height: 0,
-  margin: 0,
-  overflow: "hidden",
-  visibility: "hidden",
-};
 
 export function ToggleElement(props: PlateElementProps) {
   const element = useElement();
@@ -31,10 +29,6 @@ export function ToggleElement(props: PlateElementProps) {
   const id = typeof element.id === "string" ? element.id : "";
   const state = useToggleButtonState(id);
   const { buttonProps, open } = useToggleButton(state);
-
-  const childArray = Children.toArray(props.children);
-  const summary: ReactNode = childArray[0] ?? null;
-  const body = childArray.slice(1);
 
   const onChevronClick = (e: React.MouseEvent) => {
     // Collapsing while the selection sits in the body would strand the DOM
@@ -48,7 +42,14 @@ export function ToggleElement(props: PlateElementProps) {
   };
 
   return (
-    <PlateElement {...props} className="relative mb-1 pl-6">
+    <PlateElement
+      {...props}
+      className="relative mb-1 pl-6"
+      attributes={{
+        ...props.attributes,
+        "data-toggle-collapsed": open ? undefined : "",
+      }}
+    >
       <button
         type="button"
         aria-expanded={open}
@@ -62,8 +63,7 @@ export function ToggleElement(props: PlateElementProps) {
           className={cn("size-4 transition-transform duration-75", open ? "rotate-90" : "rotate-0")}
         />
       </button>
-      {summary}
-      {body.length > 0 ? <div style={open ? undefined : HIDDEN_STYLE}>{body}</div> : null}
+      {props.children}
     </PlateElement>
   );
 }

--- a/packages/app/src/styles.css
+++ b/packages/app/src/styles.css
@@ -52,6 +52,20 @@ textarea,
   transition: none !important;
 }
 
+/* Collapsed toggle (editor/nodes/toggle-node.tsx): hide every Slate block
+ * after the summary (the first element child). The split lives here rather
+ * than in React because Plate hands ToggleElement all rendered children as a
+ * single child. Blocks stay mounted (Slate needs their DOM) but take no space
+ * and stay invisible — the flat-model toggle plugin's hidden style, plus
+ * zeroed padding since it applies per block instead of on a plain wrapper. */
+[data-toggle-collapsed] > [data-slate-node="element"] ~ [data-slate-node="element"] {
+  height: 0;
+  margin: 0;
+  padding: 0;
+  overflow: hidden;
+  visibility: hidden;
+}
+
 /* Code-block syntax highlighting — the GitHub light/dark theme for lowlight's
  * `.hljs-*` token classes (emitted by CodeSyntaxPlugin). Syntax themes are
  * inherently color-specific, so these are fixed hex rather than theme tokens. */


### PR DESCRIPTION
The two real bugs from the Phase G acceptance drive.

- **Toggle collapse was a no-op**: Plate delivers all rendered Slate children as one React child (+ BelowRootNodes), so the child-split hider only ever hid an empty div. Now the PlateElement is stamped `data-toggle-collapsed` and CSS hides the sibling blocks (mounted-but-hidden keeps Slate happy); selection guard moves the caret out of a collapsing body. Bytes untouched by collapse (UI state only) — live byte-checked.
- **Combobox first-char caret** (fixes #367): diagnosis corrected — the absorb splice was innocent. Chromium leaves the caret *before* the text on an IME-style first commit after programmatic focus, so every later char inserted one early ('deep' → 'eepd'). A pure `reconcileInsertionCaret` reconciles the caret before React commits the controlled value; covers slash/emoji/wiki via the shared component. 6 regression tests incl. the exact repro sequences; real-keystroke typing verified unaffected at any speed.

Gates green (329 app tests); live-driven both fixes at CDP and human speeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 3a38570396fb0fa3f923639f47205784aa4e7d48. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes two acceptance bugs: collapsed toggles now actually hide their body via CSS, and the inline combobox keeps the caret in the right place on the first post-focus character. UX-only changes; document bytes are unchanged.

- **Bug Fixes**
  - Toggle collapse: render children untouched and hide body blocks via a `[data-toggle-collapsed]` CSS rule; nodes stay mounted for Slate. Selection is moved out of the body before collapsing. Open state lives in the `TogglePlugin` store, and flipping it doesn’t affect serialization (new test added).
  - Inline combobox caret: adds `reconcileInsertionCaret` to fix Chromium’s first-commit caret quirk after programmatic focus (e.g., IME/dictation). Applied in `onInputValueChange` to keep queries correct for slash/emoji/wiki; real keystrokes remain unaffected. Tests cover the exact repro sequences.

<sup>Written for commit 3a38570396fb0fa3f923639f47205784aa4e7d48. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kyh/inteligir/pull/379?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

