### PR TITLE
fix: markdown-parsed AI generation; typing survives suggestion-session bail

### DIFF
--- a/packages/app/dev/fixture-bridge.ts
+++ b/packages/app/dev/fixture-bridge.ts
@@ -617,7 +617,22 @@ export function createFixtureBridge(): Bridge {
       if (edited !== null) {
         return new Promise((resolve) => setTimeout(() => resolve({ ok: true, text: edited }), 400));
       }
-      const text = `This sentence was written by the canned dev-harness generator in response to the prompt, and it streams in word by word to exercise the live-insert path.`;
+      // Multi-block markdown so the incremental streaming parse (#370) is
+      // exercisable: heading, bold, list, fence, closing paragraph.
+      const text = [
+        "## Canned heading",
+        "",
+        "The dev-harness generator streams **markdown** now, and each construct lands as a real block.",
+        "",
+        "- first canned bullet",
+        "- second canned bullet with _emphasis_",
+        "",
+        "```ts",
+        "const canned = true;",
+        "```",
+        "",
+        "A closing paragraph follows the fence.",
+      ].join("\n");
       return new Promise((resolve) => {
         streamText(
           text,

--- a/packages/app/src/__tests__/ai-settle.test.ts
+++ b/packages/app/src/__tests__/ai-settle.test.ts
@@ -1,0 +1,88 @@
+// Teardown of a pending AI suggestion session (#374) — typing the user
+// interleaves during a review rides ONLY the live editor value (the save
+// buffer is frozen), so abandoning the session must resolve deterministically:
+// reject-all reverts ONLY the suggestion-marked ranges — the user's typing
+// survives byte-for-byte while the AI proposal disappears. Plus the settle
+// registry (transient-settle) the flush path routes through.
+
+import { describe, expect, it } from "vitest";
+import { NodeApi, createSlateEditor, type Value } from "platejs";
+import { serializeMd } from "@platejs/markdown";
+
+import { applyEditSuggestions, resolveAllSuggestions } from "@repo/app/editor/ai/suggestions";
+import { hasTransientAiState } from "@repo/app/editor/ai/transient";
+import { registerTransientSettler, settleTransients } from "@repo/app/editor/ai/transient-settle";
+import { EDITOR_KIT } from "@repo/app/editor/kits/editor-kit";
+import { MD_STRINGIFY, parseMarkdown } from "@repo/app/editor/markdown/markdown-doc";
+
+function seedEditor(md: string) {
+  const parsed = parseMarkdown(md);
+  if (!parsed.ok) throw new Error("fixture must parse");
+  return createSlateEditor({ plugins: EDITOR_KIT, value: parsed.value });
+}
+
+function serialize(editor: ReturnType<typeof seedEditor>): string {
+  return serializeMd(editor, { remarkStringifyOptions: MD_STRINGIFY });
+}
+
+function parsedValue(md: string): Value {
+  const parsed = parseMarkdown(md);
+  if (!parsed.ok) throw new Error("replacement must parse");
+  return parsed.value;
+}
+
+const ORIGINAL = "The cat is black.\n\nKeep me unchanged.\n";
+const REWRITE = "The dog was black.\n\nKeep me unchanged.\n\nA whole new paragraph.\n";
+
+/** Simulate the user typing at the end of the paragraph containing `marker`
+ * — an untouched block, i.e. one the suggestion session didn't mark. */
+function typeInto(editor: ReturnType<typeof seedEditor>, marker: string, text: string): void {
+  const index = editor.children.findIndex((node) => NodeApi.string(node).includes(marker));
+  expect(index).toBeGreaterThanOrEqual(0);
+  const end = editor.api.end([index]);
+  expect(end).toBeDefined();
+  if (end) editor.tf.insertText(text, { at: end });
+}
+
+describe("reject-all teardown preserves interleaved typing", () => {
+  it("typing in an untouched paragraph survives byte-for-byte", () => {
+    const editor = seedEditor(ORIGINAL);
+    applyEditSuggestions(editor, [[0]], parsedValue("The dog was black.\n"));
+    expect(hasTransientAiState(editor)).toBe(true);
+    typeInto(editor, "Keep me unchanged", " Typed mid-review.");
+    resolveAllSuggestions(editor, "reject");
+    expect(hasTransientAiState(editor)).toBe(false);
+    expect(serialize(editor)).toBe("The cat is black.\n\nKeep me unchanged. Typed mid-review.\n");
+  });
+
+  it("a multi-block rewrite rejects away whole, typing intact", () => {
+    const editor = seedEditor(ORIGINAL);
+    applyEditSuggestions(editor, [[0], [1]], parsedValue(REWRITE));
+    typeInto(editor, "Keep me unchanged", " Still mine.");
+    resolveAllSuggestions(editor, "reject");
+    const out = serialize(editor);
+    expect(out).toContain("The cat is black.");
+    expect(out).toContain("Keep me unchanged. Still mine.");
+    expect(out).not.toContain("dog");
+    expect(out).not.toContain("A whole new paragraph.");
+  });
+});
+
+describe("transient-settle registry", () => {
+  it("routes settle by path and unregisters cleanly", () => {
+    const off = registerTransientSettler("a.md", () => "settled-a");
+    expect(settleTransients("b.md")).toBeNull();
+    expect(settleTransients("a.md")).toBe("settled-a");
+    off();
+    expect(settleTransients("a.md")).toBeNull();
+  });
+
+  it("a stale unregister never clears a newer registration", () => {
+    const offA = registerTransientSettler("a.md", () => "A");
+    const offB = registerTransientSettler("b.md", () => "B");
+    offA(); // a.md's editor unmounted after b.md's mounted — must be a no-op
+    expect(settleTransients("b.md")).toBe("B");
+    offB();
+    expect(settleTransients("b.md")).toBeNull();
+  });
+});

--- a/packages/app/src/__tests__/ai-stream-markdown.test.ts
+++ b/packages/app/src/__tests__/ai-stream-markdown.test.ts
@@ -1,0 +1,152 @@
+// Streaming markdown insert (#370) — generate-intent deltas land as PARSED
+// blocks (headings/lists/bold/fences), not literal text in one paragraph.
+// Contracts: chunked and one-shot streams converge; mid-stream bytes stay
+// frozen (transient gate + serializer defense); discard (undo unwind)
+// removes everything inserted; accept (mark strip) keeps the parsed blocks
+// and the saved bytes are canonical.
+
+import { describe, expect, it } from "vitest";
+import { NodeApi, TextApi, createSlateEditor, type Descendant, type Value } from "platejs";
+import { serializeMd } from "@platejs/markdown";
+
+import { createMarkdownStream, stripAiMarks } from "@repo/app/editor/ai/stream-markdown";
+import { hasTransientAiState } from "@repo/app/editor/ai/transient";
+import { EDITOR_KIT } from "@repo/app/editor/kits/editor-kit";
+import {
+  MD_STRINGIFY,
+  analyzeMarkdown,
+  parseMarkdown,
+} from "@repo/app/editor/markdown/markdown-doc";
+
+function seedEditor(md: string) {
+  const parsed = parseMarkdown(md);
+  if (!parsed.ok) throw new Error("fixture must parse");
+  return createSlateEditor({ plugins: EDITOR_KIT, value: parsed.value });
+}
+
+function emptyEditor() {
+  const value: Value = [{ children: [{ text: "" }], type: "p" }];
+  return createSlateEditor({ plugins: EDITOR_KIT, value });
+}
+
+function serialize(editor: ReturnType<typeof seedEditor>): string {
+  return serializeMd(editor, { remarkStringifyOptions: MD_STRINGIFY });
+}
+
+// The dev harness's streaming shape: word-boundary splits, three per chunk
+// (fixture-bridge's streamText), so chunk edges land mid-construct.
+function chunkify(text: string): string[] {
+  const words = text.split(/(?<= )/);
+  const chunks: string[] = [];
+  for (let i = 0; i < words.length; i += 3) chunks.push(words.slice(i, i + 3).join(""));
+  return chunks;
+}
+
+// Mirrors the fixture bridge's canned generate reply: one of each construct.
+const GENERATED = [
+  "## Canned heading",
+  "",
+  "The dev-harness generator streams **markdown** now, and each construct lands as a real block.",
+  "",
+  "- first canned bullet",
+  "- second canned bullet with _emphasis_",
+  "",
+  "```ts",
+  "const canned = true;",
+  "```",
+  "",
+  "A closing paragraph follows the fence.",
+].join("\n");
+
+const SEED = "Start here.\n";
+
+function someText(nodes: Descendant[], pred: (t: Record<string, unknown>) => boolean): boolean {
+  return nodes.some((node) => {
+    if (TextApi.isText(node)) return pred(node);
+    return "children" in node && someText(node.children, pred);
+  });
+}
+
+describe("streaming markdown insert", () => {
+  it("a multi-block markdown stream lands as parsed blocks", () => {
+    const editor = seedEditor(SEED);
+    const stream = createMarkdownStream(editor, 0);
+    for (const chunk of chunkify(GENERATED)) stream.append(chunk);
+
+    // The seed paragraph is untouched; the generation follows as blocks.
+    const first = editor.children[0];
+    expect(first && NodeApi.string(first)).toBe("Start here.");
+    const types = editor.children.map((node) => node.type);
+    expect(types).toContain("h2");
+    expect(types).toContain("code_block");
+    expect(editor.children.some((node) => node["listStyleType"] === "disc")).toBe(true);
+    expect(someText(editor.children, (t) => t["bold"] === true)).toBe(true);
+    // Every inserted node carries the transient mark — the byte-safety gate.
+    expect(hasTransientAiState(editor)).toBe(true);
+  });
+
+  it("chunked and one-shot streams converge to the same document", () => {
+    const chunked = seedEditor(SEED);
+    const chunkedStream = createMarkdownStream(chunked, 0);
+    for (const chunk of chunkify(GENERATED)) chunkedStream.append(chunk);
+
+    const oneShot = seedEditor(SEED);
+    createMarkdownStream(oneShot, 0).append(GENERATED);
+
+    expect(chunked.children).toEqual(oneShot.children);
+  });
+
+  it("a mid-stream autosave writes the pre-stream bytes", () => {
+    const editor = seedEditor(SEED);
+    const before = serialize(editor);
+    const stream = createMarkdownStream(editor, 0);
+    for (const chunk of chunkify(GENERATED).slice(0, 5)) stream.append(chunk);
+    expect(hasTransientAiState(editor)).toBe(true);
+    expect(serialize(editor)).toBe(before);
+  });
+
+  it("discard unwinds every inserted block", () => {
+    const editor = seedEditor(SEED);
+    const before = serialize(editor);
+    const undoDepth = editor.history.undos.length;
+    const stream = createMarkdownStream(editor, 0);
+    for (const chunk of chunkify(GENERATED)) stream.append(chunk);
+    while (editor.history.undos.length > undoDepth) editor.undo();
+    expect(hasTransientAiState(editor)).toBe(false);
+    expect(serialize(editor)).toBe(before);
+  });
+
+  it("accept strips the marks and the saved bytes are canonical", () => {
+    const editor = seedEditor(SEED);
+    const stream = createMarkdownStream(editor, 0);
+    for (const chunk of chunkify(GENERATED)) stream.append(chunk);
+    stripAiMarks(editor);
+    expect(hasTransientAiState(editor)).toBe(false);
+    const out = serialize(editor);
+    expect(out).toContain("## Canned heading");
+    expect(out).toContain("- first canned bullet");
+    expect(out).toContain("const canned = true;");
+    expect(analyzeMarkdown(out).canonical).toBe(true);
+  });
+
+  it("an empty seed paragraph is replaced, and restored on discard", () => {
+    const editor = emptyEditor();
+    const undoDepth = editor.history.undos.length;
+    const stream = createMarkdownStream(editor, 0);
+    stream.append("## Title\n\nBody text.");
+    const first = editor.children[0];
+    expect(first?.type).toBe("h2");
+    while (editor.history.undos.length > undoDepth) editor.undo();
+    expect(editor.children.length).toBe(1);
+    const restored = editor.children[0];
+    expect(restored && NodeApi.string(restored)).toBe("");
+  });
+
+  it("unparseable stream text degrades to visible plain paragraphs", () => {
+    const editor = seedEditor(SEED);
+    const stream = createMarkdownStream(editor, 0);
+    stream.append("<div>legacy html tail");
+    expect(NodeApi.string(editor)).toContain("<div>legacy html tail");
+    expect(hasTransientAiState(editor)).toBe(true);
+  });
+});

--- a/packages/app/src/__tests__/ai-transient-serialize.test.ts
+++ b/packages/app/src/__tests__/ai-transient-serialize.test.ts
@@ -10,6 +10,7 @@ import { getTransientSuggestionKey } from "@platejs/suggestion";
 import { serializeMd } from "@platejs/markdown";
 
 import { AI_MARK } from "@repo/app/editor/ai/ai-mark";
+import { createMarkdownStream } from "@repo/app/editor/ai/stream-markdown";
 import {
   applyEditSuggestions,
   resolveAllSuggestions,
@@ -64,6 +65,18 @@ describe("mid-stream autosave (ai mark)", () => {
     editor.tf.select(editor.api.end([]));
     editor.tf.addMark(AI_MARK, true);
     editor.tf.insertText("streamed remnant");
+    expect(serialize(editor)).toBe(before);
+  });
+
+  // #370's block streaming: whole ai-stamped BLOCKS (heading/list/bold) must
+  // vanish from the serializer's output, not leave empty husks behind —
+  // that's the element-level arm of shouldSerializeNode.
+  it("streamed markdown blocks never serialize mid-stream", () => {
+    const editor = seedEditor(ORIGINAL);
+    const before = serialize(editor);
+    const stream = createMarkdownStream(editor, editor.children.length - 1);
+    stream.append("## Streamed heading\n\n- a bullet\n\n**bold** tail");
+    expect(hasTransientAiState(editor)).toBe(true);
     expect(serialize(editor)).toBe(before);
   });
 });

--- a/packages/app/src/editor/ai/ai-session.ts
+++ b/packages/app/src/editor/ai/ai-session.ts
@@ -4,23 +4,24 @@
 // same instance through the exported functions.
 //
 // Two flows, routed by intent:
-// - generate: streams text into the document at the caret under the transient
-//   `ai` mark (accept keeps the text and strips the mark; discard undoes the
-//   inserts precisely).
+// - generate: streams markdown below the caret's block, incrementally parsed
+//   into real blocks under the transient `ai` mark (stream-markdown.ts;
+//   accept keeps the blocks and strips the marks; discard undoes the inserts
+//   precisely).
 // - edit: rewrites the selection's blocks host-side, then lands the result as
 //   per-change track-changes suggestions (suggestions.ts) reviewed in the
 //   floating bar.
 // Free-form prompts are classified host-side (generate on any failure);
 // canned actions carry a fixed intent.
 
-import { isHotkey, PointApi, RangeApi, type Path, type PluginConfig, type TRange } from "platejs";
+import { isHotkey, RangeApi, type Path, type PluginConfig, type TRange } from "platejs";
 import { createTPlatePlugin, type PlateEditor } from "platejs/react";
 import { serializeMd } from "@platejs/markdown";
 
 import type { AiIntentResult } from "@repo/core/inline-ai";
 
 import { getBridge } from "@repo/app/lib/bridge";
-import { AI_MARK } from "@repo/app/editor/ai/ai-mark";
+import { createMarkdownStream, stripAiMarks } from "@repo/app/editor/ai/stream-markdown";
 import { applyEditSuggestions } from "@repo/app/editor/ai/suggestions";
 import { MD_STRINGIFY, parseMarkdown } from "@repo/app/editor/markdown/markdown-doc";
 
@@ -279,7 +280,7 @@ export function retryLastRun(editor: PlateEditor): void {
 }
 
 // ---------------------------------------------------------------------------
-// Generate flow (streaming insert under the transient ai mark)
+// Generate flow (streaming markdown parsed into blocks, transient ai mark)
 // ---------------------------------------------------------------------------
 
 function startGenerate(editor: PlateEditor, action: CannedActionId | null, request: string): void {
@@ -291,15 +292,16 @@ function startGenerate(editor: PlateEditor, action: CannedActionId | null, reque
   const context =
     hasSelection && action !== "continue" ? editor.api.string(sel) : editor.api.string([]);
 
-  // Generations INSERT at the end of the captured selection — they never
-  // replace content (that's the edit flow's job).
+  // Generations INSERT below the block holding the captured selection's end —
+  // they never replace content (that's the edit flow's job). Deltas
+  // accumulate as markdown and land as incrementally parsed blocks (#370).
   editor.tf.select(sel);
   editor.tf.collapse({ edge: "end" });
-  const insertion = editor.selection;
-  if (!insertion) return;
+  const caretBlock = editor.selection?.anchor.path[0];
+  if (caretBlock === undefined) return;
 
   undoDepth = editor.history.undos.length;
-  const startRef = editor.api.pointRef(RangeApi.start(insertion));
+  const stream = createMarkdownStream(editor, caretBlock);
   const token = ++runToken;
   runCounter += 1;
   const requestId = `menu-${runCounter}`;
@@ -308,41 +310,23 @@ function startGenerate(editor: PlateEditor, action: CannedActionId | null, reque
 
   streamOff = bridge.onAiStreamed(({ requestId: id, delta }) => {
     if (id !== requestId || delta.length === 0 || runToken !== token) return;
-    editor.tf.addMark(AI_MARK, true);
-    editor.tf.insertText(delta);
+    stream.append(delta);
   });
 
   void bridge
     .generateInlineAi({ prompt: generatePromptFor(action, request, context), requestId })
     .then((result) => {
-      if (runToken !== token) {
-        startRef.unref();
-        return undefined;
-      }
+      if (runToken !== token) return undefined;
       streamOff?.();
       streamOff = null;
       activeRequestId = null;
-      const start = startRef.current;
-      startRef.unref();
-      const end = editor.selection?.anchor;
       if (!result.ok) {
-        if (start && end) editor.tf.delete({ at: { anchor: start, focus: end } });
+        unwindGenerate(editor);
         setOptions(editor, { status: "error", error: result.error });
         return undefined;
       }
-      // Fallback for models that don't stream: insert the final text now.
-      if (start && end && PointApi.equals(start, end)) {
-        editor.tf.addMark(AI_MARK, true);
-        editor.tf.insertText(result.text);
-      }
-      const focus = editor.selection?.anchor;
-      if (start && focus) {
-        // Sweep the mark across the whole streamed range (covers any splits).
-        editor.tf.setNodes(
-          { [AI_MARK]: true },
-          { at: { anchor: start, focus }, match: (n) => "text" in n, split: true },
-        );
-      }
+      // Fallback for models that don't stream: land the whole reply now.
+      if (stream.text().length === 0) stream.append(result.text);
       setOptions(editor, { status: "review" });
       return undefined;
     })
@@ -355,9 +339,9 @@ function startGenerate(editor: PlateEditor, action: CannedActionId | null, reque
     });
 }
 
-/** Keep the generated text: strip the highlight, close the menu. */
+/** Keep the generated blocks: strip the highlight, close the menu. */
 export function acceptGenerate(editor: PlateEditor): void {
-  editor.tf.unsetNodes([AI_MARK], { at: [], match: (n) => AI_MARK in n, mode: "lowest" });
+  stripAiMarks(editor);
   editor.tf.collapse({ edge: "end" });
   const at = editor.selection;
   setOptions(editor, { status: "closed", anchor: null, savedSelection: null, error: null });

--- a/packages/app/src/editor/ai/stream-markdown.ts
+++ b/packages/app/src/editor/ai/stream-markdown.ts
@@ -1,0 +1,147 @@
+// Incremental markdown parsing for the generate flow (#370): streamed deltas
+// accumulate as markdown TEXT, and each append re-parses the accumulated
+// stream through the owned pipeline (markdown-doc's parseMarkdown) and
+// reconciles the streamed block range in place — blocks whose parse didn't
+// change are left untouched; only the trailing block(s) the stream is still
+// refining get replaced. Headings, lists, bold, fences land as real blocks
+// instead of literal text in one paragraph.
+//
+// Pattern adapted from @platejs/ai's streamInsertChunk (MIT, © Ziad Beyens /
+// Udecode contributors — the utility Plate Plus' potion template drives).
+// Reworked rather than imported: the package's ai-sdk peer range (ai@7)
+// conflicts with ours (ai@6), and its per-chunk bookkeeping serializes the
+// trailing block back to markdown to keep appending — a whole
+// serialize/deserialize drift class we sidestep by re-parsing the full
+// accumulated text (generations are short; the parse is our owned pipeline)
+// and diffing parses structurally.
+//
+// Byte-safety: every inserted node — text AND element — is stamped with the
+// transient AI_MARK, so markdown-editor's save gate
+// (transient.ts::hasTransientAiState) freezes autosave for the whole stream
+// and the serializer predicate (transient.ts::shouldSerializeNode) drops the
+// streamed blocks wholesale if anything serializes mid-stream. Discard stays
+// the caller's undo-unwind: every mutation here runs through editor.tf, one
+// history batch per append.
+
+import { ElementApi, KEYS, NodeApi, TextApi, type Descendant, type SlateEditor } from "platejs";
+
+import { AI_MARK } from "@repo/app/editor/ai/ai-mark";
+import { parseMarkdown } from "@repo/app/editor/markdown/markdown-doc";
+
+/** Stamp the transient AI mark on every node (recursively), so the save gate
+ * and the serializer predicate cover the entire streamed range. */
+function stampAiMark(nodes: Descendant[]): Descendant[] {
+  return nodes.map((node) =>
+    TextApi.isText(node)
+      ? { ...node, [AI_MARK]: true }
+      : { ...node, [AI_MARK]: true, children: stampAiMark(node.children) },
+  );
+}
+
+/** Parse the accumulated stream. Mid-stream text can be transiently
+ * unparseable (a half-arrived tag) or out-of-vocabulary — degrade to plain
+ * paragraphs so the stream stays visible; a later append re-parses the full
+ * text and the reconcile heals the range. */
+function parseStreamed(md: string): Descendant[] {
+  if (md.trim().length === 0) return [];
+  const parsed = parseMarkdown(md);
+  if (parsed.ok && parsed.value.length > 0) return parsed.value;
+  return md.split(/\n{2,}/).flatMap((part) => {
+    const text = part.trim();
+    return text.length === 0 ? [] : [{ children: [{ text }], type: KEYS.p }];
+  });
+}
+
+/** Structural node equality (props + children, order-insensitive on keys) —
+ * how the reconcile decides a streamed block is settled. */
+function nodesEqual(a: Descendant, b: Descendant): boolean {
+  const aKeys = Object.keys(a);
+  if (aKeys.length !== Object.keys(b).length) return false;
+  for (const key of aKeys) {
+    if (key === "children") continue;
+    if (!Object.is(a[key], b[key])) return false;
+  }
+  const aChildren = ElementApi.isElement(a) ? a.children : null;
+  const bChildren = ElementApi.isElement(b) ? b.children : null;
+  if (aChildren === null || bChildren === null) return aChildren === bChildren;
+  if (aChildren.length !== bChildren.length) return false;
+  return aChildren.every((child, i) => {
+    const other = bChildren[i];
+    return other !== undefined && nodesEqual(child, other);
+  });
+}
+
+/** A plain empty paragraph the stream may replace (generating on a blank line
+ * must not leave the blank line behind; discard's undo restores it). Empty
+ * LIST items keep their bullet — only unadorned paragraphs qualify. */
+function isReplaceableSeed(node: Descendant): boolean {
+  return (
+    ElementApi.isElement(node) &&
+    node.type === KEYS.p &&
+    !("listStyleType" in node) &&
+    NodeApi.string(node).length === 0
+  );
+}
+
+/**
+ * Create a markdown stream inserting below the top-level block at
+ * `caretBlock` (or in its place when it's an empty plain paragraph). Assumes
+ * nothing else moves top-level blocks while the stream runs — the AI menu
+ * owns the surface for the duration.
+ */
+export function createMarkdownStream(
+  editor: SlateEditor,
+  caretBlock: number,
+): { append: (delta: string) => void; text: () => string } {
+  let text = "";
+  let anchor: number | null = null;
+  let blocks: Descendant[] = [];
+
+  const reconcile = (next: Descendant[]): void => {
+    editor.tf.withoutNormalizing(() => {
+      if (anchor === null) {
+        const seed = editor.api.node([caretBlock]);
+        const replaceSeed = seed !== undefined && isReplaceableSeed(seed[0]);
+        anchor = replaceSeed ? caretBlock : caretBlock + 1;
+        if (replaceSeed) editor.tf.removeNodes({ at: [caretBlock] });
+        editor.tf.insertNodes(next, { at: [anchor] });
+      } else {
+        // Replace only from the first block whose parse changed — settled
+        // blocks stay untouched (no flicker, minimal ops).
+        let stable = 0;
+        while (stable < blocks.length && stable < next.length) {
+          const prev = blocks[stable];
+          const parsed = next[stable];
+          if (prev === undefined || parsed === undefined || !nodesEqual(prev, parsed)) break;
+          stable += 1;
+        }
+        for (let i = blocks.length - 1; i >= stable; i--) {
+          editor.tf.removeNodes({ at: [anchor + i] });
+        }
+        if (stable < next.length) {
+          editor.tf.insertNodes(next.slice(stable), { at: [anchor + stable] });
+        }
+      }
+      const end = editor.api.end([anchor + next.length - 1]);
+      if (end) editor.tf.select(end);
+    });
+    blocks = next;
+  };
+
+  return {
+    append: (delta: string): void => {
+      if (delta.length === 0) return;
+      text += delta;
+      const next = stampAiMark(parseStreamed(text));
+      if (next.length === 0) return; // nothing visible yet (leading whitespace)
+      reconcile(next);
+    },
+    text: () => text,
+  };
+}
+
+/** Strip every transient AI_MARK stamp — accept: the parsed blocks become
+ * ordinary content and the byte-safety gate releases. */
+export function stripAiMarks(editor: SlateEditor): void {
+  editor.tf.unsetNodes([AI_MARK], { at: [], match: (n) => AI_MARK in n, mode: "all" });
+}

--- a/packages/app/src/editor/ai/transient-settle.ts
+++ b/packages/app/src/editor/ai/transient-settle.ts
@@ -1,0 +1,38 @@
+// Deterministic teardown for a pending AI suggestion session (#374).
+//
+// While suggestions are under review, the save buffer is frozen at the
+// pre-session bytes (transient.ts) — any typing the user interleaves rides
+// ONLY the live editor value. If the session is abandoned (tab replaced or
+// closed, folder switched, an explicit flush), that typing must not vanish
+// with the AI marks: the mounted editor registers a settler here, and
+// VaultProvider's flushTab invokes it BEFORE flushing — the settler resolves
+// the session reject-all (reject reverts only suggestion-marked ranges, so
+// the user's typing survives while the AI's proposal disappears) and returns
+// the settled markdown for the flush to persist.
+//
+// Mirrors the open-note-flush seam: the editor owns the implementation, this
+// module is just the wire. One rich editor mounts at a time, so one slot
+// suffices; the entry carries its path so flushing some OTHER tab never
+// settles the active editor's session.
+
+let current: { path: string; settle: () => string | null } | null = null;
+
+/** Wire the mounted editor's settler: `path` is the vault-relative file it
+ * serves; `settle` resolves any pending suggestion session (reject-all) and
+ * returns the settled markdown, or null when nothing was pending. Returns
+ * the unregister function. */
+export function registerTransientSettler(path: string, settle: () => string | null): () => void {
+  const entry = { path, settle };
+  current = entry;
+  return () => {
+    if (current === entry) current = null;
+  };
+}
+
+/** Settle the pending AI suggestion session of the editor mounted on `path`,
+ * if any. Returns the settled markdown when a session was resolved, else
+ * null (no editor on that path, or nothing pending). */
+export function settleTransients(path: string): string | null {
+  if (current === null || current.path !== path) return null;
+  return current.settle();
+}

--- a/packages/app/src/editor/ai/transient.ts
+++ b/packages/app/src/editor/ai/transient.ts
@@ -3,9 +3,11 @@
 //
 // 1. `shouldSerializeNode` (markdown-kit's allowNode.serialize): if transient
 //    nodes ever reach the serializer, the output is REJECT-EQUIVALENT —
-//    pending INSERT suggestions (proposed content) are dropped; remove/update
-//    suggestions keep their text (it's the user's original; the suggestion
-//    props have no markdown form and serialize to nothing).
+//    AI-streamed nodes (stream-markdown stamps AI_MARK on the whole inserted
+//    block, element AND texts) and pending INSERT suggestions (proposed
+//    content) are dropped; remove/update suggestions keep their text (it's
+//    the user's original; the suggestion props have no markdown form and
+//    serialize to nothing).
 // 2. `hasTransientAiState` (markdown-editor's onChange gate): while an AI
 //    stream or a suggestion session is touching the document, serialization
 //    is skipped entirely — the save buffer freezes at the pre-session bytes
@@ -15,7 +17,7 @@
 // mark-only `update` suggestions, which a node-level predicate can't revert);
 // the serializer predicate is defense in depth.
 
-import { ElementApi, KEYS, TextApi, type Descendant, type SlateEditor, type TText } from "platejs";
+import { ElementApi, KEYS, type Descendant, type SlateEditor } from "platejs";
 
 import { AI_MARK } from "@repo/app/editor/ai/ai-mark";
 
@@ -49,6 +51,10 @@ function suggestionDataList(node: Descendant): SuggestionDataLite[] {
 /**
  * allowNode.serialize predicate for the shared markdown kit. Excludes nodes
  * whose CONTENT is a pending AI proposal:
+ * - AI-streamed nodes (the generate flow stamps AI_MARK on every inserted
+ *   node — dropping the marked TEXTS alone would leave empty husk blocks, so
+ *   the marked ELEMENTS are excluded here too; disallowedNodes already drops
+ *   the texts),
  * - insert-type suggestion texts/inline elements (proposed text),
  * - insert-type block suggestions (proposed blocks) — except line-break
  *   inserts, whose children are original text that a proposed split merely
@@ -57,6 +63,7 @@ function suggestionDataList(node: Descendant): SuggestionDataLite[] {
  * the suggestion props themselves have no markdown form.
  */
 export function shouldSerializeNode(node: Descendant): boolean {
+  if (node[AI_MARK] === true) return false;
   return !suggestionDataList(node).some((data) => data.type === "insert" && !data.isLineBreak);
 }
 
@@ -65,24 +72,20 @@ export function shouldSerializeNode(node: Descendant): boolean {
  * don't need the package at runtime. Pinned by test against the real key. */
 export const TRANSIENT_SUGGESTION_KEY = `${KEYS.suggestion}Transient`;
 
-function isAiMarkedText(node: Descendant): node is TText {
-  return TextApi.isText(node) && node[AI_MARK] === true;
-}
-
 function isTransientSuggestionNode(node: Descendant): boolean {
   return node[TRANSIENT_SUGGESTION_KEY] === true;
 }
 
 /**
  * True while the document holds in-flight AI state: an ai-marked streaming
- * range or an unresolved (transient) suggestion. markdown-editor skips
- * serialization while this holds, freezing the save buffer at the
- * pre-session bytes.
+ * range (texts AND the stamped block elements — see stream-markdown) or an
+ * unresolved (transient) suggestion. markdown-editor skips serialization
+ * while this holds, freezing the save buffer at the pre-session bytes.
  */
 export function hasTransientAiState(editor: SlateEditor): boolean {
   const walk = (nodes: Descendant[]): boolean =>
     nodes.some((node) => {
-      if (isAiMarkedText(node) || isTransientSuggestionNode(node)) return true;
+      if (node[AI_MARK] === true || isTransientSuggestionNode(node)) return true;
       return ElementApi.isElement(node) && walk(node.children);
     });
   return walk(editor.children);

--- a/packages/app/src/editor/editor-pane.tsx
+++ b/packages/app/src/editor/editor-pane.tsx
@@ -11,7 +11,7 @@ import { useVault } from "@repo/app/workspace/vault-context";
  * composer.
  */
 export function EditorPane() {
-  const { editor, onEdit, isMarkdownOpen, richSafe, mode, renameEntry } = useVault();
+  const { editor, onEdit, editTab, isMarkdownOpen, richSafe, mode, renameEntry } = useVault();
   const selected = editor.path;
 
   const fileName = selected ? (selected.split("/").pop() ?? selected) : "";
@@ -96,9 +96,16 @@ export function EditorPane() {
       {showRich ? (
         <MarkdownEditor
           key={selected}
+          path={selected}
           value={editor.content}
           onChange={(md) => {
             if (md !== editor.content) onEdit(md);
+          }}
+          // Teardown settle (#374): route by the path THIS editor served —
+          // the closure captures `selected` from the render that mounted it,
+          // so a tab switch can't misdeliver the settled bytes.
+          onSettled={(md) => {
+            if (md !== editor.content) editTab(selected, md);
           }}
         />
       ) : (

--- a/packages/app/src/editor/markdown-editor.tsx
+++ b/packages/app/src/editor/markdown-editor.tsx
@@ -6,19 +6,23 @@
 // Thin by design (WP2): the plugin/component composition lives in
 // kits/editor-kit.ts (per-feature kit files whose Base halves compose the
 // headless serialization mirror — see kits/base-kit.ts); this file owns only
-// the seed/echo-dedupe lifecycle and the Plate surface.
+// the seed/echo-dedupe lifecycle, the transient-AI settle seam, and the Plate
+// surface.
 
-import { useEffect, useRef } from "react";
+import { useCallback, useEffect, useRef } from "react";
 import type { Value } from "platejs";
 import { Plate, usePlateEditor } from "platejs/react";
 import { serializeMd } from "@platejs/markdown";
 
+import { hasTransientSuggestions, resolveAllSuggestions } from "@repo/app/editor/ai/suggestions";
 import { hasTransientAiState } from "@repo/app/editor/ai/transient";
+import { registerTransientSettler } from "@repo/app/editor/ai/transient-settle";
 import { Editor, EditorContainer } from "@repo/app/editor/editor-chrome";
 import { WRITE_PLACEHOLDER } from "@repo/app/editor/kits/block-placeholder-kit";
 import { EDITOR_KIT } from "@repo/app/editor/kits/editor-kit";
 import { MD_STRINGIFY, parseMarkdown } from "@repo/app/editor/markdown/markdown-doc";
 import { TableOfContents } from "@repo/app/editor/toc";
+import { useAiReviewStore } from "@repo/app/stores/ai-review-store";
 
 // Seed markdown → Plate value through the owned pipeline. Unparseable content
 // is impossible behind the richSafe gate, but never crash the surface: fall
@@ -31,14 +35,23 @@ function seedValue(md: string): Value {
 }
 
 type Props = {
+  /** Vault-relative path this editor serves — keys the transient-settle seam
+   * so a flush of some OTHER tab never resolves this editor's AI session. */
+  path: string;
   /** Markdown to render. Seeds the editor on mount and re-seeds it when the
    * prop changes externally (a vault reload / file switch) — see the effect. */
   value: string;
   /** Called with serialized markdown on every change. */
   onChange: (markdown: string) => void;
+  /** Teardown escape hatch (#374): called with the settled markdown when the
+   * editor unmounts while an AI suggestion session was still pending
+   * (reject-all — the user's typing survives, the AI marks disappear). The
+   * OWNER must route these bytes by `path`: by unmount time the active tab
+   * may already have changed, so the normal onChange must not carry them. */
+  onSettled: (markdown: string) => void;
 };
 
-export function MarkdownEditor({ value, onChange }: Props) {
+export function MarkdownEditor({ path, value, onChange, onSettled }: Props) {
   const editor = usePlateEditor({
     plugins: EDITOR_KIT,
     value: () => seedValue(value),
@@ -67,10 +80,51 @@ export function MarkdownEditor({ value, onChange }: Props) {
     seeded.current = serializeMd(editor, { remarkStringifyOptions: MD_STRINGIFY });
   }, [value, editor]);
 
+  // ---- Transient-AI settle seam (#374) -------------------------------------
+  // While a suggestion session pends, autosave is frozen (the gate below) and
+  // any typing the user interleaves exists ONLY in this editor's value.
+  // Abandoning the session must not drop it: settle resolves reject-all (the
+  // user's typing survives; the AI proposal reverts) and hands back the
+  // settled markdown. The Plate onChange is suppressed for the duration —
+  // settled bytes reach exactly ONE controller, routed by the caller.
+  const settling = useRef(false);
+  const settleSuggestions = useCallback((): string | null => {
+    if (!hasTransientSuggestions(editor)) return null;
+    settling.current = true;
+    try {
+      resolveAllSuggestions(editor, "reject");
+    } finally {
+      settling.current = false;
+    }
+    const md = serializeMd(editor, { remarkStringifyOptions: MD_STRINGIFY });
+    // The settled bytes round back as the value prop — don't re-seed on them.
+    lastValueProp.current = md;
+    return md;
+  }, [editor]);
+
+  // Flush path: VaultProvider settles through this registration BEFORE
+  // flushing this file (tab replace/close, folder switch, explicit flush).
+  useEffect(() => registerTransientSettler(path, settleSuggestions), [path, settleSuggestions]);
+
+  // Unmount path (tab switch without a flush, raw-mode flip, surface change):
+  // settle and hand the bytes to the owner for path-routed persistence.
+  const onSettledRef = useRef(onSettled);
+  onSettledRef.current = onSettled;
+  useEffect(
+    () => () => {
+      const md = settleSuggestions();
+      if (md !== null) onSettledRef.current(md);
+      useAiReviewStore.getState().setReviewing(false);
+    },
+    [settleSuggestions],
+  );
+
   return (
     <Plate
       editor={editor}
       onChange={() => {
+        // Teardown settle routes its bytes itself (see settleSuggestions).
+        if (settling.current) return;
         // Selection-only flushes (caret moves, slate-react selection
         // re-syncs) never change bytes — skip the serialize pass and the
         // vault-context re-render it would otherwise trigger on every caret
@@ -80,8 +134,12 @@ export function MarkdownEditor({ value, onChange }: Props) {
         // session is touching the document, freeze the save buffer at the
         // pre-session bytes — the marks are UI state, never content. The
         // resolving edit (accept/reject/discard) clears the transients and
-        // the next onChange serializes the settled document.
-        if (hasTransientAiState(editor)) return;
+        // the next onChange serializes the settled document. The header's
+        // save badge surfaces the suggestion freeze as "Reviewing
+        // suggestions" via the store.
+        const reviewing = hasTransientSuggestions(editor);
+        useAiReviewStore.getState().setReviewing(reviewing);
+        if (reviewing || hasTransientAiState(editor)) return;
         const md = serializeMd(editor, { remarkStringifyOptions: MD_STRINGIFY });
         // Drop the echo a programmatic (re)seed produces — only real edits,
         // which diverge from the seeded text, propagate.

--- a/packages/app/src/layout/header.tsx
+++ b/packages/app/src/layout/header.tsx
@@ -14,6 +14,7 @@ import { SidebarTrigger, useSidebar } from "@repo/ui/components/sidebar";
 import { cn } from "@repo/ui/lib/utils";
 
 import { describeRawReason } from "@repo/app/editor/markdown/markdown-doc";
+import { useAiReviewStore } from "@repo/app/stores/ai-review-store";
 import { useVault } from "@repo/app/workspace/vault-context";
 
 /**
@@ -37,6 +38,9 @@ export function Header() {
     deleteEntry,
   } = useVault();
   const { state } = useSidebar();
+  // While an AI suggestion session pends, autosave is frozen (the transient
+  // gate) — say so instead of silently reading "Saved" over stale bytes.
+  const reviewing = useAiReviewStore((s) => s.reviewing);
   const path = editor.path;
   const segments = path ? path.split("/") : [];
 
@@ -112,8 +116,22 @@ export function Header() {
               ))}
             </div>
           )}
-          <Badge variant="dot" className="text-muted-foreground">
-            {editor.saving ? "Saving…" : editor.dirty ? "Unsaved" : "Saved"}
+          <Badge
+            variant="dot"
+            className="text-muted-foreground"
+            title={
+              reviewing
+                ? "Saving is paused while AI suggestions await review — resolve or leave to settle them"
+                : undefined
+            }
+          >
+            {reviewing
+              ? "Reviewing suggestions"
+              : editor.saving
+                ? "Saving…"
+                : editor.dirty
+                  ? "Unsaved"
+                  : "Saved"}
           </Badge>
           <Button
             variant="ghost"

--- a/packages/app/src/stores/ai-review-store.ts
+++ b/packages/app/src/stores/ai-review-store.ts
@@ -1,0 +1,19 @@
+import { create } from "zustand";
+
+// Whether the mounted rich editor holds an unresolved AI suggestion session.
+// While one pends, autosave is frozen at the pre-session bytes (see
+// editor/ai/transient.ts) — the header's save badge reads this store to show
+// "Reviewing suggestions" instead of silently claiming Saved (#374). Written
+// by markdown-editor's onChange (and cleared on unmount); read by the header.
+
+type AiReviewStore = {
+  reviewing: boolean;
+  setReviewing: (reviewing: boolean) => void;
+};
+
+export const useAiReviewStore = create<AiReviewStore>((set, get) => ({
+  reviewing: false,
+  setReviewing: (reviewing) => {
+    if (get().reviewing !== reviewing) set({ reviewing });
+  },
+}));

--- a/packages/app/src/workspace/vault-context.tsx
+++ b/packages/app/src/workspace/vault-context.tsx
@@ -13,6 +13,7 @@ import {
 import { toast } from "@repo/ui/components/sonner";
 
 import { getBridge } from "@repo/app/lib/bridge";
+import { settleTransients } from "@repo/app/editor/ai/transient-settle";
 import { registerOpenNoteFlush, registerOpenNotePath } from "@repo/app/workspace/open-note-flush";
 import {
   type RawReason,
@@ -128,6 +129,12 @@ type VaultContextValue = {
   isTabDirty: (path: string) => boolean;
   /** Record an edit to the active tab's buffer (debounced autosave). */
   onEdit: (content: string) => void;
+  /** Record an edit to a SPECIFIC tab's buffer (debounced autosave). The
+   * editor's teardown settle path (#374) routes through this — by the time an
+   * unmounting editor settles a pending AI session, the active tab may
+   * already have changed, so the bytes carry their own path. No-op when the
+   * tab has no live runtime (e.g. it was deleted). */
+  editTab: (path: string, content: string) => void;
   /** Create a file at `path` (e.g. "folder/note.md") and open it. */
   createFile: (path: string) => Promise<void>;
   /** Create an empty file WITHOUT opening it (wiki create-on-complete). An
@@ -260,10 +267,19 @@ export function VaultProvider({ children }: { children: ReactNode }) {
     [notifyTab],
   );
 
-  /** Flush one tab's pending edits (clearing its debounce). True when clean. */
+  /** Flush one tab's pending edits (clearing its debounce). True when clean.
+   * A pending AI suggestion session on this file is settled first (#374):
+   * reject-all reverts only the suggestion-marked ranges, so typing the user
+   * interleaved during the review persists while the AI marks disappear —
+   * without this, the flush would write the frozen pre-session buffer and
+   * the typing would die with the unmounting editor. */
   const flushTab = useCallback(async (path: string): Promise<boolean> => {
     const runtime = runtimes.current.get(path);
     if (!runtime) return true;
+    const settled = settleTransients(path);
+    if (settled !== null && settled !== runtime.controller.getState().content) {
+      runtime.controller.edit(settled);
+    }
     if (runtime.saveTimer) {
       clearTimeout(runtime.saveTimer);
       runtime.saveTimer = null;
@@ -375,9 +391,8 @@ export function VaultProvider({ children }: { children: ReactNode }) {
     })();
   }, []);
 
-  const onEdit = useCallback((next: string) => {
-    const active = sessionRef.current.active;
-    const runtime = active !== null ? runtimes.current.get(active) : undefined;
+  const editTab = useCallback((path: string, next: string) => {
+    const runtime = runtimes.current.get(path);
     if (!runtime) return;
     runtime.controller.edit(next);
     if (runtime.saveTimer) clearTimeout(runtime.saveTimer);
@@ -386,6 +401,14 @@ export function VaultProvider({ children }: { children: ReactNode }) {
       void runtime.controller.flush();
     }, AUTOSAVE_DEBOUNCE_MS);
   }, []);
+
+  const onEdit = useCallback(
+    (next: string) => {
+      const active = sessionRef.current.active;
+      if (active !== null) editTab(active, next);
+    },
+    [editTab],
+  );
 
   const createFileAt = useCallback(
     async (rawPath: string): Promise<boolean> => {
@@ -663,6 +686,7 @@ export function VaultProvider({ children }: { children: ReactNode }) {
       subscribeTab,
       isTabDirty,
       onEdit,
+      editTab,
       createFile,
       createFileAt,
       renameEntry,
@@ -690,6 +714,7 @@ export function VaultProvider({ children }: { children: ReactNode }) {
       subscribeTab,
       isTabDirty,
       onEdit,
+      editTab,
       createFile,
       createFileAt,
       renameEntry,


### PR DESCRIPTION
Two AI-surface polish items from the acceptance ledger.

- **Fixes #370**: generate-intent streams now parse as markdown — deltas accumulate and re-parse through the owned pipeline per append, reconciling settled blocks structurally (unparseable mid-stream text degrades to paragraphs and self-heals). Every inserted node carries the transient AI mark, and the serializer defense grew element arms so stamped blocks drop wholesale from mid-stream saves. `@platejs/ai` not imported (ai@7 peer conflict; per-chunk reserialization drift) — pattern adapted with attribution. Discard = undo-unwind; accept = strip marks → canonical bytes.
- **Fixes #374**: a settle seam rejects-all pending suggestions **before** any flush/teardown path (tab close/replace/rename/unmount), so interleaved user typing persists byte-for-byte while AI marks vanish — pinned by test. The save badge now reads "Reviewing suggestions" during the freeze instead of silently holding.

341 app tests green; live-driven both flows with Raw-mode byte checks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes autosave, serialization gates, and tab flush ordering—areas where bugs could drop user edits—but behavior is heavily tested and scoped to AI transient state.
> 
> **Overview**
> **Generate flow (#370)** no longer appends raw text at the caret. Streamed deltas accumulate as markdown, re-parse on each chunk via the owned pipeline, and render as headings, lists, fences, etc. under a transient mark stamped on whole blocks (not just text). `ai-session` wires the bridge stream through `createMarkdownStream`; accept strips marks, discard still undo-unwinds. Serializer and transient gates now drop or freeze **element-level** AI-marked blocks so mid-stream saves stay pre-generation bytes. The dev harness streams multi-block canned markdown to exercise this.
> 
> **Suggestion teardown (#374)** adds a path-keyed settle registry: before tab flush/close (and on editor unmount), pending edit suggestions are **reject-all** so only suggestion ranges revert while typing during review survives. Vault flush applies settled markdown via new **`editTab(path, …)`**; unmount uses **`onSettled`** routed by file path. The header save badge shows **"Reviewing suggestions"** while the autosave freeze is active (zustand store).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7149eecec3a81d3983a369b413859ce8dea23d52. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Streamed generation now parses markdown into real blocks and never saves mid-stream. Rejecting a pending suggestion review no longer drops user typing. Fixes #370 and #374.

- **Bug Fixes**
  - Generation: deltas re-parse as markdown and reconcile settled blocks; headings/lists/fences/bold land as real blocks; autosave is frozen mid-stream; discard undoes inserts; accept strips transient marks; tests cover streaming, convergence, and serializer defense.
  - Suggestions: teardown settles before any flush/unmount so interleaved typing persists while proposed changes are rejected; unmount path routes settled bytes by file; header shows “Reviewing suggestions” during the freeze; tests verify teardown and registry behavior.

<sup>Written for commit 7149eecec3a81d3983a369b413859ce8dea23d52. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kyh/inteligir/pull/384?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

