### PR TITLE
feat: knowledge index learns images/attachments

### DIFF
--- a/packages/app/dev/fixture-bridge.ts
+++ b/packages/app/dev/fixture-bridge.ts
@@ -353,8 +353,22 @@ function cannedEditResponse(prompt: string): string | null {
   return `${rewritten}\n\nA canned closing thought from the dev harness.`;
 }
 
+// A non-doc vault file so attachment flows are exercisable in the harness:
+// the `[[` picker's Attachments group, `![[diagram.png]]` resolution, and
+// asset rename-rewrite. The Map is string-valued, so a placeholder stands in
+// for the binary bytes — listVault classifies by extension, and the knowledge
+// engine only ever needs the PATH of a non-doc file. Kept out of SAMPLE_NOTES:
+// that record is the markdown-corpus test's contract (every entry must
+// classify as a doc).
+const SAMPLE_ASSETS: Record<string, string> = {
+  "wiki/diagram.png": "png-placeholder (dev harness fixture, not real image bytes)",
+};
+
 export function createFixtureBridge(): Bridge {
-  const vault = new Map<string, string>(Object.entries(SAMPLE_NOTES));
+  const vault = new Map<string, string>([
+    ...Object.entries(SAMPLE_NOTES),
+    ...Object.entries(SAMPLE_ASSETS),
+  ]);
   // Ghost text defaults ON in the harness — there is no cost here and the
   // whole AI surface should be drivable out of the box.
   const uiState: Record<string, unknown> = { [GHOST_TEXT_ENABLED_UI_STATE]: true };

--- a/packages/app/src/__tests__/fixture-knowledge.test.ts
+++ b/packages/app/src/__tests__/fixture-knowledge.test.ts
@@ -54,6 +54,35 @@ describe("fixture bridge knowledge channels", () => {
     expect(await bridge.getBacklinks({ path: "review/probe renamed.md" })).toEqual([]);
   });
 
+  it("lists the seeded attachment as a grouped asset target, after docs", async () => {
+    const bridge = createFixtureBridge();
+    const targets = await bridge.listWikiTargets();
+    const asset = targets.find((t) => t.path === "wiki/diagram.png");
+    expect(asset).toEqual({ path: "wiki/diagram.png", title: "diagram.png", type: "asset" });
+    // Docs first, assets after — the picker renders the groups in this order.
+    const firstAssetIndex = targets.findIndex((t) => t.type === "asset");
+    expect(targets.slice(0, firstAssetIndex).every((t) => t.type === "doc")).toBe(true);
+    expect(targets.slice(firstAssetIndex).every((t) => t.type === "asset")).toBe(true);
+  });
+
+  it("renaming an asset rewrites md image and wiki embed references", async () => {
+    const bridge = createFixtureBridge();
+    await bridge.writeVaultDoc({
+      path: "review/gallery.md",
+      content: "shot ![alt](../wiki/diagram.png), embed ![[diagram.png]]\n",
+    });
+
+    const renamed = await bridge.renameVaultEntry({
+      from: "wiki/diagram.png",
+      to: "assets/schematic.png",
+    });
+    expect(renamed.ok).toBe(true);
+    expect(await bridge.readVaultDoc({ path: "review/gallery.md" })).toBe(
+      "shot ![alt](../assets/schematic.png), embed ![[schematic.png]]\n",
+    );
+    expect(await bridge.getBacklinks({ path: "assets/schematic.png" })).toHaveLength(2);
+  });
+
   it("refuses a clobbering rename like the host", async () => {
     const bridge = createFixtureBridge();
     await bridge.writeVaultDoc({ path: "a.md", content: "A\n" });

--- a/packages/app/src/__tests__/wiki-autocomplete.test.ts
+++ b/packages/app/src/__tests__/wiki-autocomplete.test.ts
@@ -91,6 +91,24 @@ describe("picker completion", () => {
     expect(out(editor)).toBe("see ![[target note]]\n");
   });
 
+  it("an attachment pick forces a wikiEmbed even from a plain [[", () => {
+    const editor = makeEditor("see ");
+    const element = openWikiPicker(editor);
+    commitComboboxInput(editor, element, false);
+    insertWikiChipFromPicker(editor, "diagram.png", true);
+    expect(findByType(editor, "wikiEmbed")?.body).toBe("diagram.png");
+    expect(findByType(editor, "wikiLink")).toBeNull();
+    expect(out(editor)).toBe("see ![[diagram.png]]\n");
+  });
+
+  it("a forced embed after ![[ still consumes the bang (no double bang)", () => {
+    const editor = makeEditor("see !");
+    const element = openWikiPicker(editor);
+    commitComboboxInput(editor, element, false);
+    insertWikiChipFromPicker(editor, "diagram.png", true);
+    expect(out(editor)).toBe("see ![[diagram.png]]\n");
+  });
+
   it("keeps typing after completion in the text flow (caret escaped the void)", () => {
     const editor = makeEditor("");
     const element = openWikiPicker(editor);

--- a/packages/app/src/editor/wiki-autocomplete.tsx
+++ b/packages/app/src/editor/wiki-autocomplete.tsx
@@ -1,13 +1,16 @@
 // `[[` wiki autocomplete — the third inline-combobox consumer (after slash
 // and emoji). Typing `[` after `[` swaps in a trigger element listing every
-// linkable note (listWikiTargets, fuzzy-filtered); Enter/click completes the
-// chip and the closing brackets. `|alias` and `#anchor` typed into the query
-// pass straight through into the chip body, typing `]]` completes verbatim
-// (fluent-typing parity with the kit's `]]` input rule), and an unresolved
-// query offers a create-note entry that also inserts the (now-resolving) chip.
+// linkable target (listWikiTargets, fuzzy-filtered): notes first, then
+// attachments in their own group — picking an attachment inserts an
+// `![[embed]]` chip (a bare link to a binary renders nothing useful).
+// Enter/click completes the chip and the closing brackets. `|alias` and
+// `#anchor` typed into the query pass straight through into the chip body,
+// typing `]]` completes verbatim (fluent-typing parity with the kit's `]]`
+// input rule), and an unresolved query offers a create-note entry that also
+// inserts the (now-resolving) chip.
 
 import { useCallback, useEffect, useState } from "react";
-import { FilePlusIcon, FileTextIcon } from "lucide-react";
+import { FilePlusIcon, FileTextIcon, PaperclipIcon } from "lucide-react";
 import { KEYS, createTSlatePlugin, type PluginConfig } from "platejs";
 import { PlateElement, createPlatePlugin, type PlateElementProps } from "platejs/react";
 import {
@@ -23,6 +26,7 @@ import {
   InlineComboboxContent,
   InlineComboboxEmpty,
   InlineComboboxGroup,
+  InlineComboboxGroupLabel,
   InlineComboboxItem,
   InlineComboboxInput,
   type FilterFn,
@@ -70,7 +74,10 @@ function WikiInputElement(props: PlateElementProps) {
 
   const typed = parseWikiBody(value);
 
-  const complete = useCallback((body: string) => insertWikiChipFromPicker(editor, body), [editor]);
+  const complete = useCallback(
+    (body: string, embed = false) => insertWikiChipFromPicker(editor, body, embed),
+    [editor],
+  );
 
   // Typing the closing `]]` completes the chip verbatim, exactly like the
   // editor-level input rule would have without the picker in the way.
@@ -88,6 +95,36 @@ function WikiInputElement(props: PlateElementProps) {
 
   const showCreate = typed.target !== "" && resolveWikiTarget(typed.target) === null;
 
+  // The engine returns docs first, assets after; split so each renders in its
+  // own labeled group. Picking an attachment inserts an embed (`![[asset]]`).
+  const notes = targets.filter((target) => target.type === "doc");
+  const assets = targets.filter((target) => target.type === "asset");
+
+  const itemFor = (target: WikiTarget) => (
+    <InlineComboboxItem
+      key={target.path}
+      value={target.path}
+      label={target.title}
+      keywords={[target.title]}
+      onClick={() =>
+        complete(
+          composeWikiBody(wikiBodyForPath(target.path, resolveWikiTarget), typed),
+          target.type === "asset",
+        )
+      }
+    >
+      {target.type === "doc" ? (
+        <FileTextIcon className="mr-2 text-muted-foreground" />
+      ) : (
+        <PaperclipIcon className="mr-2 text-muted-foreground" />
+      )}
+      <span className="flex min-w-0 flex-1 items-baseline gap-2">
+        <span className="truncate">{target.title}</span>
+        <span className="truncate text-xs text-muted-foreground">{target.path}</span>
+      </span>
+    </InlineComboboxItem>
+  );
+
   return (
     <PlateElement {...props} as="span">
       <InlineCombobox
@@ -101,23 +138,7 @@ function WikiInputElement(props: PlateElementProps) {
         <InlineComboboxContent>
           <InlineComboboxEmpty>No notes found</InlineComboboxEmpty>
           <InlineComboboxGroup>
-            {targets.map((target) => (
-              <InlineComboboxItem
-                key={target.path}
-                value={target.path}
-                label={target.title}
-                keywords={[target.title]}
-                onClick={() =>
-                  complete(composeWikiBody(wikiBodyForPath(target.path, resolveWikiTarget), typed))
-                }
-              >
-                <FileTextIcon className="mr-2 text-muted-foreground" />
-                <span className="flex min-w-0 flex-1 items-baseline gap-2">
-                  <span className="truncate">{target.title}</span>
-                  <span className="truncate text-xs text-muted-foreground">{target.path}</span>
-                </span>
-              </InlineComboboxItem>
-            ))}
+            {notes.map(itemFor)}
             {showCreate && (
               <InlineComboboxItem
                 value={CREATE_VALUE}
@@ -135,6 +156,12 @@ function WikiInputElement(props: PlateElementProps) {
               </InlineComboboxItem>
             )}
           </InlineComboboxGroup>
+          {assets.length > 0 && (
+            <InlineComboboxGroup>
+              <InlineComboboxGroupLabel>Attachments</InlineComboboxGroupLabel>
+              {assets.map(itemFor)}
+            </InlineComboboxGroup>
+          )}
         </InlineComboboxContent>
       </InlineCombobox>
       {children}

--- a/packages/app/src/editor/wiki-insert.ts
+++ b/packages/app/src/editor/wiki-insert.ts
@@ -12,11 +12,18 @@ import { insertVoidAndEscape } from "@repo/app/editor/insert-void";
  * At that point the caret sits right after the literal `[` that preceded the
  * trigger (the FIRST bracket of `[[` — withTriggerCombobox swallowed the
  * second). Consume it, and when a `!` precedes it (`![[`), consume that too
- * and insert a wikiEmbed instead of a wikiLink.
+ * and insert a wikiEmbed instead of a wikiLink. `forceEmbed` inserts a
+ * wikiEmbed regardless (attachment picks embed as `![[asset]]` even from a
+ * plain `[[` — a bare `[[img.png]]` link would render nothing useful); any
+ * preceding `!` is still consumed so `![[` + attachment can't double up.
  */
-export function insertWikiChipFromPicker(editor: SlateEditor, body: string): void {
+export function insertWikiChipFromPicker(
+  editor: SlateEditor,
+  body: string,
+  forceEmbed = false,
+): void {
   editor.tf.deleteBackward("character"); // the "[" the trigger left in the text
-  let type = "wikiLink";
+  let type = forceEmbed ? "wikiEmbed" : "wikiLink";
   const selection = editor.selection;
   if (selection && editor.api.isCollapsed()) {
     const before = editor.api.before(selection.anchor);

--- a/packages/core/src/__tests__/knowledge-index.test.ts
+++ b/packages/core/src/__tests__/knowledge-index.test.ts
@@ -15,6 +15,8 @@ function seeded(): KnowledgeIndex {
       "",
       "Md link to [other](../notes/other.md).",
       "",
+      "Image: ![the diagram](../diagram.png)",
+      "",
     ].join("\n"),
   );
   index.setDoc("wiki/target note.md", "# Target note\n\nBody text.\n");
@@ -48,6 +50,18 @@ describe("KnowledgeIndex — backlinks", () => {
     expect(seeded().backlinks("wiki/hub.md")).toHaveLength(1); // via [[hub]]
     expect(seeded().backlinks("nowhere.md")).toEqual([]);
   });
+
+  it("answers asset backlinks: wiki embeds AND md images", () => {
+    const backlinks = seeded().backlinks("diagram.png");
+    expect(backlinks).toHaveLength(2);
+    expect(backlinks[0]).toMatchObject({ sourcePath: "wiki/hub.md", kind: "wiki", embed: true });
+    expect(backlinks[1]).toMatchObject({
+      sourcePath: "wiki/hub.md",
+      kind: "image",
+      embed: true,
+      alias: "the diagram",
+    });
+  });
 });
 
 describe("KnowledgeIndex — forward links", () => {
@@ -58,7 +72,14 @@ describe("KnowledgeIndex — forward links", () => {
     expect(byTarget.get("missing note")?.targetPath).toBeNull();
     expect(byTarget.get("diagram.png")).toMatchObject({
       targetPath: "diagram.png",
+      kind: "wiki",
       embed: true,
+    });
+    expect(byTarget.get("../diagram.png")).toMatchObject({
+      targetPath: "diagram.png",
+      kind: "image",
+      embed: true,
+      alias: "the diagram",
     });
     expect(byTarget.get("../notes/other.md")?.targetPath).toBe("notes/other.md");
   });
@@ -70,7 +91,6 @@ describe("KnowledgeIndex — graph", () => {
     const ids = graph.nodes.map((n) => n.id);
     expect(ids).toContain("wiki/hub.md");
     expect(ids).toContain("wiki/target note.md");
-    expect(ids).toContain("diagram.png");
     const phantom = graph.nodes.find((n) => n.phantom);
     expect(phantom).toMatchObject({ id: "phantom:missing note", title: "missing note" });
     expect(phantom?.path).toBeUndefined();
@@ -86,8 +106,21 @@ describe("KnowledgeIndex — graph", () => {
     expect(mdEdge?.kind).toBe("md");
 
     const hub = graph.nodes.find((n) => n.id === "wiki/hub.md");
-    // hub edges: ->target, ->phantom, ->diagram, ->other, <-other = 5 touching.
-    expect(hub?.degree).toBe(5);
+    // hub edges: ->target, ->phantom, ->other, <-other = 4 touching (asset
+    // references stay off the graph).
+    expect(hub?.degree).toBe(4);
+  });
+
+  it("keeps the graph a notes graph: no asset nodes, edges, or phantoms", () => {
+    const index = seeded();
+    index.setDoc("gallery.md", "![](../diagram.png) and ![gone](missing.png) and [[lost.pdf]]\n");
+    const graph = index.graph();
+    const ids = graph.nodes.map((n) => n.id);
+    // Resolved asset target: excluded even for the wiki embed in hub.md.
+    expect(ids).not.toContain("diagram.png");
+    // Dangling asset-extension targets never become phantom "create" nodes.
+    expect(ids.filter((id) => id.startsWith("phantom:"))).toEqual(["phantom:missing note"]);
+    expect(graph.edges.some((e) => e.source === "gallery.md")).toBe(false);
   });
 
   it("collapses a self-link into one edge counted once in the degree", () => {
@@ -150,11 +183,12 @@ describe("KnowledgeIndex — incremental updates", () => {
 });
 
 describe("KnowledgeIndex — wiki targets and search", () => {
-  it("lists docs (not assets) with titles, sorted by path", () => {
+  it("lists docs first, then attachments, each sorted by path and type-flagged", () => {
     expect(seeded().wikiTargets()).toEqual([
-      { path: "notes/other.md", title: "Other" },
-      { path: "wiki/hub.md", title: "Hub" },
-      { path: "wiki/target note.md", title: "Target note" },
+      { path: "notes/other.md", title: "Other", type: "doc" },
+      { path: "wiki/hub.md", title: "Hub", type: "doc" },
+      { path: "wiki/target note.md", title: "Target note", type: "doc" },
+      { path: "diagram.png", title: "diagram.png", type: "asset" },
     ]);
   });
 
@@ -168,6 +202,8 @@ describe("KnowledgeIndex — wiki targets and search", () => {
   it("falls back to the filename title for headingless docs", () => {
     const index = new KnowledgeIndex();
     index.setDoc("plain notes.md", "just text\n");
-    expect(index.wikiTargets()).toEqual([{ path: "plain notes.md", title: "plain notes" }]);
+    expect(index.wikiTargets()).toEqual([
+      { path: "plain notes.md", title: "plain notes", type: "doc" },
+    ]);
   });
 });

--- a/packages/core/src/__tests__/link-extract.test.ts
+++ b/packages/core/src/__tests__/link-extract.test.ts
@@ -138,8 +138,11 @@ describe("scanDoc — standard md links", () => {
     expect(links(src)).toHaveLength(0);
   });
 
-  it("skips images and asset links", () => {
-    expect(links("![alt](diagram.png) and [pdf](paper.pdf)")).toHaveLength(0);
+  it("extracts asset links as md links (rename safety beats note-only graphs)", () => {
+    const src = "[pdf](paper.pdf)";
+    const link = only(src);
+    expect(link).toMatchObject({ kind: "md", embed: false, target: "paper.pdf", alias: "pdf" });
+    expect(sliceTarget(src, link)).toBe("paper.pdf");
   });
 
   it("extracts reference definitions", () => {
@@ -150,9 +153,68 @@ describe("scanDoc — standard md links", () => {
     expect(all[0] ? sliceTarget(src, all[0]) : null).toBe("notes/other.md");
   });
 
+  it("extracts asset-target reference definitions", () => {
+    const src = "![shot][ref]\n\n[ref]: img/shot.png\n";
+    const all = links(src);
+    expect(all).toHaveLength(1);
+    expect(all[0]).toMatchObject({ kind: "md", target: "img/shot.png" });
+    expect(all[0] ? sliceTarget(src, all[0]) : null).toBe("img/shot.png");
+  });
+
   it("extracts a wiki link nested in an md link label", () => {
     const src = "[[inner]] and [label](outer.md)";
     expect(links(src).map((l) => l.target)).toEqual(["inner", "outer.md"]);
+  });
+});
+
+describe("scanDoc — md images", () => {
+  it("extracts an image as a distinct embed kind with alt as alias", () => {
+    const src = "see ![a diagram](img/diagram.png) here";
+    const link = only(src);
+    expect(link).toMatchObject({
+      kind: "image",
+      embed: true,
+      target: "img/diagram.png",
+      alias: "a diagram",
+      line: 1,
+    });
+    expect(src.slice(link.span.start, link.span.end)).toBe("![a diagram](img/diagram.png)");
+    expect(sliceTarget(src, link)).toBe("img/diagram.png");
+  });
+
+  it("omits the alias for an empty alt", () => {
+    const link = only("![](shot.png)");
+    expect(link.alias).toBeUndefined();
+    expect(link.target).toBe("shot.png");
+  });
+
+  it("percent-decodes the target but records the raw span", () => {
+    const src = "![x](my%20pic.png)";
+    const link = only(src);
+    expect(link.target).toBe("my pic.png");
+    expect(sliceTarget(src, link)).toBe("my%20pic.png");
+  });
+
+  it("handles angle-bracket destinations (span excludes the brackets)", () => {
+    const src = "![x](<my pic.png>)";
+    const link = only(src);
+    expect(link.target).toBe("my pic.png");
+    expect(sliceTarget(src, link)).toBe("my pic.png");
+  });
+
+  it("locates the destination past a bracketed alt", () => {
+    const src = "![see [inner] note](pic.png)";
+    const link = only(src);
+    expect(link.target).toBe("pic.png");
+    expect(sliceTarget(src, link)).toBe("pic.png");
+  });
+
+  it("skips external image urls", () => {
+    expect(links("![x](https://example.com/pic.png)")).toHaveLength(0);
+  });
+
+  it("ignores images inside fenced code", () => {
+    expect(links("```\n![x](pic.png)\n```\n")).toHaveLength(0);
   });
 });
 

--- a/packages/core/src/__tests__/rename-links.test.ts
+++ b/packages/core/src/__tests__/rename-links.test.ts
@@ -143,6 +143,61 @@ describe("computeRenameEdits — md links", () => {
   });
 });
 
+describe("computeRenameEdits — asset renames", () => {
+  it("rewrites md image links byte-surgically, preserving alt, ./ style, and encoding", () => {
+    const hub =
+      "Shot: ![the alt](old%20pic.png), styled ![x](./old%20pic.png), bare ![](<old pic.png>).\n";
+    const result = edits({ "hub.md": hub }, "old pic.png", "img/new pic.png", ["old pic.png"]);
+    expect(result.get("hub.md")).toBe(
+      "Shot: ![the alt](img/new%20pic.png), styled ![x](./img/new%20pic.png), bare ![](<img/new%20pic.png>).\n",
+    );
+  });
+
+  it("rewrites every reference form to a renamed asset in one pass", () => {
+    const hub = [
+      "Embed ![[pic.png]], image ![alt](pic.png), link [download](pic.png).",
+      "",
+      "![ref image][shot]",
+      "",
+      "[shot]: pic.png",
+      "",
+    ].join("\n");
+    const result = edits({ "hub.md": hub }, "pic.png", "assets/photo.png", ["pic.png"]);
+    expect(result.get("hub.md")).toBe(
+      [
+        "Embed ![[photo.png]], image ![alt](assets/photo.png), link [download](assets/photo.png).",
+        "",
+        "![ref image][shot]",
+        "",
+        "[shot]: assets/photo.png",
+        "",
+      ].join("\n"),
+    );
+  });
+
+  it("never rewrites images inside fences", () => {
+    const hub = "![x](pic.png)\n\n```\n![x](pic.png) stays\n```\n";
+    const result = edits({ "hub.md": hub }, "pic.png", "new.png", ["pic.png"]);
+    expect(result.get("hub.md")).toBe("![x](new.png)\n\n```\n![x](pic.png) stays\n```\n");
+  });
+
+  it("re-bases the moved doc's own outgoing image urls", () => {
+    const result = edits({ "a/doc.md": "![shot](shot.png)\n" }, "a/doc.md", "b/c/doc.md", [
+      "a/shot.png",
+    ]);
+    expect(result.get("b/c/doc.md")).toBe("![shot](../../a/shot.png)\n");
+  });
+
+  it("re-pins an image url whose case-insensitive fallback the rename steals", () => {
+    // ![x](Pic.png) fell back case-insensitively to pic.png; the renamed file
+    // lands exactly at Pic.png and would capture the reference.
+    const result = edits({ "hub.md": "![x](Pic.png)\n", "misc.md": "" }, "misc.md", "Pic.png", [
+      "pic.png",
+    ]);
+    expect(result.get("hub.md")).toBe("![x](pic.png)\n");
+  });
+});
+
 describe("computeRenameEdits — shadow protection", () => {
   it("qualifies another doc's short link when the rename would steal its tie-break", () => {
     // misc.md -> note.md (root): [[note]] would now tie-break to the new root

--- a/packages/core/src/ipc-registry.ts
+++ b/packages/core/src/ipc-registry.ts
@@ -339,7 +339,9 @@ export const IPC = {
     "knowledge:search",
     KnowledgeSearchSchema,
   ),
-  /** Every linkable note, for the `[[`-autocomplete picker. */
+  /** Every linkable target for the `[[`-autocomplete picker: notes first,
+   * then attachments (flagged `type: "asset"` so the picker groups them and
+   * inserts `![[embeds]]`). */
   listWikiTargets: invokeVoid<WikiTarget[]>("knowledge:wiki-targets"),
   /** Fired after every index refresh (revision is monotonic) so backlink
    * panes / graph views re-query. */

--- a/packages/core/src/knowledge/knowledge-index.ts
+++ b/packages/core/src/knowledge/knowledge-index.ts
@@ -12,11 +12,12 @@
 // raw links, no re-parsing.
 // ---------------------------------------------------------------------------
 
+import { isDocPath } from "./doc-file";
 import type { ExtractedLink, LinkKind } from "./link-extract";
 import { scanDoc, titleFromPath } from "./link-extract";
 import { buildResolver } from "./link-resolve";
 import { SearchIndex, tokenize } from "./search-index";
-import { basenamePath } from "./vault-path";
+import { basenamePath, extnamePath } from "./vault-path";
 
 // ---- Wire types (Bridge channel results) ------------------------------------
 
@@ -71,7 +72,9 @@ export type LinkGraph = { nodes: GraphNode[]; edges: GraphEdge[] };
 
 export type SearchResult = { path: string; title: string; snippet: string; score: number };
 
-export type WikiTarget = { path: string; title: string };
+/** A `[[` picker entry: notes AND attachments suggest (Obsidian-style); the
+ * `type` flag lets the picker group them and insert `![[..]]` for assets. */
+export type WikiTarget = { path: string; title: string; type: "doc" | "asset" };
 
 export const SEARCH_DEFAULT_LIMIT = 20;
 const SNIPPET_MAX = 200;
@@ -182,20 +185,21 @@ export class KnowledgeIndex {
     const edgeMap = new Map<string, GraphEdge>();
     for (const [sourcePath, links] of forward) {
       for (const { link, targetPath } of links) {
+        // The graph is a NOTES graph: asset references (md images, `![[x.png]]`
+        // embeds, `[pdf](x.pdf)` links) are content inside a note, not
+        // knowledge edges between notes — they stay out so the graph doesn't
+        // silt up with attachment leaves. backlinks() still answers asset
+        // queries; only the graph filters.
+        if (link.kind === "image") continue;
         let targetId: string;
         if (targetPath !== null) {
+          if (!this.docs.has(targetPath)) continue; // resolved asset target
           targetId = targetPath;
-          if (!nodes.has(targetId)) {
-            // A resolved non-doc file (image/pdf embed target).
-            nodes.set(targetId, {
-              id: targetId,
-              title: basenamePath(targetPath),
-              path: targetPath,
-              phantom: false,
-              degree: 0,
-            });
-          }
         } else {
+          // A dangling target written with a non-doc extension is an asset
+          // reference too — no phantom "create this note" node for it.
+          const ext = extnamePath(link.target);
+          if (ext !== "" && !isDocPath(link.target)) continue;
           targetId = `phantom:${link.target.toLowerCase()}`;
           if (!nodes.has(targetId)) {
             nodes.set(targetId, { id: targetId, title: link.target, phantom: true, degree: 0 });
@@ -216,10 +220,16 @@ export class KnowledgeIndex {
     return { nodes: [...nodes.values()], edges: [...edgeMap.values()] };
   }
 
+  /** Docs first (title-bearing), assets after — the picker renders them as
+   * two groups in this order. */
   wikiTargets(): WikiTarget[] {
-    return [...this.docs.entries()]
-      .map(([path, record]) => ({ path, title: record.title }))
-      .toSorted((a, b) => (a.path < b.path ? -1 : 1));
+    const docs = [...this.docs.entries()].map(
+      ([path, record]): WikiTarget => ({ path, title: record.title, type: "doc" }),
+    );
+    const assets = [...this.others].map(
+      (path): WikiTarget => ({ path, title: basenamePath(path), type: "asset" }),
+    );
+    return [...docs.toSorted(byPath), ...assets.toSorted(byPath)];
   }
 
   search(query: string, limit: number = SEARCH_DEFAULT_LIMIT): SearchResult[] {
@@ -281,4 +291,8 @@ export class KnowledgeIndex {
 
 function clip(text: string): string {
   return text.length <= SNIPPET_MAX ? text : `${text.slice(0, SNIPPET_MAX - 1)}…`;
+}
+
+function byPath(a: WikiTarget, b: WikiTarget): number {
+  return a.path < b.path ? -1 : 1;
 }

--- a/packages/core/src/knowledge/link-extract.ts
+++ b/packages/core/src/knowledge/link-extract.ts
@@ -1,6 +1,7 @@
 // ---------------------------------------------------------------------------
 // Doc scanning for the knowledge index: one remark parse per doc yields the
-// title, the headings, and every note link (wiki + standard relative md) with
+// title, the headings, and every vault-local link — wiki links/embeds,
+// standard relative md links (note AND asset targets), and md images — with
 // exact source spans. Parsing reuses the SAME remark-wiki-link tokenizer the
 // editor pipeline runs, so extraction agrees with what the editor renders —
 // and fence/code-span safety is inherited from the parser (text constructs
@@ -26,18 +27,21 @@ import { parseWikiBodyRange, remarkWikiLink } from "../markdown/remark-wiki-link
 import { basenamePath, extnamePath } from "./vault-path";
 
 export type Span = { start: number; end: number };
-export type LinkKind = "wiki" | "md";
+/** `wiki` = `[[..]]` / `![[..]]`, `md` = `[..](..)` + reference definitions,
+ * `image` = `![..](..)` standard md images. */
+export type LinkKind = "wiki" | "md" | "image";
 
 export type ExtractedLink = {
   kind: LinkKind;
-  /** `![[embed]]` (transclusion) vs `[[link]]`. Always false for md links. */
+  /** Rendered-inline reference: `![[embed]]` transclusions and md images.
+   * Always false for plain wiki/md links. */
   embed: boolean;
   /** Resolution input: the target as written (percent-decoded for md links),
    * anchor/alias stripped. Never empty. */
   target: string;
   /** Heading anchor after `#`, when present. */
   anchor?: string;
-  /** Display text: the wiki `|alias`, or an md link's label. */
+  /** Display text: the wiki `|alias`, an md link's label, or an image's alt. */
   alias?: string;
   /** 1-based source line the link starts on. */
   line: number;
@@ -88,7 +92,15 @@ export function scanDoc(source: string): DocScan {
         const lastEnd = last ? position(last)?.span.end : pos.span.start + 1;
         const dest =
           lastEnd === undefined ? null : locateDestination(source, lastEnd, pos.span.end);
-        const link = mdToLink(source, node.url, textOf(node), pos, dest);
+        const link = mdToLink(source, "md", node.url, textOf(node), pos, dest);
+        if (link) scan.links.push(link);
+        return;
+      }
+      case "image": {
+        const pos = position(node);
+        if (!pos) return;
+        const dest = locateImageDestination(source, pos.span);
+        const link = mdToLink(source, "image", node.url, node.alt ?? "", pos, dest);
         if (link) scan.links.push(link);
         return;
       }
@@ -96,7 +108,7 @@ export function scanDoc(source: string): DocScan {
         const pos = position(node);
         if (!pos) return;
         const dest = locateDefinitionDestination(source, pos.span);
-        const link = mdToLink(source, node.url, node.label ?? "", pos, dest);
+        const link = mdToLink(source, "md", node.url, node.label ?? "", pos, dest);
         if (link) scan.links.push(link);
         return;
       }
@@ -166,24 +178,19 @@ function wikiToLink(
   return link;
 }
 
-// ---- Standard markdown links --------------------------------------------------
+// ---- Standard markdown links and images ---------------------------------------
 
 // Everything with a scheme (`https:`, `mailto:`, `C:\…`) or protocol-relative
 // `//` is external; pure-fragment urls are same-file references.
 const SCHEME = /^[A-Za-z][A-Za-z0-9+.-]*:/;
 
-// Mirror of the vault's editable-doc set: an md link is a NOTE link only when
-// its target is extension-less (`.md` implied) or carries a doc extension —
-// links to images/pdfs are assets, not graph edges.
-const DOC_LINK_EXTENSIONS = new Set([".md", ".markdown", ".mdx", ".txt"]);
-
-function isNoteUrl(target: string): boolean {
-  const ext = extnamePath(target);
-  return ext === "" || DOC_LINK_EXTENSIONS.has(ext.toLowerCase());
-}
-
+// Every LOCAL url extracts, note or asset alike — `![](img.png)` and
+// `[pdf](paper.pdf)` must survive a rename of their target exactly like
+// `[[note]]` does. Queries that only want notes (the graph) filter on the
+// RESOLVED target, not at extraction.
 function mdToLink(
   source: string,
+  kind: "md" | "image",
   url: string,
   label: string,
   pos: NodePosition,
@@ -195,7 +202,6 @@ function mdToLink(
   const anchor = hash === -1 ? "" : url.slice(hash + 1);
   if (urlPath === "") return null;
   const target = safeDecode(urlPath);
-  if (!isNoteUrl(target)) return null;
   // Verify the located destination bytes re-derive the parsed url path; only
   // then is the span trusted for rewriting.
   let targetSpan: Span | undefined;
@@ -206,8 +212,8 @@ function mdToLink(
     }
   }
   const link: ExtractedLink = {
-    kind: "md",
-    embed: false,
+    kind,
+    embed: kind === "image",
     target,
     line: pos.line,
     span: pos.span,
@@ -275,6 +281,31 @@ function scanDestination(source: string, from: number, end: number): Span | null
 function locateDestination(source: string, lastEnd: number, end: number): Span | null {
   if (source.slice(lastEnd, lastEnd + 2) !== "](") return null;
   return scanDestination(source, lastEnd + 2, end);
+}
+
+/** For an image: skip `![`, walk the description with balanced brackets
+ * (image alt may contain nested link syntax), expect `](`, then scan. An alt
+ * whose brackets defeat the walk (e.g. a code span holding a stray `]`) just
+ * fails byte verification downstream — indexed, never rewritten. */
+function locateImageDestination(source: string, span: Span): Span | null {
+  if (source.slice(span.start, span.start + 2) !== "![") return null;
+  let i = span.start + 2;
+  let depth = 1;
+  while (i < span.end) {
+    const c = source.charAt(i);
+    if (c === "\\") {
+      i += 2;
+      continue;
+    }
+    if (c === "[") depth++;
+    else if (c === "]") {
+      depth--;
+      if (depth === 0) break;
+    }
+    i++;
+  }
+  if (depth !== 0 || source.charAt(i + 1) !== "(") return null;
+  return scanDestination(source, i + 2, span.end);
 }
 
 /** For a definition: skip the `[label]`, expect `:`, then scan. */

--- a/packages/core/src/knowledge/rename-links.ts
+++ b/packages/core/src/knowledge/rename-links.ts
@@ -6,13 +6,15 @@
 //
 // Only the recorded target span of each link changes (extraction emits spans
 // exclusively after byte verification): aliases (`[[old|alias]]`), anchors
-// (`[[old#sec]]`), body padding, and `<>` url wrappers all survive verbatim.
-// Links inside fences/code spans were never extracted, so they are never
-// touched. Three link populations are rewritten:
+// (`[[old#sec]]`), image alts (`![alt](..)`), body padding, and `<>` url
+// wrappers all survive verbatim. Links inside fences/code spans were never
+// extracted, so they are never touched. Assets rename like docs: `from` may
+// be any vault file, and `![](img.png)` / `![[img.png]]` references rewrite
+// exactly like `[[note]]` ones. Three link populations are rewritten:
 //   1. links in ANY doc that resolve to `from` (including self-links inside
 //      the moved doc) — retargeted at `to`;
-//   2. relative md links FROM the moved doc to other files — re-based when
-//      the move changed directories (wiki links are location-independent);
+//   2. relative md/image urls FROM the moved doc to other files — re-based
+//      when the move changed directories (wiki links are location-independent);
 //   3. links in ANY doc whose target the rename SHADOWS (`[[note]]` reached
 //      a/note.md; the file just renamed to note.md now wins the tie-break) —
 //      qualified so they keep meaning what they meant.
@@ -72,9 +74,9 @@ export function computeRenameEdits(
             ? wikiTargetText(toPath, fromPath, postResolver, othersResolver, raw)
             : mdUrlText(postDocPath, toPath, raw);
       } else if (resolved !== null) {
-        if (link.kind === "md") {
-          // The moved doc's own outgoing relative md links re-base to its new
-          // directory; elsewhere an md url only changes when the rename
+        if (link.kind !== "wiki") {
+          // The moved doc's own outgoing relative md/image urls re-base to its
+          // new directory; elsewhere an md url only changes when the rename
           // shadowed its resolution (a case-insensitive tie now lost).
           if (
             (path === fromPath && movedDirs) ||

--- a/packages/host/src/__tests__/knowledge-manager.test.ts
+++ b/packages/host/src/__tests__/knowledge-manager.test.ts
@@ -116,12 +116,16 @@ describe("KnowledgeManager", () => {
     expect(manager.wikiTargets().map((t) => t.path)).toEqual(["second.md"]);
   });
 
-  it("indexes non-doc files for resolution but not as wiki targets", () => {
-    vault.writeText("hub.md", "embed ![[pic.png]]\n");
+  it("indexes non-doc files for resolution and lists them as asset targets", () => {
+    vault.writeText("hub.md", "embed ![[pic.png]] and image ![alt](pic.png)\n");
     fs.writeFileSync(path.join(root, "pic.png"), "binary-ish");
     manager.refresh();
-    expect(manager.forwardLinks("hub.md")[0]?.targetPath).toBe("pic.png");
-    expect(manager.wikiTargets().map((t) => t.path)).toEqual(["hub.md"]);
+    expect(manager.forwardLinks("hub.md").map((f) => f.targetPath)).toEqual(["pic.png", "pic.png"]);
+    expect(manager.backlinks("pic.png")).toHaveLength(2);
+    expect(manager.wikiTargets()).toEqual([
+      { path: "hub.md", title: "hub", type: "doc" },
+      { path: "pic.png", title: "pic.png", type: "asset" },
+    ]);
   });
 
   it("serves ranked search over the vault", () => {

--- a/packages/host/src/__tests__/rename-rewrite.test.ts
+++ b/packages/host/src/__tests__/rename-rewrite.test.ts
@@ -59,6 +59,19 @@ describe("renameWithLinkRewrite", () => {
     );
   });
 
+  it("renames a non-md asset and rewrites md image + wiki embed references", () => {
+    vault.writeText("hub.md", "shot ![the alt](pic.png), embed ![[pic.png]]\n");
+    fs.writeFileSync(path.join(root, "pic.png"), "binary-ish");
+
+    expect(renameWithLinkRewrite(vault, "pic.png", "assets/photo.png")).toEqual({ ok: true });
+
+    expect(fs.existsSync(path.join(root, "pic.png"))).toBe(false);
+    expect(fs.readFileSync(path.join(root, "assets/photo.png"), "utf8")).toBe("binary-ish");
+    expect(vault.readText("hub.md")).toBe(
+      "shot ![the alt](assets/photo.png), embed ![[photo.png]]\n",
+    );
+  });
+
   it("rewrites the moved doc's own self-link and relative links at its new path", () => {
     vault.writeText("a/doc.md", "self [[doc]] plus [sibling](sib.md)\n");
     vault.writeText("a/sib.md", "# Sib\n");


### PR DESCRIPTION
Fixes #373.

- **Md image extraction** (`![](img.png)`) as a distinct link kind — balanced-bracket destination walk (nested-alt-safe), byte-verified spans, fence-aware; plain `[pdf](x.pdf)` asset links and reference definitions extract too (extraction extracts, queries filter — every local reference must survive a rename).
- **Asset rename-rewrite**: already reachable end-to-end (VaultManager.rename is extension-agnostic, sidebar offers rename on every row) — now the engine rewrites all four reference forms byte-surgically with alt/`<>`/%-encoding preserved, shadow re-pin included.
- **Backlinks yes, graph no**: `backlinks("pic.png")` answers; the graph is now strictly a notes graph (asset nodes wiki-embeds used to create are gone — assets are content, not knowledge edges; pinned by tests).
- **`[[` picker gains an Attachments group** (docs first); picking an attachment inserts `![[asset]]`.

Gates green ×force (core 132 / host 241 / app 345); harness-driven: grouped picker, byte-checked `![[diagram.png]]` insert, live asset rename rewrote references surgically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes link extraction, rename-rewrite, and graph semantics across core/host/app; behavior is heavily tested but renames and backlink/graph views are user-visible.
> 
> **Overview**
> Extends the knowledge pipeline so **local asset references** (md images, `[pdf](x.pdf)` links, wiki embeds) are extracted, backlinked, and **byte-surgically rewritten on rename**—same contract as note links. Extraction adds an **`image`** link kind with nested-alt-safe destination scanning; note-only filtering moves to **query time** (graph stays notes-only).
> 
> **Graph behavior changes:** resolved assets and md images no longer appear as nodes/edges; dangling non-doc targets no longer spawn phantom “create note” nodes. **`backlinks()`** still lists wiki embeds and images pointing at an asset.
> 
> **`[[` autocomplete:** `listWikiTargets` returns docs then attachments (`type: "asset"`); the picker shows an **Attachments** group and inserts **`![[…]]`** via `forceEmbed` on attachment picks (including from plain `[[`). Dev harness seeds `wiki/diagram.png` to exercise picker and asset rename.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 87e298f5f7e125b59f8fa85f4995743638a6e078. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Teaches the knowledge index to understand images and other attachments. Adds attachment-aware backlinks, safe renames, and an Attachments group in the `[[` picker while keeping the graph notes-only.

- **New Features**
  - Extracts md images and local asset links; asset backlinks now include `![[embeds]]` and `![alt](img.png)`.
  - Renaming an asset rewrites all references byte-surgically: `![](…)`, `![[…]]`, `[label](asset)`, and `[ref]: asset` (preserves alt/alias, `./` style, angle brackets, and %-encoding; fences untouched).
  - `[[` picker shows notes first and an Attachments group after; picking an attachment inserts `![[asset]]` and consumes any preceding `!`.
  - Graph stays a notes graph: no asset nodes, edges, or phantoms; asset queries still work via backlinks.
  - `wikiTargets()` now returns type-flagged entries `{ type: "doc" | "asset" }`, sorted with docs first, then assets.

<sup>Written for commit 87e298f5f7e125b59f8fa85f4995743638a6e078. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kyh/inteligir/pull/386?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

