### PR TITLE
docs: CONTEXT.md + ADRs + plans 015-018 (hubble.md adoptions)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,94 @@
+# inteligir context
+
+Glossary for shared terms across the project. Implementation detail belongs
+in code, `CLAUDE.md` (architecture), or `docs/adr/` (decisions) — not here.
+Use these words in code, comments, specs, and prompts; the _Avoid_ lines are
+the synonyms that have caused confusion.
+
+## Flagged ambiguities
+
+- **"Vault changed" ≠ "the watcher fired."** `onVaultChanged` is the
+  renderer-facing event meaning "re-read your view of the vault." Its
+  SOURCES are app-initiated writes, the open-note watcher, focus/manual
+  refresh, and delegation completion (see ADR-0001) — not a recursive
+  filesystem watcher.
+- **"Open" is overloaded.** In the renderer, opening a note replaces the
+  single document surface (no tabs — a product decision). In the HTML App
+  File API, `open(path)` means "navigate the editor," never an OS-level open.
+- **"Assets" today = the flat `assets/` folder** used by image paste
+  (plan 012). Any future per-note asset convention is a migration, not a
+  synonym.
+
+## Glossary
+
+### Vault
+
+The user-chosen folder of markdown files that IS the user's content. Files
+are canonical; the app never quarantines or shadow-copies them. App state
+lives in `~/.inteligir`, never in the vault.
+_Avoid_: workspace (that word belongs to the AGENT's working dir).
+
+### Note
+
+A markdown file in the Vault (`.md`). Markdown with the fixed MDX
+vocabulary; anything outside the vocabulary opens in Raw mode instead of
+being normalized.
+
+### Raw mode
+
+The byte-exact textarea surface for files the Rich editor cannot represent
+without changing bytes. Raw is a safety hatch, not a second editor.
+
+### Kit
+
+One editor node type as a Base (headless) + React pair under `editor/kits/`.
+Base halves compose into the serializer mirror; kit-parity tests enforce the
+pairing.
+
+### Bridge
+
+The injected, transport-agnostic API the renderer talks to — derived from
+the IPC registry. The renderer never imports electron/node; the dev harness
+substitutes an in-memory fixture Bridge.
+
+### Knowledge index
+
+The derived, per-device indexes (links, backlinks, lexical search, wiki
+targets) built by `@repo/core/knowledge` over the Vault. Rebuilt locally,
+NEVER synced.
+
+### Delegation
+
+A checkbox task handed to the background agent: snapshot first, agent edits
+via its workspace symlink, result appended, restorable byte-exactly from the
+snapshot.
+
+### Agent workspace
+
+The pi agent's working directory containing the `./vault` symlink. The agent
+reaches notes through it with native file tools; capabilities that are not
+plain file access arrive as ports (`AgentPorts`).
+
+### Sync base
+
+The last-synced manifest anchor the 3-way reconcile diffs against. A PURE
+CACHE: missing/corrupt/legacy means "re-sync from empty," never data loss.
+
+### Conflict copy
+
+The losing side of a sync conflict, preserved as a sibling file named by
+`conflictCopyName` (core owns the name AND the reverse matcher). Surfaced in
+Settings → Sync; dismissing deletes the COPY, never the note.
+
+### HTML App
+
+A vault-local `.html` file rendered as a sandboxed interactive view (opaque
+origin, host-injected dependencies). It reaches notes ONLY through the
+capability-scoped async broker (`window.inteligir.files`), never the Bridge
+or the filesystem. See ADR-0002.
+
+### File Properties
+
+Typed fields parsed from a Note's YAML frontmatter. The file is the only
+store — no metadata database. Unsupported or invalid YAML is preserved
+byte-exactly, never coerced.

--- a/docs/adr/0001-ephemeral-vault-index.md
+++ b/docs/adr/0001-ephemeral-vault-index.md
@@ -1,0 +1,52 @@
+# ADR 0001: Ephemeral vault index — no recursive watcher
+
+Status: accepted (2026-07-08). Implementation: `plans/016-ephemeral-vault-index.md`.
+Adopted from studying hubble.md's ADR-0008; the trade-offs transfer.
+
+## Context
+
+A recursive `fs.watch` on the vault root drove every liveness feature:
+sidebar refresh, knowledge re-index, and sync kicks — one broadcast per file
+event, including the app's own autosaves. Recursive watching is the scaling
+hazard on large or repo-shaped vaults (`.git/`, `node_modules/`), it is why
+the 2,000-entry listing cap existed (and that cap fed the sync manifest —
+the plan-001 data-loss bug), and platform fallbacks (Linux non-recursive)
+made behavior divergent.
+
+## Decision
+
+The vault listing is an **ephemeral, refreshable snapshot**, not a watched
+mirror:
+
+- One-shot crawl on demand — no recursive watcher, no cap; respects
+  `.gitignore`/`.ignore` plus the hard-pruned dirs.
+- The snapshot refreshes on: window focus, every app-initiated
+  write/delete/rename, delegation completion, and an explicit "Refresh
+  vault" command.
+- Only the **currently open note** gets a watcher (single file,
+  non-recursive). Its events run a pure change classifier
+  (`none | reload | conflict | match`) with self-save filtering.
+- Sync passes trigger on save, focus refresh, and a periodic interval —
+  not on watcher events.
+- `onVaultChanged` remains the renderer contract; only its sources changed.
+
+## Considered options
+
+- **Keep the recursive watcher, raise the cap** — treats the symptom;
+  event storms and platform divergence remain.
+- **Watchman / chokidar** — heavier dependency to do the thing we're
+  choosing not to need.
+- **Persist the snapshot between launches** — rejected for v1: rebuild on
+  boot avoids stale-cache invalidation (renames, ignore-rule changes,
+  version bumps).
+
+## Consequences
+
+- External edits to files that are NOT open appear on refocus or manual
+  refresh — accepted: the user refocuses the window to look. Delegation
+  results are exempted (explicit kick on completion).
+- The app's own autosaves stop generating any vault-changed traffic.
+- Ignore rules filter DISCOVERY, not access: explicitly opened files outside
+  the snapshot still work.
+- If a second window or live-collab surface ever exists, add an OPT-IN
+  scoped watcher — never a recursive root watcher again.

--- a/docs/adr/0002-html-apps-sandboxed-iframes.md
+++ b/docs/adr/0002-html-apps-sandboxed-iframes.md
@@ -1,0 +1,60 @@
+# ADR 0002: HTML Apps run as sandboxed iframes with host-injected deps and a file broker
+
+Status: accepted (2026-07-08). Implementation: `plans/015-feature-html-apps.md`.
+Adopted from hubble.md's ADR-0007, whose superseded predecessors (per-embed
+iframes; in-realm Shadow DOM) document the dead ends — we inherit their
+conclusions rather than re-deriving them.
+
+## Context
+
+"Turn this folder of notes into a table / kanban / bookshelf" needs
+arbitrary UI the markdown vocabulary can't express. Our agent is local and
+already writes vault files — it can author a view directly if a vault-local
+`.html` file renders as an interactive app. But an HTML file in a synced,
+agent-written vault must be treated as **untrusted code that executes on
+open**.
+
+## Decision
+
+- A vault `.html` file opens as an **iframe** in the content panel:
+  `sandbox="allow-scripts allow-forms"` and **no `allow-same-origin`** —
+  opaque origin; the frame cannot reach the preload bridge, parent DOM, or
+  storage.
+- Loaded by **`src` via a custom privileged protocol** (`vault-app://`,
+  token-per-open, path-confined through `VaultManager`) — never `srcdoc`
+  (renders blank in Electron sandboxes; hubble issue-tested).
+- **Dependencies are injected at serve time** (tiny vanilla runtime,
+  Tailwind browser, Alpine, theme CSS — vendored, no CDN). Authored apps are
+  ONE self-contained file; no bundler, no `node_modules`, ever. The injected
+  set is a versioned contract: additions append-only, removals breaking.
+- Vault access goes ONLY through a **capability-scoped async broker**:
+  `window.inteligir.files.{list,read,open,create,update,remove}` over
+  token-authenticated postMessage. These are **markdown-file operations,
+  not filesystem access**: `read` returns `{path, body, properties}`,
+  `update` is patch-like (omitted keys preserved, `null` deletes a
+  property), `remove` requires user confirmation. Every method has a `safe*`
+  non-throwing variant.
+
+## Considered options
+
+- **Render in-realm (Web Component / Shadow DOM)** — CSS isolation without
+  JS isolation; foreign code runs with host privileges. Rejected (hubble's
+  ADR-0005 retreat).
+- **Per-embed iframes for inline placements** — popover clipping and
+  nested-iframe composition are fatal for inline editor UI (hubble ADR-0004
+  retreat). Inline embeds are a follow-up with the trust boundary at the
+  document level.
+- **A bundler/build step for apps** — kills the "agent writes one file"
+  loop. Rejected as a non-goal.
+
+## Consequences
+
+- Apps are viewable as static HTML anywhere, but `window.inteligir` and the
+  injected deps only exist when served by the app.
+- The protocol handler and broker are privileged surfaces — reviewed like
+  vault path confinement (traversal, token replay, `event.source` spoofing).
+- Vaults are single-user today; if sharing ever ships, foreign HTML is the
+  RCE surface and the broker's capability set must be re-audited first.
+- Inline `<iframe src="./x.html">` embeds inside notes are deferred: they
+  require an MDX-vocabulary decision (raw iframes currently send a note to
+  Raw mode) and height-sync plumbing (the runtime already reports height).

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,0 +1,14 @@
+# Architecture Decision Records
+
+One file per durable decision: context, the decision, options considered,
+consequences (including the debts it creates). When a decision is replaced,
+the old ADR stays — mark it `Status: superseded by ADR-NNNN` at the top with
+one line on why. The chain is the point: it stops re-derivation of dead ends.
+
+Vocabulary used in ADRs is defined in `/CONTEXT.md`; current architecture is
+summarized in `/CLAUDE.md`. An ADR records WHY, not HOW.
+
+| ADR  | Title                                                                        | Status                               |
+| ---- | ---------------------------------------------------------------------------- | ------------------------------------ |
+| 0001 | Ephemeral vault index — no recursive watcher                                 | accepted (implementation: plans/016) |
+| 0002 | HTML Apps run as sandboxed iframes with host-injected deps and a file broker | accepted (implementation: plans/015) |

--- a/plans/015-feature-html-apps.md
+++ b/plans/015-feature-html-apps.md
@@ -1,0 +1,262 @@
+# Plan 015: Feature — HTML Apps: render vault `.html` files as sandboxed, agent-buildable views
+
+> **Executor instructions**: Follow this plan step by step. This is a FEATURE
+> plan with an investigation gate (Step 0). Run every verification command
+> before moving on. On any STOP condition, stop and report. When done, update
+> this plan's row in `plans/README.md`.
+>
+> **Drift check (run first)**: `git diff --stat cd4bde1b..HEAD -- apps/desktop/src/main packages/features/src/ipc-registry.ts apps/desktop/src/renderer/workspace packages/core/src/markdown`
+> On any mismatch with the excerpts below, STOP.
+
+## Status
+
+- **Priority**: P1 (product direction — "build any view")
+- **Effort**: L (two milestones; M2 may split into its own PR)
+- **Risk**: MED (new privileged protocol + a second broker surface — security-sensitive)
+- **Depends on**: none (builds on merged plans 007/012)
+- **Category**: direction (feature)
+- **Planned at**: commit `cd4bde1b`, 2026-07-08
+
+## Why this matters
+
+The agent can edit markdown, but a vault is more than prose: "turn this folder
+of notes into a table / kanban / bookshelf" needs arbitrary UI. hubble.md
+(github.com/bholmesdev/hubble.md) proved the shape: a folder-local `.html`
+file rendered as a sandboxed app, with host-injected dependencies (so the
+agent writes ONE self-contained file, no build step) and a capability-scoped
+broker for reading/patching notes. Our agent is local and already has vault
+write access — it can author these apps directly; we only need to render them
+safely and hand them a read/patch API.
+
+Design debts hubble already paid (adopt their conclusions, do not re-derive):
+per-embed decisions in their ADR-0004/0005 failed (popover clipping, in-realm
+trust); the accepted design is ADR-0007 — iframe by `src` (NOT `srcdoc`,
+which renders blank in Electron sandboxes), custom protocol, deps injected at
+serve time, `sandbox="allow-scripts allow-forms"` with NO `allow-same-origin`.
+
+## Current state (inteligir, at `cd4bde1b`)
+
+- `.html` vault files: `classify()` in `packages/features/src/server/vault/vault.ts`
+  marks non-doc files `kind: "other"`; the sidebar renders them via `FileRow`
+  (`apps/desktop/src/renderer/sidebar/app-sidebar.tsx`) and opening one goes
+  through `useVault().openFile` → the editor tries to read it as a doc. There
+  is NO html view surface.
+- Electron main: `apps/desktop/src/main/index.ts` — hardened webPreferences
+  (contextIsolation, sandbox:true, nodeIntegration off), will-navigate guard
+  (plan 007), NO custom protocol registered anywhere (grep `protocol.` under
+  `apps/desktop/src/main` → nothing).
+- Vault confinement: `VaultManager.resolve()` is realpath-safe (plan 007);
+  `readBytes`/`readText`/`writeText` are the confined ops. Reuse — never
+  bypass.
+- Frontmatter: `@repo/core/markdown` owns the parse pipeline; frontmatter
+  parsing exists (frontmatter-kit round-trips it). Investigate the exact
+  helper for splitting body vs frontmatter in Step 0.
+- IPC: registry pattern per `docs/development.md` (registry entry + handler +
+  fixture-bridge line, typecheck-enforced). The broker in this plan does NOT
+  go through the renderer Bridge — it is main-process ↔ iframe postMessage —
+  but note-open/read paths it needs on the RENDERER side do.
+- Embed kit (`editor/kits/embed-kit.tsx`) renders `media_embed` generic
+  iframes by URL — url-only by charter; HTML-app embeds (M3) are related but
+  the vocabulary treatment of raw `<iframe>` HTML in markdown must be checked
+  in Step 0 (raw HTML is outside the MDX vocabulary → Raw mode today).
+- Conventions: strict TS (no `any`/`as`/`!`), kebab-case, TypeBox schemas for
+  every untrusted input, kit Base+React pairs, byte-pinned fixtures generated
+  through the pipeline.
+
+## Commands you will need
+
+| Purpose       | Command                                                                                                     | Expected |
+| ------------- | ----------------------------------------------------------------------------------------------------------- | -------- |
+| Real app      | `pnpm dev:desktop` (CDP :9222)                                                                              | boots    |
+| Harness       | `pnpm --filter @repo/desktop dev:harness`                                                                   | :5173    |
+| Desktop tests | `pnpm --filter @repo/desktop test`                                                                          | pass     |
+| Full gate     | `pnpm format:fix` then `pnpm typecheck && pnpm lint && pnpm knip && pnpm format && pnpm test && pnpm build` | exit 0   |
+
+## Suggested executor toolkit
+
+- `agent-browser` skill (drive both harness and Electron; the app-view iframe
+  is verifiable over CDP).
+- Reference: hubble.md's ADR-0007 text is quoted above — do not fetch the repo.
+
+## Scope
+
+**In scope**:
+
+- NEW `apps/desktop/src/main/vault-app-protocol.ts` (protocol + runtime injection)
+- `apps/desktop/src/main/index.ts` (register protocol; wire open-html-app)
+- NEW `apps/desktop/resources/html-app-runtime/` (vendored: runtime.js you write, Tailwind browser v4 vendored file, Alpine vendored file, theme css)
+- NEW `apps/desktop/src/renderer/workspace/html-app-view.tsx` (+ wiring in `workspace-page.tsx` / `vault-context.tsx` so opening `kind:"other"` `.html` shows it)
+- NEW broker host: `apps/desktop/src/main/html-app-broker.ts` (postMessage RPC handler — main-side or preload-side per Step 0 findings)
+- `packages/features/src/ipc-registry.ts` + handlers + fixture-bridge ONLY if renderer-side channels are needed (e.g. `readVaultDocSplit` returning body+properties)
+- `packages/core/src/markdown/` ONLY the frontmatter split helper if none exists
+- Tests for: protocol path confinement, broker validation, frontmatter split
+- `plans/README.md`
+
+**Out of scope**:
+
+- Inline embeds in markdown (`<iframe src="./x.html">` inside a note) — that
+  is M3, a FOLLOW-UP plan: it needs an MDX-vocabulary decision (raw iframes
+  currently force Raw mode) and its own round-trip fixtures. This plan ships
+  full-panel HTML Apps only.
+- Any bundler/build step for apps — hubble's explicit non-goal; ours too.
+- Web/mobile rendering of HTML apps.
+- An opt-in/out mechanism for injected deps (canonical set only, v1).
+- Sharing/foreign-vault trust model — our vaults are single-user; note the
+  same tracked debt hubble carries: if vault SHARING ever ships, revisit.
+
+## Git workflow
+
+- Branch: `kyh/plan-015-html-apps`
+- Conventional commits per milestone: `feat(desktop): vault-app:// protocol`, `feat(renderer): html app view`, `feat(desktop): html-app file broker`
+
+## Steps
+
+### Step 0: Investigation gate
+
+Answer and record in your report:
+
+1. Where does opening a `kind:"other"` file currently land? (Trace
+   `openFile` in vault-context → editor behavior for a `.html` path.)
+2. Does `@repo/core/markdown` export a body/frontmatter split usable
+   server-side (the broker needs `read → {body, properties}` and patch-like
+   recombine)? Name the functions or note the gap.
+3. Electron protocol registration: confirm `protocol.handle` +
+   `registerSchemesAsPrivileged` availability in our Electron version and
+   that a fetch from inside a sandboxed iframe to the custom scheme works
+   (hubble's flags: `standard, secure, supportFetchAPI, corsEnabled`).
+4. Sandbox inheritance: verify (small spike) that an iframe with
+   `sandbox="allow-scripts"` and NO `allow-same-origin`, loaded via the
+   custom protocol inside our renderer, does NOT see `window.desktopBridge`
+   (the preload). If it does — STOP, that is the whole security model.
+
+### M1a: The `vault-app://` protocol
+
+In `vault-app-protocol.ts`:
+
+- `registerSchemesAsPrivileged([{ scheme: "vault-app", privileges: { standard: true, secure: true, supportFetchAPI: true, corsEnabled: true } }])`
+  before app ready; `protocol.handle("vault-app", handler)` after.
+- URL shape: `vault-app://app/<vault-relative-path>?token=<per-open token>`.
+  The handler: reject unless a token minted for the CURRENT open app matches
+  (tokens are random per app-open, held main-side); resolve the path through
+  `VaultManager` (confined read — reuse `readBytes`; never `fs` directly);
+  `content-type` by extension; `cache-control: no-store`.
+- For `.html` responses ONLY: inject before `</head>`: `<script>` runtime
+  (`runtime.js`), `<style type="text/tailwindcss">`-loader script (Tailwind
+  browser v4, vendored), theme CSS variables; before `</body>`: Alpine
+  (vendored, defer). Tag every injected node `data-inteligir-injected`.
+  Non-html assets (images/css/js the app references relatively) are served
+  raw — apps may split files, but the canonical form is one file.
+- Vendor the dependency files under `apps/desktop/resources/html-app-runtime/`
+  imported `?raw` (build-time, no CDN at runtime).
+
+**Verify**: unit test the handler's path confinement (traversal, absolute,
+symlink — mirror plan 007's vault tests) and token rejection; `pnpm typecheck`.
+
+### M1b: The runtime + broker
+
+`runtime.js` (vanilla, keep it ~hubble-sized, ≤150 lines): exposes
+`window.inteligir.files` with `list()`, `read(path)`, `open(path)`,
+`create(path, {body, properties})`, `update(path, patch)`, `remove(path)` —
+each a `postMessage` RPC (`inteligir:request` / `inteligir:response`) carrying
+a request id + the frame token (`window.name`), 10s timeout; each has a
+`safe*` variant returning `{ok, value|error}` instead of throwing. Also post
+`inteligir:height` from a ResizeObserver (unused in M1, needed by the M3
+embed follow-up — cheap to include now).
+
+Broker host (`html-app-view.tsx` listens on `window`, since the iframe's
+parent is the RENDERER): validate `event.source === iframe.contentWindow`
+AND token === the iframe's `name`; validate every payload with TypeBox;
+map to Bridge calls:
+
+- `list` → `listVault()` filtered to docs
+- `read` → doc bytes → split `{path, body, properties}` (frontmatter helper)
+- `open` → `useVault().openFile(path)` (navigates the editor)
+- `update` → patch-like: merge onto current body/properties, recombine,
+  `writeVaultDoc` (omitted keys preserved; `properties: {k: null}` deletes k)
+- `create` → fails if exists; `remove` → the existing confirm-dialog, then
+  `deleteVaultEntry`.
+  All paths are vault-relative doc paths; reject anything `..`/absolute/scheme-
+  looking BEFORE it reaches the Bridge (defense in depth — the vault confines
+  again underneath).
+
+**Verify**: broker unit tests against a fake Bridge (token mismatch ignored,
+patch semantics, null-deletes-property, create-exists error, safe\* shapes).
+
+### M1c: The view
+
+`html-app-view.tsx`: when the open path ends `.html`, `workspace-page`
+renders it instead of the editor — an iframe
+`sandbox="allow-scripts allow-forms"` (NO allow-same-origin),
+`src=vault-app://app/<path>?token=…` (token requested from main over a new
+IPC channel `mintHtmlAppToken` — registry + handler + fixture stub). A
+header bar shows the file name + "Open as text" (routes to the Raw editor
+surface — the file is still just a vault file). External navigation from
+inside the iframe is already covered by plan 007's guard; confirm.
+Live reload: watch the open `.html` via the existing open-note
+vanish/change machinery (`onVaultChanged` broadcast → bump an iframe key)
+so the agent editing the app hot-reloads it.
+Harness: the fixture bridge can't serve `vault-app://`; in the harness build
+the view falls back to a `blob:` URL assembled from the fixture's bytes with
+the same runtime injected (keeps the UI drivable in dev:harness; note the
+broker works identically — it's parent-window postMessage either way).
+
+**Verify** (agent-browser, REQUIRED):
+
+1. Harness: create `demo.html` (an Alpine counter + `inteligir.files.list()`
+   rendered as a `<ul>`) via the fixture vault; open it → renders, counter
+   clicks, list shows the sample notes.
+2. Electron: write the same demo into a temp vault note folder; open it →
+   renders; `window.desktopBridge` is UNDEFINED inside the frame (eval in
+   the iframe context via CDP); `files.read()` of a note returns body+
+   properties; `files.update()` patch round-trips (re-read shows the change,
+   file on disk correct, frontmatter preserved).
+3. Editing the `.html` on disk (echo >>) hot-reloads the view.
+
+### M1d: Teach the agent
+
+Append a short section to the agent's vault instructions (find where the
+chat agent's system context describes the vault — `resources/agent/AGENTS.md`
+or equivalent per Step 0): what an HTML App is, the one-file rule (deps are
+injected — never add `<script src>` for Tailwind/Alpine/runtime), and the
+`window.inteligir.files` API with the patch semantics. Keep it ≤30 lines —
+this is prompt copy; write it like documentation, not marketing.
+
+**Verify**: live chat ask — "build me an html app at apps/notes-table.html
+that lists my notes as a table" → agent writes the file → opening it renders.
+(pi login available on this machine; if the run flakes, operator-pending.)
+
+### Step final: Gates
+
+`pnpm format:fix` then the full canonical gate.
+
+## Done criteria
+
+- [ ] Opening a vault `.html` file shows the sandboxed app view; "Open as text" still works
+- [ ] Inside the frame: `window.desktopBridge` undefined; `window.inteligir.files` works (read/update patch semantics unit- AND live-verified)
+- [ ] Protocol handler rejects traversal/symlink/absolute/foreign-token requests (tested)
+- [ ] Hot-reload on `.html` change; harness path works via blob fallback
+- [ ] No bundler, no CDN fetches at runtime (grep the injected HTML for http)
+- [ ] Full gate exits 0; `plans/README.md` updated
+
+## STOP conditions
+
+- Step 0.4 fails (sandboxed iframe can see the preload bridge) — the design is unsound on our Electron version; report.
+- `srcdoc`-style shortcuts get tempting because the protocol fights you — do NOT switch to srcdoc (hubble documented it renders blank); report the friction instead.
+- The frontmatter split helper doesn't exist in core and writing it requires touching the Plate round-trip rules — report scope before writing it.
+- Any broker capability seems to need RAW fs access — the API is markdown-file ops only, full stop; report the use case.
+
+## Maintenance notes
+
+- M3 follow-up (separate plan): inline `<iframe src="./x.html">` embeds inside
+  notes — needs the MDX-vocabulary decision (admit relative-src iframes as a
+  node vs keep Raw), height sync (runtime already posts it), and byte-pinned
+  fixtures.
+- The injected-deps set (runtime/Tailwind/Alpine/theme) is the versioned
+  contract with every app an agent has ever written — treat additions as
+  append-only; removals are breaking.
+- If vault sharing/multi-user ever ships, foreign `.html` is untrusted code
+  on open: the sandbox already assumes this, but re-audit the broker's
+  capability set then (hubble tracks the same debt).
+- Reviewer focus: the protocol handler and broker are the new privileged
+  surfaces — review them like plan 007's resolve() (path games, token reuse,
+  event.source spoofing).

--- a/plans/016-ephemeral-vault-index.md
+++ b/plans/016-ephemeral-vault-index.md
@@ -1,0 +1,177 @@
+# Plan 016: Ephemeral vault index — no recursive watcher; refresh on focus/save/manual
+
+> **Executor instructions**: Follow this plan step by step. Run every
+> verification command before moving on. On any STOP condition, stop and
+> report. When done, update this plan's row in `plans/README.md`.
+>
+> **Drift check (run first)**: `git diff --stat cd4bde1b..HEAD -- packages/features/src/server/vault/vault.ts packages/features/src/server/create-host.ts packages/features/src/server/knowledge/knowledge-manager.ts packages/features/src/server/sync/sync-coordinator.ts apps/desktop/src/renderer/workspace`
+> NOTE: plan 015 (`kyh/plan-015-html-apps`) may have landed on these renderer
+> files first — merge its branch/main before starting if so; treat its changes
+> as expected, not drift.
+
+## Status
+
+- **Priority**: P1 (adopted architecture decision — operator-approved 2026-07-08)
+- **Effort**: L
+- **Risk**: MED-HIGH (changes the liveness model of listing, knowledge, and sync)
+- **Depends on**: 015 landing first (shared renderer files)
+- **Category**: tech-debt / architecture
+- **Planned at**: commit `cd4bde1b`, 2026-07-08
+
+## Why this matters
+
+Adopted from hubble.md's ADR-0008. Today one recursive `fs.watch` on the
+vault root drives everything: every file event broadcasts `onVaultChanged`,
+which re-lists the vault for the sidebar, re-scans for the knowledge index
+(full walk + stat per event burst), and kicks the sync debounce — including
+for OUR OWN autosaves. On large or repo-shaped vaults (node_modules, .git)
+recursive watching is the scaling hazard, and it is why `MAX_LIST_ENTRIES`
+exists. The ephemeral model deletes the class: one-shot crawl, refreshed on
+window focus / app-initiated writes / manual sync; only the OPEN note is
+watched (non-recursively) for external edits. Liveness trade (accepted):
+agent edits to NON-open files appear when the window regains focus — which
+is when the user looks.
+
+## Current state
+
+- Watcher: `packages/features/src/server/vault/vault.ts` — `fs.watch`
+  recursive (with a Linux non-recursive fallback), started post-`ensureReady`
+  via `create-host.ts` (`setVaultChangeNotifier` wrapper), broadcasting
+  through `notifiers.vaultChange` → `emitEvent("onVaultChanged")` +
+  `getKnowledgeManager().scheduleRefresh()` (`host-context.ts`
+  `buildHostNotifiers`) + `getSyncCoordinator().onVaultChanged()`
+  (`create-host.ts` start()).
+- Cap: `MAX_LIST_ENTRIES = 2000` in `list()` (UI listing); `listAllPaths()`
+  (uncapped) feeds sync — plan 001. `SKIP_DIRS = {.git, node_modules,
+.obsidian, .trash}`.
+- Renderer: `vault-context.tsx` — `onVaultChanged` handler re-lists (with
+  plan 011's equality skip) and routes the open note's reload/vanish through
+  the note-runtime; plan 014 seeded conflicts on boot and prunes on state
+  reads.
+- Sync: `sync-coordinator.ts` — engine's debounced reconcile kicked by
+  `onVaultChanged()`; also `syncNow` IPC and an initial pass on start.
+- Read `docs/adr/0001-ephemeral-vault-index.md` (committed with this plan's
+  batch) — it records the decision and its trade; your implementation must
+  match it.
+
+## Commands you will need
+
+| Purpose        | Command                                                                                                     | Expected |
+| -------------- | ----------------------------------------------------------------------------------------------------------- | -------- |
+| Features tests | `pnpm --filter @repo/features test`                                                                         | pass     |
+| Desktop tests  | `pnpm --filter @repo/desktop test`                                                                          | pass     |
+| Harness        | `pnpm --filter @repo/desktop dev:harness`                                                                   | :5173    |
+| Real app       | `pnpm dev:desktop`                                                                                          | boots    |
+| Full gate      | `pnpm format:fix` then `pnpm typecheck && pnpm lint && pnpm knip && pnpm format && pnpm test && pnpm build` | exit 0   |
+
+## Scope
+
+**In scope**:
+
+- `packages/features/src/server/vault/vault.ts` (watcher → open-file watcher; cap removal; `.gitignore` respect in the crawl)
+- `packages/features/src/server/create-host.ts`, `host-context.ts` (trigger rewiring)
+- `packages/features/src/server/knowledge/knowledge-manager.ts` (refresh triggers only — not the index)
+- `packages/features/src/server/sync/sync-coordinator.ts` (save/focus/interval triggers)
+- `packages/features/src/ipc-registry.ts` + handlers + fixture-bridge (a `notifyWindowFocus` channel or equivalent; a `refreshVault` command)
+- `apps/desktop/src/renderer/workspace/vault-context.tsx`, command palette (manual "Refresh vault" action)
+- NEW `packages/features/src/server/vault/classify-file-change.ts` (pure: none|reload|conflict|match + self-save filtering) + tests
+- Existing tests that pin watcher behavior (adapt deliberately, one by one — each adaptation named in your report)
+
+**Out of scope**:
+
+- The knowledge INDEX internals and sync ENGINE internals — triggers only.
+- The `onVaultChanged` renderer event contract — it stays; only its SOURCES change.
+- Mobile. The 2k cap in any non-UI consumer (already gone from sync via 001).
+
+## Git workflow
+
+- Branch: `kyh/plan-016-ephemeral-index`
+- Conventional commits per step: `refactor(vault): ...`, `feat(vault): ...`
+
+## Steps
+
+### Step 1: Pure change classifier
+
+`classify-file-change.ts`: given (lastKnownContentHashOrMtime, currentDiskState,
+editorDirtyState) → `none | reload | conflict | match`, plus a self-save
+registry (record app-initiated writes; prune by age; `isSelfSave(path, mtime)`).
+Unit-test exhaustively — this is the open-note watcher's brain.
+**Verify**: new tests pass.
+
+### Step 2: Open-file watcher replaces the recursive watcher
+
+In `vault.ts`: remove the recursive `fs.watch` + fallback. Add
+`watchOpenFile(path)` — ONE non-recursive `fs.watch` on the currently-open
+file's path (rewired on note switch via a new host handler the renderer
+calls on open; simplest: an IPC channel `setWatchedNote` — registry +
+handler + fixture stub). Its events run the Step-1 classifier; `reload`
+and vanish broadcast `onVaultChanged` exactly as today (the renderer's
+existing reload/vanish machinery keeps working unchanged); `conflict`
+broadcasts too (same behavior as today's external-change path); self-saves
+are filtered OUT (today they round-trip a broadcast per autosave).
+**Verify**: existing vault tests adapted; renderer note-runtime tests
+untouched and green.
+
+### Step 3: Crawl improvements
+
+`list()`: drop `MAX_LIST_ENTRIES` (the crawl is now on-demand, not per-event).
+Respect `.gitignore`/`.ignore` files (use the `ignore` npm package — add to
+features deps; parse the root ignore files only, v1) in addition to
+`SKIP_DIRS` (keep those unconditionally). `listAllPaths()` (sync) keeps its
+current semantics — sync must see everything NOT ignored; apply the same
+ignore rules there ONLY if plan 001's regression tests still pass unchanged
+in spirit (adapt the 2050-file test: it now asserts NO cap instead of the
+cap boundary — rewrite it as "list() === listAllPaths() count on a plain
+vault").
+**Verify**: adapted vault tests; `pnpm --filter @repo/features test`.
+
+### Step 4: Trigger rewiring
+
+- Renderer: on `window` focus → call a new `refreshVault` command (re-list +
+  knowledge refresh + sync kick). Debounce 1s. Command palette gains
+  "Refresh vault" invoking the same.
+- Host: every app-initiated write path already flows through VaultManager —
+  after each write/delete/rename, fire the SAME pipeline (list consumers
+  refresh via the existing `onVaultChanged` broadcast, knowledge
+  scheduleRefresh, sync onVaultChanged) — i.e. app actions keep today's
+  behavior exactly; only EXTERNAL discovery moves to focus/manual.
+- Sync: `sync-coordinator.ts` adds a periodic pass (`SYNC_INTERVAL_MS = 5 *
+60_000`, only when enabled+authed) and a kick on the focus refresh. Remove
+  nothing else.
+- Delegation: the background agent writes via `./vault` (external!) — its
+  completion already flows through delegation-manager events; ADD a vault
+  refresh kick when a delegation completes (find the completion point in
+  `delegation-manager.ts`) so results appear without refocus.
+  **Verify**: harness — edit fixture files через the app: sidebar updates
+  immediately (app-initiated). Electron — `touch` a new file in the vault
+  externally: sidebar does NOT update; refocus the window: it appears; open
+  note edited externally: reloads (classifier). Delegation completion path:
+  code-read + note in report (live delegation run optional).
+
+### Step 5: Gates + docs
+
+Update `docs/development.md`'s watcher/liveness paragraph (it documents the
+recursive watcher today — find and rewrite honestly). Full canonical gate.
+
+## Done criteria
+
+- [ ] No recursive watcher exists (`grep -n "recursive: true" packages/features/src/server/vault/` → none)
+- [ ] Open-note external edits still reload/conflict correctly (classifier tested; harness/Electron verified)
+- [ ] Own autosaves no longer trigger vault-changed broadcasts (verify: type in a note, no sidebar refresh event — plan 011's skip made it cheap, this makes it zero)
+- [ ] External file appears on refocus + manual refresh; delegation results appear on completion
+- [ ] Cap gone; `.gitignore` respected; sync periodic+focus+save triggers work
+- [ ] Full gate exits 0; development.md updated
+
+## STOP conditions
+
+- The renderer's reload/vanish machinery turns out to depend on watcher
+  events for NON-open files in a way focus-refresh can't cover — report the
+  dependency.
+- Sync's e2e tests fail under the new triggers — report, don't loosen tests.
+- The `ignore` package pulls surprising transitive weight — report before adding.
+
+## Maintenance notes
+
+- If "live updates while unfocused" is ever wanted (e.g. a second window),
+  reintroduce watching as an OPT-IN per-folder watcher, never recursive-root.
+- The interval constant is policy; revisit with real sync usage.

--- a/plans/017-frontmatter-properties-panel.md
+++ b/plans/017-frontmatter-properties-panel.md
@@ -1,0 +1,126 @@
+# Plan 017: File-properties panel over frontmatter (file stays the only store)
+
+> **Executor instructions**: Follow this plan step by step. Run every
+> verification command before moving on. On any STOP condition, stop and
+> report. When done, update this plan's row in `plans/README.md`.
+>
+> **Drift check (run first)**: `git diff --stat cd4bde1b..HEAD -- apps/desktop/src/renderer/editor packages/core/src/markdown`
+> Plans 015/016 may have landed first — merge main; their changes are
+> expected, not drift.
+
+## Status
+
+- **Priority**: P2
+- **Effort**: M
+- **Risk**: MED (touches note bytes — round-trip discipline applies)
+- **Depends on**: 015 (if it added a frontmatter split helper in core, reuse it)
+- **Category**: direction (feature — adopted from hubble ADR-0003)
+- **Planned at**: commit `cd4bde1b`, 2026-07-08
+
+## Why this matters
+
+Frontmatter exists in the editor (frontmatter-kit round-trips it) but is
+shown as raw YAML — no typed editing. The adopted model (hubble ADR-0003):
+the markdown file is the ONLY property store — no metadata DB — with a panel
+of typed controls parsed from frontmatter and recombined on save.
+Conservative typing rules prevent YAML foot-guns.
+
+## Current state
+
+- `apps/desktop/src/renderer/editor/kits/frontmatter-kit.tsx` — the existing
+  kit (read it end-to-end first: how frontmatter is represented as a node,
+  how it serializes back byte-exactly).
+- `@repo/core/markdown` — frontmatter parsing in the remark pipeline
+  (`remark-frontmatter` presumably; locate). If plan 015 added a
+  split/recombine helper, build on it.
+- Round-trip law: byte-pinned fixtures under
+  `apps/desktop/src/renderer/__tests__/fixtures/` — a note whose properties
+  are NOT edited must round-trip byte-exactly, including odd-but-valid YAML.
+- UI: panel components come from `@repo/ui` (Base UI) — inputs, checkbox,
+  date is a plain `YYYY-MM-DD` text input v1 (no date-picker dep).
+
+## Typing rules (adopt verbatim — they are the feature)
+
+- YAML 1.2 core schema; duplicate keys invalid.
+- `true`/`false` → checkbox; `yes/no/on/off` STAY TEXT (no coercion).
+- Dates recognized ONLY from explicit `YYYY-MM-DD` strings.
+- Numbers → number input; plain strings → text; string arrays → tags.
+- Anything else (nested maps, mixed arrays, anchors) → "unsupported": shown
+  as read-only raw YAML for that key, PRESERVED byte-exactly on save.
+- Whole-frontmatter parse failure → panel shows "properties unavailable"
+  and the raw block stays untouched; the panel never destroys what it can't
+  read.
+- Type overrides (user forces text→date etc.): session-memory only, never
+  written to the file.
+
+## Commands you will need
+
+| Purpose       | Command                                                                                                     | Expected |
+| ------------- | ----------------------------------------------------------------------------------------------------------- | -------- |
+| Desktop tests | `pnpm --filter @repo/desktop test`                                                                          | pass     |
+| Harness       | `pnpm --filter @repo/desktop dev:harness`                                                                   | :5173    |
+| Full gate     | `pnpm format:fix` then `pnpm typecheck && pnpm lint && pnpm knip && pnpm format && pnpm test && pnpm build` | exit 0   |
+
+## Scope
+
+**In scope**:
+
+- NEW `apps/desktop/src/renderer/editor/properties/` (panel + per-type field components + a pure `property-typing.ts` with the rules above)
+- `frontmatter-kit.tsx` / editor wiring so the panel renders above the doc (collapsed by default when empty; "Add property" affordance)
+- Core markdown frontmatter helpers ONLY if 015 didn't already add them
+- Tests: `property-typing.test.ts` (every rule above), round-trip fixtures
+  (pipeline-generated) for edited-property notes, jsdom panel tests for the
+  edit→serialize flow
+
+**Out of scope**:
+
+- Any property index/search/query over properties (future knowledge-engine work)
+- Templates for properties; property suggestions across the vault
+- Date pickers, rich tag autocomplete — plain inputs v1
+
+## Git workflow
+
+- Branch: `kyh/plan-017-properties-panel`
+- Commit: `feat(editor): typed file-properties panel over frontmatter`
+
+## Steps
+
+1. **`property-typing.ts`** (pure): `parseProperties(yamlText)` →
+   `{kind:"valid", props: TypedProp[]} | {kind:"invalid"} | {kind:"none"}`
+   with `TypedProp = {key, type: text|number|checkbox|date|tags|unsupported,
+value, rawYaml}` per the rules; `serializeProperties(props, priorRaw)` —
+   recombines, preserving unsupported keys' raw bytes and key ORDER.
+   Exhaustive unit tests (each rule + order preservation + unsupported
+   passthrough). **Verify**: tests pass.
+2. **Panel UI**: render above the editor for the open note when frontmatter
+   exists (or via "Add property"); per-type controls; edits flow through the
+   SAME editNote path as body edits (the panel edits the document's
+   frontmatter node — never a second write path). **Verify**: jsdom tests +
+   harness drive (edit a checkbox → serialized bytes show `key: true`; raw
+   YAML for an unsupported key untouched).
+3. **Round-trip fixtures**: a properties-rich note (all types + one
+   unsupported nested map + one invalid-frontmatter note) generated through
+   the pipeline; assert byte-exactness un-edited, and correct minimal diff
+   when one property is edited. **Verify**: fixture tests pass; NO existing
+   fixture bytes change.
+4. **Gates**: full canonical gate.
+
+## Done criteria
+
+- [ ] Typed panel edits properties; file remains the only store; unsupported/invalid YAML preserved byte-exactly
+- [ ] All typing rules unit-tested; fixtures pipeline-generated; zero existing fixture changes
+- [ ] Harness-verified edit flow; full gate exits 0
+
+## STOP conditions
+
+- The frontmatter node's Plate representation can't express "edit properties
+  without normalizing the body" — report before touching round-trip rules.
+- Preserving unsupported-key BYTE ranges requires YAML source-surgery beyond
+  the `yaml` lib's document API — report with options (the `yaml` package's
+  Document API preserves formatting; prefer it).
+
+## Maintenance notes
+
+- Properties become agent-visible automatically (they're file bytes) and are
+  already exposed via 015's broker `read → properties`; keep the two
+  parse paths ONE path (core helper) or they will drift.

--- a/plans/018-roundtrip-property-tests.md
+++ b/plans/018-roundtrip-property-tests.md
@@ -1,0 +1,109 @@
+# Plan 018: Seeded property-based round-trip tests for the markdown pipeline
+
+> **Executor instructions**: Follow this plan step by step. Run every
+> verification command before moving on. On any STOP condition, stop and
+> report. When done, update this plan's row in `plans/README.md`.
+>
+> **Drift check (run first)**: `git diff --stat cd4bde1b..HEAD -- apps/desktop/src/renderer/editor/markdown packages/core/src/markdown`
+
+## Status
+
+- **Priority**: P3
+- **Effort**: S-M
+- **Risk**: LOW (tests only — but may DISCOVER real bugs; that is the point)
+- **Depends on**: none
+- **Category**: tests (adopted from hubble's MarkdownRoundtrip.test.ts pattern)
+- **Planned at**: commit `cd4bde1b`, 2026-07-08
+
+## Why this matters
+
+Our round-trip safety is byte-pinned fixtures — strong for KNOWN shapes,
+blind to unknown ones. hubble complements hand-written cases with a
+property-based test: a seeded RNG generates random documents from the node
+vocabulary, asserts parse→serialize idempotence, and prints the seed on
+failure so any counterexample is replayable. Adding this to our pipeline
+turns "we round-trip everything we thought of" into "a fuzzer agrees".
+
+## Current state
+
+- The round-trip brain: `apps/desktop/src/renderer/editor/markdown/`
+  (Slate↔mdast rules, bounded-fixpoint `roundTrip`/`toCanonical` — read the
+  existing fixture tests under `apps/desktop/src/renderer/__tests__/` for
+  the exact entry points and the canonical/richSafe vocabulary).
+- Vocabulary: GFM + `[[wiki-links]]` (+aliases, transclusion), `$$` math,
+  mermaid fences, alerts, `<toggle>`, `<column_group>/<column>`, `<video>`,
+  `<media_embed>`, `<file>`, `<date>`, images (plan 012).
+- Invariant to test: for a GENERATED canonical document `d`:
+  `serialize(parse(d)) === d` (idempotence at the canonical fixpoint), and
+  `toCanonical` converges within the bounded fixpoint for arbitrary
+  vocabulary-composed input.
+
+## Commands you will need
+
+| Purpose       | Command                                                                                                     | Expected |
+| ------------- | ----------------------------------------------------------------------------------------------------------- | -------- |
+| Desktop tests | `pnpm --filter @repo/desktop test`                                                                          | pass     |
+| Full gate     | `pnpm format:fix` then `pnpm typecheck && pnpm lint && pnpm knip && pnpm format && pnpm test && pnpm build` | exit 0   |
+
+## Scope
+
+**In scope**:
+
+- NEW `apps/desktop/src/renderer/__tests__/markdown-roundtrip-property.test.ts`
+- NEW generator module beside it (`markdown-doc-generator.ts`, test-only)
+- Bug FIXES the fuzzer finds: report them in NOTES; fix ONLY if the fix is
+  a one-liner in an obvious direction — otherwise pin the failing seed as a
+  `test.skip` with a comment and report (each is a finding, not your scope)
+
+**Out of scope**:
+
+- New round-trip RULES or vocabulary changes.
+- Touching existing byte-pinned fixtures.
+
+## Git workflow
+
+- Branch: `kyh/plan-018-roundtrip-property-tests`
+- Commit: `test(editor): seeded property-based markdown round-trip fuzzing`
+
+## Steps
+
+1. **Deterministic generator**: mulberry32 (or equivalent tiny seeded PRNG —
+   hand-roll ~10 lines, no dependency) + a document generator composing the
+   vocabulary: headings, paragraphs with nested marks (bold/italic/code,
+   including adjacent + nested combinations — the classic serializer
+   killers), lists (nested, task), tables, blockquotes/alerts, code fences
+   (mermaid + plain), math, wiki-links (plain/alias/transclusion), images,
+   toggles, columns. Sized ~5–40 blocks. Every generated doc must be WITHIN
+   vocabulary (the fuzzer tests round-trip, not the Raw-mode gate).
+2. **The test**: for N=200 seeds (fixed base seed + index): generate →
+   `toCanonical` → assert fixpoint reached; take the canonical bytes →
+   parse → serialize → assert byte-equality. ON FAILURE: the assertion
+   message MUST include the seed and the failing document bytes (truncated
+   to ~2KB) so it's replayable with `SEED=<n>`. Support an env override
+   (`ROUNDTRIP_SEED`) to re-run one seed.
+3. **Budget**: the 200-seed run must stay under ~10s in the suite; tune N
+   down before tuning doc size down.
+4. **Gates**: full canonical gate. If the fuzzer finds failures you did not
+   fix (pinned as skips), the gate must still be green and every pinned seed
+   listed in NOTES.
+
+## Done criteria
+
+- [ ] 200-seed property test in the desktop suite, deterministic, replayable via env seed
+- [ ] Failure output includes seed + doc excerpt
+- [ ] Any discovered counterexamples either one-line-fixed or seed-pinned and reported
+- [ ] Suite time impact <10s; full gate exits 0
+
+## STOP conditions
+
+- The generator can't produce vocabulary-legal docs without importing live
+  editor React code into a node test (the base-kit/headless mirror should
+  suffice — that's what it exists for); report if not.
+- More than ~5 distinct failing shapes surface — stop pinning and report;
+  that's a finding batch needing its own plan.
+
+## Maintenance notes
+
+- When new node types land (they will — 012 added images), extend the
+  generator in the same PR as the kit; the kit-parity test won't catch a
+  generator gap.

--- a/plans/README.md
+++ b/plans/README.md
@@ -26,6 +26,10 @@ Canonical gate (see plan 002): `pnpm format:fix` first, then
 | 009  | Base-store dedup into core                                                  | P3       | M      | 001, 003          | DONE (`kyh/plan-009-base-store-dedup` @ f0edc928, reviewed)                                                   |
 | 010  | Hygiene: stale comment, vitest catalog, mobile README, generated-file attrs | P3       | S      | —                 | DONE (`kyh/plan-010-hygiene` @ 9762918d, reviewed; also fixed repo-wide format drift)                         |
 | 011  | Knowledge perf tail (link resolve, prefix search, sidebar skip)             | P3       | M      | 005 (item C only) | DONE (`kyh/plan-011-knowledge-perf` @ 93c901b8, reviewed)                                                     |
+| 015  | Feature: HTML Apps — sandboxed vault `.html` views + files broker           | P1       | L      | —                 | IN PROGRESS (ADR-0002)                                                                                        |
+| 016  | Ephemeral vault index — no recursive watcher (ADR-0001)                     | P1       | L      | 015               | TODO                                                                                                          |
+| 017  | Frontmatter properties panel (file is the only store)                       | P2       | M      | 015               | TODO                                                                                                          |
+| 018  | Seeded property-based markdown round-trip tests                             | P3       | S-M    | —                 | TODO                                                                                                          |
 
 Status values: TODO | IN PROGRESS | DONE | BLOCKED (one-line reason) |
 REJECTED (one-line rationale).
@@ -95,6 +99,27 @@ gate run on the integrated tree before the PR.
 - **Agent's unconfined filesystem access** — intentional: the agent equals
   the user; the `./vault` symlink adds no new escape (the renderer IPC path is
   the one being hardened, in plan 007).
+
+## From the hubble.md study (2026-07-08) — decisions + backlog
+
+DECIDED 2026-07-08 (operator yes) → ADR-0001 + plan 016: **ephemeral sidebar index** —
+drop the recursive vault watcher; one-shot crawl respecting .gitignore,
+refresh listing+knowledge on window focus / save / manual sync; keep ONE
+watcher on the open note; sync passes trigger on save+focus+interval instead
+of vault-change events. Deletes the watcher fan-out and the cap-class of
+problems; liveness trade is "agent edits to non-open files appear on
+refocus" (delegation completion gets an explicit kick).
+
+Smaller steals, unplanned: frontmatter properties PANEL (file-is-the-store
+typing rules: true/false→checkbox, yes/no stay text, dates only YYYY-MM-DD,
+invalid YAML preserved); seeded property-based round-trip tests alongside the
+byte-pinned fixtures; `classifyFileChange` none|reload|conflict|match with
+self-save filtering; grace-period orphan-asset cleanup; CONTEXT.md glossary +
+docs/adr with supersession chains (repo-workflow, not code).
+
+Explicitly NOT taking: their sync (last-writer, no auth, WIP — ours is
+strictly ahead), Tiptap migration (pure churn), Biome (oxlint stays),
+non-atomic writes (they lack tmp+rename; keep ours).
 
 ## Direction backlog (audited, not yet planned)
 


### PR DESCRIPTION
Adopts the repo-workflow practices from the hubble.md study: a domain glossary (CONTEXT.md) and ADRs with supersession chains. ADR-0001 records the approved ephemeral-vault-index decision (plan 016); ADR-0002 records the HTML Apps sandbox+broker design (plan 015, in execution). Plans 016-018 cover the remaining adoptions (ephemeral index, frontmatter properties panel, seeded round-trip property tests). Docs only — no code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a shared glossary (`CONTEXT.md`), sets up ADRs with supersession chains, and commits plans 015–018 to guide upcoming work (docs only). ADR-0001 approves the ephemeral vault index (plan 016) and ADR-0002 defines sandboxed HTML Apps + file broker (plan 015), with plans 017–018 covering a frontmatter properties panel and seeded round‑trip tests.

<sup>Written for commit 9a362e46ca33ac30f485a696d68511d37518f096. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kyh/inteligir/pull/408?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

