### PR TITLE
fix: styled confirm dialog, ino fingerprints, live sirv asset serving

### DIFF
--- a/packages/app/src/app.tsx
+++ b/packages/app/src/app.tsx
@@ -1,6 +1,7 @@
 import { useEffect } from "react";
 import { Navigate, Outlet, useLocation } from "react-router";
 
+import { ConfirmDialogHost } from "@repo/ui/components/confirm-dialog";
 import { Toaster } from "@repo/ui/components/sonner";
 import { ReauthDialog } from "@repo/app/components/reauth-dialog";
 import { useAgentStore } from "@repo/app/stores/agent-store";
@@ -46,6 +47,8 @@ export function AppLayout() {
       </div>
 
       <ReauthDialog />
+      {/* One shared confirm() dialog for the whole workspace. */}
+      <ConfirmDialogHost />
       {/* Desktop toasts join the smoked-glass overlay language. */}
       <Toaster glass />
     </div>

--- a/packages/app/src/layout/header.tsx
+++ b/packages/app/src/layout/header.tsx
@@ -3,6 +3,7 @@ import { Trash2Icon, WandSparklesIcon } from "lucide-react";
 
 import { Badge } from "@repo/ui/components/badge";
 import { Button } from "@repo/ui/components/button";
+import { confirm } from "@repo/ui/components/confirm-dialog";
 import {
   Breadcrumb,
   BreadcrumbItem,
@@ -39,6 +40,17 @@ export function Header() {
   const { state } = useSidebar();
   const path = editor.path;
   const segments = path ? path.split("/") : [];
+
+  const confirmDelete = async () => {
+    if (!path) return;
+    const confirmed = await confirm({
+      title: `Delete ${path}?`,
+      body: "This permanently deletes the file from your vault.",
+      confirmLabel: "Delete",
+      destructive: true,
+    });
+    if (confirmed) await deleteEntry(path);
+  };
 
   return (
     <header
@@ -118,9 +130,7 @@ export function Header() {
           <Button
             variant="ghost"
             size="sm"
-            onClick={() => {
-              if (window.confirm(`Delete ${path}?`)) void deleteEntry(path);
-            }}
+            onClick={() => void confirmDelete()}
             className="size-7 px-0 text-muted-foreground hover:text-destructive"
             title="Delete note"
           >

--- a/packages/app/src/sidebar/app-sidebar.tsx
+++ b/packages/app/src/sidebar/app-sidebar.tsx
@@ -18,6 +18,7 @@ import {
   CollapsibleContent,
   CollapsibleTrigger,
 } from "@repo/ui/components/collapsible";
+import { confirm } from "@repo/ui/components/confirm-dialog";
 import { Input } from "@repo/ui/components/input";
 import {
   Sidebar,
@@ -263,6 +264,16 @@ function FileRow({
 }: { name: string; path: string; kind: "doc" | "other" } & RowHandlers) {
   const [draft, setDraft] = useState(name);
 
+  const confirmDelete = async () => {
+    const confirmed = await confirm({
+      title: `Delete ${path}?`,
+      body: "This permanently deletes the file from your vault.",
+      confirmLabel: "Delete",
+      destructive: true,
+    });
+    if (confirmed) onDelete(path);
+  };
+
   if (renaming === path) {
     return (
       <SidebarMenuItem>
@@ -307,9 +318,7 @@ function FileRow({
         showOnHover
         title="Delete"
         className="hover:text-destructive"
-        onClick={() => {
-          if (window.confirm(`Delete ${path}?`)) onDelete(path);
-        }}
+        onClick={() => void confirmDelete()}
       >
         <Trash2Icon />
       </SidebarMenuAction>

--- a/packages/app/src/workspace/graph-view.tsx
+++ b/packages/app/src/workspace/graph-view.tsx
@@ -22,6 +22,8 @@ import {
   type SimulationNodeDatum,
 } from "d3-force";
 
+import { confirm } from "@repo/ui/components/confirm-dialog";
+
 import { getBridge } from "@repo/app/lib/bridge";
 import { useTheme } from "@repo/app/lib/use-theme";
 import { useViewStore } from "@repo/app/stores/view-store";
@@ -374,7 +376,15 @@ export default function GraphView() {
       if (node.phantom) {
         // Phantom → offer to create the missing note (created at the vault
         // root, matching wiki resolution for a bare target).
-        if (window.confirm(`Create "${node.title}.md"?`)) void createFile(node.title);
+        const offerCreate = async () => {
+          const confirmed = await confirm({
+            title: `Create "${node.title}.md"?`,
+            body: "This note doesn't exist yet — create it at the vault root.",
+            confirmLabel: "Create",
+          });
+          if (confirmed) await createFile(node.title);
+        };
+        void offerCreate();
         return;
       }
       if (node.path !== undefined) openFile(node.path, { newTab: e.metaKey || e.ctrlKey });

--- a/packages/host/src/__tests__/knowledge-manager.test.ts
+++ b/packages/host/src/__tests__/knowledge-manager.test.ts
@@ -54,6 +54,25 @@ describe("KnowledgeManager", () => {
     expect(updates).toEqual([1, 2]);
   });
 
+  it("re-indexes an atomic swap that collides on mtime and size (ino differs)", () => {
+    const abs = path.join(root, "note.md");
+    const pinned = new Date("2026-01-01T00:00:00Z");
+    vault.writeText("note.md", "links [[alpha]]\n");
+    fs.utimesSync(abs, pinned, pinned);
+    manager.refresh();
+    expect(manager.forwardLinks("note.md").map((l) => l.target)).toEqual(["alpha"]);
+
+    // Same byte count, same pinned mtime — only the inode betrays the swap
+    // (an atomic write always renames a fresh temp file into place).
+    const swap = path.join(tmp, "swap.md");
+    fs.writeFileSync(swap, "links [[bravo]]\n");
+    fs.renameSync(swap, abs);
+    fs.utimesSync(abs, pinned, pinned);
+    manager.refresh();
+    expect(manager.forwardLinks("note.md").map((l) => l.target)).toEqual(["bravo"]);
+    expect(updates).toEqual([1, 2]);
+  });
+
   it("does not emit when nothing changed", () => {
     vault.writeText("note.md", "# Note\n");
     manager.refresh();

--- a/packages/host/src/knowledge/knowledge-manager.ts
+++ b/packages/host/src/knowledge/knowledge-manager.ts
@@ -5,7 +5,7 @@
 //
 // Update flow: VaultManager's watcher already coalesces fs event bursts into
 // one notification; the manager adds its own short debounce, then diffs the
-// listing against recorded (mtime, size) fingerprints so only added/changed
+// listing against recorded (mtime, size, ino) fingerprints so only added/changed
 // docs are re-parsed and removed ones dropped — a save touches one file's
 // extraction, not the vault. A root switch (or first use) rebuilds from
 // scratch. Queries before any notification build lazily, so handlers never
@@ -29,11 +29,14 @@ import { getVaultManager, type VaultManager } from "../vault/vault";
 
 const REFRESH_DEBOUNCE_MS = 100;
 
-type Fingerprint = { mtimeMs: number; size: number };
+// ino rides along because vault writes are atomic (write temp + rename): a
+// swap always lands on a fresh inode, so even an exact (mtime, size)
+// collision can't masquerade as "unchanged".
+type Fingerprint = { mtimeMs: number; size: number; ino: number };
 
 export class KnowledgeManager {
   private readonly index = new KnowledgeIndex();
-  /** (mtime, size) per indexed doc — the incremental-refresh diff basis. */
+  /** (mtime, size, ino) per indexed doc — the incremental-refresh diff basis. */
   private readonly fingerprints = new Map<string, Fingerprint>();
   private readonly otherPaths = new Set<string>();
   private builtRoot: string | null = null;
@@ -111,7 +114,12 @@ export class KnowledgeManager {
       const fingerprint = statFingerprint(path.join(root, entry.path));
       if (fingerprint === null) continue; // vanished mid-scan; next refresh drops it
       const prior = this.fingerprints.get(entry.path);
-      if (prior && prior.mtimeMs === fingerprint.mtimeMs && prior.size === fingerprint.size) {
+      if (
+        prior &&
+        prior.mtimeMs === fingerprint.mtimeMs &&
+        prior.size === fingerprint.size &&
+        prior.ino === fingerprint.ino
+      ) {
         continue;
       }
       try {
@@ -159,7 +167,7 @@ export class KnowledgeManager {
 function statFingerprint(absolute: string): Fingerprint | null {
   try {
     const stat = fs.statSync(absolute);
-    return { mtimeMs: stat.mtimeMs, size: stat.size };
+    return { mtimeMs: stat.mtimeMs, size: stat.size, ino: stat.ino };
   } catch {
     return null;
   }

--- a/packages/server/src/__tests__/create-server.test.ts
+++ b/packages/server/src/__tests__/create-server.test.ts
@@ -117,6 +117,16 @@ describe("createServer", () => {
     expect(await fallback.text()).toContain("<title>app</title>");
   });
 
+  it("serves assets added after boot (rebuild under a running server)", async () => {
+    const { server } = await boot();
+    // A rebuild writes freshly hashed bundles into assetsDir; the server must
+    // pick them up without a restart (sirv dev mode, no boot-time manifest).
+    fs.writeFileSync(path.join(assetsDir, "app-abc123.js"), "console.log('rebuilt')");
+    const rebuilt = await fetch(`${server.url}/app-abc123.js`);
+    expect(rebuilt.status).toBe(200);
+    expect(await rebuilt.text()).toContain("rebuilt");
+  });
+
   it("rejects non-loopback Host headers (DNS rebinding)", async () => {
     const { server } = await boot();
     // fetch() silently drops the forbidden Host header — go through raw http.

--- a/packages/server/src/create-server.ts
+++ b/packages/server/src/create-server.ts
@@ -93,7 +93,14 @@ function isTtsAudioPayload(payload: unknown): payload is { audio: ArrayBuffer } 
 export async function createServer(options: ServerOptions): Promise<RunningServer> {
   const { host, assetsDir } = options;
 
-  const serveAssets = sirv(assetsDir, { single: true, etag: true });
+  // dev: true makes sirv stat the filesystem per request instead of
+  // snapshotting the asset manifest at boot — without it, rebuilding
+  // packages/app/dist-web under a running server 404s the new hashed assets
+  // (and serves stale ETags/lengths for changed ones). The trade-offs are a
+  // stat syscall per request and no maxage headers (etag revalidation still
+  // works: dev mode sends Cache-Control: no-cache) — both irrelevant for a
+  // single-user loopback server, where correctness wins.
+  const serveAssets = sirv(assetsDir, { single: true, etag: true, dev: true });
 
   const httpServer = http.createServer((req, res) => {
     if (!isAllowedHostHeader(req.headers.host)) {

--- a/packages/ui/src/components/button.tsx
+++ b/packages/ui/src/components/button.tsx
@@ -22,6 +22,7 @@ const buttonVariants = cva(
         secondary: "text-foreground",
         tertiary: "border border-border text-foreground",
         ghost: "text-muted-foreground hover:text-foreground",
+        destructive: "text-destructive-foreground",
       },
       size: {
         sm: "h-7 px-3 text-[12px] gap-1",
@@ -66,6 +67,8 @@ const bgVariants: Record<string, string> = {
   secondary: "bg-accent group-hover/button:bg-accent/80 group-active/button:bg-accent",
   tertiary: "bg-transparent group-hover/button:bg-hover group-active/button:bg-active",
   ghost: "bg-transparent group-hover/button:bg-hover group-active/button:bg-active",
+  destructive:
+    "bg-destructive group-hover/button:bg-destructive/90 group-active/button:bg-destructive/80",
 };
 
 const activeBgVariants: Record<string, string> = {
@@ -73,6 +76,7 @@ const activeBgVariants: Record<string, string> = {
   secondary: "bg-accent",
   tertiary: "bg-active",
   ghost: "bg-active",
+  destructive: "bg-destructive/80",
 };
 
 const Button = forwardRef<HTMLButtonElement, ButtonProps>(

--- a/packages/ui/src/components/confirm-dialog.tsx
+++ b/packages/ui/src/components/confirm-dialog.tsx
@@ -1,0 +1,128 @@
+"use client";
+
+// Promise-based confirm on the alert-dialog primitives — the styled
+// replacement for the browser-native confirm. Call `confirm({ ... })` from any event
+// handler and await the user's answer; render <ConfirmDialogHost /> once at
+// the app root. Generalizes the delegation dock's restore dialog (local
+// state + AlertDialog* composition) into a single shared affordance.
+//
+// Keyboard contract: the confirm button takes initial focus so Enter
+// confirms; Base UI's alert dialog traps focus, cancels on Escape, and
+// returns focus to the previously focused element on close.
+
+import * as React from "react";
+
+import {
+  AlertDialog,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@repo/ui/components/alert-dialog";
+import { Button } from "@repo/ui/components/button";
+
+export type ConfirmOptions = {
+  title: React.ReactNode;
+  body?: React.ReactNode;
+  confirmLabel?: React.ReactNode;
+  cancelLabel?: React.ReactNode;
+  /** Styles the confirm button as destructive (delete-shaped actions). */
+  destructive?: boolean;
+};
+
+type PendingConfirm = {
+  options: ConfirmOptions;
+  resolve: (confirmed: boolean) => void;
+};
+
+type Listener = () => void;
+
+type ConfirmStore = {
+  pending: PendingConfirm | null;
+  listeners: Set<Listener>;
+  subscribe: (listener: Listener) => () => void;
+  getSnapshot: () => PendingConfirm | null;
+  set: (pending: PendingConfirm | null) => void;
+};
+
+const confirmStore: ConfirmStore = {
+  pending: null,
+  listeners: new Set<Listener>(),
+  subscribe(listener: Listener): () => void {
+    confirmStore.listeners.add(listener);
+    return () => {
+      confirmStore.listeners.delete(listener);
+    };
+  },
+  getSnapshot(): PendingConfirm | null {
+    return confirmStore.pending;
+  },
+  set(pending: PendingConfirm | null): void {
+    confirmStore.pending = pending;
+    for (const listener of confirmStore.listeners) listener();
+  },
+};
+
+/**
+ * Ask the user to confirm an action. Resolves true on confirm, false on
+ * cancel (button, Escape, or backdrop). Requires a mounted
+ * <ConfirmDialogHost />; without one the promise stays pending — same shape
+ * as a dismissed dialog, never a false positive.
+ */
+export function confirm(options: ConfirmOptions): Promise<boolean> {
+  return new Promise<boolean>((resolve) => {
+    // One confirm at a time: a newer ask settles the older one as canceled.
+    confirmStore.pending?.resolve(false);
+    confirmStore.set({ options, resolve });
+  });
+}
+
+export function ConfirmDialogHost() {
+  const pending = React.useSyncExternalStore(
+    confirmStore.subscribe,
+    confirmStore.getSnapshot,
+    confirmStore.getSnapshot,
+  );
+  const confirmButtonRef = React.useRef<HTMLButtonElement>(null);
+  // Hold the last options through the close animation so the popup doesn't
+  // blank out while it fades.
+  const lastOptionsRef = React.useRef<ConfirmOptions | null>(null);
+  if (pending) lastOptionsRef.current = pending.options;
+  const options = pending?.options ?? lastOptionsRef.current;
+
+  const settle = (confirmed: boolean) => {
+    pending?.resolve(confirmed);
+    confirmStore.set(null);
+  };
+
+  return (
+    <AlertDialog
+      open={pending !== null}
+      onOpenChange={(open) => {
+        if (!open) settle(false);
+      }}
+    >
+      <AlertDialogContent size="sm" initialFocus={confirmButtonRef}>
+        <AlertDialogHeader>
+          <AlertDialogTitle>{options?.title}</AlertDialogTitle>
+        </AlertDialogHeader>
+        {options?.body !== undefined && (
+          <AlertDialogDescription>{options.body}</AlertDialogDescription>
+        )}
+        <AlertDialogFooter>
+          <Button variant="secondary" onClick={() => settle(false)}>
+            {options?.cancelLabel ?? "Cancel"}
+          </Button>
+          <Button
+            ref={confirmButtonRef}
+            variant={options?.destructive ? "destructive" : "primary"}
+            onClick={() => settle(true)}
+          >
+            {options?.confirmLabel ?? "Confirm"}
+          </Button>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  );
+}


### PR DESCRIPTION
Three hardening follow-ups from the review/acceptance ledger.

- **Fixes #371**: promise-based `confirm()` + `ConfirmDialogHost` on @repo/ui's alert-dialog primitives; sidebar/header delete and graph phantom-create converted; `window.confirm` grep-zero. Keyboard-complete (Enter/Escape, focus trap + return). Adds a `destructive` button variant.
- **Fixes #372**: knowledge fingerprints gain `ino` — atomic writes always change inode, closing the theoretical mtime-collision staleness; regression test pins it (utimesSync + same-length rename swap).
- **Fixes #378**: sirv `dev: true` — per-request stat instead of a boot-time manifest crawl, so rebuilding `dist-web` under a running server serves the new hashed assets; test covers file-added-after-boot.

Gates green (--force, 329 app tests); dialog flows driven live in the harness.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Targeted UX and dev-server correctness fixes plus a narrow indexing edge case; delete still requires explicit confirmation and tests cover the inode and sirv behavior.
> 
> **Overview**
> Introduces a workspace-wide **promise-based `confirm()`** with a single **`ConfirmDialogHost`** at the app root, replacing **`window.confirm`** in header/sidebar delete flows and graph phantom-note creation. Adds a **`destructive`** button variant for delete confirmations.
> 
> **Knowledge incremental refresh** now fingerprints **`ino`** alongside mtime and size so atomic rename swaps still re-index when mtime/size collide; includes a regression test for that swap scenario.
> 
> The loopback static server enables **sirv `dev: true`** so new hashed bundles written after boot are served without restart, with a test for post-boot asset files.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a6c710f405fc8eb031783c46dafa169f48c0bf87. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced native confirm prompts with a reusable, promise-based dialog; hardened indexing with inode fingerprints; and enabled live asset serving during dev rebuilds. Better UX, safer refresh on atomic writes, and no more 404s for new hashed bundles.

- **New Features**
  - Added promise-based confirm via `@repo/ui` (`confirm()` + `ConfirmDialogHost`) and replaced `window.confirm` in header, sidebar, and graph; supports Enter/Escape. Addresses #371.
  - Added a `destructive` button variant for clear delete actions.

- **Bug Fixes**
  - Knowledge fingerprints now include `ino` to detect atomic swaps even when `mtime` and size match; prevents stale indexes. Addresses #372.
  - Serve assets with `sirv` in `dev: true` so files added after boot are served without restart. Addresses #378.

<sup>Written for commit a6c710f405fc8eb031783c46dafa169f48c0bf87. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kyh/inteligir/pull/381?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

