### PR TITLE
Simplify: unify text-turn, dedup editor helpers, consistency

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -8,7 +8,9 @@
     ".output",
     ".tanstack",
     "out",
-    "routeTree.gen.ts"
+    "routeTree.gen.ts",
+    ".design-sync",
+    ".ds-sync"
   ],
   "plugins": ["eslint", "typescript", "unicorn", "react", "oxc", "node", "promise"],
   "categories": {

--- a/apps/desktop/src/renderer/editor/ai/ai-prompts.ts
+++ b/apps/desktop/src/renderer/editor/ai/ai-prompts.ts
@@ -1,0 +1,147 @@
+// AI menu prompt data + builders — the pure, editor-agnostic half of the AI
+// session. No Plate/editor state here: canned actions, translate targets, and
+// the functions that turn an (action, request, context) into the exact prompt
+// string the host runs. Kept separate from the run/token state machine in
+// ai-session.ts so each file reads as one concern.
+
+export type CannedActionId =
+  | "continue"
+  | "summarize"
+  | "explain"
+  | "improve"
+  | "longer"
+  | "shorter"
+  | "grammar"
+  | "simplify";
+
+export type CannedAction = {
+  id: CannedActionId;
+  label: string;
+  intent: "generate" | "edit";
+  /** Which command set offers the action (potion's split): `cursor` when the
+   * captured selection is collapsed, `selection` when text is selected. */
+  scope: "cursor" | "selection";
+  keywords: string[];
+};
+
+export const CANNED_ACTIONS: CannedAction[] = [
+  {
+    id: "continue",
+    label: "Continue writing",
+    intent: "generate",
+    scope: "cursor",
+    keywords: ["write", "more"],
+  },
+  {
+    id: "summarize",
+    label: "Summarize",
+    intent: "generate",
+    scope: "cursor",
+    keywords: ["tldr", "summary"],
+  },
+  {
+    id: "explain",
+    label: "Explain",
+    intent: "generate",
+    scope: "cursor",
+    keywords: ["what", "meaning"],
+  },
+  {
+    id: "improve",
+    label: "Improve writing",
+    intent: "edit",
+    scope: "selection",
+    keywords: ["rewrite", "better"],
+  },
+  {
+    id: "longer",
+    label: "Make longer",
+    intent: "edit",
+    scope: "selection",
+    keywords: ["expand", "elaborate"],
+  },
+  {
+    id: "shorter",
+    label: "Make shorter",
+    intent: "edit",
+    scope: "selection",
+    keywords: ["concise", "shorten"],
+  },
+  {
+    id: "grammar",
+    label: "Fix spelling & grammar",
+    intent: "edit",
+    scope: "selection",
+    keywords: ["spelling", "typo"],
+  },
+  {
+    id: "simplify",
+    label: "Simplify language",
+    intent: "edit",
+    scope: "selection",
+    keywords: ["plain", "simple"],
+  },
+];
+
+/** Translate targets offered on the AI menu's language page — a pragmatic
+ * subset (free-form prompts cover the rest). */
+export const TRANSLATE_LANGUAGES = [
+  "English",
+  "Spanish",
+  "French",
+  "German",
+  "Portuguese",
+  "Japanese",
+  "Korean",
+  "Chinese (Simplified)",
+] as const;
+
+const PROMPT_BASE =
+  "You are a writing assistant inside a notes editor. Respond with ONLY the resulting text — no preamble, no surrounding quotes, no markdown code fences, no explanation.";
+
+export function generatePromptFor(
+  action: CannedActionId | null,
+  request: string,
+  context: string,
+): string {
+  switch (action) {
+    case "continue":
+      return `${PROMPT_BASE}\n\nContinue the following text naturally with one short paragraph:\n\n${context}`;
+    case "summarize":
+      return `${PROMPT_BASE}\n\nWrite a concise summary of the following:\n\n${context}`;
+    case "explain":
+      return `${PROMPT_BASE}\n\nExplain the following in one short, plain-language paragraph:\n\n${context}`;
+    default:
+      return `${PROMPT_BASE}\n\nContext:\n\n${context}\n\nRequest: ${request}`;
+  }
+}
+
+export function editInstructionFor(action: CannedActionId | null, request: string): string {
+  switch (action) {
+    case "improve":
+      return "Improve the writing for clarity and flow, keeping the meaning and the markdown structure.";
+    case "longer":
+      return "Make the content longer by elaborating on the existing ideas, without changing meaning or adding new information. Keep the markdown structure.";
+    case "shorter":
+      return "Make the content more concise, keeping the meaning and the markdown structure.";
+    case "grammar":
+      return "Fix spelling, grammar, and punctuation only. Do not change meaning, tone, or structure.";
+    case "simplify":
+      return "Simplify the language using clearer, more straightforward wording, without changing meaning. Keep the markdown structure.";
+    default:
+      return request;
+  }
+}
+
+// The <markdown> sentinel is load-bearing: the host passes the prompt through
+// verbatim, and the dev-harness fixture parses the block back out to fake an
+// edit. Keep in sync with fixture-bridge.ts.
+export function buildEditPrompt(instruction: string, markdown: string): string {
+  return [
+    "You are a writing assistant inside a notes editor. Apply the instruction to the markdown document below.",
+    "Respond with ONLY the full rewritten markdown — same dialect (GitHub-flavored), no code fences around the whole answer, no commentary.",
+    "",
+    `<instruction>\n${instruction}\n</instruction>`,
+    `<markdown>\n${markdown}\n</markdown>`,
+  ].join("\n");
+}

--- a/apps/desktop/src/renderer/editor/ai/ai-session.ts
+++ b/apps/desktop/src/renderer/editor/ai/ai-session.ts
@@ -13,6 +13,11 @@
 //   floating bar.
 // Free-form prompts are classified host-side (generate on any failure);
 // canned actions carry a fixed intent.
+//
+// Two siblings hold what used to live inline here: prompt DATA + builders in
+// ai-prompts.ts, and the run/token lifecycle (supersession fencing, streaming
+// requestIds, host-side abort) in run-manager.ts. This file is the
+// editor-facing state machine that wires them together.
 
 import {
   isHotkey,
@@ -31,7 +36,22 @@ import type { AiIntentResult } from "@repo/features/inline-ai";
 import { getBridge } from "@renderer/lib/bridge";
 import { createMarkdownStream, stripAiMarks } from "@renderer/editor/ai/stream-markdown";
 import { applyEditSuggestions } from "@renderer/editor/ai/suggestions";
+import {
+  buildEditPrompt,
+  CANNED_ACTIONS,
+  editInstructionFor,
+  generatePromptFor,
+  TRANSLATE_LANGUAGES,
+  type CannedAction,
+  type CannedActionId,
+} from "@renderer/editor/ai/ai-prompts";
+import { runManager } from "@renderer/editor/ai/run-manager";
 import { MD_STRINGIFY, parseMarkdown } from "@renderer/editor/markdown/markdown-doc";
+
+// The menu UI + canned-action tests import these from here — re-exported so
+// their import paths stay put while the definitions live in ai-prompts.ts.
+export { CANNED_ACTIONS, TRANSLATE_LANGUAGES };
+export type { CannedActionId };
 
 // ---------------------------------------------------------------------------
 // Plugin state
@@ -103,169 +123,20 @@ export const AiSessionPlugin = createTPlatePlugin<PluginConfig<"aiSession", AiSe
 });
 
 // ---------------------------------------------------------------------------
-// Canned actions
-// ---------------------------------------------------------------------------
-
-export type CannedActionId =
-  | "continue"
-  | "summarize"
-  | "explain"
-  | "improve"
-  | "longer"
-  | "shorter"
-  | "grammar"
-  | "simplify";
-
-export type CannedAction = {
-  id: CannedActionId;
-  label: string;
-  intent: "generate" | "edit";
-  /** Which command set offers the action (potion's split): `cursor` when the
-   * captured selection is collapsed, `selection` when text is selected. */
-  scope: "cursor" | "selection";
-  keywords: string[];
-};
-
-export const CANNED_ACTIONS: CannedAction[] = [
-  {
-    id: "continue",
-    label: "Continue writing",
-    intent: "generate",
-    scope: "cursor",
-    keywords: ["write", "more"],
-  },
-  {
-    id: "summarize",
-    label: "Summarize",
-    intent: "generate",
-    scope: "cursor",
-    keywords: ["tldr", "summary"],
-  },
-  {
-    id: "explain",
-    label: "Explain",
-    intent: "generate",
-    scope: "cursor",
-    keywords: ["what", "meaning"],
-  },
-  {
-    id: "improve",
-    label: "Improve writing",
-    intent: "edit",
-    scope: "selection",
-    keywords: ["rewrite", "better"],
-  },
-  {
-    id: "longer",
-    label: "Make longer",
-    intent: "edit",
-    scope: "selection",
-    keywords: ["expand", "elaborate"],
-  },
-  {
-    id: "shorter",
-    label: "Make shorter",
-    intent: "edit",
-    scope: "selection",
-    keywords: ["concise", "shorten"],
-  },
-  {
-    id: "grammar",
-    label: "Fix spelling & grammar",
-    intent: "edit",
-    scope: "selection",
-    keywords: ["spelling", "typo"],
-  },
-  {
-    id: "simplify",
-    label: "Simplify language",
-    intent: "edit",
-    scope: "selection",
-    keywords: ["plain", "simple"],
-  },
-];
-
-/** Translate targets offered on the AI menu's language page — a pragmatic
- * subset (free-form prompts cover the rest). */
-export const TRANSLATE_LANGUAGES = [
-  "English",
-  "Spanish",
-  "French",
-  "German",
-  "Portuguese",
-  "Japanese",
-  "Korean",
-  "Chinese (Simplified)",
-] as const;
-
-const PROMPT_BASE =
-  "You are a writing assistant inside a notes editor. Respond with ONLY the resulting text — no preamble, no surrounding quotes, no markdown code fences, no explanation.";
-
-function generatePromptFor(
-  action: CannedActionId | null,
-  request: string,
-  context: string,
-): string {
-  switch (action) {
-    case "continue":
-      return `${PROMPT_BASE}\n\nContinue the following text naturally with one short paragraph:\n\n${context}`;
-    case "summarize":
-      return `${PROMPT_BASE}\n\nWrite a concise summary of the following:\n\n${context}`;
-    case "explain":
-      return `${PROMPT_BASE}\n\nExplain the following in one short, plain-language paragraph:\n\n${context}`;
-    default:
-      return `${PROMPT_BASE}\n\nContext:\n\n${context}\n\nRequest: ${request}`;
-  }
-}
-
-function editInstructionFor(action: CannedActionId | null, request: string): string {
-  switch (action) {
-    case "improve":
-      return "Improve the writing for clarity and flow, keeping the meaning and the markdown structure.";
-    case "longer":
-      return "Make the content longer by elaborating on the existing ideas, without changing meaning or adding new information. Keep the markdown structure.";
-    case "shorter":
-      return "Make the content more concise, keeping the meaning and the markdown structure.";
-    case "grammar":
-      return "Fix spelling, grammar, and punctuation only. Do not change meaning, tone, or structure.";
-    case "simplify":
-      return "Simplify the language using clearer, more straightforward wording, without changing meaning. Keep the markdown structure.";
-    default:
-      return request;
-  }
-}
-
-// The <markdown> sentinel is load-bearing: the host passes the prompt through
-// verbatim, and the dev-harness fixture parses the block back out to fake an
-// edit. Keep in sync with fixture-bridge.ts.
-function buildEditPrompt(instruction: string, markdown: string): string {
-  return [
-    "You are a writing assistant inside a notes editor. Apply the instruction to the markdown document below.",
-    "Respond with ONLY the full rewritten markdown — same dialect (GitHub-flavored), no code fences around the whole answer, no commentary.",
-    "",
-    `<instruction>\n${instruction}\n</instruction>`,
-    `<markdown>\n${markdown}\n</markdown>`,
-  ].join("\n");
-}
-
-// ---------------------------------------------------------------------------
-// Run bookkeeping (module-level: one editor surface, one session at a time)
+// Session bookkeeping (module-level: one editor surface, one session at a time).
+// The run/token lifecycle — supersession fencing, streaming, host-side abort —
+// lives in run-manager.ts; what stays here is session-level state: the last
+// request (for "Try again") and the generate-flow undo depth.
 // ---------------------------------------------------------------------------
 
 type LastRun =
   | { kind: "canned"; action: CannedActionId }
   | { kind: "prompt"; text: string; intent: "generate" | "edit" };
 
-let runCounter = 0;
-// Bumped on every cancel/close; async continuations check it before touching
-// the editor so a stale response can't land after the user moved on.
-let runToken = 0;
 let lastRun: LastRun | null = null;
-// Generate-flow unwind state: history depth before the AI touched the doc,
-// stream unsubscribe, and the in-flight requestId (for host-side abort).
+// Generate-flow unwind state: editor history depth before the AI touched the
+// doc, so discard/cancel can undo precisely back to it.
 let undoDepth = 0;
-let streamOff: (() => void) | null = null;
-let activeRequestId: string | null = null;
 
 /**
  * Release the module-level session bookkeeping when the (single) editor
@@ -276,13 +147,7 @@ let activeRequestId: string | null = null;
  * disk never saw it).
  */
 export function releaseAiSession(): void {
-  runToken += 1;
-  streamOff?.();
-  streamOff = null;
-  if (activeRequestId !== null) {
-    void getBridge()?.cancelInlineAi({ requestId: activeRequestId });
-    activeRequestId = null;
-  }
+  runManager.abort();
   lastRun = null;
 }
 
@@ -326,7 +191,7 @@ export function closeAiMenu(editor: PlateEditor): void {
   } else if (status === "review") {
     unwindGenerate(editor);
   }
-  runToken += 1;
+  runManager.bumpToken();
   const sel = savedSelection(editor);
   setOptions(editor, { status: "closed", anchor: null, savedSelection: null, error: null });
   lastRun = null;
@@ -336,13 +201,7 @@ export function closeAiMenu(editor: PlateEditor): void {
 
 /** Abort the in-flight run (Escape / stop button) and return to the prompt. */
 export function cancelActiveRun(editor: PlateEditor): void {
-  runToken += 1;
-  streamOff?.();
-  streamOff = null;
-  if (activeRequestId !== null) {
-    void getBridge()?.cancelInlineAi({ requestId: activeRequestId });
-    activeRequestId = null;
-  }
+  runManager.abort();
   const status = editor.getOption(AiSessionPlugin, "status");
   if (status === "generating") unwindGenerate(editor);
   setOptions(editor, { status: "input", error: null });
@@ -364,7 +223,7 @@ export function submitAiPrompt(editor: PlateEditor, text: string): void {
   const prompt = text.trim();
   if (!bridge || prompt.length === 0) return;
   if (editor.getOption(AiSessionPlugin, "status") === "review") unwindGenerate(editor);
-  const token = ++runToken;
+  const token = runManager.bumpToken();
   setOptions(editor, { status: "classifying", error: null });
   const sel = savedSelection(editor);
   const hasSelection = sel !== null && RangeApi.isExpanded(sel);
@@ -373,7 +232,7 @@ export function submitAiPrompt(editor: PlateEditor, text: string): void {
     .classifyAiIntent({ prompt, hasSelection })
     .catch(() => fallback)
     .then(({ intent }) => {
-      if (runToken !== token) return; // canceled / closed while classifying
+      if (!runManager.isCurrent(token)) return; // canceled / closed while classifying
       lastRun = { kind: "prompt", text: prompt, intent };
       if (intent === "edit") startEdit(editor, editInstructionFor(null, prompt));
       else startGenerate(editor, null, prompt);
@@ -431,24 +290,22 @@ function startGenerate(editor: PlateEditor, action: CannedActionId | null, reque
 
   undoDepth = editor.history.undos.length;
   const stream = createMarkdownStream(editor, caretBlock);
-  const token = ++runToken;
-  runCounter += 1;
-  const requestId = `menu-${runCounter}`;
-  activeRequestId = requestId;
+  const { token, requestId } = runManager.begin();
   setOptions(editor, { status: "generating", error: null });
 
-  streamOff = bridge.onAiStreamed(({ requestId: id, delta }) => {
-    if (id !== requestId || delta.length === 0 || runToken !== token) return;
-    stream.append(delta);
-  });
+  runManager.setStream(
+    bridge.onAiStreamed(({ requestId: id, delta }) => {
+      if (id !== requestId || delta.length === 0 || !runManager.isCurrent(token)) return;
+      stream.append(delta);
+    }),
+  );
 
   void bridge
     .generateInlineAi({ prompt: generatePromptFor(action, request, context), requestId })
     .then((result) => {
-      if (runToken !== token) return undefined;
-      streamOff?.();
-      streamOff = null;
-      activeRequestId = null;
+      if (!runManager.isCurrent(token)) return undefined;
+      runManager.stopStream();
+      runManager.clearActive();
       if (!result.ok) {
         unwindGenerate(editor);
         setOptions(editor, { status: "error", error: result.error });
@@ -460,10 +317,9 @@ function startGenerate(editor: PlateEditor, action: CannedActionId | null, reque
       return undefined;
     })
     .catch(() => {
-      if (runToken !== token) return;
-      streamOff?.();
-      streamOff = null;
-      activeRequestId = null;
+      if (!runManager.isCurrent(token)) return;
+      runManager.stopStream();
+      runManager.clearActive();
       setOptions(editor, { status: "error", error: "AI request failed." });
     });
 }
@@ -475,7 +331,7 @@ export function acceptGenerate(editor: PlateEditor): void {
   const at = editor.selection;
   setOptions(editor, { status: "closed", anchor: null, savedSelection: null, error: null });
   lastRun = null;
-  runToken += 1;
+  runManager.bumpToken();
   if (at) editor.tf.select(at);
   editor.tf.focus();
 }
@@ -527,17 +383,14 @@ function startEdit(editor: PlateEditor, instruction: string): void {
     return;
   }
   const markdown = serializeMd(editor, { remarkStringifyOptions: MD_STRINGIFY, value: nodes });
-  const token = ++runToken;
-  runCounter += 1;
-  const requestId = `menu-${runCounter}`;
-  activeRequestId = requestId;
+  const { token, requestId } = runManager.begin();
   setOptions(editor, { status: "editing", error: null });
 
   void bridge
     .generateInlineAi({ prompt: buildEditPrompt(instruction, markdown), requestId })
     .then((result) => {
-      if (runToken !== token) return undefined; // canceled / closed
-      activeRequestId = null;
+      if (!runManager.isCurrent(token)) return undefined; // canceled / closed
+      runManager.clearActive();
       if (!result.ok) {
         setOptions(editor, { status: "error", error: result.error });
         return undefined;
@@ -552,15 +405,15 @@ function startEdit(editor: PlateEditor, instruction: string): void {
         return undefined;
       }
       // Suggestions are in the document; the review bar owns them from here.
-      runToken += 1;
+      runManager.bumpToken();
       setOptions(editor, { status: "closed", anchor: null, savedSelection: null, error: null });
       lastRun = null;
       editor.tf.focus();
       return undefined;
     })
     .catch(() => {
-      if (runToken !== token) return;
-      activeRequestId = null;
+      if (!runManager.isCurrent(token)) return;
+      runManager.clearActive();
       setOptions(editor, { status: "error", error: "AI request failed." });
     });
 }

--- a/apps/desktop/src/renderer/editor/ai/run-manager.ts
+++ b/apps/desktop/src/renderer/editor/ai/run-manager.ts
@@ -1,0 +1,72 @@
+// Run/token lifecycle for the editor's AI menu. One editor surface, one run at
+// a time — so the bookkeeping is module-level, exactly like the session it
+// serves. A monotonic `token` fences async continuations: every cancel / close
+// / new run bumps it, and a continuation that finds its token stale drops its
+// result rather than touching an editor the user has moved on from. A streaming
+// run also carries a host `requestId` (to filter its stream events and abort it
+// host-side) plus the stream's unsubscribe handle.
+
+import { getBridge } from "@renderer/lib/bridge";
+
+// Bumped on every cancel / close / new run; continuations compare their captured
+// token against isCurrent() before mutating the editor.
+let runToken = 0;
+// Monotonic per-run id source — pairs a run with the host for streaming + abort.
+let runCounter = 0;
+// The in-flight host requestId (for host-side abort), null when idle.
+let activeRequestId: string | null = null;
+// The active stream's unsubscribe, null when not streaming.
+let streamOff: (() => void) | null = null;
+
+export const runManager = {
+  /** Start a new streaming / host run: invalidate any prior run, mint a fresh
+   * requestId, and mark it in-flight. Returns the `token` that fences
+   * continuations and the `requestId` used to filter stream events + abort. */
+  begin(): { token: number; requestId: string } {
+    const token = ++runToken;
+    runCounter += 1;
+    const requestId = `menu-${runCounter}`;
+    activeRequestId = requestId;
+    return { token, requestId };
+  },
+
+  /** Invalidate the current run without minting a streaming one — used by
+   * close / accept and by the tokenless classify turn (which needs the fresh
+   * token to fence its own continuation). Returns the new token. */
+  bumpToken(): number {
+    return ++runToken;
+  },
+
+  /** True while `token` still identifies the current run. */
+  isCurrent(token: number): boolean {
+    return runToken === token;
+  },
+
+  /** Record the active stream's unsubscribe handle. */
+  setStream(off: () => void): void {
+    streamOff = off;
+  },
+
+  /** Stop the active stream (idempotent). */
+  stopStream(): void {
+    streamOff?.();
+    streamOff = null;
+  },
+
+  /** Clear the in-flight host requestId (the turn resolved on its own). */
+  clearActive(): void {
+    activeRequestId = null;
+  },
+
+  /** Supersession teardown shared by cancel + release: invalidate the run, stop
+   * the stream, and abort the host-side turn if one is still in flight. */
+  abort(): void {
+    runToken += 1;
+    streamOff?.();
+    streamOff = null;
+    if (activeRequestId !== null) {
+      void getBridge()?.cancelInlineAi({ requestId: activeRequestId });
+      activeRequestId = null;
+    }
+  },
+};

--- a/apps/desktop/src/renderer/editor/kits/basic-blocks-kit.tsx
+++ b/apps/desktop/src/renderer/editor/kits/basic-blocks-kit.tsx
@@ -37,6 +37,7 @@ import {
   ParagraphPlugin,
   PlateElement,
   PlateLeaf,
+  type PlateEditor,
   type PlateElementProps,
   type PlateLeafProps,
 } from "platejs/react";
@@ -152,6 +153,18 @@ const CalloutMarkerPlugin = createSlatePlugin({
     return [range];
   },
 }).withComponent(CalloutMarkerLeaf);
+
+/**
+ * Insert a horizontal rule (void divider), then a trailing empty paragraph so
+ * the caret has a landing spot below it. Slash-menu insert.
+ */
+export function insertHorizontalRule(editor: PlateEditor): void {
+  editor.tf.insertNodes(
+    { type: HorizontalRulePlugin.key, children: [{ text: "" }] },
+    { select: true },
+  );
+  editor.tf.insertNodes({ type: editor.getType(KEYS.p), children: [{ text: "" }] });
+}
 
 export const BasicBlocksKit = [
   ParagraphPlugin.withComponent(ParagraphElement),

--- a/apps/desktop/src/renderer/editor/kits/basic-marks-kit.tsx
+++ b/apps/desktop/src/renderer/editor/kits/basic-marks-kit.tsx
@@ -28,7 +28,8 @@ import {
   StrikethroughPlugin,
   UnderlinePlugin,
 } from "@platejs/basic-nodes/react";
-import { PlateLeaf, type PlateLeafProps } from "platejs/react";
+
+import { classNameLeaf } from "@renderer/editor/kits/kit-utils";
 
 export const BasicMarksBaseKit = [
   BaseBoldPlugin,
@@ -38,27 +39,20 @@ export const BasicMarksBaseKit = [
   BaseCodePlugin,
 ];
 
-// className-only leaf renderers keep the marks trivial and on-theme.
-function leaf(className: string) {
-  return function Leaf(props: PlateLeafProps) {
-    return <PlateLeaf {...props} className={className} />;
-  };
-}
-
 export const BasicMarksKit = [
   BoldPlugin.configure({
     inputRules: [BoldRules.markdown(), MarkComboRules.markdown({ variant: "boldItalic" })],
-  }).withComponent(leaf("font-semibold")),
+  }).withComponent(classNameLeaf("font-semibold")),
   ItalicPlugin.configure({
     inputRules: [ItalicRules.markdown(), ItalicRules.markdown({ variant: "_" })],
-  }).withComponent(leaf("italic")),
-  UnderlinePlugin.withComponent(leaf("underline")),
+  }).withComponent(classNameLeaf("italic")),
+  UnderlinePlugin.withComponent(classNameLeaf("underline")),
   StrikethroughPlugin.configure({
     inputRules: [StrikethroughRules.markdown()],
-  }).withComponent(leaf("line-through")),
+  }).withComponent(classNameLeaf("line-through")),
   CodePlugin.configure({
     inputRules: [CodeRules.markdown()],
   }).withComponent(
-    leaf("whitespace-pre-wrap rounded-md bg-muted px-[0.3em] py-[0.2em] font-mono text-sm"),
+    classNameLeaf("whitespace-pre-wrap rounded-md bg-muted px-[0.3em] py-[0.2em] font-mono text-sm"),
   ),
 ];

--- a/apps/desktop/src/renderer/editor/kits/code-block-kit.tsx
+++ b/apps/desktop/src/renderer/editor/kits/code-block-kit.tsx
@@ -5,10 +5,11 @@
 
 import { useState } from "react";
 import { CodeIcon, EyeIcon } from "lucide-react";
-import { NodeApi } from "platejs";
+import { KEYS, NodeApi } from "platejs";
 import {
   PlateElement,
   PlateLeaf,
+  type PlateEditor,
   type PlateElementProps,
   type PlateLeafProps,
 } from "platejs/react";
@@ -18,6 +19,7 @@ import { common, createLowlight } from "lowlight";
 
 import { cn } from "@repo/ui/lib/utils";
 
+import { TURN_INTO, turnIntoSelection } from "@renderer/editor/block-transforms";
 import { MermaidPreview } from "@renderer/editor/nodes/code-block-mermaid";
 
 export const CodeBlockBaseKit = [BaseCodeBlockPlugin, BaseCodeLinePlugin];
@@ -101,6 +103,21 @@ function CodeBlockElement(props: PlateElementProps) {
 
 function CodeLineElement(props: PlateElementProps) {
   return <PlateElement {...props} as="div" />;
+}
+
+// A mermaid diagram is a plain ```mermaid fence (render-only preview — zero
+// serialization surface), seeded with a minimal valid graph. Reuses the "Code
+// block" turn-into so the fence's byte-form matches every other code block's.
+export function insertMermaid(editor: PlateEditor): void {
+  const codeBlock = TURN_INTO.find((opt) => opt.label === "Code block");
+  if (codeBlock) turnIntoSelection(editor, codeBlock);
+  editor.tf.setNodes(
+    { lang: "mermaid" },
+    { match: (n) => n.type === editor.getType(KEYS.codeBlock) },
+  );
+  editor.tf.insertText("graph TD;");
+  editor.tf.insertBreak();
+  editor.tf.insertText("  A-->B;");
 }
 
 export const CodeBlockKit = [

--- a/apps/desktop/src/renderer/editor/kits/kit-utils.tsx
+++ b/apps/desktop/src/renderer/editor/kits/kit-utils.tsx
@@ -1,0 +1,29 @@
+// Shared className-only node renderers. Plate plugins ship headless, so most
+// nodes render as a fixed tag + className wrapper. Two base components are
+// covered: the live editor uses PlateElement/PlateLeaf (platejs/react); the
+// read-only transclusion render uses SlateElement (platejs/static) — same
+// shape, different render path, so it gets its own factory.
+
+import { PlateElement, PlateLeaf, type PlateElementProps, type PlateLeafProps } from "platejs/react";
+import { SlateElement, type SlateElementProps } from "platejs/static";
+
+/** className-only element renderer over the live PlateElement. */
+export function classNameElement(as: keyof HTMLElementTagNameMap, className: string) {
+  return function Element(props: PlateElementProps) {
+    return <PlateElement {...props} as={as} className={className} />;
+  };
+}
+
+/** className-only element renderer over the static SlateElement (transclusion). */
+export function classNameSlateElement(as: keyof HTMLElementTagNameMap, className: string) {
+  return function StaticElement(props: SlateElementProps) {
+    return <SlateElement {...props} as={as} className={className} />;
+  };
+}
+
+/** className-only leaf renderer over the live PlateLeaf. */
+export function classNameLeaf(className: string) {
+  return function Leaf(props: PlateLeafProps) {
+    return <PlateLeaf {...props} className={className} />;
+  };
+}

--- a/apps/desktop/src/renderer/editor/kits/table-kit.tsx
+++ b/apps/desktop/src/renderer/editor/kits/table-kit.tsx
@@ -14,8 +14,8 @@ import {
   TablePlugin,
   TableRowPlugin,
 } from "@platejs/table/react";
-import { PlateElement, type PlateElementProps } from "platejs/react";
 
+import { classNameElement } from "@renderer/editor/kits/kit-utils";
 import { TableElement } from "@renderer/editor/nodes/table-node";
 
 export const TableBaseKit = [
@@ -25,12 +25,6 @@ export const TableBaseKit = [
   BaseTableCellHeaderPlugin,
 ];
 
-function element(as: keyof HTMLElementTagNameMap, className: string) {
-  return function Element(props: PlateElementProps) {
-    return <PlateElement {...props} as={as} className={className} />;
-  };
-}
-
 // Cell styling shared with the transclusion card's read-only static render
 // (transclusion.tsx) so live tables and embedded tables can't drift apart.
 export const TABLE_CELL_CLASS = "min-w-24 border border-border px-3 py-1.5 align-top [&>*]:my-0";
@@ -39,7 +33,7 @@ export const TABLE_HEADER_CELL_CLASS =
 
 export const TableKit = [
   TablePlugin.withComponent(TableElement),
-  TableRowPlugin.withComponent(element("tr", "")),
-  TableCellPlugin.withComponent(element("td", TABLE_CELL_CLASS)),
-  TableCellHeaderPlugin.withComponent(element("th", TABLE_HEADER_CELL_CLASS)),
+  TableRowPlugin.withComponent(classNameElement("tr", "")),
+  TableCellPlugin.withComponent(classNameElement("td", TABLE_CELL_CLASS)),
+  TableCellHeaderPlugin.withComponent(classNameElement("th", TABLE_HEADER_CELL_CLASS)),
 ];

--- a/apps/desktop/src/renderer/editor/markdown/md-rules.ts
+++ b/apps/desktop/src/renderer/editor/markdown/md-rules.ts
@@ -68,19 +68,40 @@ const ALERT_RE = /^\s*\[!(NOTE|TIP|IMPORTANT|WARNING|CAUTION)\]/;
 // rules spread it — leaking `id="…"` junk into user files. These serialize
 // overrides mirror the defaults minus the leak; deserialize is not overridden
 // (rule dispatch falls back to the default per-function).
-function mediaSerializeWithoutId(node: TElement, options: SerializeMdOptions) {
-  const { id, children, type, url, ...rest } = node;
+// Shared body of the four MDX-flow serialize rules below (media, toggle,
+// column, callout): drop the leaked `id`, serialize children, emit an
+// `mdxJsxFlowElement`. Overrides carry each rule's specifics — `name` defaults
+// to the node's own type (media's video/media_embed/file), `mapProps` reshapes
+// the leftover props before they become attributes (media's url→src), and
+// `children` overrides the default child serialization (column's empty `[]`).
+type JsxFlowOverrides = {
+  name?: string;
+  children?: ReturnType<typeof convertNodesSerialize>;
+  mapProps?: (rest: Record<string, unknown>) => Record<string, unknown>;
+};
+
+function jsxFlowSerialize(node: TElement, options: SerializeMdOptions, overrides: JsxFlowOverrides) {
+  const { id, children, type, ...rest } = node;
   void id;
-  // A url-less media node (`<video />`) must OMIT src entirely: spreading
-  // `src: undefined` emits a bare `src` attribute, which the vocabulary scan
-  // itself rejects on the next parse (non-string attr → Raw).
-  const props = typeof url === "string" ? { ...rest, src: url } : rest;
   return {
-    attributes: propsToAttributes(props),
-    children: convertNodesSerialize(children, options),
-    name: type,
+    attributes: propsToAttributes(overrides.mapProps ? overrides.mapProps(rest) : rest),
+    children: overrides.children ?? convertNodesSerialize(children, options),
+    name: overrides.name ?? type,
     type: "mdxJsxFlowElement",
   };
+}
+
+function mediaSerializeWithoutId(node: TElement, options: SerializeMdOptions) {
+  return jsxFlowSerialize(node, options, {
+    // A url-less media node (`<video />`) must OMIT src entirely: spreading
+    // `src: undefined` emits a bare `src` attribute, which the vocabulary scan
+    // itself rejects on the next parse (non-string attr → Raw). `name` falls
+    // back to the node's own type (video / media_embed / file).
+    mapProps: (rest) => {
+      const { url, ...props } = rest;
+      return typeof url === "string" ? { ...props, src: url } : props;
+    },
+  });
 }
 
 // --- links -----------------------------------------------------------------
@@ -205,17 +226,8 @@ export const MD_RULES: MdRules = {
       type: "toggle",
       ...parseAttributes(node.attributes),
     }),
-    serialize: (node: TElement, options: SerializeMdOptions) => {
-      const { id, children, type, ...rest } = node;
-      void id;
-      void type;
-      return {
-        attributes: propsToAttributes(rest),
-        children: convertNodesSerialize(children, options),
-        name: "toggle",
-        type: "mdxJsxFlowElement",
-      };
-    },
+    serialize: (node: TElement, options: SerializeMdOptions) =>
+      jsxFlowSerialize(node, options, { name: "toggle" }),
   },
 
   // Serialize-only override of Plate's column rule. A column holding only an
@@ -228,9 +240,7 @@ export const MD_RULES: MdRules = {
   // before every column had content.
   column: {
     serialize: (node: TElement, options: SerializeMdOptions) => {
-      const { id, children, type, ...rest } = node;
-      void id;
-      void type;
+      const { children } = node;
       const only = children.length === 1 ? children[0] : undefined;
       const onlyText =
         only !== undefined &&
@@ -240,12 +250,12 @@ export const MD_RULES: MdRules = {
           ? only.children[0]
           : undefined;
       const isEmpty = onlyText !== undefined && TextApi.isText(onlyText) && onlyText.text === "";
-      return {
-        attributes: propsToAttributes(rest),
-        children: isEmpty ? [] : convertNodesSerialize(children, options),
+      // Empty column ⇒ self-closed `<column />` (children: []); populated ⇒
+      // default child serialization.
+      return jsxFlowSerialize(node, options, {
         name: "column",
-        type: "mdxJsxFlowElement",
-      };
+        ...(isEmpty ? { children: [] } : {}),
+      });
     },
   },
 
@@ -273,17 +283,8 @@ export const MD_RULES: MdRules = {
 
   // id-leak overrides (see mediaSerializeWithoutId).
   callout: {
-    serialize: (node: TElement, options: SerializeMdOptions) => {
-      const { id, children, type, ...rest } = node;
-      void id;
-      void type;
-      return {
-        attributes: propsToAttributes(rest),
-        children: convertNodesSerialize(children, options),
-        name: "callout",
-        type: "mdxJsxFlowElement",
-      };
-    },
+    serialize: (node: TElement, options: SerializeMdOptions) =>
+      jsxFlowSerialize(node, options, { name: "callout" }),
   },
   video: { serialize: mediaSerializeWithoutId },
   media_embed: { serialize: mediaSerializeWithoutId },

--- a/apps/desktop/src/renderer/editor/slash-menu.tsx
+++ b/apps/desktop/src/renderer/editor/slash-menu.tsx
@@ -8,7 +8,6 @@
 // Phase F slot: the `[[` wiki-link picker will be a second inline-combobox
 // consumer following the emoji-input pattern.
 
-import { HorizontalRulePlugin } from "@platejs/basic-nodes/react";
 import { SlashInputPlugin, SlashPlugin } from "@platejs/slash-command/react";
 import { insertTable } from "@platejs/table";
 import {
@@ -50,6 +49,8 @@ import {
   InlineComboboxInput,
   InlineComboboxItem,
 } from "@renderer/editor/inline-combobox";
+import { insertHorizontalRule } from "@renderer/editor/kits/basic-blocks-kit";
+import { insertMermaid } from "@renderer/editor/kits/code-block-kit";
 import { insertColumnGroup } from "@renderer/editor/kits/column-kit";
 import { insertDate } from "@renderer/editor/kits/date-kit";
 import { insertEquation, insertInlineEquation } from "@renderer/editor/kits/math-kit";
@@ -59,27 +60,6 @@ import { openAiMenu, runCannedAction } from "@renderer/editor/ai/ai-session";
 function turnInto(editor: PlateEditor, label: string): void {
   const opt = TURN_INTO.find((o) => o.label === label);
   if (opt) turnIntoSelection(editor, opt);
-}
-
-function insertHorizontalRule(editor: PlateEditor) {
-  editor.tf.insertNodes(
-    { type: HorizontalRulePlugin.key, children: [{ text: "" }] },
-    { select: true },
-  );
-  editor.tf.insertNodes({ type: editor.getType(KEYS.p), children: [{ text: "" }] });
-}
-
-// A mermaid diagram is a plain ```mermaid fence (render-only preview — zero
-// serialization surface), seeded with a minimal valid graph.
-function insertMermaid(editor: PlateEditor) {
-  turnInto(editor, "Code block");
-  editor.tf.setNodes(
-    { lang: "mermaid" },
-    { match: (n) => n.type === editor.getType(KEYS.codeBlock) },
-  );
-  editor.tf.insertText("graph TD;");
-  editor.tf.insertBreak();
-  editor.tf.insertText("  A-->B;");
 }
 
 type SlashItem = {

--- a/apps/desktop/src/renderer/editor/transclusion.tsx
+++ b/apps/desktop/src/renderer/editor/transclusion.tsx
@@ -26,6 +26,7 @@ import { cn } from "@repo/ui/lib/utils";
 
 import { getBridge } from "@renderer/lib/bridge";
 import { BASE_KIT } from "@renderer/editor/kits/base-kit";
+import { classNameSlateElement } from "@renderer/editor/kits/kit-utils";
 import { TABLE_CELL_CLASS, TABLE_HEADER_CELL_CLASS } from "@renderer/editor/kits/table-kit";
 import { parseMarkdown } from "@renderer/editor/markdown/markdown-doc";
 import {
@@ -154,12 +155,6 @@ function TableRowStatic(props: SlateElementProps) {
   return <SlateElement {...props} as="tr" />;
 }
 
-function tableCellStatic(as: "td" | "th", className: string) {
-  return function TableCellStatic(props: SlateElementProps) {
-    return <SlateElement {...props} as={as} className={className} />;
-  };
-}
-
 const STATIC_COMPONENTS: Record<string, (props: SlateElementProps) => ReactNode> = {
   a: LinkStatic,
   date: DateStatic,
@@ -171,8 +166,8 @@ const STATIC_COMPONENTS: Record<string, (props: SlateElementProps) => ReactNode>
   frontmatter: FrontmatterStatic,
   table: TableStatic,
   tr: TableRowStatic,
-  td: tableCellStatic("td", TABLE_CELL_CLASS),
-  th: tableCellStatic("th", TABLE_HEADER_CELL_CLASS),
+  td: classNameSlateElement("td", TABLE_CELL_CLASS),
+  th: classNameSlateElement("th", TABLE_HEADER_CELL_CLASS),
   wikiLink: WikiLinkStatic,
   wikiEmbed: WikiEmbedStatic,
 };

--- a/apps/desktop/src/renderer/stores/voice-store.ts
+++ b/apps/desktop/src/renderer/stores/voice-store.ts
@@ -1,5 +1,6 @@
 import { create } from "zustand";
 
+import { toErrorMessage } from "@repo/features/ipc";
 import { getBridge } from "@renderer/lib/bridge";
 import { VoicePipeline } from "@renderer/voice/voice-pipeline";
 import { VoiceMachine, type VoiceState } from "@renderer/voice/voice-machine";
@@ -98,7 +99,7 @@ async function runConnect(): Promise<void> {
     if (gen !== machine.generation) return;
     machine.dispatch({
       type: "model_download_failed",
-      message: err instanceof Error ? err.message : String(err),
+      message: toErrorMessage(err),
     });
     return;
   }
@@ -114,7 +115,7 @@ async function runConnect(): Promise<void> {
       if (gen !== machine.generation) return;
       machine.dispatch({
         type: "model_download_failed",
-        message: err instanceof Error ? err.message : String(err),
+        message: toErrorMessage(err),
       });
       return;
     }
@@ -136,7 +137,7 @@ async function runConnect(): Promise<void> {
     if (gen !== machine.generation) return;
     machine.dispatch({
       type: "connect_failed",
-      message: err instanceof Error ? err.message : String(err),
+      message: toErrorMessage(err),
     });
     return;
   }

--- a/apps/desktop/src/renderer/voice/stt.ts
+++ b/apps/desktop/src/renderer/voice/stt.ts
@@ -3,6 +3,7 @@
 // chunks to the main process where sherpa-onnx + streaming Parakeet runs.
 // ---------------------------------------------------------------------------
 
+import { toErrorMessage } from "@repo/features/ipc";
 import { getBridge } from "@renderer/lib/bridge";
 import sttWorkletUrl from "./stt-worklet.js?url"; // relative: the ./src exports map can't address a raw .js asset
 
@@ -82,7 +83,7 @@ export async function startSTT(
       // can transfer a typed chunk without exposing its backing buffer here.
       bridge.sendSttAudio(event.data);
     } catch (err) {
-      onError(err instanceof Error ? err.message : String(err));
+      onError(toErrorMessage(err));
     }
   };
   workletNode.port.addEventListener("message", handleWorkletMessage);
@@ -117,7 +118,7 @@ export async function startSTT(
           return undefined;
         })
         .catch((err: unknown) => {
-          onError(err instanceof Error ? err.message : String(err));
+          onError(toErrorMessage(err));
         })
         .finally(() => {
           workletNode.port.removeEventListener("message", handleWorkletMessage);

--- a/apps/desktop/src/renderer/workspace/vault-context.tsx
+++ b/apps/desktop/src/renderer/workspace/vault-context.tsx
@@ -35,6 +35,14 @@ const AUTOSAVE_DEBOUNCE_MS = 600;
 /** ui-state key the open note persists under (restored on boot). */
 const OPEN_NOTE_KEY = "workspace.openNote";
 
+/**
+ * Append the default `.md` extension unless `name` already ends in one (any
+ * lowercase-alphanumeric extension). `name` is assumed already trimmed.
+ */
+function withDefaultExtension(name: string): string {
+  return /\.[a-z0-9]+$/i.test(name) ? name : `${name}.md`;
+}
+
 // IO the editor controller acts through — thin wrappers over the bridge so the
 // controller stays bridge-agnostic and unit-testable. A missing bridge throws,
 // which the controller treats like any read/write failure.
@@ -307,7 +315,7 @@ export function VaultProvider({ children }: { children: ReactNode }) {
     async (rawPath: string): Promise<boolean> => {
       const trimmed = rawPath.trim();
       if (!trimmed) return false;
-      const path = /\.[a-z0-9]+$/i.test(trimmed) ? trimmed : `${trimmed}.md`;
+      const path = withDefaultExtension(trimmed);
       const bridge = getBridge();
       if (!bridge) return false;
       // Don't truncate an existing file — it already satisfies "exists".
@@ -331,7 +339,7 @@ export function VaultProvider({ children }: { children: ReactNode }) {
     async (rawPath: string) => {
       const trimmed = rawPath.trim();
       if (!trimmed) return;
-      const path = /\.[a-z0-9]+$/i.test(trimmed) ? trimmed : `${trimmed}.md`;
+      const path = withDefaultExtension(trimmed);
       if (await createFileAt(path)) openFile(path);
     },
     [createFileAt, openFile],

--- a/packages/features/src/server/agent/browser/extension.ts
+++ b/packages/features/src/server/agent/browser/extension.ts
@@ -18,6 +18,7 @@ import fs from "node:fs/promises";
 import path from "node:path";
 
 import { Type, type Static } from "@sinclair/typebox";
+import { toErrorMessage } from "@repo/features/ipc";
 import { installCliFromGithubRelease } from "@repo/features/server/agent-runtime/install";
 import { runCli } from "@repo/features/server/agent-runtime/run-cli";
 
@@ -112,7 +113,7 @@ const browserExtension: PiExtensionBundle = {
             });
             return await toToolResult(params.args, result);
           } catch (err) {
-            return textResult(`browser error: ${err instanceof Error ? err.message : String(err)}`);
+            return textResult(`browser error: ${toErrorMessage(err)}`);
           }
         },
       });
@@ -213,7 +214,7 @@ async function toToolResult(
         mimeType: mimeTypeForPath(screenshotPath),
       });
     } catch (err) {
-      textContent.text = `${textContent.text}\n\n[screenshot read failed]\n${err instanceof Error ? err.message : String(err)}`;
+      textContent.text = `${textContent.text}\n\n[screenshot read failed]\n${toErrorMessage(err)}`;
     }
   }
 

--- a/packages/features/src/server/agent/executor/extension.ts
+++ b/packages/features/src/server/agent/executor/extension.ts
@@ -21,6 +21,7 @@
  */
 
 import { Type } from "@sinclair/typebox";
+import { toErrorMessage } from "@repo/features/ipc";
 import type { ExtensionAPI } from "@repo/features/server/pi/pi-types";
 
 import type { ExecutorPort, PiExtensionBundle } from "../extension";
@@ -162,7 +163,7 @@ function registerExecute(pi: ExtensionAPI, executor: ExecutorPort): void {
         const result = await executor.execute(params.code);
         return textResult(withAuthHint(result));
       } catch (err) {
-        return textResult(`execute failed: ${err instanceof Error ? err.message : String(err)}`);
+        return textResult(`execute failed: ${toErrorMessage(err)}`);
       }
     },
   });
@@ -181,7 +182,7 @@ function registerResume(pi: ExtensionAPI, executor: ExecutorPort): void {
         const result = await executor.resume(params.executionId, params.action, params.content);
         return textResult(withAuthHint(result));
       } catch (err) {
-        return textResult(`resume failed: ${err instanceof Error ? err.message : String(err)}`);
+        return textResult(`resume failed: ${toErrorMessage(err)}`);
       }
     },
   });

--- a/packages/features/src/server/agent/peekaboo/extension.ts
+++ b/packages/features/src/server/agent/peekaboo/extension.ts
@@ -14,6 +14,7 @@
 import path from "node:path";
 
 import { Type, type Static } from "@sinclair/typebox";
+import { toErrorMessage } from "@repo/features/ipc";
 import { installCliFromGithubRelease } from "@repo/features/server/agent-runtime/install";
 import { runCli } from "@repo/features/server/agent-runtime/run-cli";
 
@@ -81,9 +82,7 @@ const peekabooExtension: PiExtensionBundle = {
             });
             return textResult(formatCliOutput(result));
           } catch (err) {
-            return textResult(
-              `peekaboo error: ${err instanceof Error ? err.message : String(err)}`,
-            );
+            return textResult(`peekaboo error: ${toErrorMessage(err)}`);
           }
         },
       });

--- a/packages/features/src/server/app/app-machine.ts
+++ b/packages/features/src/server/app/app-machine.ts
@@ -32,6 +32,7 @@ import { downloadModel } from "../voice/model-download";
 import { parseAgentEvent } from "@repo/features/agent-event-parser";
 import type { AppAgentEvent } from "@repo/features/agent-events";
 import type { AppState, MachineEvent } from "@repo/features/app-state";
+import { toErrorMessage } from "@repo/features/ipc";
 
 // ---------------------------------------------------------------------------
 // Agent singleton — runs in the main process
@@ -243,7 +244,7 @@ export async function reauthenticate(): Promise<{ ok: boolean; error?: string }>
       await newSession();
       return { ok: true };
     } catch (err) {
-      const message = err instanceof Error ? err.message : String(err);
+      const message = toErrorMessage(err);
       console.error("[machine] reauthenticate failed:", message);
       return { ok: false, error: message };
     }

--- a/packages/features/src/server/app/ghost-text.ts
+++ b/packages/features/src/server/app/ghost-text.ts
@@ -18,7 +18,7 @@ import { Agent } from "../agent/agent";
 import { AUTH_PROVIDER } from "../agent/paths";
 import { getAgentPorts } from "../lib/agent-lifecycle";
 import { getUiState } from "../ui-state";
-import { parseAgentEvent } from "@repo/features/agent-event-parser";
+import { runTextTurn } from "./text-turn";
 import {
   GHOST_TEXT_MODEL_UI_STATE,
   type GhostModelsResult,
@@ -124,30 +124,23 @@ async function runGhost(prompt: string, requestId: string): Promise<GhostTextRes
   }
   if (!a) return { ok: false, error: "No ghost-text model is available." };
   currentRequestId = requestId;
-  let captured = "";
-  const unsubscribe = a.subscribe((raw) => {
-    const event = parseAgentEvent(raw);
-    if (event?.type === "message_update") captured += event.delta;
-    else if (event?.type === "message_end" && event.role === "assistant" && event.text) {
-      captured = event.text;
-    }
-  });
   try {
-    await a.sendMessage(prompt);
-    const finished = await a.waitForIdle(GHOST_TIMEOUT_MS);
-    turns += 1;
-    if (!finished) {
-      await a.interrupt().catch(() => {});
-      return { ok: false, error: "Ghost text timed out." };
+    const result = await runTextTurn(a, prompt, { timeoutMs: GHOST_TIMEOUT_MS });
+    // A turn counts toward the recycle budget once it reaches idle or times out,
+    // but not when the send itself threw (matching the original placement of the
+    // increment right after waitForIdle).
+    if (result.ok || result.kind === "timeout") turns += 1;
+    if (!result.ok) {
+      return {
+        ok: false,
+        error: result.kind === "timeout" ? "Ghost text timed out." : result.error,
+      };
     }
     // Canceled or superseded mid-turn — the caller's completion is stale.
     if (currentRequestId !== requestId) return { ok: false, error: "Canceled." };
-    const text = captured.trim();
+    const text = result.text.trim();
     return text.length > 0 ? { ok: true, text } : { ok: false, error: "No completion." };
-  } catch (err) {
-    return { ok: false, error: err instanceof Error ? err.message : "Ghost text failed." };
   } finally {
-    unsubscribe();
     if (currentRequestId === requestId) currentRequestId = null;
   }
 }

--- a/packages/features/src/server/app/inline-ai.ts
+++ b/packages/features/src/server/app/inline-ai.ts
@@ -13,7 +13,7 @@
 import { Agent } from "../agent/agent";
 import { INLINE_AI_SESSION_DIR } from "../agent/paths";
 import { getAgentPorts } from "../lib/agent-lifecycle";
-import { parseAgentEvent } from "@repo/features/agent-event-parser";
+import { runTextTurn } from "./text-turn";
 import {
   parseAiIntent,
   type AiGenerateResult,
@@ -66,32 +66,23 @@ export async function generateInline(prompt: string, requestId: string): Promise
   if (busy) return { ok: false, error: "Another AI request is already running." };
   busy = true;
   currentRequestId = requestId;
-  let captured = "";
-  const unsubscribe = agent.subscribe((raw) => {
-    const event = parseAgentEvent(raw);
-    if (event?.type === "message_update") {
-      captured += event.delta;
-      streamNotifier?.(requestId, event.delta);
-    } else if (event?.type === "message_end" && event.role === "assistant" && event.text) {
-      captured = event.text;
-    }
-  });
   try {
-    await agent.sendMessage(prompt);
-    const finished = await agent.waitForIdle(GEN_TIMEOUT_MS);
-    if (!finished) {
-      await agent.interrupt().catch(() => {});
-      return { ok: false, error: "The AI request timed out." };
+    const result = await runTextTurn(agent, prompt, {
+      timeoutMs: GEN_TIMEOUT_MS,
+      onDelta: (delta) => streamNotifier?.(requestId, delta),
+    });
+    if (!result.ok) {
+      return {
+        ok: false,
+        error: result.kind === "timeout" ? "The AI request timed out." : result.error,
+      };
     }
     // Canceled mid-stream: the renderer already unwound its inserts; report
     // failure so no caller mistakes the truncated text for a completion.
     if (currentRequestId !== requestId) return { ok: false, error: "Canceled." };
-    const text = captured.trim();
+    const text = result.text.trim();
     return text.length > 0 ? { ok: true, text } : { ok: false, error: "No response." };
-  } catch (err) {
-    return { ok: false, error: err instanceof Error ? err.message : "AI request failed." };
   } finally {
-    unsubscribe();
     busy = false;
     if (currentRequestId === requestId) currentRequestId = null;
   }
@@ -132,25 +123,15 @@ export async function classifyIntent(
   const fallback: AiIntentResult = { intent: "generate" };
   if (!agent || busy) return fallback;
   busy = true;
-  let captured = "";
-  const unsubscribe = agent.subscribe((raw) => {
-    const event = parseAgentEvent(raw);
-    if (event?.type === "message_end" && event.role === "assistant" && event.text) {
-      captured = event.text;
-    }
-  });
   try {
-    await agent.sendMessage(buildClassifyPrompt(prompt, hasSelection));
-    const finished = await agent.waitForIdle(CLASSIFY_TIMEOUT_MS);
-    if (!finished) {
-      await agent.interrupt().catch(() => {});
-      return fallback;
-    }
-    return { intent: parseAiIntent(captured) };
-  } catch {
-    return fallback;
+    const result = await runTextTurn(agent, buildClassifyPrompt(prompt, hasSelection), {
+      timeoutMs: CLASSIFY_TIMEOUT_MS,
+    });
+    // Any failure (timeout, thrown) falls back to generate — the non-destructive
+    // branch. An unparseable reply is handled by parseAiIntent's own fallback.
+    if (!result.ok) return fallback;
+    return { intent: parseAiIntent(result.text) };
   } finally {
-    unsubscribe();
     busy = false;
   }
 }

--- a/packages/features/src/server/app/text-turn.ts
+++ b/packages/features/src/server/app/text-turn.ts
@@ -1,0 +1,90 @@
+// ---------------------------------------------------------------------------
+// runTextTurn — the shared core of "run one isolated agent text turn". The same
+// subscribe → capture streamed deltas → sendMessage → waitForIdle(timeout) →
+// interrupt-on-timeout block was hand-copied across the inline-AI generator,
+// intent classifier, ghost-text completer, and delegation runner. This owns
+// ONLY the turn mechanics; every caller keeps its own supersession/epoch/queue
+// bookkeeping and post-processes the returned text (trim, empty-reply strings,
+// parse, staleness/stop guards, custom timeout messages) itself — that's
+// exactly where the copies legitimately diverged.
+// ---------------------------------------------------------------------------
+
+import { parseAgentEvent } from "@repo/features/agent-event-parser";
+import { toErrorMessage } from "@repo/features/ipc";
+
+/** The subset of the Agent surface one text turn drives. Structural so the real
+ * Agent satisfies it and tests can pass a lightweight fake without casts
+ * (mirrors DelegationAgent). */
+export type TextTurnAgent = {
+  subscribe(listener: (event: unknown) => void): () => void;
+  sendMessage(message: string): Promise<void>;
+  waitForIdle(timeoutMs: number): Promise<boolean>;
+  interrupt(): Promise<unknown>;
+};
+
+/**
+ * Outcome of one turn. Three variants so callers can distinguish the paths the
+ * originals treated differently:
+ * - `ok`    — the turn went idle; `text` is the captured assistant text, RAW
+ *             (untrimmed) — callers trim / parse / empty-check as they see fit.
+ * - timeout — waitForIdle elapsed; the turn was interrupted before returning.
+ * - error   — sendMessage/waitForIdle threw; `error` is `toErrorMessage(err)`.
+ *
+ * The timeout/error split matters: delegation's stop-guard applies to timeouts
+ * but not throws, and ghost-text counts a turn on timeout but not on a throw.
+ * Timeout carries no message — callers supply their own ("Timed out", etc.).
+ */
+export type TextTurnResult =
+  | { ok: true; text: string }
+  | { ok: false; kind: "timeout" }
+  | { ok: false; kind: "error"; error: string };
+
+export type TextTurnOptions = {
+  /** Milliseconds to wait for the agent to go idle before interrupting. */
+  timeoutMs: number;
+  /** Each assistant text delta (message_update), for live streaming. */
+  onDelta?: (delta: string) => void;
+  /** Each tool-call start (tool_execution_start), for a live transcript. Only
+   * fires for tool-enabled agents — the pure text generators never call it. */
+  onToolCall?: (toolName: string) => void;
+};
+
+/**
+ * Run one isolated agent text turn. Subscribes and captures the streamed
+ * assistant text, sends `prompt`, waits for idle (interrupting on timeout), and
+ * returns the captured text. Capture mirrors the originals exactly: text deltas
+ * accumulate, and a final assistant `message_end` REPLACES the accumulation —
+ * so `text` is the complete reply when the model emits one, the streamed
+ * fragment otherwise.
+ */
+export async function runTextTurn(
+  agent: TextTurnAgent,
+  prompt: string,
+  opts: TextTurnOptions,
+): Promise<TextTurnResult> {
+  let captured = "";
+  const unsubscribe = agent.subscribe((raw) => {
+    const event = parseAgentEvent(raw);
+    if (event?.type === "message_update") {
+      captured += event.delta;
+      opts.onDelta?.(event.delta);
+    } else if (event?.type === "tool_execution_start") {
+      opts.onToolCall?.(event.toolName);
+    } else if (event?.type === "message_end" && event.role === "assistant" && event.text) {
+      captured = event.text;
+    }
+  });
+  try {
+    await agent.sendMessage(prompt);
+    const finished = await agent.waitForIdle(opts.timeoutMs);
+    if (!finished) {
+      await agent.interrupt().catch(() => {});
+      return { ok: false, kind: "timeout" };
+    }
+    return { ok: true, text: captured };
+  } catch (err) {
+    return { ok: false, kind: "error", error: toErrorMessage(err) };
+  } finally {
+    unsubscribe();
+  }
+}

--- a/packages/features/src/server/create-host.ts
+++ b/packages/features/src/server/create-host.ts
@@ -1,8 +1,13 @@
 // ---------------------------------------------------------------------------
-// createHost — the composition root of the node backend. A shell (Electron
-// desktop today, WebSocket server later) injects a HostPlatform, folds the
-// returned handler map into its transport, forwards `events`, and drives
-// start()/dispose() around its own lifecycle.
+// createHost — a one-shot singleton wiring/sequencer for the node backend, NOT
+// a graph composition root. It builds no object graph: the host's pieces are
+// process-global singletons (vault, knowledge, machine, executor daemon) and
+// the notifier slots it fills (store-recovery here, vault-change in start())
+// are module-global mutable function pointers. It just sequences their
+// init/teardown in order; a second call would silently share that module state,
+// so the `created` guard below makes it fail fast. A shell (Electron desktop
+// today, WebSocket server later) injects a HostPlatform, folds the returned
+// handler map into its transport, forwards `events`, and drives start()/dispose().
 // ---------------------------------------------------------------------------
 
 import { configurePaths } from "./agent/paths";

--- a/packages/features/src/server/delegation/delegation-manager.ts
+++ b/packages/features/src/server/delegation/delegation-manager.ts
@@ -17,7 +17,7 @@ import { DelegationSnapshotStore } from "./delegation-snapshots";
 import { findTaskLine } from "./find-task-line";
 import { JsonStore, inteligirPath, type FsAdapter } from "../lib/json-store";
 import { getVaultManager } from "../vault/vault";
-import { parseAgentEvent } from "@repo/features/agent-event-parser";
+import { runTextTurn } from "../app/text-turn";
 import {
   DelegationSchema,
   type CreateDelegationParams,
@@ -494,48 +494,44 @@ export class DelegationManager {
     }
     this.patch(delegation.id, { hasSnapshot: true });
 
-    const captured: { text: string | null } = { text: null };
+    // Build a live transcript for the response dock: the assistant's text deltas
+    // + a line per tool call so the user sees what it's doing before it writes
+    // anything. Only the turn's final message becomes the persisted summary.
     let streamed = "";
-    const unsubscribe = agent.subscribe((raw) => {
-      const event = parseAgentEvent(raw);
-      if (!event) return;
-      // Build a live transcript for the response dock: the assistant's text
-      // deltas + a line per tool call so the user sees what it's doing before it
-      // writes anything. Only the final message becomes the persisted summary.
-      if (event.type === "message_update") {
-        streamed += event.delta;
+    const result = await runTextTurn(agent, buildPrompt(fresh), {
+      timeoutMs: RUN_TIMEOUT_MS,
+      onDelta: (delta) => {
+        streamed += delta;
         streamNotifier?.(delegation.id, streamed);
-      } else if (event.type === "tool_execution_start") {
-        streamed += `${streamed ? "\n\n" : ""}\`⚙ ${event.toolName}\``;
+      },
+      onToolCall: (toolName) => {
+        streamed += `${streamed ? "\n\n" : ""}\`⚙ ${toolName}\``;
         streamNotifier?.(delegation.id, streamed);
-      } else if (event.type === "message_end" && event.role === "assistant" && event.text) {
-        captured.text = event.text;
-      }
+      },
     });
 
-    try {
-      await agent.sendMessage(buildPrompt(fresh));
-      const finished = await agent.waitForIdle(RUN_TIMEOUT_MS);
-      if (this.stopRequested === delegation.id) {
-        this.stopRequested = null;
-        this.finishRun(delegation.id, failedPatch("Stopped."));
-        return;
-      }
-      if (!finished) {
-        await agent.interrupt().catch(() => {});
-        this.finishRun(delegation.id, failedPatch("Timed out"));
-        return;
-      }
-      this.finishRun(delegation.id, {
-        status: "done",
-        finishedAt: Date.now(),
-        resultSummary: captured.text?.trim().slice(0, SUMMARY_LEN) ?? "Done",
-      });
-    } catch (err) {
-      this.finishRun(delegation.id, failedPatch(toErrorMessage(err)));
-    } finally {
-      unsubscribe();
+    // A thrown send/wait failure fails the run outright and — matching the
+    // original catch — is never reinterpreted as a user stop.
+    if (!result.ok && result.kind === "error") {
+      this.finishRun(delegation.id, failedPatch(result.error));
+      return;
     }
+    // A stop the user requested wins over a timeout, exactly as before (the stop
+    // path already interrupted the agent).
+    if (this.stopRequested === delegation.id) {
+      this.stopRequested = null;
+      this.finishRun(delegation.id, failedPatch("Stopped."));
+      return;
+    }
+    if (!result.ok) {
+      this.finishRun(delegation.id, failedPatch("Timed out"));
+      return;
+    }
+    this.finishRun(delegation.id, {
+      status: "done",
+      finishedAt: Date.now(),
+      resultSummary: result.text.length > 0 ? result.text.trim().slice(0, SUMMARY_LEN) : "Done",
+    });
   }
 }
 

--- a/packages/features/src/server/pi/agent.ts
+++ b/packages/features/src/server/pi/agent.ts
@@ -12,6 +12,7 @@ import type {
   ExtensionFactory,
 } from "@mariozechner/pi-coding-agent";
 import type { Api, AssistantMessage, ImageContent, Model } from "@mariozechner/pi-ai";
+import { toErrorMessage } from "@repo/features/ipc";
 
 export type PiAgentStatus = "starting" | "idle" | "busy" | "error";
 
@@ -185,7 +186,7 @@ export class PiAgent {
     this.status = "busy";
 
     void session.prompt(message, imgs ? { images: imgs } : undefined).catch((err: unknown) => {
-      this.error = err instanceof Error ? err.message : String(err);
+      this.error = toErrorMessage(err);
       console.error("[pi-driver] prompt error:", this.error);
       // Surface the rejection to subscribers — without this the user's
       // message renders as sent while the turn silently never happens (pi

--- a/packages/features/src/server/voice/model-download.ts
+++ b/packages/features/src/server/voice/model-download.ts
@@ -16,7 +16,7 @@ import unbzip2 from "unbzip2-stream";
 
 import { emitEvent } from "../events";
 import { getPlatform } from "../platform-instance";
-import type { VoiceModelStateEvent } from "@repo/features/ipc";
+import { toErrorMessage, type VoiceModelStateEvent } from "@repo/features/ipc";
 
 const streamPipeline = promisify(pipelineCb);
 
@@ -98,7 +98,7 @@ async function doDownload(): Promise<ModelDownloadResult> {
     emitProgress({ status: "ready" });
     return { ok: true };
   } catch (err) {
-    const message = err instanceof Error ? err.message : String(err);
+    const message = toErrorMessage(err);
     await rm(archive).catch(() => {});
     emitProgress({ status: "error", message });
     return { ok: false, error: message };

--- a/packages/features/src/server/voice/parakeet.ts
+++ b/packages/features/src/server/voice/parakeet.ts
@@ -6,7 +6,7 @@
 import { join } from "node:path";
 
 import { getModelDir, isModelInstalled } from "./model-download";
-import { isRecord } from "@repo/features/ipc";
+import { isRecord, toErrorMessage } from "@repo/features/ipc";
 
 // sherpa-onnx-node is loaded lazily so the app still boots when the model
 // isn't downloaded yet (the renderer just sees STT unavailable).
@@ -102,7 +102,7 @@ async function doInit(): Promise<InitResult> {
     recognizer = null;
     return {
       ok: false,
-      reason: `Failed to load sherpa-onnx native module: ${err instanceof Error ? err.message : String(err)}`,
+      reason: `Failed to load sherpa-onnx native module: ${toErrorMessage(err)}`,
     };
   }
 }


### PR DESCRIPTION
Implements the safe, high-leverage items from the codebase audit. Owned app code only — per the decisions made, `@repo/ui` (upstream mirror), `HostPlatform` (WebSocket/Expo roadmap), and `geometric-orb` (brand-critical) are left untouched, and the PiAgent merge is skipped (its pi-vendor boundary is worth keeping).

## Changes
1. **Unify the 6 hand-copied agent text-turn blocks** (the highest-leverage, most concurrency-sensitive item). Extract `runTextTurn` (`app/text-turn.ts`) reused by inline-ai (generate + classify), ghost-text, and delegation; a 3-variant result keeps timeout-vs-throw distinguishable so each caller's supersession/staleness/turn-count stays put. Renderer: extract `runManager` + `ai-prompts`, dropping `ai-session.ts` 566→419 lines to just the state machine.
2. **Editor dedup** — collapse 4 identical MDX serializers into one helper; hoist the `element()`/`leaf()` factories to `kit-utils`; move `insertHorizontalRule`/`insertMermaid` into their kits.
3. **Consistency** — 14 inlined error-ternaries → `toErrorMessage`; extract the duplicated `.md` extension helper; make `create-host`'s doc honest (it's a singleton sequencer, not a composition root); exclude `.design-sync` from lint.

## Verification
typecheck · lint · knip · **351 tests** · build all pass; app boots clean in the harness with zero console errors. All changes are behavior-preserving (the round-trip fixtures and delegation/canned-action tests are the guards). Two documented near-zero-risk deltas from the text-turn work: a non-`Error` throw now surfaces `String(err)` instead of a literal fallback, and a redundant (harmless) interrupt in a stop+timeout race.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Unifies agent text-turn logic and deduplicates editor helpers to reduce duplication and make runs safer and easier to maintain. Behavior stays the same; tests and harness pass.

- **Refactors**
  - Server: added `runTextTurn` and adopted it in inline generate/classify, ghost-text, and delegation to centralize subscribe → stream-capture → send → wait-for-idle → interrupt-on-timeout; keeps timeout vs error distinct and supports optional streaming/tool callbacks.
  - Renderer: added `runManager` (token/supersession/abort) and `ai-prompts` (prompt data/builders); `ai-session.ts` now focuses on the state machine with the same UX.
  - Markdown: introduced `jsxFlowSerialize` to replace four identical `mdxJsxFlowElement` serializers, avoid `id` leaks, and keep media `src` handling intact.
  - Editor kits: added `kit-utils` (className element/leaf factories for live/static renders) and moved `insertHorizontalRule`/`insertMermaid` into their respective kits; `slash-menu` is now pure wiring.
  - Consistency: replaced inline error coercion with `toErrorMessage`, added a `.md` defaulting helper for file creation, clarified `create-host` docs (singleton sequencer), and excluded `.design-sync`/`.ds-sync` from lint.

<sup>Written for commit 7ceffe69ac973494376e3ff72d289e68aee1a405. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kyh/inteligir/pull/396?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

