### PR TITLE
feat: per-tab editor instances — undo and scroll survive tab switches

### DIFF
--- a/packages/app/src/__tests__/ai-settle.test.ts
+++ b/packages/app/src/__tests__/ai-settle.test.ts
@@ -85,4 +85,26 @@ describe("transient-settle registry", () => {
     offB();
     expect(settleTransients("b.md")).toBeNull();
   });
+
+  it("holds settlers for every mounted pane at once (#369)", () => {
+    // Hidden tabs keep their editors mounted, so N settlers coexist —
+    // flushing one tab settles exactly that tab's editor.
+    const offA = registerTransientSettler("a.md", () => "A");
+    const offB = registerTransientSettler("b.md", () => "B");
+    expect(settleTransients("a.md")).toBe("A");
+    expect(settleTransients("b.md")).toBe("B");
+    offA();
+    expect(settleTransients("a.md")).toBeNull();
+    expect(settleTransients("b.md")).toBe("B");
+    offB();
+  });
+
+  it("a remount over the same path replaces the settler", () => {
+    const offOld = registerTransientSettler("a.md", () => "old");
+    const offNew = registerTransientSettler("a.md", () => "new");
+    offOld(); // StrictMode-style stale cleanup — must not clear the newer one
+    expect(settleTransients("a.md")).toBe("new");
+    offNew();
+    expect(settleTransients("a.md")).toBeNull();
+  });
 });

--- a/packages/app/src/__tests__/tab-session.test.ts
+++ b/packages/app/src/__tests__/tab-session.test.ts
@@ -9,6 +9,7 @@ import {
   openTab,
   parseSession,
   renameTab,
+  touchRecency,
   type TabSession,
 } from "@repo/app/workspace/tab-session";
 
@@ -136,5 +137,38 @@ describe("parseSession", () => {
     expect(parseSession({ tabs: ["a.md", "a.md"] })).toBeUndefined();
     expect(parseSession({ tabs: [1] })).toBeUndefined();
     expect(parseSession({ tabs: [] })).toEqual(EMPTY_SESSION);
+  });
+});
+
+describe("touchRecency (live-pane retention, #369)", () => {
+  const tabs = ["a.md", "b.md", "c.md"];
+
+  it("moves the active path to the front", () => {
+    expect(touchRecency(["a.md", "b.md"], tabs, "b.md")).toEqual(["b.md", "a.md"]);
+  });
+
+  it("inserts a newly activated path", () => {
+    expect(touchRecency(["a.md"], tabs, "c.md")).toEqual(["c.md", "a.md"]);
+    expect(touchRecency([], tabs, "a.md")).toEqual(["a.md"]);
+  });
+
+  it("drops paths whose tabs closed", () => {
+    expect(touchRecency(["a.md", "x.md", "b.md"], tabs, "a.md")).toEqual(["a.md", "b.md"]);
+  });
+
+  it("alternating between two tabs preserves the rest of the order", () => {
+    let recency: readonly string[] = ["c.md", "b.md", "a.md"];
+    recency = touchRecency(recency, tabs, "b.md");
+    recency = touchRecency(recency, tabs, "c.md");
+    recency = touchRecency(recency, tabs, "b.md");
+    expect(recency).toEqual(["b.md", "c.md", "a.md"]);
+  });
+
+  it("is identity-stable on no-ops (render-adjust contract)", () => {
+    const recency = ["b.md", "a.md"];
+    expect(touchRecency(recency, tabs, "b.md")).toBe(recency);
+    expect(touchRecency(recency, tabs, null)).toBe(recency);
+    const empty: string[] = [];
+    expect(touchRecency(empty, tabs, null)).toBe(empty);
   });
 });

--- a/packages/app/src/editor/ai/ai-menu.tsx
+++ b/packages/app/src/editor/ai/ai-menu.tsx
@@ -34,6 +34,7 @@ import {
   submitAiPrompt,
   type AiMenuStatus,
 } from "@repo/app/editor/ai/ai-session";
+import { useEditorPane } from "@repo/app/editor/editor-pane-context";
 
 type MenuItem = {
   key: string;
@@ -60,7 +61,13 @@ export function AiMenu() {
   // Arrow keys arm item-selection; typing re-arms free-form submit.
   const [navigated, setNavigated] = React.useState(false);
   const inputRef = React.useRef<HTMLInputElement>(null);
-  const open = status !== "closed";
+  // The popover PORTALS to <body>, escaping a hidden pane's display:none —
+  // a background tab's session (its pane stays mounted, #369) must not
+  // float its menu over the active tab. The session itself survives the
+  // hide (plugin state + streamed blocks live in the editor); the popover
+  // just re-presents when the pane is active again.
+  const paneActive = useEditorPane()?.active ?? true;
+  const open = status !== "closed" && paneActive;
 
   // Fresh prompt every time the menu opens; re-focus after busy states end.
   React.useEffect(() => {

--- a/packages/app/src/editor/ai/ai-session.ts
+++ b/packages/app/src/editor/ai/ai-session.ts
@@ -164,6 +164,13 @@ let lastRun: LastRun | null = null;
 let undoDepth = 0;
 let streamOff: (() => void) | null = null;
 let activeRequestId: string | null = null;
+// The editor whose session owns the module-level bookkeeping above. Every
+// open tab keeps its editor mounted (#369), so "one session at a time" needs
+// enforcing rather than assuming: opening the menu on another editor CLOSES
+// the owner's session first (cancel/unwind — the same teardown the user
+// closing that menu would run), or the two runs would corrupt each other's
+// tokens and leave the first editor stuck "generating" forever.
+let sessionOwner: PlateEditor | null = null;
 
 function setOptions(editor: PlateEditor, patch: Partial<AiSessionOptions>): void {
   editor.setOptions(AiSessionPlugin, patch);
@@ -180,6 +187,7 @@ function savedSelection(editor: PlateEditor): TRange | null {
 /** Open the AI menu anchored under the block holding the selection's end. */
 export function openAiMenu(editor: PlateEditor): void {
   if (editor.getOption(AiSessionPlugin, "status") !== "closed") return;
+  if (sessionOwner !== null && sessionOwner !== editor) closeAiMenu(sessionOwner);
   const sel = editor.selection;
   if (!sel) return;
   const blockIndex = RangeApi.end(sel).path[0];
@@ -189,6 +197,7 @@ export function openAiMenu(editor: PlateEditor): void {
   const anchor = editor.api.toDOMNode(entry[0]);
   if (!anchor) return;
   setOptions(editor, { status: "input", anchor, savedSelection: sel, error: null });
+  sessionOwner = editor;
 }
 
 /**
@@ -209,6 +218,7 @@ export function closeAiMenu(editor: PlateEditor): void {
   const sel = savedSelection(editor);
   setOptions(editor, { status: "closed", anchor: null, savedSelection: null, error: null });
   lastRun = null;
+  if (sessionOwner === editor) sessionOwner = null;
   if (sel) editor.tf.select(sel);
   editor.tf.focus();
 }
@@ -347,6 +357,7 @@ export function acceptGenerate(editor: PlateEditor): void {
   setOptions(editor, { status: "closed", anchor: null, savedSelection: null, error: null });
   lastRun = null;
   runToken += 1;
+  if (sessionOwner === editor) sessionOwner = null;
   if (at) editor.tf.select(at);
   editor.tf.focus();
 }
@@ -426,6 +437,7 @@ function startEdit(editor: PlateEditor, instruction: string): void {
       runToken += 1;
       setOptions(editor, { status: "closed", anchor: null, savedSelection: null, error: null });
       lastRun = null;
+      if (sessionOwner === editor) sessionOwner = null;
       editor.tf.focus();
       return undefined;
     })

--- a/packages/app/src/editor/ai/ghost-text-kit.tsx
+++ b/packages/app/src/editor/ai/ghost-text-kit.tsx
@@ -167,7 +167,10 @@ const GhostTextPlugin = createTPlatePlugin<PluginConfig<"ghostText", GhostTextOp
       // handlers. Without a ghost both keys fall through untouched.
       const editable = editor.api.toDOMNode(editor);
       const onKeyDown = (event: KeyboardEvent) => {
-        if (event.key === "Tab" && !event.shiftKey && machine.onTab()) {
+        // Bare Tab only — Ctrl+Tab is the tab-strip cycle (#369) and must
+        // never accept a visible ghost on its way through.
+        const modified = event.ctrlKey || event.metaKey || event.altKey || event.shiftKey;
+        if (event.key === "Tab" && !modified && machine.onTab()) {
           event.preventDefault();
           event.stopPropagation();
           return;

--- a/packages/app/src/editor/ai/transient-settle.ts
+++ b/packages/app/src/editor/ai/transient-settle.ts
@@ -11,21 +11,20 @@
 // the settled markdown for the flush to persist.
 //
 // Mirrors the open-note-flush seam: the editor owns the implementation, this
-// module is just the wire. One rich editor mounts at a time, so one slot
-// suffices; the entry carries its path so flushing some OTHER tab never
-// settles the active editor's session.
+// module is just the wire. One rich editor mounts PER OPEN TAB (#369 keeps
+// hidden tabs' editors alive), so this is a registry keyed by path — flushing
+// one tab settles exactly that tab's editor, never a sibling's.
 
-let current: { path: string; settle: () => string | null } | null = null;
+const settlers = new Map<string, () => string | null>();
 
-/** Wire the mounted editor's settler: `path` is the vault-relative file it
+/** Wire a mounted editor's settler: `path` is the vault-relative file it
  * serves; `settle` resolves any pending suggestion session (reject-all) and
  * returns the settled markdown, or null when nothing was pending. Returns
  * the unregister function. */
 export function registerTransientSettler(path: string, settle: () => string | null): () => void {
-  const entry = { path, settle };
-  current = entry;
+  settlers.set(path, settle);
   return () => {
-    if (current === entry) current = null;
+    if (settlers.get(path) === settle) settlers.delete(path);
   };
 }
 
@@ -33,6 +32,5 @@ export function registerTransientSettler(path: string, settle: () => string | nu
  * if any. Returns the settled markdown when a session was resolved, else
  * null (no editor on that path, or nothing pending). */
 export function settleTransients(path: string): string | null {
-  if (current === null || current.path !== path) return null;
-  return current.settle();
+  return settlers.get(path)?.() ?? null;
 }

--- a/packages/app/src/editor/block-menu.tsx
+++ b/packages/app/src/editor/block-menu.tsx
@@ -10,7 +10,7 @@
 // revisit if upstream fixes the nesting. Omitted: copy-link-to-block
 // (markdown files have no block-anchor concept) and Ask-AI (Phase F slot).
 
-import { useMemo } from "react";
+import { useEffect, useMemo } from "react";
 import { BlockMenuPlugin, BlockSelectionPlugin } from "@platejs/selection/react";
 import { ArrowDownIcon, ArrowUpIcon, CopyIcon, Trash2Icon } from "lucide-react";
 import type { Path } from "platejs";
@@ -26,11 +26,21 @@ import {
 } from "@repo/ui/components/menu";
 
 import { TURN_INTO, moveBlocks, turnIntoBlocks } from "@repo/app/editor/block-transforms";
+import { useEditorPane } from "@repo/app/editor/editor-pane-context";
 
 export function BlockMenu() {
   const { api, editor } = useEditorPlugin(BlockMenuPlugin);
   const openId = usePluginOption(BlockMenuPlugin, "openId");
   const position = usePluginOption(BlockMenuPlugin, "position");
+
+  // Switching tabs hides this pane WITHOUT unmounting it (#369), and the
+  // MenuContent PORTALS to <body> — left open it would float over the next
+  // tab and its items would edit the hidden document. Hide on deactivate;
+  // the stale anchor position is meaningless after a switch anyway.
+  const paneActive = useEditorPane()?.active ?? true;
+  useEffect(() => {
+    if (!paneActive) api.blockMenu.hide();
+  }, [paneActive, api]);
 
   const anchor = useMemo(() => {
     const { x, y } = position;
@@ -49,7 +59,7 @@ export function BlockMenu() {
 
   return (
     <Menu
-      open={openId !== null}
+      open={openId !== null && paneActive}
       onOpenChange={(open) => {
         if (!open) api.blockMenu.hide();
       }}

--- a/packages/app/src/editor/editor-pane-context.ts
+++ b/packages/app/src/editor/editor-pane-context.ts
@@ -1,0 +1,33 @@
+// Which pane a piece of editor UI lives in, and whether that pane is the
+// active (visible) tab. Every open tab keeps its editor mounted (#369 —
+// hidden with display:none so undo history, DOM, and transient AI state
+// survive tab switches), which breaks the old "exactly one editor is
+// mounted" assumption. Surfaces that used to lean on it consume this
+// context instead:
+//
+// - portalled float UI (the AI menu) renders only in the active pane —
+//   a portal escapes the pane's display:none, so it must self-gate;
+// - module-level runner bridges (embed dialog opener) register only from
+//   the active pane, so a background pane can't capture a global trigger;
+// - inline comboboxes cancel when their pane deactivates (their popup is
+//   portalled and their trigger element must not linger in a hidden doc);
+// - per-note lookups (transclusion cycle roots, delegation source files)
+//   read the PANE's path, not the active tab's.
+//
+// `null` means "not inside a tab pane" (tests, standalone mounts) — treat as
+// an active pane serving the vault-context's open note.
+
+import { createContext, useContext } from "react";
+
+export type EditorPaneInfo = {
+  /** Vault-relative path of the note this pane serves. */
+  path: string;
+  /** Whether this pane is the visible tab (false = mounted but hidden). */
+  active: boolean;
+};
+
+export const EditorPaneContext = createContext<EditorPaneInfo | null>(null);
+
+export function useEditorPane(): EditorPaneInfo | null {
+  return useContext(EditorPaneContext);
+}

--- a/packages/app/src/editor/editor-pane.tsx
+++ b/packages/app/src/editor/editor-pane.tsx
@@ -1,4 +1,5 @@
 import {
+  memo,
   useCallback,
   useEffect,
   useLayoutEffect,
@@ -11,6 +12,7 @@ import {
 
 import { EditorPaneContext } from "@repo/app/editor/editor-pane-context";
 import { MarkdownEditor } from "@repo/app/editor/markdown-editor";
+import type { VaultEditorState } from "@repo/app/editor/vault-editor";
 import { BacklinksPanel } from "@repo/app/workspace/backlinks-panel";
 import { touchRecency } from "@repo/app/workspace/tab-session";
 import { useVault } from "@repo/app/workspace/vault-context";
@@ -123,6 +125,45 @@ function TabPane({ path, active }: { path: string; active: boolean }) {
   if (coherent && frozenShowRich !== ctxShowRich) setFrozenShowRich(ctxShowRich);
   const showRich = coherent ? ctxShowRich : frozenShowRich;
 
+  return (
+    <TabPaneBody
+      path={path}
+      active={active}
+      state={state}
+      showRich={showRich}
+      getTabState={getTabState}
+      editTab={editTab}
+      renameEntry={renameEntry}
+    />
+  );
+}
+
+type TabPaneBodyProps = {
+  path: string;
+  active: boolean;
+  state: VaultEditorState;
+  showRich: boolean;
+  getTabState: (path: string) => VaultEditorState;
+  editTab: (path: string, content: string) => void;
+  renameEntry: (from: string, to: string) => Promise<boolean>;
+};
+
+/** The pane's actual DOM — split out and memoized so a HIDDEN pane's Plate
+ * tree doesn't re-render on every keystroke in the active tab: the vault
+ * context value changes per edit, TabPane consumes it, and without the memo
+ * boundary every live pane would re-render its whole editor shell in
+ * sympathy. For a hidden pane every prop here is identity-stable (its own
+ * state only changes on its own edits; the callbacks are stable; showRich is
+ * frozen), so the memo bails out and only the active pane pays. */
+const TabPaneBody = memo(function TabPaneBody({
+  path,
+  active,
+  state,
+  showRich,
+  getTabState,
+  editTab,
+  renameEntry,
+}: TabPaneBodyProps) {
   const fileName = state.path !== null ? (state.path.split("/").pop() ?? state.path) : "";
   const dot = fileName.lastIndexOf(".");
   const displayName = dot > 0 ? fileName.slice(0, dot) : fileName;
@@ -231,4 +272,4 @@ function TabPane({ path, active }: { path: string; active: boolean }) {
       </div>
     </EditorPaneContext.Provider>
   );
-}
+});

--- a/packages/app/src/editor/editor-pane.tsx
+++ b/packages/app/src/editor/editor-pane.tsx
@@ -1,34 +1,76 @@
-import { useEffect, useRef, type KeyboardEvent } from "react";
+import {
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+  useSyncExternalStore,
+  type KeyboardEvent,
+} from "react";
 
+import { EditorPaneContext } from "@repo/app/editor/editor-pane-context";
 import { MarkdownEditor } from "@repo/app/editor/markdown-editor";
 import { BacklinksPanel } from "@repo/app/workspace/backlinks-panel";
+import { touchRecency } from "@repo/app/workspace/tab-session";
 import { useVault } from "@repo/app/workspace/vault-context";
 
 /**
- * The editor body — Rich (Plate) for canonical markdown, Raw textarea otherwise.
- * The per-file controls (raw/rich, Format, delete, status) live in the shell
- * header; this is just the scrolling document. Bottom padding clears the pinned
- * composer.
+ * How many tabs keep a live (mounted) pane. Every live pane holds a full
+ * Plate editor whose undo history, DOM, selection, and scroll position
+ * survive tab switches (#369) — but each one costs memory, so only the N
+ * most-recently-active tabs stay live; older tabs fall back to the v1
+ * behavior (remount on activation, history starts fresh). Five covers the
+ * working set people actually alternate between without letting a
+ * twenty-tab session hold twenty documents' DOM alive.
+ */
+const MAX_LIVE_PANES = 5;
+
+/** The most-recently-activated open tabs, capped — the set of tabs whose
+ * panes stay mounted. Maintained with the render-adjust pattern so the set
+ * is correct in the same render that changes the active tab. */
+function useLivePaths(tabs: readonly string[], active: string | null): readonly string[] {
+  const [recency, setRecency] = useState<readonly string[]>([]);
+  const next = touchRecency(recency, tabs, active);
+  if (next !== recency) setRecency(next);
+  return useMemo(() => next.slice(0, MAX_LIVE_PANES), [next]);
+}
+
+/**
+ * The editor body — one pane per live tab, all mounted, only the active one
+ * visible. Hiding (display:none) instead of remounting is what preserves
+ * each tab's undo history and in-progress editor state across switches; the
+ * workspace <main> is the single scroll container, so per-tab scroll offsets
+ * are captured/restored around the visibility swap. The per-file controls
+ * (raw/rich, Format, delete, status) live in the shell header; this is just
+ * the scrolling document. Bottom padding clears the pinned composer.
  */
 export function EditorPane() {
-  const { editor, onEdit, editTab, isMarkdownOpen, richSafe, mode, renameEntry } = useVault();
-  const selected = editor.path;
+  const { tabs, activeTab } = useVault();
+  const livePaths = useLivePaths(tabs, activeTab);
 
-  const fileName = selected ? (selected.split("/").pop() ?? selected) : "";
-  const dot = fileName.lastIndexOf(".");
-  const displayName = dot > 0 ? fileName.slice(0, dot) : fileName;
-
-  // The title is a contentEditable, so React must NOT own its text children
-  // (reconciling a contentEditable's children accumulates stale text across
-  // note switches). We set the text imperatively when the open file changes;
-  // the browser owns it while editing.
-  const titleRef = useRef<HTMLHeadingElement>(null);
-  const paneRef = useRef<HTMLDivElement>(null);
+  // Per-tab scroll offsets. The scroller is the workspace <main> (a shared
+  // container — toc.tsx keys off the same element), so hidden panes don't
+  // retain a scroll position of their own: save the active tab's offset as
+  // it scrolls, restore it right after the pane swap (layout effect = after
+  // the DOM shows the new pane, before paint — no flicker).
+  const scrollTops = useRef(new Map<string, number>());
+  useLayoutEffect(() => {
+    if (activeTab === null) return;
+    const scroller = document.querySelector("main");
+    if (!scroller) return;
+    scroller.scrollTop = scrollTops.current.get(activeTab) ?? 0;
+    const save = () => scrollTops.current.set(activeTab, scroller.scrollTop);
+    scroller.addEventListener("scroll", save, { passive: true });
+    return () => scroller.removeEventListener("scroll", save);
+  }, [activeTab]);
   useEffect(() => {
-    if (titleRef.current) titleRef.current.textContent = displayName;
-  }, [displayName]);
+    for (const path of scrollTops.current.keys()) {
+      if (!tabs.includes(path)) scrollTops.current.delete(path);
+    }
+  }, [tabs]);
 
-  if (selected === null) {
+  if (activeTab === null) {
     return (
       <div className="flex flex-1 items-center justify-center p-8 text-center text-sm text-muted-foreground">
         Select a note to edit, or create one. The agent edits these same files.
@@ -36,10 +78,74 @@ export function EditorPane() {
     );
   }
 
-  const showRich = mode === "rich" && isMarkdownOpen && richSafe;
+  // Panes render in STRIP order (stable while tabs stay open), not recency
+  // order — reordering keyed children moves DOM nodes, which reloads iframes
+  // (embeds/transclusions) and drops native textarea state.
+  return (
+    <>
+      {tabs
+        .filter((path) => livePaths.includes(path))
+        .map((path) => (
+          <TabPane key={path} path={path} active={path === activeTab} />
+        ))}
+    </>
+  );
+}
+
+/** One tab's pane: page title + body (+ backlinks), fed by its OWN tab
+ * state. Stays mounted while the tab is live; `active: false` only hides it. */
+function TabPane({ path, active }: { path: string; active: boolean }) {
+  const {
+    subscribeTab,
+    getTabState,
+    editTab,
+    renameEntry,
+    isMarkdownOpen,
+    richSafe,
+    mode,
+    analyzedPath,
+  } = useVault();
+
+  const subscribe = useCallback((fn: () => void) => subscribeTab(path, fn), [subscribeTab, path]);
+  const getSnapshot = useCallback(() => getTabState(path), [getTabState, path]);
+  const state = useSyncExternalStore(subscribe, getSnapshot);
+
+  // The context's mode/richSafe describe the tab the provider ANALYZED —
+  // the active tab, except while a just-activated tab is still dirty
+  // (analysis waits for saved bytes). Adopt the context view only when it's
+  // coherent for THIS pane; otherwise keep the last adopted surface, so a
+  // hidden pane never flips between rich/raw because a sibling tab changed
+  // the shared view state. Render-adjusted so surface and content can't
+  // disagree within a commit (same pattern as the provider's analysis gate).
+  const coherent = active && analyzedPath === path;
+  const ctxShowRich = mode === "rich" && isMarkdownOpen && richSafe;
+  const [frozenShowRich, setFrozenShowRich] = useState(false);
+  if (coherent && frozenShowRich !== ctxShowRich) setFrozenShowRich(ctxShowRich);
+  const showRich = coherent ? ctxShowRich : frozenShowRich;
+
+  const fileName = state.path !== null ? (state.path.split("/").pop() ?? state.path) : "";
+  const dot = fileName.lastIndexOf(".");
+  const displayName = dot > 0 ? fileName.slice(0, dot) : fileName;
+
+  // The title is a contentEditable, so React must NOT own its text children
+  // (reconciling a contentEditable's children accumulates stale text across
+  // note switches). We set the text imperatively when the file (re)names;
+  // the browser owns it while editing.
+  const titleRef = useRef<HTMLHeadingElement>(null);
+  const paneRef = useRef<HTMLDivElement>(null);
+  useEffect(() => {
+    if (titleRef.current) titleRef.current.textContent = displayName;
+  }, [displayName]);
+
+  const paneInfo = useMemo(() => ({ path, active }), [path, active]);
+
+  // Still loading (or vanishing) — nothing to show yet; the runtime either
+  // fills in content or closes the tab.
+  if (state.path === null) return null;
+
   const ext = dot > 0 ? fileName.slice(dot) : "";
-  const slash = selected.lastIndexOf("/");
-  const dir = slash === -1 ? "" : selected.slice(0, slash + 1);
+  const slash = path.lastIndexOf("/");
+  const dir = slash === -1 ? "" : path.slice(0, slash + 1);
 
   // Editing the title renames the underlying file (the filename IS the title).
   const commitTitle = (raw: string) => {
@@ -48,10 +154,10 @@ export function EditorPane() {
       if (titleRef.current) titleRef.current.textContent = displayName;
       return;
     }
-    void renameEntry(selected, `${dir}${next}${ext}`).then((ok) => {
-      // On success the path changes and the effect resets the title to the new
-      // name; on failure roll the contentEditable back to the real filename so
-      // the header never shows a name that was never saved.
+    void renameEntry(path, `${dir}${next}${ext}`).then((ok) => {
+      // On success the path changes and the renamed tab mounts a fresh pane;
+      // on failure roll the contentEditable back to the real filename so the
+      // title never shows a name that was never saved.
       if (!ok && titleRef.current) titleRef.current.textContent = displayName;
       return undefined;
     });
@@ -78,47 +184,51 @@ export function EditorPane() {
   // never serialized), then the body. Same column wraps the Raw textarea; the
   // pb-72 is the breathing room below the last block (spec §4.1 — the pane,
   // not PlateContent, owns column + padding so title/raw/rich share bytes-
-  // exact geometry).
+  // exact geometry). Inactive panes hide via inline display:none (inline so
+  // no utility-class cascade order can override it) — never unmount, that's
+  // the whole point (#369).
   return (
-    <div
-      ref={paneRef}
-      className="flex w-full flex-1 cursor-text flex-col px-12 pt-10 pb-72 sm:px-[max(48px,calc(50%-350px))]"
-    >
-      <h1
-        ref={titleRef}
-        contentEditable
-        suppressContentEditableWarning
-        spellCheck={false}
-        onBlur={(e) => commitTitle(e.currentTarget.textContent ?? "")}
-        onKeyDown={onTitleKeyDown}
-        className="mb-1 w-full break-words text-4xl font-bold leading-[1.2] text-foreground outline-none empty:before:text-muted-foreground/40 empty:before:content-['Untitled']"
-      />
-      {showRich ? (
-        <MarkdownEditor
-          key={selected}
-          path={selected}
-          value={editor.content}
-          onChange={(md) => {
-            if (md !== editor.content) onEdit(md);
-          }}
-          // Teardown settle (#374): route by the path THIS editor served —
-          // the closure captures `selected` from the render that mounted it,
-          // so a tab switch can't misdeliver the settled bytes.
-          onSettled={(md) => {
-            if (md !== editor.content) editTab(selected, md);
-          }}
-        />
-      ) : (
-        <textarea
-          value={editor.content}
-          onChange={(e) => onEdit(e.target.value)}
+    <EditorPaneContext.Provider value={paneInfo}>
+      <div
+        ref={paneRef}
+        style={active ? undefined : { display: "none" }}
+        className="flex w-full flex-1 cursor-text flex-col px-12 pt-10 pb-72 sm:px-[max(48px,calc(50%-350px))]"
+      >
+        <h1
+          ref={titleRef}
+          contentEditable
+          suppressContentEditableWarning
           spellCheck={false}
-          className="min-h-[60vh] flex-1 resize-none bg-transparent pt-4 font-mono text-sm leading-relaxed text-foreground outline-none"
-          placeholder="Empty note"
+          onBlur={(e) => commitTitle(e.currentTarget.textContent ?? "")}
+          onKeyDown={onTitleKeyDown}
+          className="mb-1 w-full break-words text-4xl font-bold leading-[1.2] text-foreground outline-none empty:before:text-muted-foreground/40 empty:before:content-['Untitled']"
         />
-      )}
-      {/* Linked mentions live in the same centered column, below the doc. */}
-      <BacklinksPanel />
-    </div>
+        {showRich ? (
+          <MarkdownEditor
+            path={path}
+            value={state.content}
+            onChange={(md) => {
+              if (md !== getTabState(path).content) editTab(path, md);
+            }}
+            // Teardown settle (#374): route by the path THIS editor served —
+            // panes unmount on close/eviction, when the active tab may
+            // already differ, so the bytes carry their own path.
+            onSettled={(md) => {
+              if (md !== getTabState(path).content) editTab(path, md);
+            }}
+          />
+        ) : (
+          <textarea
+            value={state.content}
+            onChange={(e) => editTab(path, e.target.value)}
+            spellCheck={false}
+            className="min-h-[60vh] flex-1 resize-none bg-transparent pt-4 font-mono text-sm leading-relaxed text-foreground outline-none"
+            placeholder="Empty note"
+          />
+        )}
+        {/* Linked mentions live in the same centered column, below the doc. */}
+        <BacklinksPanel path={path} />
+      </div>
+    </EditorPaneContext.Provider>
   );
 }

--- a/packages/app/src/editor/embed-url-dialog.tsx
+++ b/packages/app/src/editor/embed-url-dialog.tsx
@@ -49,6 +49,14 @@ export function EmbedUrlDialogHost() {
     };
   }, [paneActive]);
 
+  // The dialog itself PORTALS to <body>, so a tab switch (the pane hides but
+  // never unmounts, #369) would leave it floating over the next tab, with
+  // Insert targeting the now-hidden document. Close on deactivate — same
+  // semantics as dismissing it.
+  useEffect(() => {
+    if (!paneActive) setOpen(false);
+  }, [paneActive]);
+
   const trimmed = url.trim();
 
   const submit = () => {

--- a/packages/app/src/editor/embed-url-dialog.tsx
+++ b/packages/app/src/editor/embed-url-dialog.tsx
@@ -17,6 +17,7 @@ import {
 } from "@repo/ui/components/dialog";
 import { Input } from "@repo/ui/components/input";
 
+import { useEditorPane } from "@repo/app/editor/editor-pane-context";
 import { insertEmbedFromUrl } from "@repo/app/editor/kits/embed-kit";
 
 let activeOpener: (() => void) | null = null;
@@ -31,7 +32,13 @@ export function EmbedUrlDialogHost() {
   const [open, setOpen] = useState(false);
   const [url, setUrl] = useState("");
 
+  // One host mounts per open tab (#369) but the module-level opener is a
+  // single global slot — only the ACTIVE pane's host claims it, so the slash
+  // menu (which always runs on the active editor) can't open a dialog that
+  // inserts into a hidden tab.
+  const paneActive = useEditorPane()?.active ?? true;
   useEffect(() => {
+    if (!paneActive) return;
     const opener = () => {
       setUrl("");
       setOpen(true);
@@ -40,7 +47,7 @@ export function EmbedUrlDialogHost() {
     return () => {
       if (activeOpener === opener) activeOpener = null;
     };
-  }, []);
+  }, [paneActive]);
 
   const trimmed = url.trim();
 

--- a/packages/app/src/editor/inline-combobox.tsx
+++ b/packages/app/src/editor/inline-combobox.tsx
@@ -34,6 +34,7 @@ import {
   reconcileInsertionCaret,
   type ComboboxCancelCause,
 } from "@repo/app/editor/combobox-input";
+import { useEditorPane } from "@repo/app/editor/editor-pane-context";
 
 type FilterItem = {
   value: string;
@@ -196,6 +197,16 @@ function InlineCombobox({
     if (previousSelected.current && !selected) cancel("deselect");
     previousSelected.current = selected;
   }, [selected, cancel]);
+
+  // Switching tabs hides this pane WITHOUT unmounting it (#369) and doesn't
+  // move the Slate selection, so the deselect path above never fires — but
+  // the popup portals to <body> (it would float over the next tab) and the
+  // trigger element must not linger in a hidden document. Same restore
+  // semantics as clicking elsewhere.
+  const paneActive = useEditorPane()?.active ?? true;
+  React.useEffect(() => {
+    if (!paneActive) cancel("deselect");
+  }, [paneActive, cancel]);
 
   const onKeyDown = React.useCallback(
     (event: React.KeyboardEvent<HTMLInputElement>) => {

--- a/packages/app/src/editor/markdown-editor.tsx
+++ b/packages/app/src/editor/markdown-editor.tsx
@@ -114,9 +114,9 @@ export function MarkdownEditor({ path, value, onChange, onSettled }: Props) {
     () => () => {
       const md = settleSuggestions();
       if (md !== null) onSettledRef.current(md);
-      useAiReviewStore.getState().setReviewing(false);
+      useAiReviewStore.getState().setReviewing(path, false);
     },
-    [settleSuggestions],
+    [settleSuggestions, path],
   );
 
   return (
@@ -138,7 +138,7 @@ export function MarkdownEditor({ path, value, onChange, onSettled }: Props) {
         // save badge surfaces the suggestion freeze as "Reviewing
         // suggestions" via the store.
         const reviewing = hasTransientSuggestions(editor);
-        useAiReviewStore.getState().setReviewing(reviewing);
+        useAiReviewStore.getState().setReviewing(path, reviewing);
         if (reviewing || hasTransientAiState(editor)) return;
         const md = serializeMd(editor, { remarkStringifyOptions: MD_STRINGIFY });
         // Drop the echo a programmatic (re)seed produces — only real edits,

--- a/packages/app/src/editor/selection-toolbar.tsx
+++ b/packages/app/src/editor/selection-toolbar.tsx
@@ -1,4 +1,5 @@
 import {
+  useEffect,
   useMemo,
   useRef,
   useState,
@@ -50,6 +51,7 @@ import {
   turnIntoLabelFor,
   turnIntoSelection,
 } from "@repo/app/editor/block-transforms";
+import { useEditorPane } from "@repo/app/editor/editor-pane-context";
 
 // Elevation: toolbars sit on the menu tier (surface-4; popovers float higher
 // at surface-5 — @repo/ui's ladder). animate-in runs once on mount.
@@ -212,6 +214,18 @@ export function SelectionToolbar() {
   // them and the bar keeps its last computed position. Base UI portals
   // escape clickOutsideRef, so this explicit gate is the reliable one.
   const frozen = openMenu !== null || linkMode;
+
+  // Switching tabs hides this pane WITHOUT unmounting it (#369). The bar
+  // itself dies with the pane's display:none, but the Turn-into MenuContent
+  // PORTALS to <body> — left open it floats over the next tab and its items
+  // would edit the hidden document. Drop the frozen state on deactivate.
+  const paneActive = useEditorPane()?.active ?? true;
+  useEffect(() => {
+    if (!paneActive) {
+      setOpenMenu(null);
+      setLinkMode(false);
+    }
+  }, [paneActive]);
 
   // Remember the live selection at the moment an action starts — opening a
   // popover or the link input moves DOM focus off the editable and collapses

--- a/packages/app/src/editor/toc.tsx
+++ b/packages/app/src/editor/toc.tsx
@@ -10,6 +10,8 @@ import { useEditorRef, useEditorSelector } from "platejs/react";
 
 import { cn } from "@repo/ui/lib/utils";
 
+import { useEditorPane } from "@repo/app/editor/editor-pane-context";
+
 type HeadingItem = { id: string; depth: number; title: string };
 
 const HEADING_DEPTH: Record<string, number> = { [KEYS.h1]: 1, [KEYS.h2]: 2, [KEYS.h3]: 3 };
@@ -29,11 +31,13 @@ function collectHeadings(editor: ReturnType<typeof useEditorRef>): HeadingItem[]
   return out;
 }
 
-// The heading elements in the live editable, in document order — the same order
-// as collectHeadings, so index i lines up. Excludes the page-title <h1>, which
-// lives outside the Slate editable.
-function editorHeadingEls(): HTMLElement[] {
-  const root = document.querySelector("[data-slate-editor]");
+// The heading elements in THIS editor's live editable, in document order —
+// the same order as collectHeadings, so index i lines up. Excludes the
+// page-title <h1>, which lives outside the Slate editable. Scoped to the
+// editor's own DOM node because every open tab keeps its editor mounted
+// (#369) — a bare [data-slate-editor] query would read a hidden sibling's.
+function editorHeadingEls(editor: ReturnType<typeof useEditorRef>): HTMLElement[] {
+  const root = editor.api.toDOMNode(editor);
   return root ? [...root.querySelectorAll<HTMLElement>("h1, h2, h3")] : [];
 }
 
@@ -43,17 +47,22 @@ export function TableOfContents() {
   // ref inside so the helper keeps its concrete PlateEditor type.
   const headings = useEditorSelector(() => collectHeadings(editor), []);
   const [activeIndex, setActiveIndex] = useState(0);
+  // A hidden pane's rail must not render (it's position:fixed, so it escapes
+  // the pane's layout even though display:none on the ancestor hides it) nor
+  // scrollspy against zero-size boxes.
+  const paneActive = useEditorPane()?.active ?? true;
 
   // Scrollspy: the last heading scrolled above the header line is "active". A
   // scroll listener on the workspace scroller (IntersectionObserver never fires
   // with a custom root in this Electron renderer).
   useEffect(() => {
+    if (!paneActive) return;
     const scroller = document.querySelector("main");
     if (!scroller || headings.length === 0) return;
     const onScroll = () => {
       const scannerY = scroller.getBoundingClientRect().top + HEADER_OFFSET + 8;
       let active = 0;
-      editorHeadingEls().forEach((el, i) => {
+      editorHeadingEls(editor).forEach((el, i) => {
         if (el.getBoundingClientRect().top <= scannerY) active = i;
       });
       setActiveIndex(active);
@@ -61,15 +70,15 @@ export function TableOfContents() {
     onScroll();
     scroller.addEventListener("scroll", onScroll, { passive: true });
     return () => scroller.removeEventListener("scroll", onScroll);
-  }, [headings]);
+  }, [headings, paneActive, editor]);
 
-  if (headings.length < 2) return null;
+  if (!paneActive || headings.length < 2) return null;
 
   // Smooth scrolling is a no-op in this Electron renderer (both scrollIntoView
   // and scrollTo ignore `behavior: "smooth"`), so compute the target offset and
   // jump instantly, leaving room for the sticky header.
   const scrollTo = (index: number) => {
-    const el = editorHeadingEls()[index];
+    const el = editorHeadingEls(editor)[index];
     const scroller = document.querySelector("main");
     if (el && scroller) {
       const top =

--- a/packages/app/src/editor/todo-delegation.tsx
+++ b/packages/app/src/editor/todo-delegation.tsx
@@ -24,6 +24,7 @@ import { type PlateEditor, useEditorRef } from "platejs/react";
 
 import { toast } from "@repo/ui/components/sonner";
 
+import { useEditorPane } from "@repo/app/editor/editor-pane-context";
 import { isTodoItem } from "@repo/app/editor/todo-item";
 import { findDelegation, useDelegationStore } from "@repo/app/stores/delegation-store";
 import { useVault } from "@repo/app/workspace/vault-context";
@@ -52,7 +53,11 @@ function DelegateControl({ element, checked }: { element: TElement; checked: boo
   const cancel = useDelegationStore((s) => s.cancel);
   const submittingRef = useRef(false);
 
-  const sourceFile = vaultEditor.path;
+  // The checkbox belongs to the note THIS pane serves — panes for background
+  // tabs stay mounted (#369), so the active tab's path would mis-key their
+  // badges. Delegate itself only fires from the active pane (hidden panes
+  // aren't clickable), where flush() flushes exactly this file.
+  const sourceFile = useEditorPane()?.path ?? vaultEditor.path;
   const text = elementText(element);
   const index = todoIndex(plateEditor, element);
 

--- a/packages/app/src/editor/transclusion.tsx
+++ b/packages/app/src/editor/transclusion.tsx
@@ -25,6 +25,7 @@ import { PlateStatic, SlateElement, type SlateElementProps } from "platejs/stati
 import { cn } from "@repo/ui/lib/utils";
 
 import { getBridge } from "@repo/app/lib/bridge";
+import { useEditorPane } from "@repo/app/editor/editor-pane-context";
 import { BASE_KIT } from "@repo/app/editor/kits/base-kit";
 import { TABLE_CELL_CLASS, TABLE_HEADER_CELL_CLASS } from "@repo/app/editor/kits/table-kit";
 import { parseMarkdown } from "@repo/app/editor/markdown/markdown-doc";
@@ -269,7 +270,11 @@ function TransclusionBody({ content }: { content: string }) {
 
 export default function Transclusion({ body }: { body: string }) {
   const { resolveWikiTarget, openFile } = useVault();
-  const vaultEditorPath = useVault().editor.path;
+  // The cycle chain roots at the note HOSTING this embed — the pane's path,
+  // not the active tab's (every open tab keeps its pane mounted, #369).
+  // Outside a pane (standalone mounts) fall back to the open note.
+  const activePath = useVault().editor.path;
+  const hostPath = useEditorPane()?.path ?? activePath;
   const scope = useContext(TransclusionScopeContext);
   const parsed = parseWikiBody(body);
   const resolved = parsed.target === "" ? null : resolveWikiTarget(parsed.target);
@@ -279,9 +284,9 @@ export default function Transclusion({ body }: { body: string }) {
     () =>
       scope ?? {
         depth: 0,
-        chain: vaultEditorPath !== null ? [vaultEditorPath] : [],
+        chain: hostPath !== null ? [hostPath] : [],
       },
-    [scope, vaultEditorPath],
+    [scope, hostPath],
   );
   const innerScope = useMemo(
     () => (resolved !== null ? nestedScope(effectiveScope, resolved) : null),

--- a/packages/app/src/layout/header.tsx
+++ b/packages/app/src/layout/header.tsx
@@ -39,10 +39,13 @@ export function Header() {
     deleteEntry,
   } = useVault();
   const { state } = useSidebar();
-  // While an AI suggestion session pends, autosave is frozen (the transient
-  // gate) — say so instead of silently reading "Saved" over stale bytes.
-  const reviewing = useAiReviewStore((s) => s.reviewing);
   const path = editor.path;
+  // While an AI suggestion session pends ON THIS note, its autosave is frozen
+  // (the transient gate) — say so instead of silently reading "Saved" over
+  // stale bytes. Keyed by path: a background tab's pending review (its pane
+  // stays mounted, #369) must not relabel the active tab's badge.
+  const reviewingPaths = useAiReviewStore((s) => s.reviewing);
+  const reviewing = path !== null && reviewingPaths.has(path);
   const segments = path ? path.split("/") : [];
 
   const confirmDelete = async () => {

--- a/packages/app/src/stores/ai-review-store.ts
+++ b/packages/app/src/stores/ai-review-store.ts
@@ -1,19 +1,27 @@
 import { create } from "zustand";
 
-// Whether the mounted rich editor holds an unresolved AI suggestion session.
-// While one pends, autosave is frozen at the pre-session bytes (see
-// editor/ai/transient.ts) — the header's save badge reads this store to show
-// "Reviewing suggestions" instead of silently claiming Saved (#374). Written
-// by markdown-editor's onChange (and cleared on unmount); read by the header.
+// The notes whose mounted rich editor holds an unresolved AI suggestion
+// session. While one pends, that file's autosave is frozen at the pre-session
+// bytes (see editor/ai/transient.ts) — the header's save badge reads this
+// store to show "Reviewing suggestions" instead of silently claiming Saved
+// (#374). Keyed by path because every open tab keeps its editor mounted
+// (#369): a background tab's pending review must not relabel the ACTIVE
+// tab's badge. Written by markdown-editor's onChange (and cleared on
+// unmount); read by the header for the active path.
 
 type AiReviewStore = {
-  reviewing: boolean;
-  setReviewing: (reviewing: boolean) => void;
+  reviewing: ReadonlySet<string>;
+  setReviewing: (path: string, reviewing: boolean) => void;
 };
 
 export const useAiReviewStore = create<AiReviewStore>((set, get) => ({
-  reviewing: false,
-  setReviewing: (reviewing) => {
-    if (get().reviewing !== reviewing) set({ reviewing });
+  reviewing: new Set<string>(),
+  setReviewing: (path, reviewing) => {
+    const current = get().reviewing;
+    if (current.has(path) === reviewing) return;
+    const next = new Set(current);
+    if (reviewing) next.add(path);
+    else next.delete(path);
+    set({ reviewing: next });
   },
 }));

--- a/packages/app/src/workspace/backlinks-panel.tsx
+++ b/packages/app/src/workspace/backlinks-panel.tsx
@@ -1,5 +1,5 @@
-// Backlinks for the open note — a collapsible section at the bottom of the
-// editor column (below the document, sharing its geometry) rather than a
+// Backlinks for the hosting pane's note — a collapsible section at the bottom
+// of the editor column (below the document, sharing its geometry) rather than a
 // right rail: the workspace is a single centered text column with the
 // composer pinned bottom, so a rail would fight both the 700px measure and
 // the chat popover. Entries group by source note with the linking line as a
@@ -26,9 +26,8 @@ function noteTitle(path: string): string {
   return dot > 0 ? name.slice(0, dot) : name;
 }
 
-export function BacklinksPanel() {
-  const { editor, openFile } = useVault();
-  const path = editor.path;
+export function BacklinksPanel({ path }: { path: string }) {
+  const { openFile } = useVault();
   const [backlinks, setBacklinks] = useState<BacklinkEntry[]>([]);
 
   const refresh = useCallback((notePath: string) => {
@@ -41,16 +40,12 @@ export function BacklinksPanel() {
   }, []);
 
   useEffect(() => {
-    if (path === null) {
-      setBacklinks([]);
-      return;
-    }
     refresh(path);
     const bridge = getBridge();
     return bridge?.onKnowledgeUpdated(() => refresh(path));
   }, [path, refresh]);
 
-  if (path === null || backlinks.length === 0) return null;
+  if (backlinks.length === 0) return null;
 
   // Group occurrences by source note (index order preserved), one row per
   // source LINE — two links on the same line share a snippet and a target.

--- a/packages/app/src/workspace/tab-session.ts
+++ b/packages/app/src/workspace/tab-session.ts
@@ -79,6 +79,22 @@ export function moveTab(session: TabSession, from: number, to: number): TabSessi
   return { tabs, active: session.active };
 }
 
+/** Most-recently-activated tab order — the pane host keeps one to decide
+ * which tabs retain a live (mounted) editor across switches (#369). The
+ * active path moves (or inserts) at the front; paths no longer open drop
+ * out. Pure and identity-stable: returns `recency` itself when the update
+ * is a no-op, so render-adjust callers can compare by reference. */
+export function touchRecency(
+  recency: readonly string[],
+  tabs: readonly string[],
+  active: string | null,
+): readonly string[] {
+  const kept = recency.filter((path) => tabs.includes(path));
+  const next = active === null ? kept : [active, ...kept.filter((path) => path !== active)];
+  const unchanged = next.length === recency.length && next.every((p, i) => p === recency[i]);
+  return unchanged ? recency : next;
+}
+
 /** Parse a persisted ui-state value back into a session, dropping anything
  * malformed (unknown shape, duplicates, active not a member). */
 export function parseSession(value: unknown): TabSession | undefined {

--- a/packages/app/src/workspace/vault-context.tsx
+++ b/packages/app/src/workspace/vault-context.tsx
@@ -127,13 +127,17 @@ type VaultContextValue = {
   subscribeTab: (path: string, listener: () => void) => () => void;
   /** Whether a tab has unsaved edits (read inside a subscribeTab store). */
   isTabDirty: (path: string) => boolean;
-  /** Record an edit to the active tab's buffer (debounced autosave). */
-  onEdit: (content: string) => void;
-  /** Record an edit to a SPECIFIC tab's buffer (debounced autosave). The
-   * editor's teardown settle path (#374) routes through this — by the time an
-   * unmounting editor settles a pending AI session, the active tab may
-   * already have changed, so the bytes carry their own path. No-op when the
-   * tab has no live runtime (e.g. it was deleted). */
+  /** Snapshot of one open tab's live editor state (a stable empty state for
+   * unknown/still-loading paths). Pair with subscribeTab for
+   * useSyncExternalStore — every open tab's pane renders its OWN state, not
+   * the active tab's (#369). */
+  getTabState: (path: string) => VaultEditorState;
+  /** Record an edit to a SPECIFIC tab's buffer (debounced autosave). Every
+   * pane routes its edits through this with its own path — panes for
+   * background tabs stay mounted (#369) and their editors can still emit
+   * (AI settle on teardown #374, external re-seeds), so bytes always carry
+   * the path of the editor that produced them. No-op when the tab has no
+   * live runtime (e.g. it was deleted). */
   editTab: (path: string, content: string) => void;
   /** Create a file at `path` (e.g. "folder/note.md") and open it. */
   createFile: (path: string) => Promise<void>;
@@ -166,6 +170,11 @@ type VaultContextValue = {
   /** Why the open file is Raw-only (parse error / out-of-vocabulary construct),
    * or null. Drives the header's Raw badge tooltip. */
   rawReason: RawReason | null;
+  /** The path `canonical`/`richSafe`/`rawReason`/`mode` were computed for.
+   * Normally the active tab, but it LAGS during the switch-to-a-dirty-tab
+   * window (analysis only recomputes over saved bytes) — panes compare it to
+   * their own path before adopting the context view (#369). */
+  analyzedPath: string | null;
   /** Raw (byte-exact textarea) vs Rich (Plate) editing surface. */
   mode: "raw" | "rich";
   setMode: (mode: "raw" | "rich") => void;
@@ -364,6 +373,10 @@ export function VaultProvider({ children }: { children: ReactNode }) {
 
   const isTabDirty = useCallback((path: string): boolean => {
     return runtimes.current.get(path)?.controller.getState().dirty ?? false;
+  }, []);
+
+  const getTabState = useCallback((path: string): VaultEditorState => {
+    return runtimes.current.get(path)?.controller.getState() ?? NO_TAB_STATE;
   }, []);
 
   // ---- Active-tab editor state ---------------------------------------------
@@ -685,7 +698,7 @@ export function VaultProvider({ children }: { children: ReactNode }) {
       cycleTab,
       subscribeTab,
       isTabDirty,
-      onEdit,
+      getTabState,
       editTab,
       createFile,
       createFileAt,
@@ -698,6 +711,7 @@ export function VaultProvider({ children }: { children: ReactNode }) {
       canonical: analysis.canonical,
       richSafe: analysis.richSafe,
       rawReason: analysis.rawReason,
+      analyzedPath: analyzed.path,
       mode,
       setMode,
       formatDoc,
@@ -713,7 +727,7 @@ export function VaultProvider({ children }: { children: ReactNode }) {
       cycleTab,
       subscribeTab,
       isTabDirty,
-      onEdit,
+      getTabState,
       editTab,
       createFile,
       createFileAt,
@@ -724,6 +738,7 @@ export function VaultProvider({ children }: { children: ReactNode }) {
       resolveWikiTarget,
       isMarkdownOpen,
       analysis,
+      analyzed.path,
       mode,
       formatDoc,
     ],


### PR DESCRIPTION
Fixes #369 — the last deliberate v1 tradeoff, done properly.

## Architecture

Hidden-but-mounted panes: one Plate editor per live tab (`display:none` when inactive), MRU-capped at 5 (older tabs fall back to remount-on-activate). Instance-swap was rejected — it fights Plate at every seam (unmount-settle refires per switch, out-of-band mutation during streams, seed reconciliation). Scroll saved/restored per tab; hidden panes do zero per-keystroke work.

## The one-editor-assumption rework

Nine module-level single-editor assumptions audited and fixed: settle registry → per-path Map, `ai-session` gains a session owner (a second-editor run used to orphan the first's tokens forever), per-path review store, visibility-gated AI menu/embed dialog, combobox cancel-on-hide, scoped TOC, pane-path transclusion/delegation roots. Drive-by: ghost-text no longer eats Ctrl+Tab.

## Review catches (fixed + measured)

- **Perf**: hidden panes re-rendered per keystroke through the context — 7×55–110ms long tasks per 90-char burst at 5 panes; memoized pane body → back to 1. 
- **Three portalled-UI leaks**: turn-into menu (live-confirmed floating over the next tab, editing the hidden doc), block menu, embed dialog — all close on pane deactivate.

## Verification

793 tests green ×force post-rebase; live attack drive: undo isolation both directions, AI stream across Ctrl+Tab landing hidden + review re-presenting, close-tab-with-pending-suggestions (typing survives — #374 holds through close), cap eviction, rename-during-hidden-stream, combobox absorb leak check, 18-cycle stress.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Large editor/workspace refactor with many global singletons (AI session, embed opener, settle registry) and portalled UI edge cases; incorrect pane gating could edit the wrong document or corrupt AI runs across tabs.
> 
> **Overview**
> **Per-tab live editors (#369)** — The workspace now mounts one pane per “live” tab (MRU-capped at five), hiding inactive panes with `display:none` instead of unmounting so undo history, in-progress AI, and DOM state survive tab switches. Per-tab scroll offsets are saved/restored on the shared `<main>` scroller; older tabs beyond the cap remount on activation as before.
> 
> **Vault API** — Panes subscribe to **`getTabState(path)`** / **`editTab(path, …)`** instead of a single active **`onEdit`**. **`analyzedPath`** lets hidden panes freeze rich/raw until analysis matches their file.
> 
> **Multi-editor fixes** — **`EditorPaneContext`** gates portalled UI (AI menu, block menu, embed dialog, comboboxes, selection toolbar) and scopes TOC, transclusion cycle roots, delegation, and backlinks per pane. **`transient-settle`** and **`ai-review-store`** are keyed by path; **`ai-session`** tracks a **`sessionOwner`** so opening AI on another tab tears down the previous session. Ghost text accepts Tab only without modifiers so **Ctrl+Tab** still cycles tabs.
> 
> **Perf** — Memoized **`TabPaneBody`** avoids re-rendering hidden panes on every keystroke in the active tab.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 49e05605e117283974e73e58f4fdcc5bd3a9cbd2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Keeps one live editor per open tab so undo history and scroll survive tab switches, capped to the 5 most-recent tabs. Fixes #369 and closes several UI leaks from portalled components.

- New Features
  - Per-tab editor instances: inactive panes are hidden (not unmounted), with MRU cap of 5.
  - Per-tab scroll is saved/restored on the shared main scroller.
  - Each pane renders its own tab state via getTabState/subscribeTab and routes edits with editTab(path,...).
  - Added EditorPaneContext {path, active} to scope UI and behavior to the hosting pane.

- Bug Fixes
  - Portalled UI gates to the active pane and closes on deactivate: AI menu, block menu, selection toolbar, and embed URL dialog.
  - AI session now has an explicit session owner to prevent cross-editor token leaks.
  - Transient settle is per-path; review state is per-path (useAiReviewStore holds a set) so background tabs don’t affect the active badge.
  - TOC, transclusion, delegation, and inline combobox are pane-scoped; combobox cancels on deactivate; ghost text ignores modified Tab.
  - Performance: memoized TabPaneBody so hidden panes skip per-keystroke re-renders.

<sup>Written for commit 49e05605e117283974e73e58f4fdcc5bd3a9cbd2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kyh/inteligir/pull/387?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

