### PR TITLE
refactor(vault): ephemeral index — no recursive watcher (ADR-0001)

### DIFF
--- a/apps/desktop/dev/fixture-bridge.ts
+++ b/apps/desktop/dev/fixture-bridge.ts
@@ -687,6 +687,12 @@ export function createFixtureBridge(): Bridge {
     // No vault-app:// protocol in the browser harness — the HTML-App view falls
     // back to a blob: URL, so the token is unused. Return a stable stub.
     mintHtmlAppToken: async () => "harness-html-app-token",
+    // No filesystem to watch in the harness — the in-memory Map fires touchVault
+    // directly on every write, so there is no external-edit channel to arm.
+    setWatchedNote: async () => {},
+    // The harness has no external mutations to discover, but re-emitting keeps
+    // the "Refresh vault" command exercisable (sidebar re-lists, panes re-query).
+    refreshVault: async () => touchVault(),
     onVaultChanged: vaultEvents.subscribe,
 
     // Knowledge — live queries against the in-memory index.

--- a/apps/desktop/src/renderer/command/command-palette.tsx
+++ b/apps/desktop/src/renderer/command/command-palette.tsx
@@ -4,6 +4,7 @@ import {
   FileTextIcon,
   FolderIcon,
   MoonIcon,
+  RefreshCwIcon,
   SunIcon,
   WaypointsIcon,
 } from "lucide-react";
@@ -52,7 +53,7 @@ export function CommandPalette({
   open: boolean;
   onOpenChange: (open: boolean) => void;
 }) {
-  const { entries, openFile, createFile, changeFolder } = useVault();
+  const { entries, openFile, createFile, changeFolder, refreshVault } = useVault();
   const setSurface = useViewStore((s) => s.setSurface);
   const { resolved, setTheme } = useTheme();
   const [query, setQuery] = useState("");
@@ -129,6 +130,13 @@ export function CommandPalette({
       icon: resolved === "dark" ? <SunIcon /> : <MoonIcon />,
       label: `Switch to ${resolved === "dark" ? "light" : "dark"} theme`,
       onSelect: () => setTheme(resolved === "dark" ? "light" : "dark"),
+    },
+    {
+      value: "refresh",
+      keywords: "refresh vault reload rescan files sync snapshot",
+      icon: <RefreshCwIcon />,
+      label: "Refresh vault",
+      onSelect: () => refreshVault(),
     },
     {
       value: "vault",

--- a/apps/desktop/src/renderer/workspace/vault-context.tsx
+++ b/apps/desktop/src/renderer/workspace/vault-context.tsx
@@ -31,6 +31,10 @@ import type { VaultEntry } from "@repo/features/ipc-registry";
 /** ui-state key the open note persists under (restored on boot). */
 const OPEN_NOTE_KEY = "workspace.openNote";
 
+/** Debounce window-focus → vault refresh so a flurry of focus/blur (alt-tab,
+ * dialogs) coalesces into one snapshot rebuild (ADR-0001). */
+const FOCUS_REFRESH_DEBOUNCE_MS = 1000;
+
 /**
  * Append the default `.md` extension unless `name` already ends in one (any
  * lowercase-alphanumeric extension). `name` is assumed already trimmed.
@@ -114,6 +118,10 @@ type VaultContextValue = {
   /** Resolve a wiki target (`[[target]]`) against the current file listing —
    * the same Obsidian-style tiers the host's knowledge index uses. */
   resolveWikiTarget: (target: string) => string | null;
+  /** Rebuild the ephemeral vault snapshot now (re-list + reindex + sync kick).
+   * The command palette's "Refresh vault" invokes this; window focus does too,
+   * debounced (ADR-0001). */
+  refreshVault: () => void;
 
   // ---- Editor view (lifted so the header can own the controls) -------------
   /** Whether the open file is a markdown doc the rich editor can render. */
@@ -175,6 +183,11 @@ export function VaultProvider({ children }: { children: ReactNode }) {
       setOpenPath(next);
       setHtmlAsText(false);
       setUiState(OPEN_NOTE_KEY, next);
+      // Point the host's single open-note watcher at the new file (or clear it).
+      // This is the only file watched for external edits (ADR-0001).
+      getBridge()
+        ?.setWatchedNote({ path: next })
+        .catch(() => {});
     },
     [setUiState],
   );
@@ -416,6 +429,12 @@ export function VaultProvider({ children }: { children: ReactNode }) {
 
   const flush = useCallback((): Promise<boolean> => flushCurrent(), [flushCurrent]);
 
+  const refreshVault = useCallback(() => {
+    getBridge()
+      ?.refreshVault()
+      .catch(() => {});
+  }, []);
+
   // Initial load: adopt the root + list files.
   useEffect(() => {
     getBridge()
@@ -462,6 +481,27 @@ export function VaultProvider({ children }: { children: ReactNode }) {
       refreshList();
     });
   }, [applyOpenPath, disposeRuntime, refreshList]);
+
+  // External edits to files OTHER than the open note surface on window focus —
+  // the ephemeral model's "the user refocuses to look" trade (ADR-0001). One
+  // debounced refresh per focus flurry rebuilds the snapshot (re-list + reindex
+  // + sync kick). The open note itself is covered live by the host's open-note
+  // watcher, so this is about the rest of the vault.
+  useEffect(() => {
+    let timer: ReturnType<typeof setTimeout> | null = null;
+    const onFocus = () => {
+      if (timer !== null) clearTimeout(timer);
+      timer = setTimeout(() => {
+        timer = null;
+        refreshVault();
+      }, FOCUS_REFRESH_DEBOUNCE_MS);
+    };
+    window.addEventListener("focus", onFocus);
+    return () => {
+      window.removeEventListener("focus", onFocus);
+      if (timer !== null) clearTimeout(timer);
+    };
+  }, [refreshVault]);
 
   // Persist on unmount so a change within the debounce window isn't lost.
   useEffect(
@@ -555,6 +595,7 @@ export function VaultProvider({ children }: { children: ReactNode }) {
       changeFolder,
       flush,
       resolveWikiTarget,
+      refreshVault,
       isMarkdownOpen,
       richAvailable,
       rawReason: analyzed.rawReason,
@@ -580,6 +621,7 @@ export function VaultProvider({ children }: { children: ReactNode }) {
       changeFolder,
       flush,
       resolveWikiTarget,
+      refreshVault,
       isMarkdownOpen,
       richAvailable,
       analyzed.rawReason,

--- a/docs/development.md
+++ b/docs/development.md
@@ -40,6 +40,17 @@ talks to the renderer over Electron IPC. pi auth (OpenAI OAuth) is on-device; if
 this machine is logged in, chat/AI/delegation are fully live. Uses the
 last-opened vault from `~/.inteligir`.
 
+**Vault liveness is ephemeral, not watched (ADR-0001).** There is NO recursive
+filesystem watcher. The file listing is an on-demand snapshot: it refreshes on
+app-initiated structural writes (new file / delete / rename), on window focus
+(debounced), on the "Refresh vault" command, and on delegation completion. The
+ONLY watcher is a single non-recursive watch on the currently open note (armed
+via `setWatchedNote`), so external edits to the file you're looking at still
+reload/conflict live; the app's own autosaves are filtered out and generate no
+`onVaultChanged` traffic. The trade (accepted): an external edit to a file that
+is NOT open appears when the window regains focus — which is when you look.
+`onVaultChanged` is still the renderer contract; only its SOURCES changed.
+
 ## Ports & shared state
 
 | What                                                                      | Where                                                                     |

--- a/packages/features/package.json
+++ b/packages/features/package.json
@@ -18,6 +18,7 @@
     "@repo/core": "workspace:*",
     "@sinclair/typebox": "catalog:",
     "better-auth": "catalog:",
+    "ignore": "^7.0.5",
     "open": "^11.0.0",
     "remark-gfm": "^4.0.1",
     "remark-parse": "^11.0.0",

--- a/packages/features/src/ipc-registry.ts
+++ b/packages/features/src/ipc-registry.ts
@@ -170,6 +170,13 @@ const NotificationsPatchSchema = Type.Object(
 // ---------------------------------------------------------------------------
 
 const VaultPathSchema = Type.Object({ path: Type.String() }, { additionalProperties: false });
+// The currently open note the host should watch for external edits (null clears
+// it). Only this ONE file is watched — the rest of the vault is an ephemeral
+// snapshot refreshed on demand (ADR-0001).
+const WatchedNoteSchema = Type.Object(
+  { path: Type.Union([Type.String(), Type.Null()]) },
+  { additionalProperties: false },
+);
 const VaultWriteDocSchema = Type.Object(
   { path: Type.String(), content: Type.String() },
   { additionalProperties: false },
@@ -363,6 +370,16 @@ export const IPC = {
    * the protocol handler checks, so this can't be a platform-neutral host
    * handler (see DESKTOP_SHELL_METHODS). */
   mintHtmlAppToken: invokeVoid<string>("vault:mint-html-app-token"),
+  /** Tell the host which note is open so it watches that single file for
+   * external edits (ADR-0001). Pass `{ path: null }` when no note is open. */
+  setWatchedNote: invoke<typeof WatchedNoteSchema, void>(
+    "vault:set-watched-note",
+    WatchedNoteSchema,
+  ),
+  /** Rebuild the ephemeral snapshot now: re-list + reindex + sync kick. The
+   * renderer calls this on window focus (debounced) and from the "Refresh vault"
+   * command; the host also calls it internally on delegation completion. */
+  refreshVault: invokeVoid<void>("vault:refresh"),
   /** Fired on every vault change (file edit by anyone, or a root switch) so the
    * sidebar re-lists and the editor reloads. */
   onVaultChanged: event<{ root: string }>("vault:changed"),

--- a/packages/features/src/server/__tests__/classify-file-change.test.ts
+++ b/packages/features/src/server/__tests__/classify-file-change.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from "vitest";
+
+import { classifyFileChange, SelfSaveRegistry } from "../vault/classify-file-change";
+
+describe("classifyFileChange", () => {
+  it("returns none when the file is missing/unreadable (vanish handled elsewhere)", () => {
+    expect(classifyFileChange({ lastKnown: "1:2", current: null, editorDirty: false })).toBe(
+      "none",
+    );
+    expect(classifyFileChange({ lastKnown: "1:2", current: null, editorDirty: true })).toBe("none");
+    expect(classifyFileChange({ lastKnown: null, current: null, editorDirty: false })).toBe("none");
+  });
+
+  it("returns none when there is no baseline to diff against", () => {
+    expect(classifyFileChange({ lastKnown: null, current: "1:2", editorDirty: false })).toBe(
+      "none",
+    );
+    expect(classifyFileChange({ lastKnown: null, current: "1:2", editorDirty: true })).toBe("none");
+  });
+
+  it("returns match when the disk fingerprint is unchanged (own write / dup event)", () => {
+    expect(classifyFileChange({ lastKnown: "9:9", current: "9:9", editorDirty: false })).toBe(
+      "match",
+    );
+    // Even with a dirty editor, an unchanged fingerprint is not an external change.
+    expect(classifyFileChange({ lastKnown: "9:9", current: "9:9", editorDirty: true })).toBe(
+      "match",
+    );
+  });
+
+  it("returns reload when disk changed and the editor is clean", () => {
+    expect(classifyFileChange({ lastKnown: "1:2", current: "3:4", editorDirty: false })).toBe(
+      "reload",
+    );
+  });
+
+  it("returns conflict when disk changed and the editor is dirty", () => {
+    expect(classifyFileChange({ lastKnown: "1:2", current: "3:4", editorDirty: true })).toBe(
+      "conflict",
+    );
+  });
+});
+
+describe("SelfSaveRegistry", () => {
+  it("matches a recorded write at the same mtime and rejects a different one", () => {
+    const reg = new SelfSaveRegistry(() => 1000);
+    reg.record("a.md", 500);
+    expect(reg.isSelfSave("a.md", 500)).toBe(true);
+    // A genuine external edit lands a different mtime.
+    expect(reg.isSelfSave("a.md", 501)).toBe(false);
+    // An unrecorded path is never a self-save.
+    expect(reg.isSelfSave("b.md", 500)).toBe(false);
+  });
+
+  it("matches repeatedly (a write can fire several watch events)", () => {
+    const reg = new SelfSaveRegistry(() => 1000);
+    reg.record("a.md", 500);
+    expect(reg.isSelfSave("a.md", 500)).toBe(true);
+    expect(reg.isSelfSave("a.md", 500)).toBe(true);
+  });
+
+  it("expires records by age so a later external edit is not masked", () => {
+    let clock = 1000;
+    const reg = new SelfSaveRegistry(() => clock);
+    reg.record("a.md", 500);
+    clock = 1000 + 5_000 + 1; // past the TTL
+    expect(reg.isSelfSave("a.md", 500)).toBe(false);
+  });
+
+  it("forget() drops a path's record", () => {
+    const reg = new SelfSaveRegistry(() => 1000);
+    reg.record("a.md", 500);
+    reg.forget("a.md");
+    expect(reg.isSelfSave("a.md", 500)).toBe(false);
+  });
+
+  it("re-recording refreshes the mtime and expiry", () => {
+    let clock = 1000;
+    const reg = new SelfSaveRegistry(() => clock);
+    reg.record("a.md", 500);
+    clock = 3000;
+    reg.record("a.md", 700);
+    expect(reg.isSelfSave("a.md", 500)).toBe(false);
+    expect(reg.isSelfSave("a.md", 700)).toBe(true);
+  });
+});

--- a/packages/features/src/server/__tests__/vault.test.ts
+++ b/packages/features/src/server/__tests__/vault.test.ts
@@ -9,6 +9,9 @@ let tmp: string;
 let root: string;
 let settingsPath: string;
 
+/** Let the OS deliver a filesystem watch event and our debounce settle. */
+const settle = (): Promise<void> => new Promise((r) => setTimeout(r, 250));
+
 function newManager(): VaultManager {
   return new VaultManager({ settingsPath, defaultRoot: root, manageAgentLink: false });
 }
@@ -137,9 +140,11 @@ describe("VaultManager", () => {
     expect(mgr.readText("a.md")).toBe("after");
   });
 
-  it("caps list() at MAX_LIST_ENTRIES but listAllPaths() sees every file (plan 001)", () => {
+  it("list() is uncapped and agrees with listAllPaths() on a plain vault (plan 016)", () => {
     const mgr = newManager();
     mgr.ensureReady();
+    // Past the old 2,000 cap — the crawl is on-demand now, so there is no cap
+    // (ADR-0001). Both listings must see every file, and agree.
     const TOTAL = 2050;
     for (let i = 0; i < TOTAL; i++) {
       const name = `f${String(i).padStart(4, "0")}.md`;
@@ -151,13 +156,38 @@ describe("VaultManager", () => {
     fs.writeFileSync(path.join(root, "foo.tmp"), "x");
     fs.writeFileSync(path.join(root, ".dotfile"), "x");
 
-    expect(mgr.list().length).toBe(2000);
+    expect(mgr.list().length).toBe(TOTAL);
     expect(mgr.listAllPaths().length).toBe(TOTAL);
+    expect(mgr.list().map((e) => e.path)).toEqual(mgr.listAllPaths());
 
     const all = mgr.listAllPaths();
     expect(all).not.toContain(".git/x");
     expect(all).not.toContain("foo.tmp");
     expect(all).not.toContain(".dotfile");
+  });
+
+  it("respects root .gitignore / .ignore in both list() and listAllPaths() (plan 016)", () => {
+    const mgr = newManager();
+    mgr.ensureReady();
+    mgr.writeText("keep.md", "x");
+    mgr.writeText("build/out.md", "x");
+    mgr.writeText("logs/today.md", "x");
+    mgr.writeText("secret.md", "x");
+    fs.writeFileSync(path.join(root, ".gitignore"), "build/\nsecret.md\n");
+    fs.writeFileSync(path.join(root, ".ignore"), "logs/\n");
+
+    const paths = mgr.list().map((e) => e.path);
+    expect(paths).toContain("keep.md");
+    expect(paths).not.toContain("build/out.md");
+    expect(paths).not.toContain("logs/today.md");
+    expect(paths).not.toContain("secret.md");
+    // The ignore files themselves are dot-prefixed, so already excluded.
+    expect(paths).not.toContain(".gitignore");
+    // Ignore filters DISCOVERY, not access: an explicitly-opened ignored file
+    // still reads fine.
+    expect(mgr.readText("secret.md")).toBe("x");
+    // Sync sees the same filtered set.
+    expect(mgr.listAllPaths()).toEqual(paths.toSorted((a, b) => a.localeCompare(b)));
   });
 
   it("repoints the root and persists it across instances", () => {
@@ -194,5 +224,50 @@ describe("VaultManager", () => {
   it("statFingerprint returns null for a path escaping the vault (confinement)", () => {
     const mgr = newManager();
     expect(mgr.statFingerprint("../escape.md")).toBeNull();
+  });
+
+  // ---- Change notifier kinds (plan 016) --------------------------------------
+  // A NEW file changes the listing → "refresh" (broadcast). Overwriting an
+  // existing file is a content save → "save" (reindex + sync, no broadcast).
+  it("fires refresh on new file / delete / rename and save on overwrite", () => {
+    const mgr = newManager();
+    mgr.ensureReady();
+    const kinds: string[] = [];
+    mgr.startWatching((_root, kind) => kinds.push(kind));
+
+    mgr.writeText("a.md", "one"); // new file
+    mgr.writeText("a.md", "two"); // overwrite (autosave-shaped)
+    mgr.writeBytes("img.png", new Uint8Array([1])); // new binary
+    mgr.delete("a.md");
+    mgr.writeText("b.md", "x");
+    mgr.rename("b.md", "c.md");
+
+    expect(kinds).toEqual(["refresh", "save", "refresh", "refresh", "refresh", "refresh"]);
+  });
+
+  // ---- Open-note watcher (plan 016) ------------------------------------------
+  // A real (non-recursive) single-file watch: external edits to the open note
+  // broadcast "refresh"; the app's own autosave (markSelfSave) is filtered.
+  it("open-note watcher broadcasts external edits but filters self-saves", async () => {
+    const mgr = newManager();
+    mgr.ensureReady();
+    mgr.writeText("open.md", "original");
+    const events: string[] = [];
+    mgr.startWatching((_root, kind) => events.push(kind));
+    mgr.watchOpenNote("open.md");
+
+    // App autosave: write, then mark it a self-save — the watch event is filtered.
+    mgr.writeText("open.md", "app-edit");
+    mgr.markSelfSave("open.md");
+    await settle();
+    const afterSelfSave = events.filter((k) => k === "refresh").length;
+
+    // External edit (NOT via the editor write path → not marked) → broadcast.
+    fs.writeFileSync(path.join(root, "open.md"), "external-edit");
+    await settle();
+    const afterExternal = events.filter((k) => k === "refresh").length;
+    expect(afterExternal).toBeGreaterThan(afterSelfSave);
+
+    mgr.stopWatching();
   });
 });

--- a/packages/features/src/server/create-host.ts
+++ b/packages/features/src/server/create-host.ts
@@ -89,18 +89,19 @@ export function createHost(platform: HostPlatform, options: HostOptions = {}): H
       configurePaths();
 
       // Vault: ensure the folder + agent symlink exist, THEN wire the change
-      // notifier (which starts the watcher — it must not start before the dir
-      // exists), streaming file changes to the UI so the sidebar and editor
-      // stay live. The notifier is module-scoped, so it survives a logout/login
-      // reset. Every vault change also nudges the knowledge index (debounced
-      // incremental refresh — that fan-out lives in notifiers.vaultChange)
-      // and, when sync is live, the sync engine (getSyncCoordinator().onVaultChanged
-      // → debounced reconcile). Wrapping here (once) keeps the sync engine
-      // rebuildable underneath without re-installing this notifier.
+      // notifier. There is no recursive watcher anymore (ADR-0001) — the notifier
+      // fires from app-initiated writes, the open-note watcher, and on-demand
+      // refresh (focus / "Refresh vault" / delegation completion). The notifier
+      // is module-scoped, so it survives a logout/login reset. Every vault change
+      // nudges the knowledge index (in notifiers.vaultChange) and, when sync is
+      // live, the sync engine — including a `save` (autosave), which must still
+      // sync even though it does not broadcast onVaultChanged. Wrapping here
+      // (once) keeps the sync engine rebuildable underneath without re-installing
+      // this notifier.
       getVaultManager().ensureReady();
       const baseVaultNotifier = notifiers.vaultChange;
-      setVaultChangeNotifier((root) => {
-        baseVaultNotifier(root);
+      setVaultChangeNotifier((root, kind) => {
+        baseVaultNotifier(root, kind);
         getSyncCoordinator().onVaultChanged();
       });
       // First index build rides the debounce too, keeping it off the boot

--- a/packages/features/src/server/delegation/delegation-manager.ts
+++ b/packages/features/src/server/delegation/delegation-manager.ts
@@ -72,6 +72,12 @@ export type DelegationManagerOptions = {
   /** Streaming transcript channel — a delegation's accumulating response text
    * (keyed by id) for the live response dock. Same injection story as onChanged. */
   onStream?: (id: string, text: string) => void;
+  /** Called after each run settles. The background agent edits the vault file
+   * through ./vault (external to VaultManager), so a completed run's result
+   * won't otherwise appear until the window regains focus — this kicks a vault
+   * refresh so it shows immediately (ADR-0001). Defaults to the live vault
+   * refresh; unit tests leave it unset. */
+  onRunSettled?: () => void;
 };
 
 export class DelegationManager {
@@ -81,6 +87,7 @@ export class DelegationManager {
   private readonly snapshots: DelegationSnapshotStore;
   private readonly onChanged: ((delegations: Delegation[]) => void) | null;
   private readonly onStream: ((id: string, text: string) => void) | null;
+  private readonly onRunSettled: (() => void) | null;
   private getAgent: (() => DelegationAgent | null) | null = null;
   private running = false;
   // Id of a running delegation the user asked to stop — the run marks it stopped
@@ -103,6 +110,7 @@ export class DelegationManager {
     this.snapshots = opts?.snapshots ?? new DelegationSnapshotStore();
     this.onChanged = opts?.onChanged ?? null;
     this.onStream = opts?.onStream ?? null;
+    this.onRunSettled = opts?.onRunSettled ?? null;
     this.store = new JsonStore<Delegation[]>(
       opts?.path ?? inteligirPath("delegations.json"),
       DelegationsFileSchema,
@@ -409,6 +417,13 @@ export class DelegationManager {
       // re-enter the queue — that would start a second concurrent run.
       if (epoch === this.runEpoch) {
         this.running = false;
+        // The run edited the vault file directly through ./vault — refresh the
+        // snapshot so the result appears without waiting for window focus.
+        try {
+          this.onRunSettled?.();
+        } catch (err) {
+          console.warn("[delegation] run-settled refresh failed:", err);
+        }
         void this.processNext();
       }
     }
@@ -574,7 +589,11 @@ export function getDelegationManager(): DelegationManager {
     const notifiers = getHostNotifiers();
     instance = new DelegationManager(
       notifiers
-        ? { onChanged: notifiers.delegationsChanged, onStream: notifiers.delegationStream }
+        ? {
+            onChanged: notifiers.delegationsChanged,
+            onStream: notifiers.delegationStream,
+            onRunSettled: () => getVaultManager().refresh(),
+          }
         : {},
     );
   }

--- a/packages/features/src/server/handlers/vault-handlers.ts
+++ b/packages/features/src/server/handlers/vault-handlers.ts
@@ -69,7 +69,21 @@ export function registerVaultHandlers(handle: HandlerRegistrar): void {
   handle("listVault", () => getVaultManager().list());
   handle("readVaultDoc", ({ path }) => getVaultManager().readText(path));
   handle("writeVaultDoc", ({ path, content }) => {
-    getVaultManager().writeText(path, content);
+    const vault = getVaultManager();
+    vault.writeText(path, content);
+    // This is the editor's write path (autosave). Mark it a self-save so the
+    // open-note watcher filters the event it triggers rather than reloading the
+    // editor onto what it just saved (ADR-0001). Restore / sync-pull do NOT go
+    // through here, so their writes still surface as reloads.
+    vault.markSelfSave(path);
+  });
+  // The renderer names the open note; the host watches that single file (ADR-0001).
+  handle("setWatchedNote", ({ path }) => {
+    getVaultManager().watchOpenNote(path);
+  });
+  // On-demand snapshot rebuild (window focus / "Refresh vault" command).
+  handle("refreshVault", () => {
+    getVaultManager().refresh();
   });
   handle("deleteVaultEntry", ({ path }) => ({ removed: getVaultManager().delete(path) }));
   handle("renameVaultEntry", ({ from, to }) => {

--- a/packages/features/src/server/host-context.ts
+++ b/packages/features/src/server/host-context.ts
@@ -43,8 +43,13 @@ import { installHostNotifiers, type HostNotifiers } from "./host-notifiers";
 function buildHostNotifiers(): HostNotifiers {
   return {
     storeRecovery: (event) => getNotifications().notifyStoreRecovered(event),
-    vaultChange: (root) => {
-      emitEvent("onVaultChanged", { root });
+    vaultChange: (root, kind) => {
+      // A `save` (autosave content overwrite) keeps the knowledge index live but
+      // must NOT broadcast — the user's own typing generates zero vault-changed
+      // traffic (ADR-0001); the open-note watcher covers the open file's own
+      // reloads. A `refresh` is a structural/external/on-demand change: broadcast
+      // so the sidebar re-lists and the editor reloads, and reindex.
+      if (kind === "refresh") emitEvent("onVaultChanged", { root });
       getKnowledgeManager().scheduleRefresh();
     },
     delegationsChanged: (delegations) => emitEvent("onDelegationsUpdated", { delegations }),

--- a/packages/features/src/server/host-notifiers.ts
+++ b/packages/features/src/server/host-notifiers.ts
@@ -13,6 +13,7 @@
 // form an import cycle with the graph that composes it.
 // ---------------------------------------------------------------------------
 
+import type { VaultChangeKind } from "./vault/vault";
 import type { StoreRecoveryEvent } from "./lib/json-store";
 import type { Delegation } from "@repo/features/delegation";
 import type { SyncState } from "@repo/features/sync";
@@ -23,8 +24,9 @@ import type { SyncState } from "@repo/features/sync";
 export type HostNotifiers = {
   /** A JsonStore quarantined a data file (json-store's default recovery seam). */
   storeRecovery: (event: StoreRecoveryEvent) => void;
-  /** A vault file changed on disk (watcher broadcast → onVaultChanged + reindex). */
-  vaultChange: (root: string) => void;
+  /** The vault changed. `refresh` broadcasts onVaultChanged + reindexes; `save`
+   * (an autosave content overwrite) reindexes only — no broadcast (ADR-0001). */
+  vaultChange: (root: string, kind: VaultChangeKind) => void;
   /** The delegation list changed (drives inline badges). */
   delegationsChanged: (delegations: Delegation[]) => void;
   /** A delegation's live transcript advanced (drives the response dock). */

--- a/packages/features/src/server/sync/sync-coordinator.ts
+++ b/packages/features/src/server/sync/sync-coordinator.ts
@@ -42,10 +42,17 @@ function toStatus(outcome: CoreSyncOutcome): SyncStatus {
 
 const DISABLED_REASON = "Enable sync and sign in first.";
 
+// Periodic reconcile cadence while sync is live (ADR-0001): with no recursive
+// watcher, a peer's remote push already wakes us through the remote-change
+// subscription, but this interval is the backstop that also flushes local
+// edits made between focus events. Policy, not law — revisit with real usage.
+const SYNC_INTERVAL_MS = 5 * 60_000;
+
 export class SyncCoordinator {
   private engine: SyncEngine | null = null;
   private status: SyncStatus = { phase: "idle" };
   private started = false;
+  private syncTimer: ReturnType<typeof setInterval> | null = null;
   // Unresolved conflict copies (derived, never persisted): seeded from a vault
   // scan on start, appended from each pass's conflictPaths, and pruned against
   // the live listing on every state read — deleting the copy resolves the row.
@@ -149,6 +156,9 @@ export class SyncCoordinator {
     const engine = createSyncManager({ vaultId, port });
     engine.start();
     this.engine = engine;
+    // Periodic background reconcile while the engine is live — a focus refresh
+    // and remote pushes already kick sync; this catches everything in between.
+    this.syncTimer = setInterval(() => this.engine?.onVaultChanged(), SYNC_INTERVAL_MS);
     if (opts.kickInitial) void this.runInitialSync(engine);
   }
 
@@ -211,6 +221,10 @@ export class SyncCoordinator {
   }
 
   private teardownEngine(): void {
+    if (this.syncTimer !== null) {
+      clearInterval(this.syncTimer);
+      this.syncTimer = null;
+    }
     this.engine?.stop();
     this.engine = null;
   }

--- a/packages/features/src/server/vault/classify-file-change.ts
+++ b/packages/features/src/server/vault/classify-file-change.ts
@@ -1,0 +1,106 @@
+// ---------------------------------------------------------------------------
+// classify-file-change — the open-note watcher's brain (ADR-0001). The
+// ephemeral index has exactly ONE filesystem watcher: a non-recursive watch on
+// the currently open note. When it fires we must decide, from disk state
+// alone, whether the editor needs to react — and crucially NOT react to the
+// app's own autosaves (which today round-trip a pointless broadcast per save).
+//
+// Two cooperating pieces, both pure/host-testable:
+//   - `classifyFileChange` — a pure verdict over (last-known fingerprint,
+//     current disk fingerprint, editor-dirty) → none | reload | conflict |
+//     match. Models the FULL space so it can be tested exhaustively; the host
+//     currently maps both `reload` and `conflict` to "broadcast onVaultChanged"
+//     (the renderer's existing external-change machinery resolves the dirty vs
+//     clean case), and treats `none`/`match` as "ignore".
+//   - `SelfSaveRegistry` — records app-initiated writes by (path, mtimeMs) with
+//     a short TTL, so the watch event a self-save necessarily produces is
+//     filtered out before it ever reaches the classifier. Only the editor's own
+//     write path records here; restore / sync-pull / external edits do NOT, so
+//     those still surface as reloads.
+// ---------------------------------------------------------------------------
+
+/** The four possible outcomes of an open-note watch event.
+ *  - `match`   — disk fingerprint equals what we last knew: nothing changed
+ *                (a duplicate/metadata-only event, or our own write echoing).
+ *  - `none`    — no basis to act (file missing/unreadable, or no baseline yet).
+ *  - `reload`  — disk changed and the editor is clean: re-read the buffer.
+ *  - `conflict`— disk changed AND the editor has unsaved edits. */
+export type FileChangeVerdict = "match" | "none" | "reload" | "conflict";
+
+export type ClassifyInput = {
+  /** Fingerprint of the watched file the last time we observed it (`mtimeMs:size`
+   * from `statFingerprint`, or a content hash), or null if we have no baseline. */
+  lastKnown: string | null;
+  /** Current on-disk fingerprint, or null when the file is missing/unreadable. */
+  current: string | null;
+  /** Whether the editor has unsaved edits to the watched note. */
+  editorDirty: boolean;
+};
+
+/** Pure verdict — see FileChangeVerdict. Deliberately total over its inputs so
+ * the unit tests can enumerate every combination. */
+export function classifyFileChange({
+  lastKnown,
+  current,
+  editorDirty,
+}: ClassifyInput): FileChangeVerdict {
+  // File gone/unreadable — a vanish is handled by the watcher (it broadcasts and
+  // the renderer's vanish watcher closes the note); nothing to classify here.
+  if (current === null) return "none";
+  // No baseline to diff against — don't guess a change.
+  if (lastKnown === null) return "none";
+  // Disk matches what we last saw: our own write landing, or a no-op event.
+  if (current === lastKnown) return "match";
+  // Disk genuinely changed underneath us.
+  return editorDirty ? "conflict" : "reload";
+}
+
+/** Age after which a recorded self-save is forgotten. Generous relative to the
+ * gap between a write and the watch event it triggers (sub-second in practice);
+ * long enough that a slow FSEvents delivery still matches, short enough that a
+ * stale entry can't mask a genuine later external edit at the same mtime. */
+const SELF_SAVE_TTL_MS = 5_000;
+
+/** Records the app's own writes so the watch event they produce can be filtered
+ * out. Keyed by vault-relative path → the mtimeMs we wrote; a genuine external
+ * edit lands a different mtime and so is NOT matched. Entries expire by age.
+ *
+ * Only the editor write path (writeVaultDoc) records here. Restore, sync-pull,
+ * and external tools do not, so their writes still surface as reloads. */
+export class SelfSaveRegistry {
+  private readonly entries = new Map<string, { mtimeMs: number; expiresAt: number }>();
+
+  constructor(private readonly now: () => number = () => Date.now()) {}
+
+  /** Record that the app just wrote `path`, landing it at `mtimeMs`. */
+  record(path: string, mtimeMs: number): void {
+    this.entries.set(path, { mtimeMs, expiresAt: this.now() + SELF_SAVE_TTL_MS });
+    this.prune();
+  }
+
+  /** True when a watch event for `path` at `mtimeMs` corresponds to a recent
+   * app-initiated write (and should therefore be ignored). Not one-shot: a
+   * single write can produce several watch events (tmp-rename + change), all of
+   * which carry the same mtime and must all be filtered. */
+  isSelfSave(path: string, mtimeMs: number): boolean {
+    const entry = this.entries.get(path);
+    if (entry === undefined) return false;
+    if (this.now() > entry.expiresAt) {
+      this.entries.delete(path);
+      return false;
+    }
+    return entry.mtimeMs === mtimeMs;
+  }
+
+  /** Drop the record for a path (e.g. when it stops being the watched note). */
+  forget(path: string): void {
+    this.entries.delete(path);
+  }
+
+  private prune(): void {
+    const now = this.now();
+    for (const [path, entry] of this.entries) {
+      if (now > entry.expiresAt) this.entries.delete(path);
+    }
+  }
+}

--- a/packages/features/src/server/vault/vault.ts
+++ b/packages/features/src/server/vault/vault.ts
@@ -12,20 +12,29 @@
 // settings file that records WHERE the vault lives.
 //
 // Electron-free so it can be unit-tested with a temp dir. The main process
-// wires a change notifier + starts the watcher at composition time; agent
-// awareness is a stable `vault` symlink in the agent workspace (so the agent's
-// native file tools always find the vault at ./vault regardless of where the
-// user put it).
+// wires a change notifier at composition time; agent awareness is a stable
+// `vault` symlink in the agent workspace (so the agent's native file tools
+// always find the vault at ./vault regardless of where the user put it).
+//
+// Liveness model (ADR-0001): the listing is an EPHEMERAL, refreshable snapshot,
+// not a watched mirror. There is NO recursive filesystem watcher. The snapshot
+// refreshes on demand — app-initiated structural writes, window focus, the
+// explicit "Refresh vault" command, and delegation completion. The ONLY watcher
+// is a single non-recursive watch on the currently open note (watchOpenNote),
+// so external edits to the file the user is looking at still reload; edits to
+// other files surface on the next refresh.
 // ---------------------------------------------------------------------------
 
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
+import ignore, { type Ignore } from "ignore";
 import { Type } from "@sinclair/typebox";
 import { Value } from "@sinclair/typebox/value";
 
 import { AGENT_DIR, WORKSPACE_DIR } from "../agent/paths";
 import { JsonStore, inteligirPath, type FsAdapter } from "../lib/json-store";
+import { classifyFileChange, SelfSaveRegistry } from "./classify-file-change";
 import { isDocPath } from "@repo/core/knowledge/doc-file";
 import type { VaultEntry } from "@repo/features/ipc-registry";
 
@@ -57,8 +66,20 @@ function classify(fileName: string): VaultEntry["kind"] {
   return isDocPath(fileName) ? "doc" : "other";
 }
 
-const MAX_LIST_ENTRIES = 2000;
+// Hard-pruned directories — never walked, never listed, regardless of ignore
+// files. Cheap protection against the classic repo-shaped-vault blowups.
 const SKIP_DIRS = new Set([".git", "node_modules", ".obsidian", ".trash"]);
+// Root-level ignore files parsed (v1) to filter DISCOVERY (not access). A file
+// the user explicitly opens outside the snapshot still reads/writes fine.
+const IGNORE_FILES = [".gitignore", ".ignore"];
+
+/** How a vault change should propagate. `refresh` runs the full pipeline
+ * (broadcast onVaultChanged + knowledge + sync) — structural writes, the open-
+ * note watcher, focus/manual refresh, delegation completion. `save` is a
+ * content overwrite of an existing file (an autosave): it keeps the knowledge
+ * index and sync live but does NOT broadcast, so the user's own typing stops
+ * generating any vault-changed traffic (ADR-0001). */
+export type VaultChangeKind = "refresh" | "save";
 
 type VaultManagerOptions = {
   fs?: FsAdapter;
@@ -75,9 +96,15 @@ export class VaultManager {
   private readonly settings: JsonStore<VaultSettings>;
   private readonly defaultRoot: string;
   private readonly manageAgentLink: boolean;
-  private watcher: fs.FSWatcher | null = null;
-  private notifyTimer: ReturnType<typeof setTimeout> | null = null;
-  private changeNotifier: ((root: string) => void) | null = null;
+  private changeNotifier: ((root: string, kind: VaultChangeKind) => void) | null = null;
+  // The single non-recursive watcher on the open note (ADR-0001). Everything
+  // else is refreshed on demand, so there is no recursive root watcher.
+  private openWatcher: fs.FSWatcher | null = null;
+  private watchedPath: string | null = null;
+  // Fingerprint of the watched note last time we observed it — the classifier's
+  // baseline for deciding reload vs. no-op.
+  private watchedFingerprint: string | null = null;
+  private readonly selfSaves = new SelfSaveRegistry();
 
   constructor(opts: VaultManagerOptions = {}) {
     this.defaultRoot = opts.defaultRoot ?? defaultVaultRoot();
@@ -137,8 +164,10 @@ export class VaultManager {
     fs.mkdirSync(resolved, { recursive: true });
     this.settings.update((s) => ({ ...s, vaultPath: resolved }));
     this.ensureAgentSymlink(resolved);
-    this.restartWatcher();
-    this.notify();
+    // The open note belonged to the old vault — stop watching it; the renderer
+    // drops the note and re-points the watcher after the switch.
+    this.watchOpenNote(null);
+    this.notify("refresh");
   }
 
   /** Create the vault dir + agent symlink. Called once at composition time. */
@@ -150,23 +179,24 @@ export class VaultManager {
 
   // ---- File operations ------------------------------------------------------
 
-  /** List every file under the vault (relative paths), skipping dot/VCS dirs.
-   * Capped at `MAX_LIST_ENTRIES` — this is for UI listing only (sidebar file
-   * tree). Do NOT feed this into anything that needs the complete vault state
-   * (e.g. sync) — use `listAllPaths()` for that. */
+  /** List every file under the vault (relative paths), respecting SKIP_DIRS and
+   * the root ignore files. Uncapped: the crawl is now on-demand (ephemeral
+   * snapshot — ADR-0001), not per-filesystem-event, so there is no scaling
+   * hazard to cap against. Drives the sidebar file tree. */
   list(): VaultEntry[] {
     const root = this.getRoot();
     if (!fs.existsSync(root)) return [];
-    return this.walk(root, MAX_LIST_ENTRIES)
+    return this.walk(root)
       .map((e) => ({ path: e.path, name: e.name, kind: classify(e.name) }))
       .toSorted((a, b) => a.path.localeCompare(b.path));
   }
 
-  /** Every file path under the vault, uncapped. Sync must see every file — a
-   * truncated manifest reads as deletions (see plan 001): the 3-way reconcile
-   * treats "was in base and remote, missing from local" as a local deletion
-   * and propagates that delete to the coordinator and every other peer. Never
-   * cap this. */
+  /** Every file path under the vault (same crawl as list(), minus the entry
+   * shaping). Sync must see every NON-ignored file — a truncated manifest reads
+   * as deletions (see plan 001): the 3-way reconcile treats "was in base and
+   * remote, missing from local" as a local deletion and propagates it to the
+   * coordinator and every peer. Ignore rules filter what sync tracks by design;
+   * SKIP_DIRS + ignore files are the only exclusions, and they match list(). */
   listAllPaths(): string[] {
     const root = this.getRoot();
     if (!fs.existsSync(root)) return [];
@@ -176,15 +206,13 @@ export class VaultManager {
   }
 
   // Shared recursive walk backing both list() and listAllPaths(): skips
-  // dot-entries, SKIP_DIRS, and the sibling *.tmp files atomicWrite creates
-  // mid-save. Returns entries in directory-read order (unsorted — callers
-  // sort). When `maxEntries` is given, stops once that many files have been
-  // collected — list()'s UI cap; omit it for the uncapped sync listing.
-  private walk(root: string, maxEntries?: number): { path: string; name: string }[] {
+  // dot-entries, SKIP_DIRS, ignore-matched paths, and the sibling *.tmp files
+  // atomicWrite creates mid-save. Returns entries in directory-read order
+  // (unsorted — callers sort).
+  private walk(root: string): { path: string; name: string }[] {
     const out: { path: string; name: string }[] = [];
-    const atCap = (): boolean => maxEntries !== undefined && out.length >= maxEntries;
+    const ig = this.loadIgnore(root);
     const visit = (dir: string): void => {
-      if (atCap()) return;
       let entries: fs.Dirent[];
       try {
         entries = fs.readdirSync(dir, { withFileTypes: true });
@@ -195,17 +223,38 @@ export class VaultManager {
         if (entry.name.startsWith(".") || SKIP_DIRS.has(entry.name)) continue;
         if (entry.isFile() && entry.name.endsWith(".tmp")) continue;
         const full = path.join(dir, entry.name);
+        const rel = path.relative(root, full).split(path.sep).join("/");
+        // `ignore` wants a trailing slash to match directory patterns.
         if (entry.isDirectory()) {
+          if (ig !== null && ig.ignores(`${rel}/`)) continue;
           visit(full);
         } else if (entry.isFile()) {
-          if (atCap()) return;
-          const rel = path.relative(root, full).split(path.sep).join("/");
+          if (ig !== null && ig.ignores(rel)) continue;
           out.push({ path: rel, name: entry.name });
         }
       }
     };
     visit(root);
     return out;
+  }
+
+  // Parse the root ignore files (.gitignore / .ignore) into a matcher, or null
+  // when none exist. v1: root-level only — nested ignore files aren't merged.
+  // Rebuilt per crawl (crawls are on-demand now, so this is cheap and always
+  // reflects the current ignore files).
+  private loadIgnore(root: string): Ignore | null {
+    let matcher: Ignore | null = null;
+    for (const name of IGNORE_FILES) {
+      let text: string;
+      try {
+        text = fs.readFileSync(path.join(root, name), "utf8");
+      } catch {
+        continue; // absent or unreadable — skip
+      }
+      matcher ??= ignore();
+      matcher.add(text);
+    }
+    return matcher;
   }
 
   /** Raw file text — what the editor panel reads/writes (JSON included). */
@@ -217,8 +266,27 @@ export class VaultManager {
   writeText(rel: string, content: string): void {
     assertVaultWritable();
     const target = this.resolve(rel);
+    const existed = fs.existsSync(target);
     fs.mkdirSync(path.dirname(target), { recursive: true });
     atomicWrite(target, content);
+    // A new file changes the listing (refresh); overwriting an existing one is a
+    // content save (sync + knowledge stay live, but no broadcast — the open-note
+    // watcher covers the open file, and the app's own autosaves go silent).
+    this.notify(existed ? "save" : "refresh");
+  }
+
+  /** Record that the app itself just wrote `rel` (the editor's autosave path),
+   * so the watch event that write triggers on the open note is filtered out
+   * rather than mistaken for an external edit. Called by the editor write
+   * handler only — restore / sync-pull deliberately do NOT record, so their
+   * writes to the open note still surface as reloads. */
+  markSelfSave(rel: string): void {
+    try {
+      const stat = fs.statSync(this.resolve(rel));
+      this.selfSaves.record(rel, stat.mtimeMs);
+    } catch {
+      // Path escaped the vault or vanished — nothing to record.
+    }
   }
 
   /** Raw file bytes — the binary-safe primitive the sync protocol reads (markdown
@@ -234,8 +302,10 @@ export class VaultManager {
   writeBytes(rel: string, content: Uint8Array): void {
     assertVaultWritable();
     const target = this.resolve(rel);
+    const existed = fs.existsSync(target);
     fs.mkdirSync(path.dirname(target), { recursive: true });
     atomicWrite(target, content);
+    this.notify(existed ? "save" : "refresh");
   }
 
   /** Cheap stat-keyed change-detection fingerprint for the sync engine's hash
@@ -257,6 +327,7 @@ export class VaultManager {
     const target = this.resolve(rel);
     if (!fs.existsSync(target)) return false;
     fs.rmSync(target, { force: true });
+    this.notify("refresh");
     return true;
   }
 
@@ -272,28 +343,73 @@ export class VaultManager {
     if (fs.existsSync(dst)) return { ok: false, error: `${to} already exists` };
     fs.mkdirSync(path.dirname(dst), { recursive: true });
     fs.renameSync(src, dst);
+    this.notify("refresh");
     return { ok: true };
   }
 
-  // ---- Watcher / notifier ---------------------------------------------------
+  // ---- Change notifier / open-note watcher ----------------------------------
 
-  startWatching(notifier: (root: string) => void): void {
+  /** Register the change notifier. Unlike the old recursive model this does NOT
+   * start any filesystem watcher — app writes fire the notifier directly and
+   * the open-note watcher is armed separately via watchOpenNote. */
+  startWatching(notifier: (root: string, kind: VaultChangeKind) => void): void {
     this.changeNotifier = notifier;
-    this.restartWatcher();
+  }
+
+  /** Point the single non-recursive watcher at `rel` (the currently open note),
+   * or clear it with `null`. Its events run the change classifier: a genuine
+   * external edit (not one of our own autosaves) broadcasts onVaultChanged, so
+   * the renderer's existing reload/vanish machinery reacts; self-saves and
+   * no-op events are filtered. Edits to any OTHER file are invisible until the
+   * next refresh — that is the whole point of the ephemeral model (ADR-0001).
+   *
+   * We watch the note's PARENT directory (non-recursive) filtered to its
+   * basename, NOT the file path directly: a single-file watch is unreliable
+   * across atomic-rename replacement (our own atomicWrite, and the way many
+   * editors save), whereas a directory watch reliably reports in-place writes,
+   * atomic renames, and deletes of the file by name. Still one note, still
+   * non-recursive — the directory is not descended. */
+  watchOpenNote(rel: string | null): void {
+    this.closeOpenWatcher();
+    if (rel === null || rel === "") return;
+    let target: string;
+    try {
+      target = this.resolve(rel);
+    } catch {
+      return; // escapes the vault — nothing to watch
+    }
+    const dir = path.dirname(target);
+    const base = path.basename(target);
+    if (!fs.existsSync(dir)) return;
+    this.watchedPath = rel;
+    this.watchedFingerprint = this.statFingerprint(rel);
+    try {
+      this.openWatcher = fs.watch(dir, (_event, filename) => {
+        // A directory watch fires for every sibling; act only on the open note.
+        // `filename` is null on some platforms — fall through and let the
+        // fingerprint check decide.
+        if (filename !== null && filename !== base) return;
+        this.onOpenNoteEvent(rel, target);
+      });
+    } catch (err) {
+      console.warn("[vault] could not watch open note:", err);
+      this.watchedPath = null;
+      this.watchedFingerprint = null;
+    }
+  }
+
+  /** Fire the full refresh pipeline on demand (window focus, the "Refresh vault"
+   * command, delegation completion). This is the ephemeral snapshot's rebuild
+   * trigger — the renderer re-lists, knowledge re-indexes, sync kicks. */
+  refresh(): void {
+    this.notify("refresh");
   }
 
   stopWatching(): void {
-    if (this.watcher) {
-      this.watcher.close();
-      this.watcher = null;
-    }
-    if (this.notifyTimer) {
-      clearTimeout(this.notifyTimer);
-      this.notifyTimer = null;
-    }
+    this.closeOpenWatcher();
   }
 
-  /** Stop the watcher and disable the settings store before the dir is wiped. */
+  /** Stop watching and disable the settings store before the dir is wiped. */
   close(): void {
     this.stopWatching();
     this.changeNotifier = null;
@@ -364,38 +480,58 @@ export class VaultManager {
     }
   }
 
-  private restartWatcher(): void {
-    this.stopWatching();
-    if (!this.changeNotifier) return;
-    const root = this.getRoot();
-    if (!fs.existsSync(root)) return;
-    const onEvent = (): void => this.scheduleNotify();
+  // An event on the open note fired. Decide from disk state whether the editor
+  // must react: filter our own autosaves (self-save registry) and no-op events
+  // (unchanged fingerprint via the classifier); a genuine external edit or a
+  // vanish broadcasts so the renderer reloads/closes as it does today.
+  private onOpenNoteEvent(rel: string, target: string): void {
+    // Still the note we're meant to be watching? (watchOpenNote(null) closes the
+    // watcher, but a queued event could still land.)
+    if (this.watchedPath !== rel) return;
+    let stat: fs.Stats | null;
     try {
-      this.watcher = fs.watch(root, { recursive: true }, onEvent);
+      stat = fs.statSync(target);
     } catch {
-      // Recursive watching is unsupported on some platforms (Linux) — fall back
-      // to watching the root non-recursively. Better than nothing for an
-      // experimental feature; nested edits still surface on the next list().
-      try {
-        this.watcher = fs.watch(root, onEvent);
-      } catch (err) {
-        console.warn("[vault] could not start watcher:", err);
-      }
+      stat = null; // vanished/unreadable
     }
+    if (stat === null) {
+      // The open note disappeared — broadcast so the renderer's vanish watcher
+      // closes it. Keep the directory watch running (and the last fingerprint)
+      // so a recreate/rename-back is still caught; the renderer clears the
+      // watcher via setWatchedNote(null) when it drops the note.
+      this.notify("refresh");
+      return;
+    }
+    // Our own autosave landing — never reload the editor onto what it just wrote.
+    if (this.selfSaves.isSelfSave(rel, stat.mtimeMs)) return;
+    const current = `${stat.mtimeMs}:${stat.size}:${stat.ino}`;
+    const verdict = classifyFileChange({
+      lastKnown: this.watchedFingerprint,
+      current,
+      // The host doesn't track the editor's dirty state; it broadcasts on any
+      // external change and lets the renderer's externalChange resolve reload
+      // vs. conflict (its behavior today). `reload` and `conflict` both
+      // broadcast, so passing false here is safe and never suppresses.
+      editorDirty: false,
+    });
+    // Advance the baseline so a duplicate event for the same state is a no-op.
+    this.watchedFingerprint = current;
+    if (verdict === "reload" || verdict === "conflict") this.notify("refresh");
   }
 
-  // Coalesce the burst of fs events a single save produces into one broadcast.
-  private scheduleNotify(): void {
-    if (this.notifyTimer) clearTimeout(this.notifyTimer);
-    this.notifyTimer = setTimeout(() => {
-      this.notifyTimer = null;
-      this.notify();
-    }, 200);
+  private closeOpenWatcher(): void {
+    if (this.openWatcher) {
+      this.openWatcher.close();
+      this.openWatcher = null;
+    }
+    if (this.watchedPath !== null) this.selfSaves.forget(this.watchedPath);
+    this.watchedPath = null;
+    this.watchedFingerprint = null;
   }
 
-  private notify(): void {
+  private notify(kind: VaultChangeKind): void {
     try {
-      this.changeNotifier?.(this.getRoot());
+      this.changeNotifier?.(this.getRoot(), kind);
     } catch (err) {
       console.warn("[vault] change notification failed:", err);
     }
@@ -443,8 +579,8 @@ function realPath(p: string): string {
 
 let instance: VaultManager | null = null;
 // Module-scoped so it survives resetVaultManager() (logout): a fresh instance
-// built on the next login re-attaches the watcher instead of going silent.
-let sharedNotifier: ((root: string) => void) | null = null;
+// built on the next login re-attaches the notifier instead of going silent.
+let sharedNotifier: ((root: string, kind: VaultChangeKind) => void) | null = null;
 // Mirrors the shell's write suspension: between logout (teardown wipes
 // ~/.inteligir, including settings.json) and the next login, a dirty autosave
 // firing from a still-mounted panel must not lazily build a fresh manager with
@@ -476,7 +612,9 @@ export function getVaultManager(): VaultManager {
 
 /** Register the broadcast hookup once at composition time. Re-applied to every
  * instance created after a logout/login reset. */
-export function setVaultChangeNotifier(notifier: (root: string) => void): void {
+export function setVaultChangeNotifier(
+  notifier: (root: string, kind: VaultChangeKind) => void,
+): void {
   sharedNotifier = notifier;
   getVaultManager().startWatching(notifier);
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -655,6 +655,9 @@ importers:
       better-auth:
         specifier: 'catalog:'
         version: 1.6.23(@opentelemetry/api@1.9.1)(@tanstack/react-start@1.168.27(esbuild@0.28.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vite@8.0.14(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.3)(yaml@2.9.0)))(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@opentelemetry/api@1.9.1)(kysely@0.29.3))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vitest@4.1.7(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.14.6(@types/node@25.9.1)(typescript@6.0.3))(vite@8.0.14(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.3)(yaml@2.9.0)))
+      ignore:
+        specifier: ^7.0.5
+        version: 7.0.5
       open:
         specifier: ^11.0.0
         version: 11.0.0


### PR DESCRIPTION
Implements plan 016 / ADR-0001 (adopted from studying hubble.md).

- Recursive vault watcher DELETED; the only watcher is one non-recursive watch on the open note's parent dir (robust across atomic-rename saves), driven by a pure `classify-file-change` model (none|reload|conflict|match) with self-save filtering
- Listing cap (`MAX_LIST_ENTRIES`) removed; crawl respects root `.gitignore`/`.ignore` (`ignore` v7, zero deps)
- Change signal split: structural writes (create/delete/rename) broadcast + reindex + sync; content overwrites (autosaves) reindex + sync silently — autosaves generate ZERO vault-changed traffic now
- Refresh triggers: window focus (1s debounce), "Refresh vault" palette command, app writes, delegation completion; sync additionally reconciles every 5 min while live
- Restore-snapshot and sync-pull writes to the open note still surface as reloads (deliberately NOT self-save-marked)
- Live-verified in Electron: external file appears on focus refresh (not before); open-note external edit reloads immediately; autosaves persist without self-triggered reloads

334 features / 397 desktop / 17 cloud tests green, full gate green. docs/development.md liveness section updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switches the vault to an ephemeral snapshot per ADR-0001: no recursive watcher, only the open note is watched, and autosaves are silent. Adds focus/command-based refresh and makes the file crawl ignore-aware.

- **Refactors**
  - Replace the recursive watcher with a single non-recursive open-note watcher (parent dir filtered to the file); external edits to the open note reload immediately, others appear on refresh.
  - Add a pure change classifier and self-save registry so editor autosaves don’t broadcast or self-reload; only genuine external edits trigger reload/conflict.
  - Make the listing an on-demand snapshot; remove the 2k cap and respect root `.gitignore`/`.ignore` via `ignore`.
  - Split notifications: create/delete/rename → “refresh” (broadcast + reindex + sync); overwrite → “save” (reindex + sync only).
  - Add refresh paths and APIs: window focus (1s debounce), “Refresh vault” command, and delegation completion; new IPC `setWatchedNote` and `refreshVault`; sync reconciles every 5 minutes while live.

- **Dependencies**
  - Add `ignore` (^7.0.5) for root ignore support.

<sup>Written for commit b81b910a86d3b45c688ae32fbe2dad59e2cf1da5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kyh/inteligir/pull/411?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

