### PR TITLE
fix: transcluded tables, embed nesting warning, callout title badges

### DIFF
--- a/packages/app/dev/fixture-bridge.ts
+++ b/packages/app/dev/fixture-bridge.ts
@@ -222,6 +222,11 @@ Embed placeholder: ![[target note]]
 ## Section
 
 The hub links here. Backlinks arrive in a later phase.
+
+| feature | status |
+| ------- | ------ |
+| embeds  | live   |
+| tables  | boxed  |
 `,
   // Phase F knowledge notes — an interlinked cluster so tabs, chips,
   // backlinks, transclusion (incl. guards), graph, and search all demo well.

--- a/packages/app/src/editor/kits/basic-blocks-kit.tsx
+++ b/packages/app/src/editor/kits/basic-blocks-kit.tsx
@@ -1,7 +1,9 @@
 // Basic blocks kit. Base half feeds the headless serialization mirror; the
 // React half adds the styled block components (paragraph/headings relocated
 // from markdown-editor.tsx, blockquote/hr from src/editor/nodes/) plus the
-// md-representable autoformat input rules (`# `→h1 … `> `→quote, `---`→hr).
+// md-representable autoformat input rules (`# `→h1 … `> `→quote, `---`→hr)
+// and the render-only calloutMarker decoration that hides GitHub-alert
+// `[!TYPE]` marker lines behind blockquote-node's variant badge.
 
 import {
   BaseBlockquotePlugin,
@@ -20,10 +22,28 @@ import {
   H3Plugin,
   HorizontalRulePlugin,
 } from "@platejs/basic-nodes/react";
-import { ElementApi, type TElement } from "platejs";
-import { ParagraphPlugin, PlateElement, type PlateElementProps } from "platejs/react";
+import {
+  ElementApi,
+  KEYS,
+  NodeApi,
+  TextApi,
+  createSlatePlugin,
+  type DecoratedRange,
+  type Path,
+  type SlateEditor,
+  type TElement,
+} from "platejs";
+import {
+  ParagraphPlugin,
+  PlateElement,
+  PlateLeaf,
+  type PlateElementProps,
+  type PlateLeafProps,
+} from "platejs/react";
 
-import { BlockquoteElement } from "@repo/app/editor/nodes/blockquote-node";
+import { cn } from "@repo/ui/lib/utils";
+
+import { BlockquoteElement, alertMarkerPrefix } from "@repo/app/editor/nodes/blockquote-node";
 import { HrElement } from "@repo/app/editor/nodes/hr-node";
 
 export const BasicBlocksBaseKit = [
@@ -61,6 +81,34 @@ function element(as: keyof HTMLElementTagNameMap, className: string) {
   };
 }
 
+// A first-child paragraph that is EXACTLY an alert marker line (`> [!TIP]`
+// followed by a blank quote line or nothing) collapses toggle-style while the
+// quote isn't being edited — its every byte is already presented by the badge,
+// so it would render as a stray blank line. CSS lives in styles.css.
+function isAlertMarkerLine(editor: SlateEditor, element: TElement, path: Path): boolean {
+  if (element.children.length !== 1) return false;
+  const leaf = element.children[0];
+  if (!TextApi.isText(leaf) || !leaf.text.startsWith("[!")) return false;
+  const marker = alertMarkerPrefix(leaf.text);
+  if (!marker || marker.hidden < leaf.text.length) return false;
+  if (path.length === 0 || path.at(-1) !== 0) return false;
+  const parent = NodeApi.get(editor, path.slice(0, -1));
+  return ElementApi.isElement(parent) && parent.type === editor.getType(KEYS.blockquote);
+}
+
+function ParagraphElement(props: PlateElementProps) {
+  return (
+    <PlateElement
+      {...props}
+      as={hostsBlockContent(props.element) ? "div" : "p"}
+      className={cn(
+        "px-0.5 py-[3px]",
+        isAlertMarkerLine(props.editor, props.element, props.path) && "callout-marker-line",
+      )}
+    />
+  );
+}
+
 // Heading margins/sizes match the previous EDITOR_COMPONENTS styling.
 function heading(as: "h1" | "h2" | "h3", top: string, size: string) {
   return element(
@@ -69,8 +117,44 @@ function heading(as: "h1" | "h2" | "h3", top: string, size: string) {
   );
 }
 
+function CalloutMarkerLeaf(props: PlateLeafProps) {
+  return <PlateLeaf {...props} className="callout-marker text-muted-foreground" />;
+}
+
+// Render-only leaf decoration over the `[!TYPE]` marker (plus its soft break)
+// at the head of an alert blockquote. Decorations never touch the document
+// model, so the marker bytes round-trip untouched; visibility is driven by
+// blockquote-node's `.callout-editing` class (caret inside ⇒ revealed).
+// React-half only by design — the BASE_KIT serialization mirror and the
+// transclusion static render never see it.
+const CalloutMarkerPlugin = createSlatePlugin({
+  key: "calloutMarker",
+  node: { isLeaf: true },
+  decorate: ({ editor, entry: [node, path] }) => {
+    if (!TextApi.isText(node) || !node.text.startsWith("[!")) return undefined;
+    // Only the first leaf of the first paragraph of a blockquote qualifies.
+    if (path.length < 3 || path.at(-1) !== 0 || path.at(-2) !== 0) return undefined;
+    const paragraph = NodeApi.get(editor, path.slice(0, -1));
+    const quote = NodeApi.get(editor, path.slice(0, -2));
+    if (!ElementApi.isElement(paragraph) || paragraph.type !== editor.getType(KEYS.p)) {
+      return undefined;
+    }
+    if (!ElementApi.isElement(quote) || quote.type !== editor.getType(KEYS.blockquote)) {
+      return undefined;
+    }
+    const marker = alertMarkerPrefix(node.text);
+    if (!marker) return undefined;
+    const range: DecoratedRange & { calloutMarker: true } = {
+      anchor: { offset: 0, path },
+      calloutMarker: true,
+      focus: { offset: marker.hidden, path },
+    };
+    return [range];
+  },
+}).withComponent(CalloutMarkerLeaf);
+
 export const BasicBlocksKit = [
-  ParagraphPlugin.withComponent(element("p", "px-0.5 py-[3px]")),
+  ParagraphPlugin.withComponent(ParagraphElement),
   H1Plugin.configure({ inputRules: [HeadingRules.markdown()] }).withComponent(
     heading("h1", "mt-8", "text-[1.875em]"),
   ),
@@ -86,4 +170,5 @@ export const BasicBlocksKit = [
   HorizontalRulePlugin.configure({ inputRules: [HorizontalRuleRules.markdown()] }).withComponent(
     HrElement,
   ),
+  CalloutMarkerPlugin,
 ];

--- a/packages/app/src/editor/kits/basic-blocks-kit.tsx
+++ b/packages/app/src/editor/kits/basic-blocks-kit.tsx
@@ -20,6 +20,7 @@ import {
   H3Plugin,
   HorizontalRulePlugin,
 } from "@platejs/basic-nodes/react";
+import { ElementApi, type TElement } from "platejs";
 import { ParagraphPlugin, PlateElement, type PlateElementProps } from "platejs/react";
 
 import { BlockquoteElement } from "@repo/app/editor/nodes/blockquote-node";
@@ -33,18 +34,27 @@ export const BasicBlocksBaseKit = [
   BaseHorizontalRulePlugin,
 ];
 
-// className-only element renderers (Plate plugins ship headless). A block
-// carrying `listStyleType` hosts BlockList's <ul>/<ol> INSIDE it
-// (list-kit's render.belowNodes) — invalid DOM inside <p>/<h*>, so React
-// logged a DOM-nesting error on every list note. List-carrying blocks render
-// as <div> instead; the tag is render-only, bytes are pinned by the
-// round-trip fixtures.
+// A block hosting block-rendering children can't stay a <p>/<h*>: a block
+// carrying `listStyleType` hosts BlockList's <ul>/<ol> INSIDE it (list-kit's
+// render.belowNodes), and a `wikiEmbed` inline void expands into a
+// transclusion CARD of block content (lists, tables, nested divs). Either
+// inside <p> is invalid DOM and React logs a nesting error on every affected
+// note. Such blocks render as <div> instead; the tag is render-only, bytes
+// are pinned by the round-trip fixtures.
+function hostsBlockContent(element: TElement): boolean {
+  if (element.listStyleType) return true;
+  return element.children.some(
+    (child) => ElementApi.isElement(child) && child.type === "wikiEmbed",
+  );
+}
+
+// className-only element renderers (Plate plugins ship headless).
 function element(as: keyof HTMLElementTagNameMap, className: string) {
   return function Element(props: PlateElementProps) {
     return (
       <PlateElement
         {...props}
-        as={props.element.listStyleType ? "div" : as}
+        as={hostsBlockContent(props.element) ? "div" : as}
         className={className}
       />
     );

--- a/packages/app/src/editor/kits/table-kit.tsx
+++ b/packages/app/src/editor/kits/table-kit.tsx
@@ -31,16 +31,15 @@ function element(as: keyof HTMLElementTagNameMap, className: string) {
   };
 }
 
+// Cell styling shared with the transclusion card's read-only static render
+// (transclusion.tsx) so live tables and embedded tables can't drift apart.
+export const TABLE_CELL_CLASS = "min-w-24 border border-border px-3 py-1.5 align-top [&>*]:my-0";
+export const TABLE_HEADER_CELL_CLASS =
+  "min-w-24 border border-border bg-muted px-3 py-1.5 text-left align-top font-semibold [&>*]:my-0";
+
 export const TableKit = [
   TablePlugin.withComponent(TableElement),
   TableRowPlugin.withComponent(element("tr", "")),
-  TableCellPlugin.withComponent(
-    element("td", "min-w-24 border border-border px-3 py-1.5 align-top [&>*]:my-0"),
-  ),
-  TableCellHeaderPlugin.withComponent(
-    element(
-      "th",
-      "min-w-24 border border-border bg-muted px-3 py-1.5 text-left align-top font-semibold [&>*]:my-0",
-    ),
-  ),
+  TableCellPlugin.withComponent(element("td", TABLE_CELL_CLASS)),
+  TableCellHeaderPlugin.withComponent(element("th", TABLE_HEADER_CELL_CLASS)),
 ];

--- a/packages/app/src/editor/nodes/blockquote-node.tsx
+++ b/packages/app/src/editor/nodes/blockquote-node.tsx
@@ -1,8 +1,13 @@
 // GitHub-style alert blockquotes (`> [!NOTE] …`) render as colored callouts.
 // They stay plain blockquotes in the model, so they round-trip byte-for-byte —
-// the callout is purely presentational (the `[!TYPE]` marker stays in the
-// text). Relocated verbatim from markdown-editor.tsx in WP2; the ALERTS map is
-// shared with the `<callout>` compat renderer (callout-node.tsx).
+// the callout is purely presentational. When the alert's first line is exactly
+// the `[!TYPE]` marker, the marker text is hidden at render behind a variant
+// title badge (icon + label) and revealed while the caret is inside the quote
+// (Obsidian live-preview convention: raw syntax shows exactly when you edit
+// that block, so the bytes stay discoverable and editable). The hiding itself
+// is a `calloutMarker` leaf decoration (kits/basic-blocks-kit.tsx) + CSS in
+// styles.css — the document model never changes. The ALERTS map is shared with
+// the `<callout>` compat renderer (callout-node.tsx).
 
 import type { ComponentType } from "react";
 import {
@@ -12,50 +17,125 @@ import {
   ShieldAlertIcon,
   TriangleAlertIcon,
 } from "lucide-react";
-import { NodeApi } from "platejs";
-import { PlateElement, type PlateElementProps } from "platejs/react";
+import { ElementApi, KEYS, NodeApi, TextApi, type SlateEditor, type TElement } from "platejs";
+import { PlateElement, useSelected, type PlateElementProps } from "platejs/react";
 
 import { cn } from "@repo/ui/lib/utils";
 
+const ALERT_VARIANTS = ["NOTE", "TIP", "IMPORTANT", "WARNING", "CAUTION"] as const;
+
+type AlertVariant = (typeof ALERT_VARIANTS)[number];
+
 const ALERTS: Record<
-  string,
-  { Icon: ComponentType<{ className?: string }>; accent: string; icon: string }
+  AlertVariant,
+  { Icon: ComponentType<{ className?: string }>; accent: string; icon: string; label: string }
 > = {
   NOTE: {
     Icon: InfoIcon,
     accent: "border-blue-500/60 bg-blue-500/[0.05]",
     icon: "text-blue-600 dark:text-blue-400",
+    label: "Note",
   },
   TIP: {
     Icon: LightbulbIcon,
     accent: "border-emerald-500/60 bg-emerald-500/[0.05]",
     icon: "text-emerald-600 dark:text-emerald-400",
+    label: "Tip",
   },
   IMPORTANT: {
     Icon: ShieldAlertIcon,
     accent: "border-violet-500/60 bg-violet-500/[0.05]",
     icon: "text-violet-600 dark:text-violet-400",
+    label: "Important",
   },
   WARNING: {
     Icon: TriangleAlertIcon,
     accent: "border-amber-500/60 bg-amber-500/[0.05]",
     icon: "text-amber-600 dark:text-amber-400",
+    label: "Warning",
   },
   CAUTION: {
     Icon: OctagonAlertIcon,
     accent: "border-red-500/60 bg-red-500/[0.05]",
     icon: "text-red-600 dark:text-red-400",
+    label: "Caution",
   },
 };
 
+// Strict form only: the marker IS the whole first line (GitHub's alert
+// grammar). `hidden` spans the marker plus its soft break, so hiding it pulls
+// the body up to the first visible line.
+const ALERT_MARKER_RE = /^\[!(NOTE|TIP|IMPORTANT|WARNING|CAUTION)\](?:\n|$)/i;
+
+// Legacy/loose form (`[!TIP] trailing words`): still tinted like an alert,
+// but the marker stays visible — hiding non-marker bytes would lie.
+const ALERT_LOOSE_RE = /^\s*\[!(NOTE|TIP|IMPORTANT|WARNING|CAUTION)\]/i;
+
+function toVariant(raw: string): AlertVariant | null {
+  const upper = raw.toUpperCase();
+  return ALERT_VARIANTS.find((variant) => variant === upper) ?? null;
+}
+
+/** Marker-line prefix of `text`, or null. `hidden` = chars to hide (marker +
+ * trailing soft break). */
+export function alertMarkerPrefix(text: string): { hidden: number; variant: AlertVariant } | null {
+  const match = ALERT_MARKER_RE.exec(text);
+  const variant = match ? toVariant(match[1] ?? "") : null;
+  if (!match || !variant) return null;
+  return { hidden: match[0].length, variant };
+}
+
+/** The badge-form marker of an alert blockquote: its first child is a
+ * paragraph whose first leaf starts with a marker-only line. The calloutMarker
+ * decoration (basic-blocks-kit.tsx) mirrors these checks through
+ * alertMarkerPrefix, so badge and hiding can never disagree. */
+function alertQuoteMarker(
+  editor: SlateEditor,
+  quote: TElement,
+): { hidden: number; variant: AlertVariant } | null {
+  const first = quote.children[0];
+  if (!ElementApi.isElement(first) || first.type !== editor.getType(KEYS.p)) return null;
+  const leaf = first.children[0];
+  if (!TextApi.isText(leaf)) return null;
+  return alertMarkerPrefix(leaf.text);
+}
+
 export function BlockquoteElement(props: PlateElementProps) {
-  const marker = /^\s*\[!(NOTE|TIP|IMPORTANT|WARNING|CAUTION)\]/i.exec(
-    NodeApi.string(props.element),
-  );
-  const variant = marker?.[1]?.toUpperCase();
-  const alert = variant ? ALERTS[variant] : undefined;
-  if (alert) {
-    const { Icon, accent, icon } = alert;
+  const selected = useSelected();
+  const marker = alertQuoteMarker(props.editor, props.element);
+  if (marker) {
+    const { Icon, accent, icon, label } = ALERTS[marker.variant];
+    return (
+      <PlateElement
+        {...props}
+        as="blockquote"
+        className={cn(
+          "callout-alert my-1 rounded-md border-l-[3px] py-2 pr-3 pl-4 [&>*]:my-0",
+          accent,
+          selected && "callout-editing",
+        )}
+      >
+        {/* The badge swaps with the raw marker line: hidden while editing so
+            the variant label never doubles up with its own bytes. */}
+        <div
+          contentEditable={false}
+          className={cn(
+            "flex items-center gap-1.5 py-[3px] text-[13px] leading-[1.3] font-semibold select-none",
+            icon,
+            selected && "hidden",
+          )}
+        >
+          <Icon className="size-4" />
+          {label}
+        </div>
+        {props.children}
+      </PlateElement>
+    );
+  }
+  const loose = ALERT_LOOSE_RE.exec(NodeApi.string(props.element));
+  const looseVariant = loose ? toVariant(loose[1] ?? "") : null;
+  if (looseVariant) {
+    const { Icon, accent, icon } = ALERTS[looseVariant];
     return (
       <PlateElement
         {...props}

--- a/packages/app/src/editor/transclusion.tsx
+++ b/packages/app/src/editor/transclusion.tsx
@@ -26,6 +26,7 @@ import { cn } from "@repo/ui/lib/utils";
 
 import { getBridge } from "@repo/app/lib/bridge";
 import { BASE_KIT } from "@repo/app/editor/kits/base-kit";
+import { TABLE_CELL_CLASS, TABLE_HEADER_CELL_CLASS } from "@repo/app/editor/kits/table-kit";
 import { parseMarkdown } from "@repo/app/editor/markdown/markdown-doc";
 import {
   decideTransclusion,
@@ -138,6 +139,27 @@ function FrontmatterStatic(props: SlateElementProps) {
   );
 }
 
+// Tables: the default static renderer is a bare <div> per node, which
+// flattens a transcluded table into stacked lines (#376). Mirror the live
+// table-kit markup — table > tbody > tr > td/th, same cell classes.
+function TableStatic(props: SlateElementProps) {
+  return (
+    <SlateElement {...props} as="table" className="my-1 w-auto border-collapse text-sm">
+      <tbody>{props.children}</tbody>
+    </SlateElement>
+  );
+}
+
+function TableRowStatic(props: SlateElementProps) {
+  return <SlateElement {...props} as="tr" />;
+}
+
+function tableCellStatic(as: "td" | "th", className: string) {
+  return function TableCellStatic(props: SlateElementProps) {
+    return <SlateElement {...props} as={as} className={className} />;
+  };
+}
+
 const STATIC_COMPONENTS: Record<string, (props: SlateElementProps) => ReactNode> = {
   a: LinkStatic,
   date: DateStatic,
@@ -147,6 +169,10 @@ const STATIC_COMPONENTS: Record<string, (props: SlateElementProps) => ReactNode>
   media_embed: MediaStatic,
   file: MediaStatic,
   frontmatter: FrontmatterStatic,
+  table: TableStatic,
+  tr: TableRowStatic,
+  td: tableCellStatic("td", TABLE_CELL_CLASS),
+  th: tableCellStatic("th", TABLE_HEADER_CELL_CLASS),
   wikiLink: WikiLinkStatic,
   wikiEmbed: WikiEmbedStatic,
 };
@@ -294,7 +320,7 @@ export default function Transclusion({ body }: { body: string }) {
           {title}
         </button>
       </span>
-      <span className="block px-3 py-2 text-sm">
+      <span className="block overflow-x-auto px-3 py-2 text-sm">
         {content.status === "loading" || innerScope === null ? (
           <span className="text-muted-foreground italic">Loading…</span>
         ) : (

--- a/packages/app/src/styles.css
+++ b/packages/app/src/styles.css
@@ -66,6 +66,25 @@ textarea,
   visibility: hidden;
 }
 
+/* GitHub-alert callouts (editor/nodes/blockquote-node.tsx + the calloutMarker
+ * decoration in kits/basic-blocks-kit.tsx). The literal `> [!TIP]` marker
+ * STAYS in the bytes — it is only hidden at render behind the variant badge.
+ * `.callout-editing` (caret anywhere inside the quote) reveals it for editing,
+ * Obsidian-live-preview style. The marker leaf needs display:none (its hidden
+ * span carries the soft break — anything layout-preserving would keep a blank
+ * first line); a marker-ONLY first paragraph collapses with the toggle-node
+ * recipe instead (Slate keeps measurable DOM for block-level APIs). */
+.callout-alert:not(.callout-editing) .callout-marker {
+  display: none;
+}
+.callout-alert:not(.callout-editing) .callout-marker-line {
+  height: 0;
+  margin: 0;
+  padding: 0;
+  overflow: hidden;
+  visibility: hidden;
+}
+
 /* Code-block syntax highlighting — the GitHub light/dark theme for lowlight's
  * `.hljs-*` token classes (emitted by CodeSyntaxPlugin). Syntax themes are
  * inherently color-specific, so these are fixed hex rather than theme tokens. */


### PR DESCRIPTION
Three render-only fixes — vault bytes proven untouched (round-trip matrix + kit-parity pass unmodified; live Raw-mode byte-diffs identical).

- **Fixes #376**: static table components for the transclusion card's PlateStatic map (@platejs/table ships headless only); cell classes shared with the live kit; horizontal scroll inside the card.
- **Fixes #368**: blocks hosting a wiki-embed render as `<div>` instead of `<p>` (the same render-only tag-swap precedent as list blocks) — inline/void pins and serialization untouched; console sweep clean.
- **Fixes #377**: GitHub-alert markers stay in the bytes but render as icon+label badges (all 5 variants); caret inside the block reveals the raw marker for editing (Obsidian live-preview convention); loose markers keep the visible tinted render.

New follow-up filed: markers inside transclusion cards still show literally (decorations don't run in PlateStatic).

Gates green; light+dark screenshots; byte-safety live-proven.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are presentation-only (DOM tags, static components, decorations/CSS) and explicitly avoid the serialization mirror; main residual risk is subtle callout/marker edge cases in the live editor.
> 
> **Overview**
> Render-only editor fixes for **transclusion cards**, **wiki embed DOM nesting**, and **GitHub-alert callouts**, without changing vault bytes or serialization.
> 
> **Transcluded tables (#376):** The transclusion card’s `PlateStatic` path now renders real `table` / `tr` / `td` / `th` markup instead of default div flattening. Cell classes are exported from `table-kit` and reused in `transclusion.tsx`; the card body gets horizontal scroll for wide tables. The dev fixture `wiki/target note.md` gains a sample table for demos.
> 
> **Wiki embed nesting (#368):** Paragraphs and headings that host a `wikiEmbed` (or list blocks) switch from `<p>` / `<h*>` to `<div>` at render time—the same pattern already used for list blocks—so expanded transclusion cards no longer trigger invalid DOM nesting warnings.
> 
> **GitHub alerts (#377):** Strict `> [!TYPE]` marker lines show an icon + variant label badge while the literal marker stays in the document. A React-only `calloutMarker` leaf decoration plus CSS hides the marker when the quote isn’t selected; caret inside adds `callout-editing` and reveals raw syntax (Obsidian-style). Loose markers keep the older tinted icon-only layout with visible marker text. Callout styling does not run in static transclusion (known follow-up).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 949c673e2969e555c9ea6b46c125aa1bee1f60df. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix three render-only issues: transcluded tables now render as real tables, wiki-embed hosts no longer cause invalid DOM, and GitHub-style callouts show badge titles instead of the literal `[!TYPE]` line. Bytes are unchanged.

- **Bug Fixes**
  - Transclusions: render tables with `table/tr/td/th` and shared cell classes; add horizontal scroll in the card body.
  - Embed nesting: paragraphs/headings that host a `wikiEmbed` render as `div` to avoid DOM nesting warnings.
  - Callouts: replace `[!TYPE]` line with an icon+label badge (5 variants); marker is hidden at render and revealed while editing; marker-only first lines collapse; loose markers stay tinted.

<sup>Written for commit 949c673e2969e555c9ea6b46c125aa1bee1f60df. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kyh/inteligir/pull/383?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

