### PR TITLE
fix(sidebar): hover reveals only the hovered row's actions

### DIFF
--- a/apps/desktop/src/renderer/sidebar/app-sidebar.tsx
+++ b/apps/desktop/src/renderer/sidebar/app-sidebar.tsx
@@ -216,7 +216,12 @@ function TreeNodes({ nodes, ...handlers }: { nodes: VaultTreeNode[] } & RowHandl
     <>
       {nodes.map((node) =>
         node.type === "folder" ? (
-          <SidebarMenuItem key={node.path}>
+          // Plain <li>, NOT SidebarMenuItem: the folder node wraps its whole
+          // subtree, so the `group/menu-item` class would make hovering
+          // anywhere in the folder match every descendant row's
+          // `group-hover/menu-item` and reveal ALL rename/delete actions at
+          // once. Folders have no row actions, so they don't need the group.
+          <li key={node.path} data-sidebar="menu-item" className="relative">
             <Collapsible defaultOpen className="group/collapsible">
               <CollapsibleTrigger
                 render={
@@ -233,7 +238,7 @@ function TreeNodes({ nodes, ...handlers }: { nodes: VaultTreeNode[] } & RowHandl
                 </SidebarMenuSub>
               </CollapsibleContent>
             </Collapsible>
-          </SidebarMenuItem>
+          </li>
         ) : (
           <FileRow
             key={node.path}
@@ -296,7 +301,12 @@ function FileRow({
         size="sm"
         isActive={selectedPath === path}
         onClick={() => onOpen(path)}
-        className={cn(selectedPath === path && "bg-sidebar-accent text-sidebar-accent-foreground")}
+        className={cn(
+          // Clear the two hover-revealed actions (Delete at right-1, Rename at
+          // right-7, w-5 each) so they never overlay the truncated name.
+          "group-focus-within/menu-item:pr-12 group-hover/menu-item:pr-12",
+          selectedPath === path && "bg-sidebar-accent text-sidebar-accent-foreground",
+        )}
       >
         {kind === "doc" ? <FileTextIcon /> : <FileIcon />}
         <span>{name}</span>


### PR DESCRIPTION
Hovering anywhere inside a folder revealed EVERY descendant row's rename/delete icons, overlapping the filenames — the folder's `SidebarMenuItem` wrapped its whole subtree, so its `group/menu-item` matched all nested `group-hover/menu-item` actions. Folder nodes now render a plain `<li>` (no row actions to reveal), and file rows reserve `pr-12` while their actions show so names truncate clear of the icons.

Verified live via CDP: at rest 0/954 actions visible; hovering one row shows exactly 2, name ellipsizes cleanly. Full gate green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes sidebar hover behavior: only the hovered file row shows its rename/delete actions. Icons no longer overlap filenames; names truncate cleanly.

- **Bug Fixes**
  - Render folder nodes as plain `<li>` instead of `SidebarMenuItem` to stop `group` hover from affecting descendants.
  - Add `pr-12` on `group-hover/menu-item` and `group-focus-within/menu-item` for file rows to reserve space for the two action icons.

<sup>Written for commit 13ff8e2fd2a0d05adeb63a1882ab7759b6c53461. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kyh/inteligir/pull/407?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

