### PR TITLE
Composition root: build an explicit HostContext graph

### DIFF
--- a/apps/desktop/src/renderer/editor/ai/ai-session.ts
+++ b/apps/desktop/src/renderer/editor/ai/ai-session.ts
@@ -42,7 +42,6 @@ import {
   editInstructionFor,
   generatePromptFor,
   TRANSLATE_LANGUAGES,
-  type CannedAction,
   type CannedActionId,
 } from "@renderer/editor/ai/ai-prompts";
 import { runManager } from "@renderer/editor/ai/run-manager";

--- a/packages/features/src/server/app/app-machine.ts
+++ b/packages/features/src/server/app/app-machine.ts
@@ -21,12 +21,8 @@ import {
   stopBackgroundAgent,
 } from "../delegation/background-agent";
 import { stopGhostAgent } from "./ghost-text";
-import { setInlineAiStreamNotifier, startInlineAiAgent, stopInlineAiAgent } from "./inline-ai";
-import {
-  getDelegationManager,
-  setDelegationsChangedNotifier,
-  setDelegationStreamNotifier,
-} from "../delegation/delegation-manager";
+import { startInlineAiAgent, stopInlineAiAgent } from "./inline-ai";
+import { getDelegationManager } from "../delegation/delegation-manager";
 import { getNotifications } from "../notifications";
 import { downloadModel } from "../voice/model-download";
 import { parseAgentEvent } from "@repo/features/agent-event-parser";
@@ -362,15 +358,11 @@ export function transition(event: MachineEvent): void {
   machine?.ingest(event);
 }
 
-/** Determine initial state from persisted auth/setup and auto-start if ready. */
+/** Determine initial state from persisted auth/setup and auto-start if ready.
+ * The delegation + inline-AI push channels are no longer wired here — the
+ * composition root (create-host → buildHostContext) owns the whole notifier
+ * composition and injects them at construction. */
 export function initMachine(): void {
-  // Delegation push channel: the manager is electron-free, so the broadcast
-  // hookup happens here (composition root for the machine's main singletons).
-  setDelegationsChangedNotifier((delegations) =>
-    emitEvent("onDelegationsUpdated", { delegations }),
-  );
-  setDelegationStreamNotifier((id, text) => emitEvent("onDelegationStreamed", { id, text }));
-  setInlineAiStreamNotifier((requestId, delta) => emitEvent("onAiStreamed", { requestId, delta }));
   const loggedIn = isLoggedIn();
   const initial: AppState = loggedIn ? { phase: "logged_in" } : { phase: "logged_out" };
   machine = new AppMachine(realDeps, broadcastAppState, initial);

--- a/packages/features/src/server/app/inline-ai.ts
+++ b/packages/features/src/server/app/inline-ai.ts
@@ -13,6 +13,7 @@
 import { Agent } from "../agent/agent";
 import { INLINE_AI_SESSION_DIR } from "../agent/paths";
 import { getAgentPorts } from "../lib/agent-lifecycle";
+import { getHostNotifiers } from "../host-notifiers";
 import { runTextTurn } from "./text-turn";
 import {
   parseAiIntent,
@@ -31,13 +32,10 @@ let busy = false;
 let currentRequestId: string | null = null;
 
 // Streaming channel — pushes each text delta (keyed by requestId) so the editor
-// can insert the generation live. Wired from app-machine to stay electron-free.
-let streamNotifier: ((requestId: string, delta: string) => void) | null = null;
-
-export function setInlineAiStreamNotifier(
-  notifier: ((requestId: string, delta: string) => void) | null,
-): void {
-  streamNotifier = notifier;
+// can insert the generation live. Sourced from the host notifier bundle
+// (composed by create-host) so this module never imports the IPC event registry.
+function streamDelta(requestId: string, delta: string): void {
+  getHostNotifiers()?.inlineAiStream(requestId, delta);
 }
 
 export async function startInlineAiAgent(): Promise<void> {
@@ -69,7 +67,7 @@ export async function generateInline(prompt: string, requestId: string): Promise
   try {
     const result = await runTextTurn(agent, prompt, {
       timeoutMs: GEN_TIMEOUT_MS,
-      onDelta: (delta) => streamNotifier?.(requestId, delta),
+      onDelta: (delta) => streamDelta(requestId, delta),
     });
     if (!result.ok) {
       return {

--- a/packages/features/src/server/create-host.ts
+++ b/packages/features/src/server/create-host.ts
@@ -1,28 +1,27 @@
 // ---------------------------------------------------------------------------
-// createHost — a one-shot singleton wiring/sequencer for the node backend, NOT
-// a graph composition root. It builds no object graph: the host's pieces are
-// process-global singletons (vault, knowledge, machine, executor daemon) and
-// the notifier slots it fills (store-recovery here, vault-change in start())
-// are module-global mutable function pointers. It just sequences their
-// init/teardown in order; a second call would silently share that module state,
-// so the `created` guard below makes it fail fast. A shell (Electron desktop
-// today, WebSocket server later) injects a HostPlatform, folds the returned
-// handler map into its transport, forwards `events`, and drives start()/dispose().
+// createHost — the composition root for the node backend. It constructs the
+// explicit HostContext object graph (host-context.ts) in dependency order,
+// owns the whole notifier composition (the 5 slots are wired at build/start,
+// not mutated from app-machine), and sequences init/teardown over that graph.
+// The pieces are still process-global singletons under the hood — getX() stays
+// an accessor into this constructed graph with a lazy test fallback — so the
+// `created` guard makes a second call fail fast rather than silently share
+// module state. A shell (Electron desktop today, WebSocket server later)
+// injects a HostPlatform, folds the returned handler map into its transport,
+// forwards `events`, and drives start()/dispose().
 // ---------------------------------------------------------------------------
 
 import { configurePaths } from "./agent/paths";
 import { initMachine, shutdown } from "./app/app-machine";
-import { getDelegationManager } from "./delegation/delegation-manager";
-import { emitEvent, subscribeEvents } from "./events";
+import { subscribeEvents } from "./events";
+import { buildHostContext } from "./host-context";
 import { initAgentLog } from "./lib/agent-log";
 import { acquireHostLock, releaseHostLock } from "./lib/host-lock";
 import { collectHandlers, type HostHandlers } from "./lib/handler-registry";
 import { registerAllHandlers } from "./handlers/register-handlers";
-import { disposeKnowledgeManager, getKnowledgeManager } from "./knowledge/knowledge-manager";
-import { getNotifications } from "./notifications";
+import { disposeKnowledgeManager } from "./knowledge/knowledge-manager";
 import { installHostRuntime } from "./platform-instance";
-import { setStoreRecoveryNotifier } from "./lib/json-store";
-import { getVaultManager, setVaultChangeNotifier } from "./vault/vault";
+import { setVaultChangeNotifier } from "./vault/vault";
 import type { HostOptions, HostPlatform } from "./platform";
 import type { EventMethod } from "@repo/features/ipc-registry";
 
@@ -60,10 +59,12 @@ export function createHost(platform: HostPlatform, options: HostOptions = {}): H
   // Crash/debug visibility first, so even boot failures land in agent.log.
   initAgentLog();
 
-  // Quarantine notices must be user-visible before any store is read. This
-  // was an import-time side effect of notifications.ts; explicit here so a
-  // shell that never constructs notifications still surfaces recovery events.
-  setStoreRecoveryNotifier((event) => getNotifications().notifyStoreRecovered(event));
+  // Build the object graph: constructs the core singletons in dependency order
+  // and installs the notifier composition (store-recovery is wired inside,
+  // before any store is read — it used to be an import-time side effect of
+  // notifications.ts). ctx.notifiers holds the other four; vault-change is wired
+  // in start() because the watcher must not start until ensureReady() has run.
+  const ctx = buildHostContext();
 
   const handlers = collectHandlers(registerAllHandlers);
 
@@ -85,23 +86,22 @@ export function createHost(platform: HostPlatform, options: HostOptions = {}): H
       // Must run before any pi-coding-agent call that consults getAgentDir().
       configurePaths();
 
-      // Vault: ensure the folder + agent symlink exist and stream file changes
-      // to the UI so the sidebar and editor stay live. The notifier is
-      // module-scoped, so it survives a logout/login reset. Every vault change
-      // also nudges the knowledge index (debounced incremental refresh).
-      getVaultManager().ensureReady();
-      setVaultChangeNotifier((root) => {
-        emitEvent("onVaultChanged", { root });
-        getKnowledgeManager().scheduleRefresh();
-      });
+      // Vault: ensure the folder + agent symlink exist, THEN wire the change
+      // notifier (which starts the watcher — it must not start before the dir
+      // exists), streaming file changes to the UI so the sidebar and editor
+      // stay live. The notifier is module-scoped, so it survives a logout/login
+      // reset. Every vault change also nudges the knowledge index (debounced
+      // incremental refresh — that fan-out lives in ctx.notifiers.vaultChange).
+      ctx.vault.ensureReady();
+      setVaultChangeNotifier(ctx.notifiers.vaultChange);
       // First index build rides the debounce too, keeping it off the boot
       // path; a query landing earlier builds lazily.
-      getKnowledgeManager().scheduleRefresh();
+      ctx.knowledge.scheduleRefresh();
 
       // Snapshot retention sweep (keep the newest SNAPSHOT_RETENTION pre-run
       // copies). Best-effort — a prune failure must never block boot.
       try {
-        getDelegationManager().pruneSnapshots();
+        ctx.delegation.pruneSnapshots();
       } catch (err) {
         console.warn("[host] delegation snapshot prune failed:", err);
       }

--- a/packages/features/src/server/delegation/delegation-manager.ts
+++ b/packages/features/src/server/delegation/delegation-manager.ts
@@ -17,6 +17,7 @@ import { DelegationSnapshotStore } from "./delegation-snapshots";
 import { findTaskLine } from "./find-task-line";
 import { JsonStore, inteligirPath, type FsAdapter } from "../lib/json-store";
 import { getVaultManager } from "../vault/vault";
+import { getHostNotifiers } from "../host-notifiers";
 import { runTextTurn } from "../app/text-turn";
 import {
   DelegationSchema,
@@ -52,26 +53,6 @@ export type DelegationAgent = {
   interrupt(): Promise<unknown>;
 };
 
-// Change notification — push channel for the editor's inline badges. Wired from
-// Electron-side composition (app-machine) so this module stays electron-free.
-let changedNotifier: ((delegations: Delegation[]) => void) | null = null;
-
-export function setDelegationsChangedNotifier(
-  notifier: ((delegations: Delegation[]) => void) | null,
-): void {
-  changedNotifier = notifier;
-}
-
-// Streaming transcript channel — pushes a delegation's accumulating response
-// text (keyed by id) for the live response dock. Same electron-free pattern.
-let streamNotifier: ((id: string, text: string) => void) | null = null;
-
-export function setDelegationStreamNotifier(
-  notifier: ((id: string, text: string) => void) | null,
-): void {
-  streamNotifier = notifier;
-}
-
 export type DelegationManagerOptions = {
   fs?: FsAdapter;
   path?: string;
@@ -83,6 +64,14 @@ export type DelegationManagerOptions = {
   writeVault?: (rel: string, content: string) => void;
   /** Pre-run snapshot store. Defaults to the real ~/.inteligir-backed one. */
   snapshots?: DelegationSnapshotStore;
+  /** Push channel for the editor's inline badges — the delegation list changed.
+   * Injected at construction by the composition root so this module never
+   * imports the IPC event registry; the live singleton (getDelegationManager)
+   * sources it from the host notifier bundle, unit tests leave it unset. */
+  onChanged?: (delegations: Delegation[]) => void;
+  /** Streaming transcript channel — a delegation's accumulating response text
+   * (keyed by id) for the live response dock. Same injection story as onChanged. */
+  onStream?: (id: string, text: string) => void;
 };
 
 export class DelegationManager {
@@ -90,6 +79,8 @@ export class DelegationManager {
   private readonly readVault: (rel: string) => string;
   private readonly writeVault: (rel: string, content: string) => void;
   private readonly snapshots: DelegationSnapshotStore;
+  private readonly onChanged: ((delegations: Delegation[]) => void) | null;
+  private readonly onStream: ((id: string, text: string) => void) | null;
   private getAgent: (() => DelegationAgent | null) | null = null;
   private running = false;
   // Id of a running delegation the user asked to stop — the run marks it stopped
@@ -110,6 +101,8 @@ export class DelegationManager {
     this.writeVault =
       opts?.writeVault ?? ((rel, content) => getVaultManager().writeText(rel, content));
     this.snapshots = opts?.snapshots ?? new DelegationSnapshotStore();
+    this.onChanged = opts?.onChanged ?? null;
+    this.onStream = opts?.onStream ?? null;
     this.store = new JsonStore<Delegation[]>(
       opts?.path ?? inteligirPath("delegations.json"),
       DelegationsFileSchema,
@@ -383,7 +376,7 @@ export class DelegationManager {
 
   private notify(): void {
     try {
-      changedNotifier?.(this.getDelegations());
+      this.onChanged?.(this.getDelegations());
     } catch (err) {
       console.warn("[delegation] change notification failed:", err);
     }
@@ -502,11 +495,11 @@ export class DelegationManager {
       timeoutMs: RUN_TIMEOUT_MS,
       onDelta: (delta) => {
         streamed += delta;
-        streamNotifier?.(delegation.id, streamed);
+        this.onStream?.(delegation.id, streamed);
       },
       onToolCall: (toolName) => {
         streamed += `${streamed ? "\n\n" : ""}\`⚙ ${toolName}\``;
-        streamNotifier?.(delegation.id, streamed);
+        this.onStream?.(delegation.id, streamed);
       },
     });
 
@@ -574,7 +567,17 @@ function buildPrompt(d: Delegation): string {
 let instance: DelegationManager | null = null;
 
 export function getDelegationManager(): DelegationManager {
-  if (!instance) instance = new DelegationManager();
+  if (!instance) {
+    // Inject the change/stream notifiers at construction from the host notifier
+    // bundle (composed by create-host). Rebuilt after a logout/login reset, the
+    // fresh instance re-reads the same bundle so badges/streams stay wired.
+    const notifiers = getHostNotifiers();
+    instance = new DelegationManager(
+      notifiers
+        ? { onChanged: notifiers.delegationsChanged, onStream: notifiers.delegationStream }
+        : {},
+    );
+  }
   return instance;
 }
 

--- a/packages/features/src/server/executor/executor-daemon.ts
+++ b/packages/features/src/server/executor/executor-daemon.ts
@@ -224,7 +224,7 @@ function executorArtifactName(): string | null {
   return `executor-${os}-${arch}.${ext}`;
 }
 
-class ExecutorDaemon {
+export class ExecutorDaemon {
   private proc: ChildProcess | null = null;
   private connection: ExecutorConnection | null = null;
   private starting: Promise<ExecutorConnection | null> | null = null;

--- a/packages/features/src/server/host-context.ts
+++ b/packages/features/src/server/host-context.ts
@@ -1,0 +1,146 @@
+// ---------------------------------------------------------------------------
+// HostContext — the explicit backend object graph the composition root builds.
+// createHost() used to be a sequencer over process-global getX() singletons
+// with notifier slots mutated in two different places (here and app-machine's
+// initMachine); this makes the graph a single, typed, dependency-ordered
+// construction that owns the whole notifier composition.
+//
+// Dependency order (leaves first). Each edge is "needs the piece to its left to
+// be constructable":
+//   platform/options ──▶ secrets, notifications, bundledResources
+//   secrets          ──▶ uiState
+//   (paths)          ──▶ vault ──▶ knowledge
+//   vault + notifiers ──▶ delegation
+//   (paths)          ──▶ executorDaemon
+//   executorDaemon   ──▶ agentPorts
+//   auth.json        ──▶ authStorage
+//
+// The notifiers are composed here (buildHostNotifiers) and installed BEFORE any
+// piece that fires them is constructed, so delegation gets its two at
+// construction and inline-AI reads its one at call time — no post-hoc
+// setXNotifier mutation from app-machine.
+//
+// The fields are live getters, not captured references: resetX() + the lazy
+// getX() rebuild an individual singleton on a logout/login cycle, so a captured
+// HostContext would go stale. Reading through getX() keeps every field current
+// while the eager block below still forces the initial, ordered construction.
+// getX() therefore remains an accessor INTO this graph, with the same lazy
+// fallback tests rely on.
+// ---------------------------------------------------------------------------
+
+import { emitEvent } from "./events";
+import { getAuthStorage } from "./agent/auth";
+import { getAgentPorts, getBundledResources } from "./lib/agent-lifecycle";
+import { getDelegationManager, type DelegationManager } from "./delegation/delegation-manager";
+import { getExecutorDaemon, type ExecutorDaemon } from "./executor/executor-daemon";
+import { getKnowledgeManager, type KnowledgeManager } from "./knowledge/knowledge-manager";
+import { getNotifications, type NotificationsManager } from "./notifications";
+import { getSecretStore, type SecretStore } from "./secrets";
+import { getUiState, type UiStateManager } from "./ui-state";
+import { getVaultManager, type VaultManager } from "./vault/vault";
+import { getHostOptions, getPlatform } from "./platform-instance";
+import { setStoreRecoveryNotifier } from "./lib/json-store";
+import { installHostNotifiers, type HostNotifiers } from "./host-notifiers";
+import type { AgentPorts } from "./agent/extension";
+import type { BundledResources } from "./agent/setup";
+import type { HostOptions, HostPlatform } from "./platform";
+import type { AuthStorage } from "@repo/features/server/pi/pi-types";
+
+/** The constructed backend object graph. Every field resolves to the live
+ * singleton (see the getter note in the header). */
+export type HostContext = {
+  readonly platform: HostPlatform;
+  readonly options: HostOptions;
+  readonly notifiers: HostNotifiers;
+  readonly secrets: SecretStore;
+  readonly notifications: NotificationsManager;
+  readonly uiState: UiStateManager;
+  readonly vault: VaultManager;
+  readonly knowledge: KnowledgeManager;
+  readonly delegation: DelegationManager;
+  readonly executorDaemon: ExecutorDaemon;
+  readonly authStorage: AuthStorage;
+  readonly bundledResources: BundledResources;
+  readonly agentPorts: AgentPorts;
+};
+
+/** Compose the five host notifiers. Each fans into the IPC event bus / the
+ * notifications manager — the only place in the host that both owns these
+ * closures and is allowed to import the event registry. */
+function buildHostNotifiers(): HostNotifiers {
+  return {
+    storeRecovery: (event) => getNotifications().notifyStoreRecovered(event),
+    vaultChange: (root) => {
+      emitEvent("onVaultChanged", { root });
+      getKnowledgeManager().scheduleRefresh();
+    },
+    delegationsChanged: (delegations) => emitEvent("onDelegationsUpdated", { delegations }),
+    delegationStream: (id, text) => emitEvent("onDelegationStreamed", { id, text }),
+    inlineAiStream: (requestId, delta) => emitEvent("onAiStreamed", { requestId, delta }),
+  };
+}
+
+/** Build the host object graph. Requires installHostRuntime() to have run
+ * (platform installed). Constructs the pi-free, read-free core singletons
+ * eagerly in dependency order; the notifier-firing pieces receive their
+ * notifiers because installHostNotifiers() runs first. */
+export function buildHostContext(): HostContext {
+  const notifiers = buildHostNotifiers();
+  installHostNotifiers(notifiers);
+  // Quarantine notices must be user-visible before any store is read; this is
+  // the json-store default recovery seam (a plain callback — json-store never
+  // imports the event registry).
+  setStoreRecoveryNotifier(notifiers.storeRecovery);
+
+  // Eager, dependency-ordered construction. Every constructor here allocates
+  // only (disk reads stay lazy inside JsonStore), so this changes nothing
+  // observable — it just materializes the graph in one place, in order, with
+  // notifiers already installed. Two pieces are deliberately NOT eager:
+  //   - uiState: its constructor reads + migrates ui-state.json; kept lazy so
+  //     that read keeps its original first-access timing.
+  //   - authStorage: it is a pi call, which must wait for configurePaths() in
+  //     start(); constructing it here would run before that.
+  // Both stay reachable via the live getters below.
+  getSecretStore(); // platform.secretCipher
+  getNotifications(); // platform.notify
+  getVaultManager(); // paths (watcher stays off until start() wires it post-ensureReady)
+  getKnowledgeManager(); // vault
+  getDelegationManager(); // vault + delegation notifiers (installed above)
+  getExecutorDaemon(); // paths
+
+  return {
+    platform: getPlatform(),
+    options: getHostOptions(),
+    notifiers,
+    get secrets() {
+      return getSecretStore();
+    },
+    get notifications() {
+      return getNotifications();
+    },
+    get uiState() {
+      return getUiState();
+    },
+    get vault() {
+      return getVaultManager();
+    },
+    get knowledge() {
+      return getKnowledgeManager();
+    },
+    get delegation() {
+      return getDelegationManager();
+    },
+    get executorDaemon() {
+      return getExecutorDaemon();
+    },
+    get authStorage() {
+      return getAuthStorage();
+    },
+    get bundledResources() {
+      return getBundledResources();
+    },
+    get agentPorts() {
+      return getAgentPorts();
+    },
+  };
+}

--- a/packages/features/src/server/host-notifiers.ts
+++ b/packages/features/src/server/host-notifiers.ts
@@ -1,0 +1,47 @@
+// ---------------------------------------------------------------------------
+// Host notifier composition — the plain callbacks the composition root
+// (host-context.ts, driven by create-host.ts) builds ONCE and installs here,
+// so the pieces that fire them (the delegation manager, inline-AI) receive them
+// at construction / call time without importing the IPC event registry
+// themselves. Keeping the registry out of the low-level pieces is the whole
+// point: they get a plain `(…) => void`, not `emitEvent`.
+//
+// This is also the survives-a-logout seam. resetX() tears an individual
+// singleton down and the next getX() rebuilds it lazily; this holder is NOT
+// reset, so a manager rebuilt after a logout re-reads the same notifiers here.
+// A dedicated leaf module (no manager imports) so the pieces that read it never
+// form an import cycle with the graph that composes it.
+// ---------------------------------------------------------------------------
+
+import type { StoreRecoveryEvent } from "./lib/json-store";
+import type { Delegation } from "@repo/features/delegation";
+
+/** The five host notifier slots, composed by the host and fired by the graph.
+ * Each is a plain callback that fans into `emitEvent(...)` / the notifications
+ * manager — that wiring lives in the composition root, not here. */
+export type HostNotifiers = {
+  /** A JsonStore quarantined a data file (json-store's default recovery seam). */
+  storeRecovery: (event: StoreRecoveryEvent) => void;
+  /** A vault file changed on disk (watcher broadcast → onVaultChanged + reindex). */
+  vaultChange: (root: string) => void;
+  /** The delegation list changed (drives inline badges). */
+  delegationsChanged: (delegations: Delegation[]) => void;
+  /** A delegation's live transcript advanced (drives the response dock). */
+  delegationStream: (id: string, text: string) => void;
+  /** Inline-AI generation streamed a text delta (drives live insertion). */
+  inlineAiStream: (requestId: string, delta: string) => void;
+};
+
+let notifiers: HostNotifiers | null = null;
+
+/** Install the composed notifier bundle. Called once by the composition root
+ * (buildHostContext), before any piece that reads it is constructed. */
+export function installHostNotifiers(next: HostNotifiers): void {
+  notifiers = next;
+}
+
+/** The installed notifier bundle, or null before composition (and in unit tests,
+ * which construct managers directly and expect the no-notifier default). */
+export function getHostNotifiers(): HostNotifiers | null {
+  return notifiers;
+}


### PR DESCRIPTION
Turns `create-host.ts` from a sequencer over ambient process-global singletons + scattered notifier mutations into a **real composition root** that constructs an explicit `HostContext` object graph and owns the whole notifier composition.

## Design
- **`host-context.ts`** — `HostContext` with **live getters** (delegate to `getX()`), not captured references, so a field never goes stale when a logout `resetX()` + lazy `getX()` rebuilds a slice. `buildHostContext()` eagerly constructs the pi-free/read-free core in dependency order (`secrets→notifications`, `vault→knowledge`, `vault+notifiers→delegation`, `executor`); `uiState`/`authStorage` stay lazy to preserve exact read/pi-call timing.
- **`host-notifiers.ts`** — the 5 notifier closures composed in one place (leaf module, no manager imports → no cycle). `delegationsChanged`/`delegationStream`/`inlineAiStream` are now **injected at construction** (removed their `setX` globals; `initMachine` no longer wires notifiers). `vaultChange` + `storeRecovery` keep their setters for principled reasons (the vault watcher must start *after* `ensureReady()`; store-recovery is json-store's process-global default, not per-instance). `emitEvent` stays out of vault/json-store.
- Consumers (handlers, app-machine) keep reaching the graph via `getX()` — the sanctioned "accessor into the constructed context" — to preserve test ergonomics.

## Scope note (honest)
This is the behavior-identical composition-root pass. `getX()` still exists as the storage layer; making `HostContext` the *sole* owner and deleting the module singletons needs the **logout path to rebuild through the composition root** (instead of piecemeal `resetX()`) — the real remaining knot, deliberately out of scope here.

## Verification
typecheck · lint · knip · build · **features 372 + desktop 351 tests** all green. Behavior preserved 1:1 (init/dispose order, `created` guard, host lock, `configurePaths`-before-pi, `resetX` rebuild paths). ⚠️ **Not yet runtime-booted in Electron** — held off to avoid the `~/.inteligir` host-lock conflicting with a running app. Confirm a clean `pnpm dev:desktop` boot before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the backend a real composition root by building an explicit `HostContext` graph and centralizing all notifier wiring. This replaces scattered globals and keeps behavior the same.

- **Refactors**
  - Added `host-context.ts`: `HostContext` with live getters; `buildHostContext()` builds core in dependency order.
  - Added `host-notifiers.ts`: composes five host notifiers; installed once and read by low-level modules.
  - Updated `create-host.ts`: builds the graph, installs store-recovery before any reads, and wires vault-change after `ensureReady()`.
  - Delegation: `DelegationManager` now takes `onChanged`/`onStream`; `getDelegationManager()` injects from `getHostNotifiers()`.
  - Inline AI: streams via `getHostNotifiers()`; removed `setInlineAiStreamNotifier`.
  - App machine: removed notifier wiring from `initMachine()`; startup flow unchanged.
  - Misc: exported `ExecutorDaemon`; removed an unused import in `ai-session.ts`.

<sup>Written for commit c840694d53912e1b31900fdf43c733b90d8b01ef. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kyh/inteligir/pull/397?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

