### PR TITLE
feat(composer): morphing AI composer capsule (land stranded branch)

### DIFF
--- a/apps/desktop/dev/fixture-bridge.ts
+++ b/apps/desktop/dev/fixture-bridge.ts
@@ -2,7 +2,8 @@
 // In-memory fixture Bridge for the browser dev harness. Fully typed against
 // the real Bridge contract — when the IPC registry changes, this file fails
 // typecheck. Vault reads/writes hit a Map seeded with sample notes; agent
-// chat streams a canned reply; voice/executor/updates report unavailable.
+// chat streams a canned reply; STT streams a canned transcript;
+// TTS/executor/updates report unavailable.
 // ---------------------------------------------------------------------------
 
 import type { AppAgentEvent } from "@repo/features/agent-events";
@@ -287,8 +288,15 @@ function simulateDelegationEdit(
   return null;
 }
 
-/** Streams `text` in small chunks via `onDelta`, then calls `onDone`. */
-function streamText(text: string, onDelta: (delta: string) => void, onDone: () => void): void {
+/** Streams `text` in small chunks via `onDelta`, then calls `onDone`.
+ * `initialDelayMs` holds the pre-stream gap — the chat reply uses a longer
+ * one so the composer's "thinking" treatment is visible in the harness. */
+function streamText(
+  text: string,
+  onDelta: (delta: string) => void,
+  onDone: () => void,
+  initialDelayMs = 120,
+): void {
   const words = text.split(/(?<= )/);
   let i = 0;
   const tick = () => {
@@ -298,7 +306,7 @@ function streamText(text: string, onDelta: (delta: string) => void, onDone: () =
     if (i < words.length) setTimeout(tick, 40);
     else onDone();
   };
-  setTimeout(tick, 120);
+  setTimeout(tick, initialDelayMs);
 }
 
 class Emitter<T> {
@@ -325,6 +333,11 @@ const IDLE_UPDATE: UpdateState = {
 
 const unavailable = (feature: string) =>
   new Error(`${feature} is not available in the dev harness`);
+
+// Canned STT transcript, streamed partial → partial → final (harness stub —
+// no recognizer runs) so the composer's listening capsule is demoable in a
+// plain browser tab.
+const STT_CANNED_TRANSCRIPT = "What should I write about today?";
 
 // ---------------------------------------------------------------------------
 // Canned editor-AI behaviors, so the whole AI surface (menu intents, edit
@@ -392,6 +405,9 @@ export function createFixtureBridge(): Bridge {
 
   const agentEvents = new Emitter<AppAgentEvent>();
   const appStateEvents = new Emitter<AppState>();
+  const sttEvents = new Emitter<{ text: string; isFinal: boolean }>();
+  let sttTimers: ReturnType<typeof setTimeout>[] = [];
+  let sttFinalPending = false;
   const vaultEvents = new Emitter<{ root: string }>();
   const aiEvents = new Emitter<{ requestId: string; delta: string }>();
   const delegationEvents = new Emitter<ListDelegationsResult>();
@@ -444,6 +460,9 @@ export function createFixtureBridge(): Bridge {
         history.push({ role: "assistant", text: reply });
         setAppState({ phase: "ready", agent: "idle" });
       },
+      // A beat of pre-stream silence so the busy-with-no-text "thinking"
+      // treatment is observable before deltas arrive.
+      1200,
     );
   };
 
@@ -486,16 +505,44 @@ export function createFixtureBridge(): Bridge {
     getAgentHistory: async () => [...history],
     reauthenticate: async () => ({ ok: true }),
 
-    // Voice — reports unavailable; the harness has no STT/TTS host.
+    // Voice — TTS reports unavailable; STT is SIMULATED: startStt arms timers
+    // that stream a canned transcript so the listening capsule is demoable.
     isTtsAvailable: async () => false,
     ttsSend: () => {},
     ttsFlush: () => {},
     ttsInterrupt: () => {},
     onTtsAudio: () => () => {},
-    startStt: async () => ({ ok: false, reason: "voice is not available in the dev harness" }),
+    startStt: async () => {
+      for (const t of sttTimers) clearTimeout(t);
+      sttFinalPending = true;
+      const words = STT_CANNED_TRANSCRIPT.split(" ");
+      sttTimers = [
+        setTimeout(
+          () => sttEvents.emit({ text: words.slice(0, 3).join(" "), isFinal: false }),
+          900,
+        ),
+        setTimeout(
+          () => sttEvents.emit({ text: words.slice(0, 5).join(" "), isFinal: false }),
+          1800,
+        ),
+        setTimeout(() => {
+          sttFinalPending = false;
+          sttEvents.emit({ text: STT_CANNED_TRANSCRIPT, isFinal: true });
+        }, 2700),
+      ];
+      return { ok: true };
+    },
     sendSttAudio: () => {},
-    stopStt: async () => [],
-    onSttTranscript: () => () => {},
+    stopStt: async () => {
+      for (const t of sttTimers) clearTimeout(t);
+      sttTimers = [];
+      // Stopped mid-stream → the "recognizer" flushes the tail final once;
+      // after the timed final already fired there is nothing left to return.
+      if (!sttFinalPending) return [];
+      sttFinalPending = false;
+      return [{ text: STT_CANNED_TRANSCRIPT, isFinal: true }];
+    },
+    onSttTranscript: sttEvents.subscribe,
     getVoiceModelStatus: async () => "missing",
     downloadVoiceModel: async () => ({
       ok: false,

--- a/apps/desktop/src/renderer/ai-elements/prompt-input.tsx
+++ b/apps/desktop/src/renderer/ai-elements/prompt-input.tsx
@@ -85,6 +85,10 @@ export type PromptInputProps = Omit<HTMLAttributes<HTMLFormElement>, "onSubmit" 
   maxFiles?: number;
   maxFileSize?: number;
   onError?: (err: { code: "max_files" | "max_file_size" | "accept"; message: string }) => void;
+  /** Fires whenever the staged attachment set changes. Lets a parent ABOVE the
+   * provider react to attachment state (e.g. hold a collapsible composer open)
+   * without a child bridging `usePromptInputAttachments` out via effects. */
+  onFilesChange?: (files: FileUIPart[]) => void;
   onSubmit: (
     message: PromptInputMessage,
     event: FormEvent<HTMLFormElement>,
@@ -98,6 +102,7 @@ export const PromptInput = ({
   maxFiles,
   maxFileSize,
   onError,
+  onFilesChange,
   onSubmit,
   children,
   ...props
@@ -120,7 +125,8 @@ export const PromptInput = ({
   useEffect(() => {
     filesRef.current = items;
     liveCountRef.current = items.length;
-  }, [items]);
+    onFilesChange?.(items);
+  }, [items, onFilesChange]);
 
   const openFileDialog = useCallback(() => {
     inputRef.current?.click();

--- a/apps/desktop/src/renderer/components/initial-orb.tsx
+++ b/apps/desktop/src/renderer/components/initial-orb.tsx
@@ -1,6 +1,6 @@
 import { GeometricOrb, type DisplayStatus } from "@repo/ui/components/geometric-orb";
 
-import { useTheme } from "@renderer/lib/use-theme";
+import { useOrbBaseColor } from "@renderer/lib/use-theme";
 import { useAgentStore } from "@renderer/stores/agent-store";
 import type { AppState } from "@repo/features/app-state";
 
@@ -13,14 +13,11 @@ function phaseToOrbStatus(phase: AppState["phase"]): DisplayStatus {
 // these pre-app pages, so there's no docking/animation to manage anymore.
 export function InitialOrb() {
   const phase = useAgentStore((s) => s.appState.phase);
-  const { resolved } = useTheme();
+  const baseColor = useOrbBaseColor();
 
   return (
     <div className="pointer-events-none fixed inset-0 z-30 m-auto h-44 w-44">
-      <GeometricOrb
-        status={phaseToOrbStatus(phase)}
-        baseColor={resolved === "dark" ? "#eeeeee" : "#0a0a0a"}
-      />
+      <GeometricOrb status={phaseToOrbStatus(phase)} baseColor={baseColor} />
     </div>
   );
 }

--- a/apps/desktop/src/renderer/composer/bottom-composer.tsx
+++ b/apps/desktop/src/renderer/composer/bottom-composer.tsx
@@ -1,6 +1,6 @@
-import { useEffect, useState } from "react";
+import { memo, useEffect, useState } from "react";
 import { PinIcon, PinOffIcon, XIcon } from "lucide-react";
-import { AnimatePresence, motion, useReducedMotion, type Transition } from "framer-motion";
+import { AnimatePresence, motion, useReducedMotion } from "framer-motion";
 
 import {
   Conversation,
@@ -11,42 +11,49 @@ import { cn } from "@repo/ui/lib/utils";
 
 import {
   CAPSULE_RADIUS,
-  CAPSULE_SPRING,
   CAPSULE_SURFACE,
   ThinkingSweep,
+  useCapsuleSpring,
 } from "@renderer/composer/capsule-motion";
-import { ChatActivityRow, ChatMessageView } from "@renderer/composer/chat-message";
+import {
+  ChatActivityRow,
+  ChatMessageView,
+  isRenderableMessage,
+} from "@renderer/composer/chat-message";
 import { Composer } from "@renderer/composer/composer";
-import { useAgentStore, type ChatMessage } from "@renderer/stores/agent-store";
+import { currentTurnMessages, useAgentStore, type ChatMessage } from "@renderer/stores/agent-store";
 import { useViewStore } from "@renderer/stores/view-store";
 
 const IDLE_LINGER_MS = 7000;
 
-/** The messages ChatMessageView actually renders as a bubble. Tool activity
- * and empty stream-starts render null — skip their motion wrappers too, so
- * the list's flex gap doesn't produce phantom rows. */
-function isRenderableMessage(msg: ChatMessage): boolean {
-  const first = msg.parts[0];
-  if (!first || first.type !== "text") return false;
-  if (msg.role === "assistant" && first.text.length === 0) return false;
-  return true;
-}
-
 /** Thinking = busy with no assistant text streamed for the CURRENT turn yet
- * (tool-only activity still counts as thinking). Walk back to the turn's
- * user prompt; steer nudges ride mid-turn and don't reset the boundary. */
+ * (tool-only activity still counts as thinking). */
 function isThinking(messages: ChatMessage[], busy: boolean): boolean {
   if (!busy) return false;
-  for (let i = messages.length - 1; i >= 0; i--) {
-    const msg = messages[i];
-    if (!msg) continue;
-    if (msg.role === "user" && !msg.metadata?.steer) return true;
-    if (msg.role !== "assistant") continue;
+  return !currentTurnMessages(messages).some((msg) => {
+    if (msg.role !== "assistant") return false;
     const first = msg.parts[0];
-    if (first?.type === "text" && first.text.length > 0) return false;
-  }
-  return true;
+    return first?.type === "text" && first.text.length > 0;
+  });
 }
+
+/** One popover row: entrance animation + the bubble. Memoized on the message
+ * object — the store preserves identity of untouched messages, so while a
+ * reply streams (a new `messages` array per delta) only the streaming row
+ * re-renders instead of every historical bubble + motion wrapper. */
+const MessageRow = memo(function MessageRow({ msg }: { msg: ChatMessage }) {
+  const reduceMotion = useReducedMotion() === true;
+  return (
+    <motion.div
+      className="flex flex-col"
+      initial={{ opacity: 0, y: 6, filter: "blur(4px)" }}
+      animate={{ opacity: 1, y: 0, filter: "blur(0px)" }}
+      transition={reduceMotion ? { duration: 0 } : { duration: 0.3, delay: 0.05 }}
+    >
+      <ChatMessageView message={msg} />
+    </motion.div>
+  );
+});
 
 /**
  * The bottom AI surface — the composer pinned to the bottom of the editor inset,
@@ -60,7 +67,7 @@ export function BottomComposer() {
   const appState = useAgentStore((s) => s.appState);
   const busy = appState.phase === "ready" && appState.agent === "busy";
   const thinking = isThinking(messages, busy);
-  const reduceMotion = useReducedMotion() === true;
+  const { capsule: popoverSpring } = useCapsuleSpring();
 
   const pinned = useViewStore((s) => s.responsePinned);
   const togglePinned = useViewStore((s) => s.togglePinned);
@@ -80,7 +87,6 @@ export function BottomComposer() {
 
   const open = (pinned || busy || recentlyActive) && messages.length > 0;
   const visibleMessages = messages.filter(isRenderableMessage);
-  const popoverSpring: Transition = reduceMotion ? { duration: 0 } : CAPSULE_SPRING;
 
   return (
     <div className="pointer-events-none absolute inset-x-0 bottom-0 z-30 flex flex-col items-center gap-2 px-4 pb-4">
@@ -126,17 +132,7 @@ export function BottomComposer() {
             <Conversation className="max-h-[46vh] min-h-0 select-text">
               <ConversationContent className="gap-1 p-2">
                 {visibleMessages.map((msg) => (
-                  // Blur-in entrance for each landing message; the bubble's own
-                  // spring (ai-elements/chat-message) supplies the rise.
-                  <motion.div
-                    key={msg.id}
-                    className="flex flex-col"
-                    initial={{ opacity: 0, y: 6, filter: "blur(4px)" }}
-                    animate={{ opacity: 1, y: 0, filter: "blur(0px)" }}
-                    transition={reduceMotion ? { duration: 0 } : { duration: 0.3, delay: 0.05 }}
-                  >
-                    <ChatMessageView message={msg} />
-                  </motion.div>
+                  <MessageRow key={msg.id} msg={msg} />
                 ))}
                 <ChatActivityRow messages={messages} busy={busy} />
               </ConversationContent>

--- a/apps/desktop/src/renderer/composer/bottom-composer.tsx
+++ b/apps/desktop/src/renderer/composer/bottom-composer.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from "react";
 import { PinIcon, PinOffIcon, XIcon } from "lucide-react";
+import { AnimatePresence, motion, useReducedMotion, type Transition } from "framer-motion";
 
 import {
   Conversation,
@@ -8,23 +9,58 @@ import {
 } from "@renderer/ai-elements/conversation";
 import { cn } from "@repo/ui/lib/utils";
 
+import {
+  CAPSULE_RADIUS,
+  CAPSULE_SPRING,
+  CAPSULE_SURFACE,
+  ThinkingSweep,
+} from "@renderer/composer/capsule-motion";
 import { ChatActivityRow, ChatMessageView } from "@renderer/composer/chat-message";
 import { Composer } from "@renderer/composer/composer";
-import { useAgentStore } from "@renderer/stores/agent-store";
+import { useAgentStore, type ChatMessage } from "@renderer/stores/agent-store";
 import { useViewStore } from "@renderer/stores/view-store";
 
 const IDLE_LINGER_MS = 7000;
+
+/** The messages ChatMessageView actually renders as a bubble. Tool activity
+ * and empty stream-starts render null — skip their motion wrappers too, so
+ * the list's flex gap doesn't produce phantom rows. */
+function isRenderableMessage(msg: ChatMessage): boolean {
+  const first = msg.parts[0];
+  if (!first || first.type !== "text") return false;
+  if (msg.role === "assistant" && first.text.length === 0) return false;
+  return true;
+}
+
+/** Thinking = busy with no assistant text streamed for the CURRENT turn yet
+ * (tool-only activity still counts as thinking). Walk back to the turn's
+ * user prompt; steer nudges ride mid-turn and don't reset the boundary. */
+function isThinking(messages: ChatMessage[], busy: boolean): boolean {
+  if (!busy) return false;
+  for (let i = messages.length - 1; i >= 0; i--) {
+    const msg = messages[i];
+    if (!msg) continue;
+    if (msg.role === "user" && !msg.metadata?.steer) return true;
+    if (msg.role !== "assistant") continue;
+    const first = msg.parts[0];
+    if (first?.type === "text" && first.text.length > 0) return false;
+  }
+  return true;
+}
 
 /**
  * The bottom AI surface — the composer pinned to the bottom of the editor inset,
  * with a transient response popover that grows upward from it. The popover opens
  * while the agent is working (and lingers briefly after), or stays open when
- * pinned. Replaces the old right-hand chat column.
+ * pinned. It shares the composer capsule's radius/surface/ring and springs
+ * open/closed so the pair reads as one object expanding upward.
  */
 export function BottomComposer() {
   const messages = useAgentStore((s) => s.messages);
   const appState = useAgentStore((s) => s.appState);
   const busy = appState.phase === "ready" && appState.agent === "busy";
+  const thinking = isThinking(messages, busy);
+  const reduceMotion = useReducedMotion() === true;
 
   const pinned = useViewStore((s) => s.responsePinned);
   const togglePinned = useViewStore((s) => s.togglePinned);
@@ -43,49 +79,72 @@ export function BottomComposer() {
   }, [busy]);
 
   const open = (pinned || busy || recentlyActive) && messages.length > 0;
+  const visibleMessages = messages.filter(isRenderableMessage);
+  const popoverSpring: Transition = reduceMotion ? { duration: 0 } : CAPSULE_SPRING;
 
   return (
     <div className="pointer-events-none absolute inset-x-0 bottom-0 z-30 flex flex-col items-center gap-2 px-4 pb-4">
-      {open && (
-        <div className="pointer-events-auto flex w-full max-w-3xl flex-col overflow-hidden rounded-xl border border-border bg-popover text-popover-foreground shadow-md">
-          <div className="flex items-center justify-between border-b border-border px-3 py-1.5 text-[11px] font-medium text-muted-foreground">
-            <span>Assistant</span>
-            <div className="flex items-center gap-0.5">
-              <button
-                type="button"
-                onClick={togglePinned}
-                title={pinned ? "Unpin" : "Keep open"}
-                className={cn(
-                  "rounded p-1 hover:bg-muted hover:text-foreground",
-                  pinned && "text-foreground",
-                )}
-              >
-                {pinned ? <PinOffIcon className="size-3.5" /> : <PinIcon className="size-3.5" />}
-              </button>
-              <button
-                type="button"
-                onClick={() => {
-                  setPinned(false);
-                  setRecentlyActive(false);
-                }}
-                title="Close"
-                className="rounded p-1 hover:bg-muted hover:text-foreground"
-              >
-                <XIcon className="size-3.5" />
-              </button>
+      <AnimatePresence initial={false}>
+        {open && (
+          <motion.div
+            key="response"
+            style={{ borderRadius: CAPSULE_RADIUS }}
+            initial={{ opacity: 0, y: 12, scale: 0.97, filter: "blur(6px)" }}
+            animate={{ opacity: 1, y: 0, scale: 1, filter: "blur(0px)" }}
+            exit={{ opacity: 0, y: 12, scale: 0.97, filter: "blur(6px)" }}
+            transition={popoverSpring}
+            className={cn("pointer-events-auto flex w-full max-w-3xl flex-col", CAPSULE_SURFACE)}
+          >
+            <AnimatePresence>{thinking && <ThinkingSweep key="sweep" />}</AnimatePresence>
+            <div className="relative flex items-center justify-between border-b border-border px-3 py-1.5 text-[11px] font-medium text-muted-foreground">
+              <span>Assistant</span>
+              <div className="flex items-center gap-0.5">
+                <button
+                  type="button"
+                  onClick={togglePinned}
+                  title={pinned ? "Unpin" : "Keep open"}
+                  className={cn(
+                    "rounded p-1 hover:bg-muted hover:text-foreground",
+                    pinned && "text-foreground",
+                  )}
+                >
+                  {pinned ? <PinOffIcon className="size-3.5" /> : <PinIcon className="size-3.5" />}
+                </button>
+                <button
+                  type="button"
+                  onClick={() => {
+                    setPinned(false);
+                    setRecentlyActive(false);
+                  }}
+                  title="Close"
+                  className="rounded p-1 hover:bg-muted hover:text-foreground"
+                >
+                  <XIcon className="size-3.5" />
+                </button>
+              </div>
             </div>
-          </div>
-          <Conversation className="max-h-[46vh] min-h-0 select-text">
-            <ConversationContent className="gap-1 p-2">
-              {messages.map((msg) => (
-                <ChatMessageView key={msg.id} message={msg} />
-              ))}
-              <ChatActivityRow messages={messages} busy={busy} />
-            </ConversationContent>
-            <ConversationScrollButton />
-          </Conversation>
-        </div>
-      )}
+            <Conversation className="max-h-[46vh] min-h-0 select-text">
+              <ConversationContent className="gap-1 p-2">
+                {visibleMessages.map((msg) => (
+                  // Blur-in entrance for each landing message; the bubble's own
+                  // spring (ai-elements/chat-message) supplies the rise.
+                  <motion.div
+                    key={msg.id}
+                    className="flex flex-col"
+                    initial={{ opacity: 0, y: 6, filter: "blur(4px)" }}
+                    animate={{ opacity: 1, y: 0, filter: "blur(0px)" }}
+                    transition={reduceMotion ? { duration: 0 } : { duration: 0.3, delay: 0.05 }}
+                  >
+                    <ChatMessageView message={msg} />
+                  </motion.div>
+                ))}
+                <ChatActivityRow messages={messages} busy={busy} />
+              </ConversationContent>
+              <ConversationScrollButton />
+            </Conversation>
+          </motion.div>
+        )}
+      </AnimatePresence>
 
       <div className="pointer-events-auto w-full max-w-3xl">
         <Composer />

--- a/apps/desktop/src/renderer/composer/capsule-motion.tsx
+++ b/apps/desktop/src/renderer/composer/capsule-motion.tsx
@@ -1,0 +1,116 @@
+// ---------------------------------------------------------------------------
+// Shared motion vocabulary for the AI capsule. The composer and its response
+// popover are styled as ONE spring-morphing surface — same radius, same ring,
+// same spring — so every state change reads as a single object stretching,
+// never a cut between panels. The decorative treatments (listening wave +
+// glow aura, thinking sweep) live here so both halves stay visually locked.
+// ---------------------------------------------------------------------------
+
+import { motion, useReducedMotion, type Transition } from "framer-motion";
+
+/** One spring drives every capsule size/shape change. */
+export const CAPSULE_SPRING: Transition = { type: "spring", duration: 0.55, bounce: 0.3 };
+
+/** Continuous corner radius across every capsule state (px). Applied via the
+ * motion `style` prop so layout animations scale-correct the corners. The
+ * hardcoded `rounded-[24px]`/`rounded-[22.5px]` below are this value and its
+ * 1.5px-inset counterpart. */
+export const CAPSULE_RADIUS = 24;
+
+/** The capsule's shared surface chrome (radius comes from CAPSULE_RADIUS). */
+export const CAPSULE_SURFACE =
+  "relative overflow-hidden bg-popover text-popover-foreground shadow-lg shadow-black/5 ring-1 ring-border";
+
+const BAR_COUNT = 27;
+
+/** Animated voice bars. Heights are deterministic pseudo-random (a fixed
+ * envelope × per-bar wobble) so the wave reads organic without re-rolling on
+ * re-render. Renders static mid-height bars under prefers-reduced-motion. */
+export function ListeningWave() {
+  const reduceMotion = useReducedMotion() === true;
+  return (
+    <div className="flex h-8 min-w-0 flex-1 items-center justify-center gap-[3px] overflow-hidden">
+      {Array.from({ length: BAR_COUNT }, (_, index) => {
+        const envelope = 0.3 + 0.7 * Math.sin((index / (BAR_COUNT - 1)) * Math.PI);
+        const wobble = 0.45 + (Math.sin(index * 12.9898) * 0.5 + 0.5) * 0.55;
+        if (reduceMotion) {
+          return (
+            <div
+              key={index}
+              className="h-7 w-[3px] rounded-full bg-primary"
+              style={{ transform: `scaleY(${envelope * wobble})` }}
+            />
+          );
+        }
+        return (
+          <motion.div
+            key={index}
+            className="h-7 w-[3px] rounded-full bg-primary"
+            animate={{ scaleY: [0.12, envelope * wobble, 0.22, envelope, 0.12] }}
+            transition={{
+              duration: 0.9 + (index % 5) * 0.13,
+              repeat: Infinity,
+              ease: "easeInOut",
+              delay: (index % 7) * 0.07,
+            }}
+          />
+        );
+      })}
+    </div>
+  );
+}
+
+/** Pulsing conic-gradient aura behind the capsule while listening. The rainbow
+ * gradient is intentionally theme-independent — an accent that reads on both
+ * light and dark surfaces. Render inside an <AnimatePresence>, as a sibling
+ * BEHIND the capsule (the capsule's opaque surface covers the center). */
+export function ListeningGlow() {
+  const reduceMotion = useReducedMotion() === true;
+  const surface =
+    "pointer-events-none absolute -inset-2 rounded-[32px] bg-[conic-gradient(from_0deg,#60a5fa,#a78bfa,#f472b6,#38bdf8,#60a5fa)] blur-xl";
+  if (reduceMotion) return <div aria-hidden className={surface} style={{ opacity: 0.4 }} />;
+  return (
+    <motion.div
+      aria-hidden
+      className={surface}
+      initial={{ opacity: 0, scale: 0.9 }}
+      animate={{ opacity: [0.35, 0.6, 0.35], scale: 1 }}
+      // Exit carries its OWN transition: without it the repeat-Infinity pulse
+      // below applies to the fade-out too, which then never completes and the
+      // glow lingers forever.
+      exit={{ opacity: 0, scale: 0.92, transition: { duration: 0.4, ease: "easeOut" } }}
+      transition={{ opacity: { duration: 2.4, repeat: Infinity, ease: "easeInOut" } }}
+    />
+  );
+}
+
+/** Rotating violet→cyan border sweep while the agent thinks. The inner fill
+ * matches the capsule surface so only a ~1.5px rim of the gradient shows.
+ * Mount as the FIRST child of the capsule inside an <AnimatePresence>;
+ * content after it must be `relative` to paint above the fill. */
+export function ThinkingSweep() {
+  const reduceMotion = useReducedMotion() === true;
+  const gradient =
+    "absolute inset-[-150%] bg-[conic-gradient(from_0deg,transparent_0%,transparent_62%,#a78bfa_80%,#67e8f9_90%,transparent_100%)]";
+  return (
+    <motion.div
+      aria-hidden
+      className="pointer-events-none absolute inset-0 overflow-hidden rounded-[24px]"
+      initial={{ opacity: 0 }}
+      animate={{ opacity: 1 }}
+      exit={{ opacity: 0 }}
+      transition={{ duration: 0.25 }}
+    >
+      {reduceMotion ? (
+        <div className={gradient} />
+      ) : (
+        <motion.div
+          className={gradient}
+          animate={{ rotate: 360 }}
+          transition={{ duration: 1.6, ease: "linear", repeat: Infinity }}
+        />
+      )}
+      <div className="absolute inset-[1.5px] rounded-[22.5px] bg-popover" />
+    </motion.div>
+  );
+}

--- a/apps/desktop/src/renderer/composer/capsule-motion.tsx
+++ b/apps/desktop/src/renderer/composer/capsule-motion.tsx
@@ -2,11 +2,15 @@
 // Shared motion vocabulary for the AI capsule. The composer and its response
 // popover are styled as ONE spring-morphing surface — same radius, same ring,
 // same spring — so every state change reads as a single object stretching,
-// never a cut between panels. The decorative treatments (listening wave +
+// never a cut between panels. The decorative treatments (listening orb +
 // glow aura, thinking sweep) live here so both halves stay visually locked.
 // ---------------------------------------------------------------------------
 
 import { motion, useReducedMotion, type Transition } from "framer-motion";
+
+import { GeometricOrb } from "@repo/ui/components/geometric-orb";
+
+import { useTheme } from "@renderer/lib/use-theme";
 
 /** One spring drives every capsule size/shape change. */
 export const CAPSULE_SPRING: Transition = { type: "spring", duration: 0.55, bounce: 0.3 };
@@ -21,41 +25,22 @@ export const CAPSULE_RADIUS = 24;
 export const CAPSULE_SURFACE =
   "relative overflow-hidden bg-popover text-popover-foreground shadow-lg shadow-black/5 ring-1 ring-border";
 
-const BAR_COUNT = 27;
-
-/** Animated voice bars. Heights are deterministic pseudo-random (a fixed
- * envelope × per-bar wobble) so the wave reads organic without re-rolling on
- * re-render. Renders static mid-height bars under prefers-reduced-motion. */
-export function ListeningWave() {
-  const reduceMotion = useReducedMotion() === true;
+/** The focal voice animation while listening: the shared GeometricOrb in its
+ * built-in "listening" mood. It's a WebGL canvas, so it gets a fixed square
+ * box; the base color tracks the theme (like the initial-surface orb) so any
+ * neutral frames stay legible on both light and dark surfaces. Fewer, thinner
+ * strands than the hero placement so the sphere reads at ~44px. The orb keeps
+ * its own internal animation under prefers-reduced-motion. */
+export function ListeningOrb() {
+  const { resolved } = useTheme();
   return (
-    <div className="flex h-8 min-w-0 flex-1 items-center justify-center gap-[3px] overflow-hidden">
-      {Array.from({ length: BAR_COUNT }, (_, index) => {
-        const envelope = 0.3 + 0.7 * Math.sin((index / (BAR_COUNT - 1)) * Math.PI);
-        const wobble = 0.45 + (Math.sin(index * 12.9898) * 0.5 + 0.5) * 0.55;
-        if (reduceMotion) {
-          return (
-            <div
-              key={index}
-              className="h-7 w-[3px] rounded-full bg-primary"
-              style={{ transform: `scaleY(${envelope * wobble})` }}
-            />
-          );
-        }
-        return (
-          <motion.div
-            key={index}
-            className="h-7 w-[3px] rounded-full bg-primary"
-            animate={{ scaleY: [0.12, envelope * wobble, 0.22, envelope, 0.12] }}
-            transition={{
-              duration: 0.9 + (index % 5) * 0.13,
-              repeat: Infinity,
-              ease: "easeInOut",
-              delay: (index % 7) * 0.07,
-            }}
-          />
-        );
-      })}
+    <div aria-hidden className="size-11 shrink-0">
+      <GeometricOrb
+        status="listening"
+        baseColor={resolved === "dark" ? "#eeeeee" : "#0a0a0a"}
+        numLines={12}
+        lineWidth={1.5}
+      />
     </div>
   );
 }

--- a/apps/desktop/src/renderer/composer/capsule-motion.tsx
+++ b/apps/desktop/src/renderer/composer/capsule-motion.tsx
@@ -10,10 +10,10 @@ import { motion, useReducedMotion, type Transition } from "framer-motion";
 
 import { GeometricOrb } from "@repo/ui/components/geometric-orb";
 
-import { useTheme } from "@renderer/lib/use-theme";
+import { useOrbBaseColor } from "@renderer/lib/use-theme";
 
-/** One spring drives every capsule size/shape change. */
-export const CAPSULE_SPRING: Transition = { type: "spring", duration: 0.55, bounce: 0.3 };
+/** One spring drives every capsule size/shape change (via useCapsuleSpring). */
+const CAPSULE_SPRING: Transition = { type: "spring", duration: 0.55, bounce: 0.3 };
 
 /** Continuous corner radius across every capsule state (px). Applied via the
  * motion `style` prop so layout animations scale-correct the corners. The
@@ -25,22 +25,38 @@ export const CAPSULE_RADIUS = 24;
 export const CAPSULE_SURFACE =
   "relative overflow-hidden bg-popover text-popover-foreground shadow-lg shadow-black/5 ring-1 ring-border";
 
+/** The content crossfade every capsule state change shares: content blurs in a
+ * beat after the shape settles, so the shape reads first and details second.
+ * Stable identities (vs inline literals) also let framer skip re-diffing. */
+export const CAPSULE_CONTENT_HIDDEN = { opacity: 0, scale: 0.96, filter: "blur(6px)" };
+export const CAPSULE_CONTENT_VISIBLE = { opacity: 1, scale: 1, filter: "blur(0px)" };
+
+/** The capsule's reduced-motion-aware transitions: `capsule` drives the shape
+ * (layout spring), `content` the crossfade (same spring, a beat later). One
+ * derivation for every consumer instead of a per-file `useReducedMotion` dance;
+ * `reduceMotion` rides along for props that need the raw flag (e.g. `layout`). */
+export function useCapsuleSpring(): {
+  capsule: Transition;
+  content: Transition;
+  reduceMotion: boolean;
+} {
+  const reduceMotion = useReducedMotion() === true;
+  if (reduceMotion) {
+    return { capsule: { duration: 0 }, content: { duration: 0 }, reduceMotion };
+  }
+  return { capsule: CAPSULE_SPRING, content: { ...CAPSULE_SPRING, delay: 0.05 }, reduceMotion };
+}
+
 /** The focal voice animation while listening: the shared GeometricOrb in its
  * built-in "listening" mood. It's a WebGL canvas, so it gets a fixed square
- * box; the base color tracks the theme (like the initial-surface orb) so any
- * neutral frames stay legible on both light and dark surfaces. Fewer, thinner
- * strands than the hero placement so the sphere reads at ~44px. The orb keeps
- * its own internal animation under prefers-reduced-motion. */
+ * box; the base color tracks the theme (shared with the initial-surface orb).
+ * Fewer, thinner strands than the hero placement so the sphere reads at ~44px.
+ * The orb keeps its own internal animation under prefers-reduced-motion. */
 export function ListeningOrb() {
-  const { resolved } = useTheme();
+  const baseColor = useOrbBaseColor();
   return (
     <div aria-hidden className="size-11 shrink-0">
-      <GeometricOrb
-        status="listening"
-        baseColor={resolved === "dark" ? "#eeeeee" : "#0a0a0a"}
-        numLines={12}
-        lineWidth={1.5}
-      />
+      <GeometricOrb status="listening" baseColor={baseColor} numLines={12} lineWidth={1.5} />
     </div>
   );
 }

--- a/apps/desktop/src/renderer/composer/chat-message.tsx
+++ b/apps/desktop/src/renderer/composer/chat-message.tsx
@@ -74,9 +74,12 @@ export function ChatActivityRow({ messages, busy }: { messages: ChatMessage[]; b
   if (!busy) return null;
 
   // Walk from the end: the latest text/tool message reflects the current step.
+  // Stop at the turn's user prompt (steer nudges ride mid-turn) — otherwise a
+  // fresh turn with history would read the PREVIOUS turn's answer as current.
   let label = "Thinking";
   for (let i = messages.length - 1; i >= 0; i--) {
     const m = messages[i];
+    if (m && m.role === "user" && !m.metadata?.steer) break;
     const part = m?.parts[0];
     if (!part) continue;
     if (part.type === "dynamic-tool") {

--- a/apps/desktop/src/renderer/composer/chat-message.tsx
+++ b/apps/desktop/src/renderer/composer/chat-message.tsx
@@ -5,7 +5,7 @@ import { Response } from "@renderer/ai-elements/response";
 import { Shimmer } from "@renderer/ai-elements/shimmer";
 
 import { getBridge } from "@renderer/lib/bridge";
-import type { ChatMessage } from "@renderer/stores/agent-store";
+import { currentTurnMessages, type ChatMessage } from "@renderer/stores/agent-store";
 import { isRecord } from "@repo/features/ipc";
 
 // Hoisted so the array reference is stable across renders.
@@ -14,17 +14,26 @@ const ASSISTANT_SHIKI_THEME: ["github-dark-dimmed", "github-dark-dimmed"] = [
   "github-dark-dimmed",
 ];
 
-export function ChatMessageView({ message }: { message: ChatMessage }) {
+/**
+ * Whether ChatMessageView renders this message as visible content. Exported so
+ * list containers can skip wrappers (flex gap would otherwise show phantom
+ * rows) — co-located with the component so the two can't drift.
+ *
+ * Renders nothing for: tool calls (the <ChatActivityRow> shimmer is the live
+ * activity signal; the store sweeps these on agent_end), non-text parts, and
+ * the empty assistant text between message_start and the first delta.
+ */
+export function isRenderableMessage(message: ChatMessage): boolean {
   const first = message.parts[0];
-  if (!first) return null;
+  if (!first || first.type !== "text") return false;
+  if (message.role === "assistant" && first.text.length === 0) return false;
+  return true;
+}
 
-  // Tool calls are never rendered as bubbles. While the turn is live, a single
-  // <ChatActivityRow> below the message list shows the current activity as a
-  // rolling shimmer line; on agent_end the store sweeps these messages so
-  // only the user prompt and final assistant answer remain.
-  if (first.type === "dynamic-tool") return null;
-
-  if (first.type !== "text") return null;
+export function ChatMessageView({ message }: { message: ChatMessage }) {
+  if (!isRenderableMessage(message)) return null;
+  const first = message.parts[0];
+  if (!first || first.type !== "text") return null; // narrowing for TS; covered above
 
   const text = first.text;
   const imageCount = message.metadata?.imageCount ?? 0;
@@ -73,13 +82,12 @@ function ErrorMessage({ text, kind }: { text: string; kind: "auth" | "unknown" }
 export function ChatActivityRow({ messages, busy }: { messages: ChatMessage[]; busy: boolean }) {
   if (!busy) return null;
 
-  // Walk from the end: the latest text/tool message reflects the current step.
-  // Stop at the turn's user prompt (steer nudges ride mid-turn) — otherwise a
-  // fresh turn with history would read the PREVIOUS turn's answer as current.
+  // Walk the current turn from the end: the latest text/tool message reflects
+  // the current step (currentTurnMessages owns the turn-boundary rule).
+  const turn = currentTurnMessages(messages);
   let label = "Thinking";
-  for (let i = messages.length - 1; i >= 0; i--) {
-    const m = messages[i];
-    if (m && m.role === "user" && !m.metadata?.steer) break;
+  for (let i = turn.length - 1; i >= 0; i--) {
+    const m = turn[i];
     const part = m?.parts[0];
     if (!part) continue;
     if (part.type === "dynamic-tool") {
@@ -104,7 +112,10 @@ export function ChatActivityRow({ messages, busy }: { messages: ChatMessage[]; b
 
 function UserMessage({ text, imageCount }: { text: string; imageCount: number }) {
   return (
-    <ChatBubble from="user" className="text-xs">
+    // initial={false}: the popover's MessageRow wrapper owns the entrance —
+    // without this the bubble's baked-in mount spring animates a second time
+    // underneath it (and ignores reduced-motion).
+    <ChatBubble from="user" initial={false} className="text-xs">
       {text && <span>{text}</span>}
       <ImageCount count={imageCount} withLabel />
     </ChatBubble>
@@ -127,13 +138,10 @@ function SteerMessage({ text, imageCount }: { text: string; imageCount: number }
 }
 
 function AssistantMessage({ text }: { text: string }) {
-  // Empty text is the brief gap between message_start and either the first
-  // tool call or the first text delta — render nothing. The compact tool
-  // rows downstream are the active "agent is working" signal; doubling up
-  // with a bubble shimmer makes the UI feel noisy.
-  if (!text) return null;
+  // Empty assistant text never reaches here — isRenderableMessage filters it.
+  // initial={false}: the popover's MessageRow wrapper owns the entrance.
   return (
-    <ChatBubble from="assistant">
+    <ChatBubble from="assistant" initial={false}>
       <Response
         className="prose prose-sm max-w-none break-words text-xs dark:prose-invert [&_*]:text-xs"
         shikiTheme={ASSISTANT_SHIKI_THEME}

--- a/apps/desktop/src/renderer/composer/composer.tsx
+++ b/apps/desktop/src/renderer/composer/composer.tsx
@@ -5,6 +5,7 @@ import {
   ListPlusIcon,
   MicIcon,
   PaperclipIcon,
+  SparklesIcon,
   SquareIcon,
   XIcon,
   ZapIcon,
@@ -42,7 +43,7 @@ import {
   CAPSULE_SPRING,
   CAPSULE_SURFACE,
   ListeningGlow,
-  ListeningWave,
+  ListeningOrb,
 } from "@renderer/composer/capsule-motion";
 import { useAgentStore } from "@renderer/stores/agent-store";
 import { startSTT, type STTHandle } from "@renderer/voice/stt";
@@ -122,13 +123,23 @@ function formatElapsed(seconds: number): string {
 
 /**
  * The AI composer — a spring-morphing capsule pinned at the bottom of the
- * workspace. Talks to the agent via agent-store (routing user/follow-up/steer
+ * workspace. It rests as a compact centered pill and springs open to the full
+ * input on click/focus, collapsing back when the draft empties and focus
+ * leaves. Talks to the agent via agent-store (routing user/follow-up/steer
  * by live busy state) and auto-attaches the open note as context. Tapping the
  * mic morphs the capsule into a listening surface driven by local STT; the
  * confirmed transcript lands in the draft for review, never auto-sent.
  */
 export function Composer() {
   const [hasInput, setHasInput] = useState(false);
+  // Attachment presence, lifted out of the PromptInput context (via
+  // AttachmentsSync) so the collapse logic below can hold the capsule open
+  // while files are staged even though the tray lives inside the form.
+  const [hasAttachments, setHasAttachments] = useState(false);
+  // User-engagement latch: set by pill click / textarea focus, cleared by an
+  // empty blur that leaves the form (see ComposerTextarea's blur handler).
+  const [engaged, setEngaged] = useState(false);
+  const engage = useCallback(() => setEngaged(true), []);
   const pendingSteerRef = useRef(false);
   const wrapperRef = useRef<HTMLDivElement | null>(null);
   const reduceMotion = useReducedMotion() === true;
@@ -165,6 +176,13 @@ export function Composer() {
   const committedRef = useRef("");
   const partialRef = useRef("");
   const voiceActive = voicePhase !== "idle";
+
+  // The capsule is expanded (full input) or resting (compact pill). `engaged`
+  // is pure user intent; everything that must hold the surface open — a
+  // running turn, the listening surface, drafted text, staged attachments —
+  // is OR'd on top so a collapse can never eat state. When busy ends with the
+  // draft empty and focus elsewhere, this falls back to the pill on its own.
+  const expanded = engaged || busy || voiceActive || hasInput || hasAttachments;
 
   const startListening = useCallback(async () => {
     if (voicePhase !== "idle") return;
@@ -242,7 +260,8 @@ export function Composer() {
   );
 
   // Returning from the listening surface hands focus back to the textarea so
-  // the transcript is immediately reviewable/editable.
+  // the transcript is immediately reviewable/editable. A cancelled pill-mic
+  // session collapses straight back to the pill — nothing to focus.
   const wasVoiceRef = useRef(false);
   useEffect(() => {
     if (voiceActive) {
@@ -251,8 +270,9 @@ export function Composer() {
     }
     if (!wasVoiceRef.current) return;
     wasVoiceRef.current = false;
+    if (!expanded) return;
     findTextarea()?.focus();
-  }, [voiceActive, findTextarea]);
+  }, [voiceActive, expanded, findTextarea]);
 
   // mm:ss fallback readout while no transcript has arrived yet.
   useEffect(() => {
@@ -285,6 +305,26 @@ export function Composer() {
     },
     [],
   );
+
+  // --- Collapse / expand -----------------------------------------------------
+
+  // The textarea owns the collapse decision (it can see the attachment tray);
+  // this only vetoes it mid-listening, where the inert input blurs itself as
+  // the listening surface takes over.
+  const requestCollapse = useCallback(() => {
+    if (voiceActive) return;
+    setEngaged(false);
+  }, [voiceActive]);
+
+  // Expanding mounts the input surface — hand focus to the textarea so typing
+  // can start immediately (skipped when the expansion IS the listening
+  // surface; the voice-return effect above focuses afterwards instead).
+  const wasExpandedRef = useRef(expanded);
+  useEffect(() => {
+    const was = wasExpandedRef.current;
+    wasExpandedRef.current = expanded;
+    if (expanded && !was && !voiceActive) findTextarea()?.focus();
+  }, [expanded, voiceActive, findTextarea]);
 
   // --- Submission ------------------------------------------------------------
 
@@ -379,7 +419,7 @@ export function Composer() {
           layout={!reduceMotion}
           transition={capsuleSpring}
           style={{ borderRadius: CAPSULE_RADIUS }}
-          className={CAPSULE_SURFACE}
+          className={cn(CAPSULE_SURFACE, expanded ? "w-full" : "w-fit mx-auto")}
         >
           <AnimatePresence initial={false} mode="popLayout">
             {voiceActive && (
@@ -401,57 +441,81 @@ export function Composer() {
             )}
           </AnimatePresence>
 
-          {/* The input surface stays MOUNTED while listening (attachments and
-           * the draft live in it) — it fades out and drops out of flow so the
-           * capsule can spring down to the listening row's height. */}
-          <motion.div
-            animate={
-              voiceActive
-                ? { opacity: 0, scale: 0.96, filter: "blur(6px)" }
-                : { opacity: 1, scale: 1, filter: "blur(0px)" }
-            }
-            transition={voiceActive ? { duration: 0.15 } : contentSpring}
-            inert={voiceActive}
-            className={cn(voiceActive && "pointer-events-none absolute inset-x-0 top-0")}
-          >
-            <PromptInput
-              accept={ACCEPTED_IMAGE_MIME}
-              multiple
-              maxFiles={MAX_ATTACHMENT_COUNT}
-              maxFileSize={MAX_ATTACHMENT_BYTES}
-              onError={onAttachError}
-              onSubmit={handleSubmit}
-              className="bg-transparent [&_[data-slot=input-group]]:flex-col [&_[data-slot=input-group]]:items-stretch [&_[data-slot=input-group]]:gap-0 [&_[data-slot=input-group]]:rounded-3xl [&_[data-slot=input-group]]:border-transparent [&_[data-slot=input-group]]:bg-transparent [&_[data-slot=input-group]]:px-0 [&_[data-slot=input-group]]:py-0 [&_[data-slot=input-group]]:shadow-none"
-            >
-              <ComposerAttachments />
-              {/* Two-row layout (the InputGroup block-end pattern): the textarea owns
-               * the top row full-width, a toolbar sits beneath with attach + mic
-               * pinned left and steer/send pinned right — so the controls stay
-               * aligned regardless of how tall the textarea grows. */}
-              <ComposerTextarea
-                busy={busy}
-                onInterrupt={interrupt}
-                onHasInputChange={setHasInput}
-              />
-              <div className="flex items-center justify-between gap-1 px-1.5 pb-1.5">
-                <div className="flex items-center gap-1">
-                  <AttachButton />
-                  <MicButton onStart={() => void startListening()} />
-                </div>
-                <div className="flex items-center gap-1">
-                  <SteerButton busy={busy} hasInput={hasInput} onSteer={requestSteer} />
-                  <SubmitOrStop busy={busy} hasInput={hasInput} onInterrupt={interrupt} />
-                </div>
-              </div>
-            </PromptInput>
-          </motion.div>
+          {/* Resting, the capsule is a compact pill; engaging (click/focus/type/
+           * attach/voice/busy) springs it open to the full input. The input
+           * surface unmounts when collapsed — the draft is empty by definition
+           * there, so nothing is lost. While listening the input stays mounted
+           * (it holds the transcript-bound draft) but blurs out of flow so the
+           * capsule can spring down to the listening row. */}
+          <AnimatePresence initial={false} mode="popLayout">
+            {expanded ? (
+              <motion.div
+                key="input"
+                initial={{ opacity: 0, scale: 0.96, filter: "blur(6px)" }}
+                animate={
+                  voiceActive
+                    ? { opacity: 0, scale: 0.96, filter: "blur(6px)" }
+                    : { opacity: 1, scale: 1, filter: "blur(0px)" }
+                }
+                exit={{ opacity: 0, scale: 0.96, filter: "blur(6px)" }}
+                transition={voiceActive ? { duration: 0.15 } : contentSpring}
+                inert={voiceActive}
+                className={cn(voiceActive && "pointer-events-none absolute inset-x-0 top-0")}
+              >
+                <PromptInput
+                  accept={ACCEPTED_IMAGE_MIME}
+                  multiple
+                  maxFiles={MAX_ATTACHMENT_COUNT}
+                  maxFileSize={MAX_ATTACHMENT_BYTES}
+                  onError={onAttachError}
+                  onSubmit={handleSubmit}
+                  className="bg-transparent [&_[data-slot=input-group]]:flex-col [&_[data-slot=input-group]]:items-stretch [&_[data-slot=input-group]]:gap-0 [&_[data-slot=input-group]]:rounded-3xl [&_[data-slot=input-group]]:border-transparent [&_[data-slot=input-group]]:bg-transparent [&_[data-slot=input-group]]:px-0 [&_[data-slot=input-group]]:py-0 [&_[data-slot=input-group]]:shadow-none"
+                >
+                  <AttachmentsSync onChange={setHasAttachments} />
+                  <ComposerAttachments />
+                  {/* Two-row layout (the InputGroup block-end pattern): the textarea owns
+                   * the top row full-width, a toolbar sits beneath with attach + mic
+                   * pinned left and steer/send pinned right — so the controls stay
+                   * aligned regardless of how tall the textarea grows. */}
+                  <ComposerTextarea
+                    busy={busy}
+                    wrapperRef={wrapperRef}
+                    onInterrupt={interrupt}
+                    onHasInputChange={setHasInput}
+                    onEngage={engage}
+                    onRequestCollapse={requestCollapse}
+                  />
+                  <div className="flex items-center justify-between gap-1 px-1.5 pb-1.5">
+                    <div className="flex items-center gap-1">
+                      <AttachButton />
+                      <MicButton onStart={() => void startListening()} />
+                    </div>
+                    <div className="flex items-center gap-1">
+                      <SteerButton busy={busy} hasInput={hasInput} onSteer={requestSteer} />
+                      <SubmitOrStop busy={busy} hasInput={hasInput} onInterrupt={interrupt} />
+                    </div>
+                  </div>
+                </PromptInput>
+              </motion.div>
+            ) : (
+              <motion.div
+                key="pill"
+                initial={{ opacity: 0, scale: 0.96, filter: "blur(6px)" }}
+                animate={{ opacity: 1, scale: 1, filter: "blur(0px)" }}
+                exit={{ opacity: 0, scale: 0.96, filter: "blur(6px)" }}
+                transition={contentSpring}
+              >
+                <CollapsedPill onExpand={engage} onStartVoice={() => void startListening()} />
+              </motion.div>
+            )}
+          </AnimatePresence>
         </motion.div>
       </div>
     </div>
   );
 }
 
-/** The listening surface: cancel | wave | live transcript (or a timer until
+/** The listening surface: cancel | orb + live transcript (or a timer until
  * words arrive) | confirm. Height-locked to one row so the capsule reads as
  * the input collapsing into a voice pill. */
 function ListeningRow({
@@ -468,7 +532,7 @@ function ListeningRow({
   onConfirm: () => void;
 }) {
   return (
-    <div className="flex h-12 items-center gap-2 px-2">
+    <div className="flex h-14 items-center gap-2 px-2">
       <button
         type="button"
         aria-label="Cancel voice input"
@@ -477,18 +541,19 @@ function ListeningRow({
       >
         <XIcon className="size-4" />
       </button>
-      <ListeningWave />
-      {transcript ? (
-        // Right-aligned in an overflow-hidden box so the TAIL of the live
-        // transcript stays visible as it grows.
-        <div className="flex max-w-[45%] justify-end overflow-hidden">
-          <span className="text-xs whitespace-nowrap text-muted-foreground">{transcript}</span>
-        </div>
-      ) : (
-        <span className="w-10 shrink-0 text-center text-xs tabular-nums text-muted-foreground">
-          {formatElapsed(elapsed)}
-        </span>
-      )}
+      {/* The orb is the focal voice animation; the live transcript (or a mm:ss
+       * timer until words arrive) rides beside it, truncated so the tail stays
+       * readable. */}
+      <div className="flex min-w-0 flex-1 items-center justify-center gap-3">
+        <ListeningOrb />
+        {transcript ? (
+          <span className="max-w-[55%] truncate text-xs text-muted-foreground">{transcript}</span>
+        ) : (
+          <span className="text-xs tabular-nums text-muted-foreground">
+            {formatElapsed(elapsed)}
+          </span>
+        )}
+      </div>
       <button
         type="button"
         aria-label="Confirm voice input"
@@ -531,12 +596,18 @@ function MicButton({ onStart }: { onStart: () => void }) {
 
 function ComposerTextarea({
   busy,
+  wrapperRef,
   onInterrupt,
   onHasInputChange,
+  onEngage,
+  onRequestCollapse,
 }: {
   busy: boolean;
+  wrapperRef: React.RefObject<HTMLDivElement | null>;
   onInterrupt: () => void;
   onHasInputChange: (has: boolean) => void;
+  onEngage: () => void;
+  onRequestCollapse: () => void;
 }) {
   const { files, clear } = usePromptInputAttachments();
   const handleKeyDown = useCallback(
@@ -555,14 +626,75 @@ function ComposerTextarea({
     },
     [busy, onInterrupt, onHasInputChange, files.length, clear],
   );
+  const handleBlur = useCallback(
+    (e: React.FocusEvent<HTMLTextAreaElement>) => {
+      // Collapse only when focus truly LEAVES the composer — clicking a toolbar
+      // button (attach/mic/send) keeps focus inside the wrapper and must not
+      // fold the capsule. The `expanded` OR-chain still holds it open if a
+      // draft, attachments, or a running turn remain.
+      const next = e.relatedTarget;
+      if (next instanceof Node && wrapperRef.current?.contains(next)) return;
+      onRequestCollapse();
+    },
+    [wrapperRef, onRequestCollapse],
+  );
   return (
     <PromptInputTextarea
       className="max-h-[160px] min-h-9 w-full bg-transparent px-3 pt-3 pb-1 text-sm leading-5 text-foreground placeholder:text-muted-foreground"
       placeholder={busy ? "Queue a message…" : "Ask the agent to edit your notes…"}
       onChange={(e) => onHasInputChange(e.currentTarget.value.trim().length > 0)}
       onKeyDown={handleKeyDown}
+      onFocus={onEngage}
+      onBlur={handleBlur}
     />
   );
+}
+
+/** The resting pill — a compact capsule that springs open to the full input on
+ * click (or when the mic starts a voice session). Kept narrow (`whitespace-
+ * nowrap` + a short prompt) so the capsule's `w-fit` reads as a small pill. */
+function CollapsedPill({
+  onExpand,
+  onStartVoice,
+}: {
+  onExpand: () => void;
+  onStartVoice: () => void;
+}) {
+  return (
+    <div className="flex h-12 items-center gap-1 pr-1.5 pl-3">
+      <button
+        type="button"
+        onClick={onExpand}
+        className="flex h-full flex-1 items-center gap-2 text-left"
+      >
+        <SparklesIcon className="size-4 shrink-0 text-muted-foreground/70" />
+        <span className="text-sm whitespace-nowrap text-muted-foreground">Ask the agent…</span>
+      </button>
+      <button
+        type="button"
+        aria-label="Start voice input"
+        onClick={onStartVoice}
+        className="grid size-8 shrink-0 place-items-center rounded-full text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+      >
+        <MicIcon className="size-4" />
+      </button>
+    </div>
+  );
+}
+
+/** Bridges the attachment tray's file count (only known inside PromptInput's
+ * context) up to the composer so the collapse logic can hold the capsule open
+ * while images are staged. Renders nothing. */
+function AttachmentsSync({ onChange }: { onChange: (has: boolean) => void }) {
+  const { files } = usePromptInputAttachments();
+  const has = files.length > 0;
+  useEffect(() => {
+    onChange(has);
+  }, [has, onChange]);
+  // On unmount (capsule collapses) report empty so a stale `true` can't wedge
+  // it open.
+  useEffect(() => () => onChange(false), [onChange]);
+  return null;
 }
 
 function useHasContent(hasInput: boolean): boolean {

--- a/apps/desktop/src/renderer/composer/composer.tsx
+++ b/apps/desktop/src/renderer/composer/composer.tsx
@@ -1,7 +1,18 @@
 import { useCallback, useEffect, useRef, useState, type ReactNode } from "react";
-import { ArrowUpIcon, ListPlusIcon, PaperclipIcon, SquareIcon, ZapIcon } from "lucide-react";
+import {
+  ArrowUpIcon,
+  CheckIcon,
+  ListPlusIcon,
+  MicIcon,
+  PaperclipIcon,
+  SquareIcon,
+  XIcon,
+  ZapIcon,
+} from "lucide-react";
+import { AnimatePresence, motion, useReducedMotion, type Transition } from "framer-motion";
 
 import { toast } from "@repo/ui/components/sonner";
+import { cn } from "@repo/ui/lib/utils";
 import {
   Attachment,
   AttachmentPreview,
@@ -24,8 +35,17 @@ import {
   QueueList,
 } from "@renderer/ai-elements/queue";
 
+import { toErrorMessage } from "@repo/features/ipc";
 import type { ImageAttachment } from "@repo/features/voice";
+import {
+  CAPSULE_RADIUS,
+  CAPSULE_SPRING,
+  CAPSULE_SURFACE,
+  ListeningGlow,
+  ListeningWave,
+} from "@renderer/composer/capsule-motion";
 import { useAgentStore } from "@renderer/stores/agent-store";
+import { startSTT, type STTHandle } from "@renderer/voice/stt";
 
 const ACCEPTED_IMAGE_MIME = "image/png,image/jpeg,image/gif,image/webp";
 const MAX_ATTACHMENT_COUNT = 8;
@@ -77,15 +97,41 @@ function QueuedRow({ msg, icon }: { msg: QueuedMessage; icon: ReactNode }) {
   );
 }
 
+// ---------------------------------------------------------------------------
+// Voice capture — the composer's listening surface over the renderer STT
+// pipeline (startSTT owns getUserMedia + the worklet + the IPC session).
+// ---------------------------------------------------------------------------
+
+/** The composer's voice-capture lifecycle. `starting` shows the listening
+ * surface immediately (mic permission + recognizer spin-up can take a beat);
+ * `stopping` covers the await on the recognizer's tail transcript. */
+type VoicePhase = "idle" | "starting" | "listening" | "stopping";
+
+/** Join transcript segments with a single space, tolerating empty sides. */
+function joinTranscript(a: string, b: string): string {
+  if (!a) return b;
+  if (!b) return a;
+  return `${a} ${b}`;
+}
+
+function formatElapsed(seconds: number): string {
+  const m = Math.floor(seconds / 60);
+  const s = seconds % 60;
+  return `${m}:${String(s).padStart(2, "0")}`;
+}
+
 /**
- * The AI composer — a flat bordered card pinned at the bottom of the workspace.
- * Talks to the agent via agent-store (routing user/follow-up/steer by live busy
- * state) and auto-attaches the open note as context.
+ * The AI composer — a spring-morphing capsule pinned at the bottom of the
+ * workspace. Talks to the agent via agent-store (routing user/follow-up/steer
+ * by live busy state) and auto-attaches the open note as context. Tapping the
+ * mic morphs the capsule into a listening surface driven by local STT; the
+ * confirmed transcript lands in the draft for review, never auto-sent.
  */
 export function Composer() {
   const [hasInput, setHasInput] = useState(false);
   const pendingSteerRef = useRef(false);
   const wrapperRef = useRef<HTMLDivElement | null>(null);
+  const reduceMotion = useReducedMotion() === true;
 
   const appState = useAgentStore((s) => s.appState);
   const send = useAgentStore((s) => s.send);
@@ -99,12 +145,153 @@ export function Composer() {
     if (!busy) pendingSteerRef.current = false;
   }, [busy]);
 
+  const findTextarea = useCallback(
+    () =>
+      wrapperRef.current?.querySelector<HTMLTextAreaElement>('textarea[name="message"]') ?? null,
+    [],
+  );
+
+  // --- Voice capture state -------------------------------------------------
+
+  const [voicePhase, setVoicePhase] = useState<VoicePhase>("idle");
+  const [transcript, setTranscript] = useState("");
+  const [elapsed, setElapsed] = useState(0);
+  const sttHandleRef = useRef<STTHandle | null>(null);
+  // Session counter: bumping it orphans in-flight callbacks (tail transcripts
+  // after cancel, a startSTT that resolves after the user backed out) so they
+  // can't mutate the next session's state.
+  const sttSessionRef = useRef(0);
+  // Finalized utterances joined so far + the live partial replacing itself.
+  const committedRef = useRef("");
+  const partialRef = useRef("");
+  const voiceActive = voicePhase !== "idle";
+
+  const startListening = useCallback(async () => {
+    if (voicePhase !== "idle") return;
+    const session = ++sttSessionRef.current;
+    committedRef.current = "";
+    partialRef.current = "";
+    setTranscript("");
+    setVoicePhase("starting");
+    try {
+      const handle = await startSTT(
+        (text, isFinal) => {
+          if (sttSessionRef.current !== session) return;
+          if (isFinal) {
+            committedRef.current = joinTranscript(committedRef.current, text);
+            partialRef.current = "";
+          } else {
+            partialRef.current = text;
+          }
+          setTranscript(joinTranscript(committedRef.current, partialRef.current));
+        },
+        (error) => {
+          if (sttSessionRef.current !== session) return;
+          toast.error(`Voice input error: ${error}`);
+        },
+      );
+      if (sttSessionRef.current !== session) {
+        // The user backed out while the mic was still spinning up.
+        void handle.stop();
+        return;
+      }
+      sttHandleRef.current = handle;
+      setVoicePhase("listening");
+    } catch (err) {
+      if (sttSessionRef.current !== session) return;
+      setVoicePhase("idle");
+      toast.error(`Voice input unavailable: ${toErrorMessage(err)}`);
+    }
+  }, [voicePhase]);
+
+  /** Leave the listening surface. On confirm the recognizer stops and the
+   * final transcript is appended to the draft for review — never auto-sent.
+   * On cancel the session is orphaned first so tail transcripts are dropped. */
+  const finishListening = useCallback(
+    async (commit: boolean) => {
+      const session = sttSessionRef.current;
+      const handle = sttHandleRef.current;
+      sttHandleRef.current = null;
+      if (!commit) {
+        sttSessionRef.current++;
+        setVoicePhase("idle");
+        if (handle) void handle.stop();
+        return;
+      }
+      if (handle) {
+        // stop() forwards the recognizer's tail transcript through
+        // onTranscript before resolving — await it so the trailing words
+        // make it into the draft.
+        setVoicePhase("stopping");
+        await handle.stop();
+      }
+      if (sttSessionRef.current !== session) return; // cancelled while stopping
+      sttSessionRef.current++;
+      setVoicePhase("idle");
+      const text = joinTranscript(committedRef.current, partialRef.current).trim();
+      if (!text) return;
+      const ta = findTextarea();
+      if (!ta) return;
+      const existing = ta.value.replace(/\s+$/, "");
+      const next = existing ? `${existing} ${text}` : text;
+      ta.value = next;
+      ta.setSelectionRange(next.length, next.length);
+      setHasInput(next.trim().length > 0);
+    },
+    [findTextarea],
+  );
+
+  // Returning from the listening surface hands focus back to the textarea so
+  // the transcript is immediately reviewable/editable.
+  const wasVoiceRef = useRef(false);
+  useEffect(() => {
+    if (voiceActive) {
+      wasVoiceRef.current = true;
+      return;
+    }
+    if (!wasVoiceRef.current) return;
+    wasVoiceRef.current = false;
+    findTextarea()?.focus();
+  }, [voiceActive, findTextarea]);
+
+  // mm:ss fallback readout while no transcript has arrived yet.
+  useEffect(() => {
+    if (!voiceActive) return;
+    setElapsed(0);
+    const interval = setInterval(() => setElapsed((s) => s + 1), 1000);
+    return () => clearInterval(interval);
+  }, [voiceActive]);
+
+  // Escape cancels listening (the textarea's own Escape handler is inert
+  // while the input surface is hidden).
+  useEffect(() => {
+    if (!voiceActive) return;
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.key !== "Escape") return;
+      e.preventDefault();
+      void finishListening(false);
+    };
+    window.addEventListener("keydown", onKeyDown);
+    return () => window.removeEventListener("keydown", onKeyDown);
+  }, [voiceActive, finishListening]);
+
+  // Unmount: orphan the session and drop the mic.
+  useEffect(
+    () => () => {
+      sttSessionRef.current++;
+      const handle = sttHandleRef.current;
+      sttHandleRef.current = null;
+      if (handle) void handle.stop();
+    },
+    [],
+  );
+
+  // --- Submission ------------------------------------------------------------
+
   const handleSubmit = useCallback(
     async (message: PromptInputMessage) => {
       const syncHasInputFromDOM = () => {
-        const ta = wrapperRef.current?.querySelector<HTMLTextAreaElement>(
-          'textarea[name="message"]',
-        );
+        const ta = findTextarea();
         setHasInput(!!(ta && ta.value.trim().length > 0));
       };
       const wantsSteer = pendingSteerRef.current;
@@ -133,7 +320,7 @@ export function Composer() {
         syncHasInputFromDOM();
       }
     },
-    [send],
+    [send, findTextarea],
   );
 
   const onAttachError = useCallback((err: { code: string; message: string }) => {
@@ -146,52 +333,171 @@ export function Composer() {
     pendingSteerRef.current = true;
   }, []);
 
+  // One spring for the capsule shape; content crossfades a beat later so the
+  // shape reads first, details second.
+  const capsuleSpring: Transition = reduceMotion ? { duration: 0 } : CAPSULE_SPRING;
+  const contentSpring: Transition = reduceMotion
+    ? { duration: 0 }
+    : { ...CAPSULE_SPRING, delay: 0.05 };
+
   return (
     <div ref={wrapperRef} className="flex flex-col gap-1.5">
-      {steeringQueue.length + followUpQueue.length > 0 && (
-        <Queue className="rounded-lg border border-border bg-card px-1.5 py-1 text-card-foreground shadow-xs">
-          <QueueList className="mt-0 -mb-1">
-            {steeringQueue.map((msg) => (
-              <QueuedRow
-                key={msg.key}
-                msg={msg}
-                icon={<ZapIcon className="size-3 shrink-0 text-primary" />}
-              />
-            ))}
-            {followUpQueue.map((msg) => (
-              <QueuedRow
-                key={msg.key}
-                msg={msg}
-                icon={<QueueItemIndicator className="size-1.5" />}
-              />
-            ))}
-          </QueueList>
-        </Queue>
-      )}
+      <AnimatePresence initial={false}>
+        {steeringQueue.length + followUpQueue.length > 0 && (
+          <motion.div
+            key="queue"
+            initial={{ opacity: 0, y: 6, filter: "blur(4px)" }}
+            animate={{ opacity: 1, y: 0, filter: "blur(0px)" }}
+            exit={{ opacity: 0, y: 6, filter: "blur(4px)" }}
+            transition={capsuleSpring}
+          >
+            <Queue className="rounded-2xl border-transparent bg-popover px-1.5 py-1 text-popover-foreground shadow-sm ring-1 ring-border">
+              <QueueList className="mt-0 -mb-1">
+                {steeringQueue.map((msg) => (
+                  <QueuedRow
+                    key={msg.key}
+                    msg={msg}
+                    icon={<ZapIcon className="size-3 shrink-0 text-primary" />}
+                  />
+                ))}
+                {followUpQueue.map((msg) => (
+                  <QueuedRow
+                    key={msg.key}
+                    msg={msg}
+                    icon={<QueueItemIndicator className="size-1.5" />}
+                  />
+                ))}
+              </QueueList>
+            </Queue>
+          </motion.div>
+        )}
+      </AnimatePresence>
 
-      <PromptInput
-        accept={ACCEPTED_IMAGE_MIME}
-        multiple
-        maxFiles={MAX_ATTACHMENT_COUNT}
-        maxFileSize={MAX_ATTACHMENT_BYTES}
-        onError={onAttachError}
-        onSubmit={handleSubmit}
-        className="rounded-xl border border-border bg-card shadow-sm [&_[data-slot=input-group]]:flex-col [&_[data-slot=input-group]]:items-stretch [&_[data-slot=input-group]]:gap-0 [&_[data-slot=input-group]]:rounded-xl [&_[data-slot=input-group]]:border-transparent [&_[data-slot=input-group]]:bg-transparent [&_[data-slot=input-group]]:px-0 [&_[data-slot=input-group]]:py-0 [&_[data-slot=input-group]]:shadow-none"
+      <div className="relative">
+        <AnimatePresence>{voiceActive && <ListeningGlow key="glow" />}</AnimatePresence>
+        <motion.div
+          layout={!reduceMotion}
+          transition={capsuleSpring}
+          style={{ borderRadius: CAPSULE_RADIUS }}
+          className={CAPSULE_SURFACE}
+        >
+          <AnimatePresence initial={false} mode="popLayout">
+            {voiceActive && (
+              <motion.div
+                key="listening"
+                initial={{ opacity: 0, scale: 0.96, filter: "blur(6px)" }}
+                animate={{ opacity: 1, scale: 1, filter: "blur(0px)" }}
+                exit={{ opacity: 0, scale: 0.96, filter: "blur(6px)" }}
+                transition={contentSpring}
+              >
+                <ListeningRow
+                  transcript={transcript}
+                  elapsed={elapsed}
+                  stopping={voicePhase === "stopping"}
+                  onCancel={() => void finishListening(false)}
+                  onConfirm={() => void finishListening(true)}
+                />
+              </motion.div>
+            )}
+          </AnimatePresence>
+
+          {/* The input surface stays MOUNTED while listening (attachments and
+           * the draft live in it) — it fades out and drops out of flow so the
+           * capsule can spring down to the listening row's height. */}
+          <motion.div
+            animate={
+              voiceActive
+                ? { opacity: 0, scale: 0.96, filter: "blur(6px)" }
+                : { opacity: 1, scale: 1, filter: "blur(0px)" }
+            }
+            transition={voiceActive ? { duration: 0.15 } : contentSpring}
+            inert={voiceActive}
+            className={cn(voiceActive && "pointer-events-none absolute inset-x-0 top-0")}
+          >
+            <PromptInput
+              accept={ACCEPTED_IMAGE_MIME}
+              multiple
+              maxFiles={MAX_ATTACHMENT_COUNT}
+              maxFileSize={MAX_ATTACHMENT_BYTES}
+              onError={onAttachError}
+              onSubmit={handleSubmit}
+              className="bg-transparent [&_[data-slot=input-group]]:flex-col [&_[data-slot=input-group]]:items-stretch [&_[data-slot=input-group]]:gap-0 [&_[data-slot=input-group]]:rounded-3xl [&_[data-slot=input-group]]:border-transparent [&_[data-slot=input-group]]:bg-transparent [&_[data-slot=input-group]]:px-0 [&_[data-slot=input-group]]:py-0 [&_[data-slot=input-group]]:shadow-none"
+            >
+              <ComposerAttachments />
+              {/* Two-row layout (the InputGroup block-end pattern): the textarea owns
+               * the top row full-width, a toolbar sits beneath with attach + mic
+               * pinned left and steer/send pinned right — so the controls stay
+               * aligned regardless of how tall the textarea grows. */}
+              <ComposerTextarea
+                busy={busy}
+                onInterrupt={interrupt}
+                onHasInputChange={setHasInput}
+              />
+              <div className="flex items-center justify-between gap-1 px-1.5 pb-1.5">
+                <div className="flex items-center gap-1">
+                  <AttachButton />
+                  <MicButton onStart={() => void startListening()} />
+                </div>
+                <div className="flex items-center gap-1">
+                  <SteerButton busy={busy} hasInput={hasInput} onSteer={requestSteer} />
+                  <SubmitOrStop busy={busy} hasInput={hasInput} onInterrupt={interrupt} />
+                </div>
+              </div>
+            </PromptInput>
+          </motion.div>
+        </motion.div>
+      </div>
+    </div>
+  );
+}
+
+/** The listening surface: cancel | wave | live transcript (or a timer until
+ * words arrive) | confirm. Height-locked to one row so the capsule reads as
+ * the input collapsing into a voice pill. */
+function ListeningRow({
+  transcript,
+  elapsed,
+  stopping,
+  onCancel,
+  onConfirm,
+}: {
+  transcript: string;
+  elapsed: number;
+  stopping: boolean;
+  onCancel: () => void;
+  onConfirm: () => void;
+}) {
+  return (
+    <div className="flex h-12 items-center gap-2 px-2">
+      <button
+        type="button"
+        aria-label="Cancel voice input"
+        onClick={onCancel}
+        className="grid size-8 shrink-0 place-items-center rounded-full text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
       >
-        <ComposerAttachments />
-        {/* Two-row layout (the InputGroup block-end pattern): the textarea owns
-         * the top row full-width, a toolbar sits beneath with attach pinned left
-         * and steer/send pinned right — so the controls stay aligned regardless
-         * of how tall the textarea grows. */}
-        <ComposerTextarea busy={busy} onInterrupt={interrupt} onHasInputChange={setHasInput} />
-        <div className="flex items-center justify-between gap-1 px-1.5 pb-1.5">
-          <AttachButton />
-          <div className="flex items-center gap-1">
-            <SteerButton busy={busy} hasInput={hasInput} onSteer={requestSteer} />
-            <SubmitOrStop busy={busy} hasInput={hasInput} onInterrupt={interrupt} />
-          </div>
+        <XIcon className="size-4" />
+      </button>
+      <ListeningWave />
+      {transcript ? (
+        // Right-aligned in an overflow-hidden box so the TAIL of the live
+        // transcript stays visible as it grows.
+        <div className="flex max-w-[45%] justify-end overflow-hidden">
+          <span className="text-xs whitespace-nowrap text-muted-foreground">{transcript}</span>
         </div>
-      </PromptInput>
+      ) : (
+        <span className="w-10 shrink-0 text-center text-xs tabular-nums text-muted-foreground">
+          {formatElapsed(elapsed)}
+        </span>
+      )}
+      <button
+        type="button"
+        aria-label="Confirm voice input"
+        onClick={onConfirm}
+        disabled={stopping}
+        className="grid size-8 shrink-0 place-items-center rounded-full bg-primary text-primary-foreground transition-transform hover:scale-105 active:scale-95 disabled:opacity-50"
+      >
+        <CheckIcon className="size-4" />
+      </button>
     </div>
   );
 }
@@ -201,10 +507,24 @@ function AttachButton() {
   return (
     <PromptInputButton
       tooltip="Attach image"
+      aria-label="Attach image"
       onClick={openFileDialog}
-      className="size-8 shrink-0 rounded-lg text-muted-foreground hover:bg-muted hover:text-foreground"
+      className="size-8 shrink-0 rounded-full text-muted-foreground hover:bg-muted hover:text-foreground"
     >
       <PaperclipIcon className="size-4" />
+    </PromptInputButton>
+  );
+}
+
+function MicButton({ onStart }: { onStart: () => void }) {
+  return (
+    <PromptInputButton
+      tooltip="Voice input"
+      aria-label="Start voice input"
+      onClick={onStart}
+      className="size-8 shrink-0 rounded-full text-muted-foreground hover:bg-muted hover:text-foreground"
+    >
+      <MicIcon className="size-4" />
     </PromptInputButton>
   );
 }
@@ -265,11 +585,12 @@ function SteerButton({
     <PromptInputButton
       type="button"
       tooltip="Send now (steer the agent)"
+      aria-label="Send now (steer the agent)"
       onClick={(e) => {
         onSteer();
         e.currentTarget.form?.requestSubmit();
       }}
-      className="size-8 shrink-0 rounded-lg text-muted-foreground hover:bg-muted hover:text-foreground"
+      className="size-8 shrink-0 rounded-full text-muted-foreground hover:bg-muted hover:text-foreground"
     >
       <ZapIcon className="size-4" />
     </PromptInputButton>
@@ -290,8 +611,9 @@ function SubmitOrStop({
     return (
       <PromptInputButton
         tooltip="Stop"
+        aria-label="Stop"
         onClick={onInterrupt}
-        className="size-8 shrink-0 rounded-lg bg-primary text-primary-foreground hover:bg-primary/90"
+        className="size-8 shrink-0 rounded-full bg-primary text-primary-foreground hover:bg-primary/90"
       >
         <SquareIcon className="size-4" />
       </PromptInputButton>
@@ -301,7 +623,7 @@ function SubmitOrStop({
     <PromptInputSubmit
       disabled={!hasContent}
       aria-label={busy ? "Queue for next turn" : "Send"}
-      className="size-8 shrink-0 rounded-lg bg-primary text-primary-foreground hover:bg-primary/90 disabled:bg-muted disabled:text-muted-foreground"
+      className="size-8 shrink-0 rounded-full bg-primary text-primary-foreground hover:bg-primary/90 disabled:bg-muted disabled:text-muted-foreground"
     >
       {busy ? <ListPlusIcon className="size-4" /> : <ArrowUpIcon className="size-4" />}
     </PromptInputSubmit>

--- a/apps/desktop/src/renderer/composer/composer.tsx
+++ b/apps/desktop/src/renderer/composer/composer.tsx
@@ -10,7 +10,7 @@ import {
   XIcon,
   ZapIcon,
 } from "lucide-react";
-import { AnimatePresence, motion, useReducedMotion, type Transition } from "framer-motion";
+import { AnimatePresence, motion } from "framer-motion";
 
 import { toast } from "@repo/ui/components/sonner";
 import { cn } from "@repo/ui/lib/utils";
@@ -36,17 +36,18 @@ import {
   QueueList,
 } from "@renderer/ai-elements/queue";
 
-import { toErrorMessage } from "@repo/features/ipc";
 import type { ImageAttachment } from "@repo/features/voice";
 import {
+  CAPSULE_CONTENT_HIDDEN,
+  CAPSULE_CONTENT_VISIBLE,
   CAPSULE_RADIUS,
-  CAPSULE_SPRING,
   CAPSULE_SURFACE,
   ListeningGlow,
   ListeningOrb,
+  useCapsuleSpring,
 } from "@renderer/composer/capsule-motion";
 import { useAgentStore } from "@renderer/stores/agent-store";
-import { startSTT, type STTHandle } from "@renderer/voice/stt";
+import { useVoiceCapture } from "@renderer/voice/use-voice-capture";
 
 const ACCEPTED_IMAGE_MIME = "image/png,image/jpeg,image/gif,image/webp";
 const MAX_ATTACHMENT_COUNT = 8;
@@ -98,29 +99,6 @@ function QueuedRow({ msg, icon }: { msg: QueuedMessage; icon: ReactNode }) {
   );
 }
 
-// ---------------------------------------------------------------------------
-// Voice capture — the composer's listening surface over the renderer STT
-// pipeline (startSTT owns getUserMedia + the worklet + the IPC session).
-// ---------------------------------------------------------------------------
-
-/** The composer's voice-capture lifecycle. `starting` shows the listening
- * surface immediately (mic permission + recognizer spin-up can take a beat);
- * `stopping` covers the await on the recognizer's tail transcript. */
-type VoicePhase = "idle" | "starting" | "listening" | "stopping";
-
-/** Join transcript segments with a single space, tolerating empty sides. */
-function joinTranscript(a: string, b: string): string {
-  if (!a) return b;
-  if (!b) return a;
-  return `${a} ${b}`;
-}
-
-function formatElapsed(seconds: number): string {
-  const m = Math.floor(seconds / 60);
-  const s = seconds % 60;
-  return `${m}:${String(s).padStart(2, "0")}`;
-}
-
 /**
  * The AI composer — a spring-morphing capsule pinned at the bottom of the
  * workspace. It rests as a compact centered pill and springs open to the full
@@ -132,17 +110,16 @@ function formatElapsed(seconds: number): string {
  */
 export function Composer() {
   const [hasInput, setHasInput] = useState(false);
-  // Attachment presence, lifted out of the PromptInput context (via
-  // AttachmentsSync) so the collapse logic below can hold the capsule open
-  // while files are staged even though the tray lives inside the form.
+  // Attachment presence, lifted out of PromptInput (its onFilesChange prop) so
+  // the collapse logic below can hold the capsule open while files are staged
+  // even though the tray lives inside the form.
   const [hasAttachments, setHasAttachments] = useState(false);
-  // User-engagement latch: set by pill click / textarea focus, cleared by an
-  // empty blur that leaves the form (see ComposerTextarea's blur handler).
+  // User-engagement latch: set by pill click / textarea focus, cleared when
+  // focus leaves the composer (the wrapper's blur handler below).
   const [engaged, setEngaged] = useState(false);
   const engage = useCallback(() => setEngaged(true), []);
   const pendingSteerRef = useRef(false);
   const wrapperRef = useRef<HTMLDivElement | null>(null);
-  const reduceMotion = useReducedMotion() === true;
 
   const appState = useAgentStore((s) => s.appState);
   const send = useAgentStore((s) => s.send);
@@ -162,20 +139,10 @@ export function Composer() {
     [],
   );
 
-  // --- Voice capture state -------------------------------------------------
+  // --- Voice capture ---------------------------------------------------------
 
-  const [voicePhase, setVoicePhase] = useState<VoicePhase>("idle");
-  const [transcript, setTranscript] = useState("");
-  const [elapsed, setElapsed] = useState(0);
-  const sttHandleRef = useRef<STTHandle | null>(null);
-  // Session counter: bumping it orphans in-flight callbacks (tail transcripts
-  // after cancel, a startSTT that resolves after the user backed out) so they
-  // can't mutate the next session's state.
-  const sttSessionRef = useRef(0);
-  // Finalized utterances joined so far + the live partial replacing itself.
-  const committedRef = useRef("");
-  const partialRef = useRef("");
-  const voiceActive = voicePhase !== "idle";
+  const voice = useVoiceCapture();
+  const voiceActive = voice.phase !== "idle";
 
   // The capsule is expanded (full input) or resting (compact pill). `engaged`
   // is pure user intent; everything that must hold the surface open — a
@@ -184,146 +151,64 @@ export function Composer() {
   // draft empty and focus elsewhere, this falls back to the pill on its own.
   const expanded = engaged || busy || voiceActive || hasInput || hasAttachments;
 
-  const startListening = useCallback(async () => {
-    if (voicePhase !== "idle") return;
-    const session = ++sttSessionRef.current;
-    committedRef.current = "";
-    partialRef.current = "";
-    setTranscript("");
-    setVoicePhase("starting");
-    try {
-      const handle = await startSTT(
-        (text, isFinal) => {
-          if (sttSessionRef.current !== session) return;
-          if (isFinal) {
-            committedRef.current = joinTranscript(committedRef.current, text);
-            partialRef.current = "";
-          } else {
-            partialRef.current = text;
-          }
-          setTranscript(joinTranscript(committedRef.current, partialRef.current));
-        },
-        (error) => {
-          if (sttSessionRef.current !== session) return;
-          toast.error(`Voice input error: ${error}`);
-        },
-      );
-      if (sttSessionRef.current !== session) {
-        // The user backed out while the mic was still spinning up.
-        void handle.stop();
-        return;
-      }
-      sttHandleRef.current = handle;
-      setVoicePhase("listening");
-    } catch (err) {
-      if (sttSessionRef.current !== session) return;
-      setVoicePhase("idle");
-      toast.error(`Voice input unavailable: ${toErrorMessage(err)}`);
-    }
-  }, [voicePhase]);
-
-  /** Leave the listening surface. On confirm the recognizer stops and the
-   * final transcript is appended to the draft for review — never auto-sent.
-   * On cancel the session is orphaned first so tail transcripts are dropped. */
-  const finishListening = useCallback(
-    async (commit: boolean) => {
-      const session = sttSessionRef.current;
-      const handle = sttHandleRef.current;
-      sttHandleRef.current = null;
-      if (!commit) {
-        sttSessionRef.current++;
-        setVoicePhase("idle");
-        if (handle) void handle.stop();
-        return;
-      }
-      if (handle) {
-        // stop() forwards the recognizer's tail transcript through
-        // onTranscript before resolving — await it so the trailing words
-        // make it into the draft.
-        setVoicePhase("stopping");
-        await handle.stop();
-      }
-      if (sttSessionRef.current !== session) return; // cancelled while stopping
-      sttSessionRef.current++;
-      setVoicePhase("idle");
-      const text = joinTranscript(committedRef.current, partialRef.current).trim();
-      if (!text) return;
-      const ta = findTextarea();
-      if (!ta) return;
-      const existing = ta.value.replace(/\s+$/, "");
-      const next = existing ? `${existing} ${text}` : text;
-      ta.value = next;
-      ta.setSelectionRange(next.length, next.length);
-      setHasInput(next.trim().length > 0);
-    },
-    [findTextarea],
-  );
-
-  // Returning from the listening surface hands focus back to the textarea so
-  // the transcript is immediately reviewable/editable. A cancelled pill-mic
-  // session collapses straight back to the pill — nothing to focus.
-  const wasVoiceRef = useRef(false);
-  useEffect(() => {
-    if (voiceActive) {
-      wasVoiceRef.current = true;
-      return;
-    }
-    if (!wasVoiceRef.current) return;
-    wasVoiceRef.current = false;
-    if (!expanded) return;
-    findTextarea()?.focus();
-  }, [voiceActive, expanded, findTextarea]);
-
-  // mm:ss fallback readout while no transcript has arrived yet.
-  useEffect(() => {
-    if (!voiceActive) return;
-    setElapsed(0);
-    const interval = setInterval(() => setElapsed((s) => s + 1), 1000);
-    return () => clearInterval(interval);
-  }, [voiceActive]);
+  /** Confirm listening: the final transcript is appended to the draft for
+   * review — never auto-sent. */
+  const { confirm: confirmVoice } = voice;
+  const confirmListening = useCallback(async () => {
+    const text = await confirmVoice();
+    if (!text) return;
+    const ta = findTextarea();
+    if (!ta) return;
+    const existing = ta.value.replace(/\s+$/, "");
+    const next = existing ? `${existing} ${text}` : text;
+    ta.value = next;
+    ta.setSelectionRange(next.length, next.length);
+    setHasInput(next.trim().length > 0);
+  }, [confirmVoice, findTextarea]);
 
   // Escape cancels listening (the textarea's own Escape handler is inert
   // while the input surface is hidden).
+  const { cancel: cancelVoice } = voice;
   useEffect(() => {
     if (!voiceActive) return;
     const onKeyDown = (e: KeyboardEvent) => {
       if (e.key !== "Escape") return;
       e.preventDefault();
-      void finishListening(false);
+      cancelVoice();
     };
     window.addEventListener("keydown", onKeyDown);
     return () => window.removeEventListener("keydown", onKeyDown);
-  }, [voiceActive, finishListening]);
-
-  // Unmount: orphan the session and drop the mic.
-  useEffect(
-    () => () => {
-      sttSessionRef.current++;
-      const handle = sttHandleRef.current;
-      sttHandleRef.current = null;
-      if (handle) void handle.stop();
-    },
-    [],
-  );
+  }, [voiceActive, cancelVoice]);
 
   // --- Collapse / expand -----------------------------------------------------
 
-  // The textarea owns the collapse decision (it can see the attachment tray);
-  // this only vetoes it mid-listening, where the inert input blurs itself as
-  // the listening surface takes over.
-  const requestCollapse = useCallback(() => {
-    if (voiceActive) return;
-    setEngaged(false);
-  }, [voiceActive]);
+  // Collapse when focus truly LEAVES the composer (focusout bubbles here from
+  // every descendant): moving between the textarea and toolbar buttons stays
+  // inside the wrapper and must not fold the capsule. The `expanded` OR-chain
+  // still holds it open if a draft, attachments, or a running turn remain.
+  // Listening vetoes — the input goes inert and blurs itself as the listening
+  // surface takes over, and that must not eat the engagement latch.
+  const handleWrapperBlur = useCallback(
+    (e: React.FocusEvent<HTMLDivElement>) => {
+      if (voiceActive) return;
+      const next = e.relatedTarget;
+      if (next instanceof Node && wrapperRef.current?.contains(next)) return;
+      setEngaged(false);
+    },
+    [voiceActive],
+  );
 
-  // Expanding mounts the input surface — hand focus to the textarea so typing
-  // can start immediately (skipped when the expansion IS the listening
-  // surface; the voice-return effect above focuses afterwards instead).
-  const wasExpandedRef = useRef(expanded);
+  // Focus the textarea whenever the input becomes the active surface: on
+  // expand (pill click mounts it) and on return from listening (so the
+  // transcript is immediately reviewable). A cancelled pill-mic session
+  // collapses back to the pill — expanded is false, nothing to focus.
+  const prevSurfaceRef = useRef({ expanded, voiceActive });
   useEffect(() => {
-    const was = wasExpandedRef.current;
-    wasExpandedRef.current = expanded;
-    if (expanded && !was && !voiceActive) findTextarea()?.focus();
+    const prev = prevSurfaceRef.current;
+    prevSurfaceRef.current = { expanded, voiceActive };
+    if (expanded && !voiceActive && (!prev.expanded || prev.voiceActive)) {
+      findTextarea()?.focus();
+    }
   }, [expanded, voiceActive, findTextarea]);
 
   // --- Submission ------------------------------------------------------------
@@ -373,15 +258,14 @@ export function Composer() {
     pendingSteerRef.current = true;
   }, []);
 
-  // One spring for the capsule shape; content crossfades a beat later so the
-  // shape reads first, details second.
-  const capsuleSpring: Transition = reduceMotion ? { duration: 0 } : CAPSULE_SPRING;
-  const contentSpring: Transition = reduceMotion
-    ? { duration: 0 }
-    : { ...CAPSULE_SPRING, delay: 0.05 };
+  const handleFilesChange = useCallback((files: PromptInputMessage["files"]) => {
+    setHasAttachments(files.length > 0);
+  }, []);
+
+  const { capsule: capsuleSpring, content: contentSpring, reduceMotion } = useCapsuleSpring();
 
   return (
-    <div ref={wrapperRef} className="flex flex-col gap-1.5">
+    <div ref={wrapperRef} onBlur={handleWrapperBlur} className="flex flex-col gap-1.5">
       <AnimatePresence initial={false}>
         {steeringQueue.length + followUpQueue.length > 0 && (
           <motion.div
@@ -425,17 +309,16 @@ export function Composer() {
             {voiceActive && (
               <motion.div
                 key="listening"
-                initial={{ opacity: 0, scale: 0.96, filter: "blur(6px)" }}
-                animate={{ opacity: 1, scale: 1, filter: "blur(0px)" }}
-                exit={{ opacity: 0, scale: 0.96, filter: "blur(6px)" }}
+                initial={CAPSULE_CONTENT_HIDDEN}
+                animate={CAPSULE_CONTENT_VISIBLE}
+                exit={CAPSULE_CONTENT_HIDDEN}
                 transition={contentSpring}
               >
                 <ListeningRow
-                  transcript={transcript}
-                  elapsed={elapsed}
-                  stopping={voicePhase === "stopping"}
-                  onCancel={() => void finishListening(false)}
-                  onConfirm={() => void finishListening(true)}
+                  transcript={voice.transcript}
+                  stopping={voice.phase === "stopping"}
+                  onCancel={cancelVoice}
+                  onConfirm={() => void confirmListening()}
                 />
               </motion.div>
             )}
@@ -451,13 +334,9 @@ export function Composer() {
             {expanded ? (
               <motion.div
                 key="input"
-                initial={{ opacity: 0, scale: 0.96, filter: "blur(6px)" }}
-                animate={
-                  voiceActive
-                    ? { opacity: 0, scale: 0.96, filter: "blur(6px)" }
-                    : { opacity: 1, scale: 1, filter: "blur(0px)" }
-                }
-                exit={{ opacity: 0, scale: 0.96, filter: "blur(6px)" }}
+                initial={CAPSULE_CONTENT_HIDDEN}
+                animate={voiceActive ? CAPSULE_CONTENT_HIDDEN : CAPSULE_CONTENT_VISIBLE}
+                exit={CAPSULE_CONTENT_HIDDEN}
                 transition={voiceActive ? { duration: 0.15 } : contentSpring}
                 inert={voiceActive}
                 className={cn(voiceActive && "pointer-events-none absolute inset-x-0 top-0")}
@@ -468,10 +347,10 @@ export function Composer() {
                   maxFiles={MAX_ATTACHMENT_COUNT}
                   maxFileSize={MAX_ATTACHMENT_BYTES}
                   onError={onAttachError}
+                  onFilesChange={handleFilesChange}
                   onSubmit={handleSubmit}
                   className="bg-transparent [&_[data-slot=input-group]]:flex-col [&_[data-slot=input-group]]:items-stretch [&_[data-slot=input-group]]:gap-0 [&_[data-slot=input-group]]:rounded-3xl [&_[data-slot=input-group]]:border-transparent [&_[data-slot=input-group]]:bg-transparent [&_[data-slot=input-group]]:px-0 [&_[data-slot=input-group]]:py-0 [&_[data-slot=input-group]]:shadow-none"
                 >
-                  <AttachmentsSync onChange={setHasAttachments} />
                   <ComposerAttachments />
                   {/* Two-row layout (the InputGroup block-end pattern): the textarea owns
                    * the top row full-width, a toolbar sits beneath with attach + mic
@@ -479,16 +358,14 @@ export function Composer() {
                    * aligned regardless of how tall the textarea grows. */}
                   <ComposerTextarea
                     busy={busy}
-                    wrapperRef={wrapperRef}
                     onInterrupt={interrupt}
                     onHasInputChange={setHasInput}
                     onEngage={engage}
-                    onRequestCollapse={requestCollapse}
                   />
                   <div className="flex items-center justify-between gap-1 px-1.5 pb-1.5">
                     <div className="flex items-center gap-1">
                       <AttachButton />
-                      <MicButton onStart={() => void startListening()} />
+                      <MicButton onStart={() => void voice.start()} />
                     </div>
                     <div className="flex items-center gap-1">
                       <SteerButton busy={busy} hasInput={hasInput} onSteer={requestSteer} />
@@ -500,12 +377,12 @@ export function Composer() {
             ) : (
               <motion.div
                 key="pill"
-                initial={{ opacity: 0, scale: 0.96, filter: "blur(6px)" }}
-                animate={{ opacity: 1, scale: 1, filter: "blur(0px)" }}
-                exit={{ opacity: 0, scale: 0.96, filter: "blur(6px)" }}
+                initial={CAPSULE_CONTENT_HIDDEN}
+                animate={CAPSULE_CONTENT_VISIBLE}
+                exit={CAPSULE_CONTENT_HIDDEN}
                 transition={contentSpring}
               >
-                <CollapsedPill onExpand={engage} onStartVoice={() => void startListening()} />
+                <CollapsedPill onExpand={engage} onStartVoice={() => void voice.start()} />
               </motion.div>
             )}
           </AnimatePresence>
@@ -515,22 +392,37 @@ export function Composer() {
   );
 }
 
+function formatElapsed(seconds: number): string {
+  const m = Math.floor(seconds / 60);
+  const s = seconds % 60;
+  return `${m}:${String(s).padStart(2, "0")}`;
+}
+
 /** The listening surface: cancel | orb + live transcript (or a timer until
  * words arrive) | confirm. Height-locked to one row so the capsule reads as
  * the input collapsing into a voice pill. */
 function ListeningRow({
   transcript,
-  elapsed,
   stopping,
   onCancel,
   onConfirm,
 }: {
   transcript: string;
-  elapsed: number;
   stopping: boolean;
   onCancel: () => void;
   onConfirm: () => void;
 }) {
+  // mm:ss readout until the first words arrive. Owned here (not the composer)
+  // so the 1 Hz tick re-renders only this row — and stops entirely once a
+  // transcript is showing (the readout is hidden then anyway). Mount-scoped
+  // per session: AnimatePresence remounts the row for each listening session.
+  const [elapsed, setElapsed] = useState(0);
+  useEffect(() => {
+    if (transcript) return;
+    const interval = setInterval(() => setElapsed((s) => s + 1), 1000);
+    return () => clearInterval(interval);
+  }, [transcript]);
+
   return (
     <div className="flex h-14 items-center gap-2 px-2">
       <button
@@ -596,18 +488,14 @@ function MicButton({ onStart }: { onStart: () => void }) {
 
 function ComposerTextarea({
   busy,
-  wrapperRef,
   onInterrupt,
   onHasInputChange,
   onEngage,
-  onRequestCollapse,
 }: {
   busy: boolean;
-  wrapperRef: React.RefObject<HTMLDivElement | null>;
   onInterrupt: () => void;
   onHasInputChange: (has: boolean) => void;
   onEngage: () => void;
-  onRequestCollapse: () => void;
 }) {
   const { files, clear } = usePromptInputAttachments();
   const handleKeyDown = useCallback(
@@ -626,18 +514,6 @@ function ComposerTextarea({
     },
     [busy, onInterrupt, onHasInputChange, files.length, clear],
   );
-  const handleBlur = useCallback(
-    (e: React.FocusEvent<HTMLTextAreaElement>) => {
-      // Collapse only when focus truly LEAVES the composer — clicking a toolbar
-      // button (attach/mic/send) keeps focus inside the wrapper and must not
-      // fold the capsule. The `expanded` OR-chain still holds it open if a
-      // draft, attachments, or a running turn remain.
-      const next = e.relatedTarget;
-      if (next instanceof Node && wrapperRef.current?.contains(next)) return;
-      onRequestCollapse();
-    },
-    [wrapperRef, onRequestCollapse],
-  );
   return (
     <PromptInputTextarea
       className="max-h-[160px] min-h-9 w-full bg-transparent px-3 pt-3 pb-1 text-sm leading-5 text-foreground placeholder:text-muted-foreground"
@@ -645,7 +521,6 @@ function ComposerTextarea({
       onChange={(e) => onHasInputChange(e.currentTarget.value.trim().length > 0)}
       onKeyDown={handleKeyDown}
       onFocus={onEngage}
-      onBlur={handleBlur}
     />
   );
 }
@@ -680,21 +555,6 @@ function CollapsedPill({
       </button>
     </div>
   );
-}
-
-/** Bridges the attachment tray's file count (only known inside PromptInput's
- * context) up to the composer so the collapse logic can hold the capsule open
- * while images are staged. Renders nothing. */
-function AttachmentsSync({ onChange }: { onChange: (has: boolean) => void }) {
-  const { files } = usePromptInputAttachments();
-  const has = files.length > 0;
-  useEffect(() => {
-    onChange(has);
-  }, [has, onChange]);
-  // On unmount (capsule collapses) report empty so a stale `true` can't wedge
-  // it open.
-  useEffect(() => () => onChange(false), [onChange]);
-  return null;
 }
 
 function useHasContent(hasInput: boolean): boolean {

--- a/apps/desktop/src/renderer/lib/use-theme.tsx
+++ b/apps/desktop/src/renderer/lib/use-theme.tsx
@@ -5,6 +5,14 @@ import { useDiskState } from "@renderer/lib/use-disk-state";
 export { useTheme };
 export type { Theme };
 
+/** The GeometricOrb's neutral palette, tracked to the theme. One source for
+ * every orb placement (initial surface, composer listening) so a retune can't
+ * drift between them. */
+export function useOrbBaseColor(): string {
+  const { resolved } = useTheme();
+  return resolved === "dark" ? "#eeeeee" : "#0a0a0a";
+}
+
 const THEME_KEY = "theme";
 
 /**

--- a/apps/desktop/src/renderer/stores/agent-store.ts
+++ b/apps/desktop/src/renderer/stores/agent-store.ts
@@ -35,6 +35,21 @@ export type ChatMessageMetadata = {
 
 export type ChatMessage = UIMessage<ChatMessageMetadata>;
 
+/**
+ * The messages of the CURRENT turn: everything after the last non-steer user
+ * message (steer nudges ride mid-turn and don't reset the boundary). This is
+ * the one place the turn-boundary rule lives — every consumer that asks "what
+ * is the agent doing right now" (thinking flag, activity label) derives from
+ * this slice instead of re-walking with its own copy of the steer exception.
+ */
+export function currentTurnMessages(messages: ChatMessage[]): ChatMessage[] {
+  for (let i = messages.length - 1; i >= 0; i--) {
+    const msg = messages[i];
+    if (msg && msg.role === "user" && !msg.metadata?.steer) return messages.slice(i + 1);
+  }
+  return messages;
+}
+
 type SendOptions = {
   intent?: "steer";
 };

--- a/apps/desktop/src/renderer/voice/use-voice-capture.ts
+++ b/apps/desktop/src/renderer/voice/use-voice-capture.ts
@@ -1,0 +1,127 @@
+// ---------------------------------------------------------------------------
+// useVoiceCapture — the renderer's push-to-talk STT lifecycle as a hook.
+// Wraps startSTT (which owns getUserMedia + the worklet + the IPC session)
+// with the state a capture UI needs: a phase, the live transcript, and
+// start/cancel/confirm. Extracted from the composer so the race handling is
+// reusable and lives beside the rest of renderer/voice; when hands-free voice
+// returns, this is also where a single STT-session arbiter belongs (main's
+// recognizer is a singleton — two uncoordinated clients would finalize each
+// other's streams).
+// ---------------------------------------------------------------------------
+
+import { useCallback, useEffect, useRef, useState } from "react";
+
+import { toast } from "@repo/ui/components/sonner";
+import { toErrorMessage } from "@repo/features/ipc";
+import { startSTT, type STTHandle } from "@renderer/voice/stt";
+
+/** The capture lifecycle. `starting` shows the listening surface immediately
+ * (mic permission + recognizer spin-up can take a beat); `stopping` covers the
+ * await on the recognizer's tail transcript. */
+export type VoicePhase = "idle" | "starting" | "listening" | "stopping";
+
+/** Join transcript segments with a single space, tolerating empty sides. */
+function joinTranscript(a: string, b: string): string {
+  if (!a) return b;
+  if (!b) return a;
+  return `${a} ${b}`;
+}
+
+export function useVoiceCapture(): {
+  phase: VoicePhase;
+  /** Finalized utterances + the live partial, joined for display. */
+  transcript: string;
+  start: () => Promise<void>;
+  /** Abandon the session; tail transcripts are dropped. */
+  cancel: () => void;
+  /** Stop the recognizer, await its tail, and resolve with the final
+   * transcript ("" when nothing was heard or the session was cancelled). */
+  confirm: () => Promise<string>;
+} {
+  const [phase, setPhase] = useState<VoicePhase>("idle");
+  const [transcript, setTranscript] = useState("");
+  const handleRef = useRef<STTHandle | null>(null);
+  // Session counter: bumping it orphans in-flight callbacks (tail transcripts
+  // after cancel, a startSTT that resolves after the user backed out) so they
+  // can't mutate the next session's state.
+  const sessionRef = useRef(0);
+  // Finalized utterances + the live partial that replaces itself. A ref (not
+  // state) because confirm() reads it after `await handle.stop()`, where a
+  // state closure would be stale.
+  const textRef = useRef({ committed: "", partial: "" });
+
+  const start = useCallback(async () => {
+    if (handleRef.current || phase !== "idle") return;
+    const session = ++sessionRef.current;
+    textRef.current = { committed: "", partial: "" };
+    setTranscript("");
+    setPhase("starting");
+    try {
+      const handle = await startSTT(
+        (text, isFinal) => {
+          if (sessionRef.current !== session) return;
+          if (isFinal) {
+            textRef.current.committed = joinTranscript(textRef.current.committed, text);
+            textRef.current.partial = "";
+          } else {
+            textRef.current.partial = text;
+          }
+          setTranscript(joinTranscript(textRef.current.committed, textRef.current.partial));
+        },
+        (error) => {
+          if (sessionRef.current !== session) return;
+          toast.error(`Voice input error: ${error}`);
+        },
+      );
+      if (sessionRef.current !== session) {
+        // The user backed out while the mic was still spinning up.
+        void handle.stop();
+        return;
+      }
+      handleRef.current = handle;
+      setPhase("listening");
+    } catch (err) {
+      if (sessionRef.current !== session) return;
+      setPhase("idle");
+      toast.error(`Voice input unavailable: ${toErrorMessage(err)}`);
+    }
+  }, [phase]);
+
+  const cancel = useCallback(() => {
+    // Orphan the session FIRST so tail transcripts are dropped.
+    sessionRef.current++;
+    setPhase("idle");
+    const handle = handleRef.current;
+    handleRef.current = null;
+    if (handle) void handle.stop();
+  }, []);
+
+  const confirm = useCallback(async (): Promise<string> => {
+    const session = sessionRef.current;
+    const handle = handleRef.current;
+    handleRef.current = null;
+    if (handle) {
+      // stop() forwards the recognizer's tail transcript through onTranscript
+      // before resolving — await it so the trailing words are included.
+      setPhase("stopping");
+      await handle.stop();
+    }
+    if (sessionRef.current !== session) return ""; // cancelled while stopping
+    sessionRef.current++;
+    setPhase("idle");
+    return joinTranscript(textRef.current.committed, textRef.current.partial).trim();
+  }, []);
+
+  // Unmount: orphan the session and drop the mic.
+  useEffect(
+    () => () => {
+      sessionRef.current++;
+      const handle = handleRef.current;
+      handleRef.current = null;
+      if (handle) void handle.stop();
+    },
+    [],
+  );
+
+  return { phase, transcript, start, cancel, confirm };
+}


### PR DESCRIPTION
Lands `kyh/composer-capsule` (3 commits, never PR'd): morphing capsule composer, collapse-to-pill resting state + orb voice animation, and its /simplify pass. Zero conflicts with main; full gate green on the merge (typecheck/lint/knip/format/882 tests/build).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaces the bottom composer and response popover with a single spring‑morphing capsule that collapses to a centered pill and expands on engage. Adds push‑to‑talk voice with an orb animation and a rainbow glow, plus clearer “thinking” feedback and smoother message entrance.

- New Features
  - Morphing capsule: shared spring/radius/ring between composer and Assistant popover; collapses to a pill and expands on click/type/attachments/busy; blur crossfades and prefers‑reduced‑motion support.
  - Voice input: `useVoiceCapture` manages start/cancel/confirm; listening row with cancel | orb + live transcript | confirm; Escape cancels; confirm appends transcript to the draft (never auto‑sends).
  - Feedback: “thinking” rim before any assistant text in the current turn; message rows animate in; popover stays open when pinned or briefly after activity.
  - Dev harness: simulated STT streaming (partial → final) and a pre‑stream delay for replies to showcase thinking in the browser harness.

- Refactors
  - Motion/visuals: `capsule-motion.tsx` with `CAPSULE_RADIUS`, `CAPSULE_SURFACE`, `useCapsuleSpring`, `ListeningOrb`, `ListeningGlow`, `ThinkingSweep`.
  - State/logic: `currentTurnMessages` centralizes turn boundaries; `isRenderableMessage` filters non‑visible rows; `ChatActivityRow` and thinking use the shared rule; `MessageRow` memoized.
  - Composer plumbing: `PromptInput` adds `onFilesChange` so attachments keep the capsule open; focus/blur handled on the wrapper; focus returns to the textarea after listening.
  - Theme: `useOrbBaseColor` unifies orb colors for the initial surface and listening.

<sup>Written for commit ced3e4f98610d02caaa95d9778aa4821dc84ae18. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kyh/inteligir/pull/406?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

