### PR TITLE
feat(desktop): verify:packaged asserts notarization

### DIFF
--- a/apps/desktop/scripts/verify-packaged-runtime-deps.mjs
+++ b/apps/desktop/scripts/verify-packaged-runtime-deps.mjs
@@ -13,6 +13,7 @@
 //     excludes node_modules wholesale, so the failure mode is "didn't bundle,"
 //     not "missing from package.json."
 
+import { execFileSync } from "node:child_process";
 import { existsSync, readdirSync, readFileSync, statSync } from "node:fs";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -113,6 +114,29 @@ for (const dep of BUNDLED_RUNTIME_DEPS) {
     console.log(`[verify-packaged] OK: ${dep} bundled into main process`);
   } else {
     fail(`${dep} not found in the built main bundle — agent boot will crash in the DMG`);
+  }
+}
+
+// Notarization: a regression here is silent until a user's Gatekeeper
+// rejects the download. Hard-fail unless the build deliberately skipped
+// notarization (dry runs set INTELIGIR_SKIP_NOTARY_CHECK=1).
+if (process.env.INTELIGIR_SKIP_NOTARY_CHECK === "1") {
+  console.log("[verify-packaged] SKIPPED: notarization checks (INTELIGIR_SKIP_NOTARY_CHECK=1)");
+} else {
+  try {
+    execFileSync("xcrun", ["stapler", "validate", app], { stdio: "pipe" });
+    console.log("[verify-packaged] OK: notarization ticket stapled");
+  } catch (err) {
+    fail(`stapler validate failed — app is not notarized/stapled: ${err.message}`);
+  }
+  try {
+    const out = execFileSync("spctl", ["-a", "-vv", app], { stdio: "pipe" }).toString();
+    // spctl writes its verdict to stderr; execFileSync throws on non-zero, so
+    // reaching here means accepted. Log the source line when available.
+    console.log(`[verify-packaged] OK: Gatekeeper accepted${out.trim() ? ` (${out.trim()})` : ""}`);
+  } catch (err) {
+    const detail = err.stderr?.toString().trim() ?? err.message;
+    fail(`spctl rejected the app — Gatekeeper would block it: ${detail}`);
   }
 }
 


### PR DESCRIPTION
Adds `xcrun stapler validate` + `spctl -a -vv` to the packaged-app verification — a notarization regression is now loud instead of surfacing as a user's Gatekeeper rejection. `INTELIGIR_SKIP_NOTARY_CHECK=1` escapes for deliberate unsigned dry runs.

Verified against the real notarized 0.3.0 .app (all checks pass incl. the new two) and the skip path.

Also swept (untracked, no diff): the stale 0.1.x/0.2.0 DMGs out of `.output/bin` — 1.1G → 649M.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Release-time verification only on macOS; no runtime app behavior changes, with an explicit skip for unsigned builds.
> 
> **Overview**
> Extends **`verify-packaged-runtime-deps.mjs`** (run via `pnpm verify:packaged` after `electron-builder --mac`) with **macOS notarization/Gatekeeper checks** so a broken release fails at build time instead of when users download the DMG.
> 
> After the existing bundle and native-dep assertions, the script now runs **`xcrun stapler validate`** on the built `.app` and **`spctl -a -vv`** to confirm Gatekeeper would accept it; either failure hard-exits with a clear message. **`INTELIGIR_SKIP_NOTARY_CHECK=1`** skips both checks for deliberate unsigned/dry-run builds.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0232e60c249b728149aeedbbb3a754ef0e2b6be5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enforces macOS notarization in the packaged-app verification so failures happen in CI, not on users’ machines. The `verify:packaged` script now checks for a stapled ticket and Gatekeeper acceptance.

- **New Features**
  - Adds `xcrun stapler validate` and `spctl -a -vv` checks; hard-fails if missing or rejected.
  - Supports `INTELIGIR_SKIP_NOTARY_CHECK=1` to skip checks for deliberate unsigned dry runs.

<sup>Written for commit 0232e60c249b728149aeedbbb3a754ef0e2b6be5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kyh/inteligir/pull/390?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

