### PR TITLE
test(editor): seeded property-based markdown round-trip fuzzing

### DIFF
--- a/apps/desktop/src/renderer/__tests__/markdown-doc-generator.ts
+++ b/apps/desktop/src/renderer/__tests__/markdown-doc-generator.ts
@@ -1,0 +1,233 @@
+// Deterministic seeded document generator over the fixed MDX vocabulary
+// (headings, marks, lists, tables, blockquotes/alerts, code fences, math,
+// wiki-links, images, toggles, columns) — the property test's source of
+// "arbitrary but legal" documents. Test-only; see plan 018 and
+// markdown-roundtrip-property.test.ts.
+//
+// The generator does NOT aim to produce byte-canonical markdown (padding,
+// exact list markers, etc.) — `toCanonical` normalizes whatever it produces.
+// It only has to stay within the vocabulary the pipeline claims to handle
+// (see packages/core/src/markdown/vocabulary.ts): no unknown JSX, no
+// expressions, no ESM, no HTML comments.
+
+// Tiny seeded PRNG (mulberry32) — deterministic, no dependency.
+function mulberry32(seed: number): () => number {
+  let a = seed >>> 0;
+  return () => {
+    a = (a + 0x6d2b79f5) >>> 0;
+    let t = a;
+    t = Math.imul(t ^ (t >>> 15), t | 1);
+    t ^= t + Math.imul(t ^ (t >>> 7), t | 61);
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+type Rng = () => number;
+
+function int(rng: Rng, n: number): number {
+  return Math.floor(rng() * n);
+}
+function pick<T>(rng: Rng, xs: readonly T[]): T {
+  const item = xs[int(rng, xs.length)];
+  if (item === undefined) throw new Error("pick from empty array");
+  return item;
+}
+function chance(rng: Rng, p: number): boolean {
+  return rng() < p;
+}
+
+const WORDS = [
+  "alpha",
+  "bravo",
+  "charlie",
+  "delta",
+  "echo",
+  "foxtrot",
+  "golf",
+  "hotel",
+  "india",
+  "juliet",
+  "kilo",
+  "lima",
+  "mike",
+  "november",
+  "oscar",
+  "papa",
+  "quebec",
+  "romeo",
+  "sierra",
+  "tango",
+  "uniform",
+  "victor",
+  "whiskey",
+  "yankee",
+  "zulu",
+];
+
+const WIKI_TARGETS = ["Alpha Note", "Some Note", "Other", "Project X", "Hub"];
+
+const ALERT_KINDS = ["NOTE", "TIP", "IMPORTANT", "WARNING", "CAUTION"];
+
+const MATH_BODIES = ["E=mc^2", "\\int_0^1 x^2 dx", "a^2 + b^2 = c^2", "x + y = z"];
+
+function words(rng: Rng, n: number): string {
+  return Array.from({ length: n }, () => pick(rng, WORDS)).join(" ");
+}
+
+// A wiki-link/embed with NO pipe alias — safe to drop inside a GFM table cell
+// without needing `\|` escaping (the generator's choice, not a vocabulary
+// limit: markdown-adversarial.test.ts already covers escaped-pipe cells).
+function wikiLinkPlain(rng: Rng): string {
+  const target = pick(rng, WIKI_TARGETS);
+  return chance(rng, 0.2) ? `![[${target}]]` : `[[${target}]]`;
+}
+
+// Every wiki-link shape the vocabulary supports: plain, alias, section+alias,
+// transclusion.
+function wikiLink(rng: Rng): string {
+  const target = pick(rng, WIKI_TARGETS);
+  switch (int(rng, 4)) {
+    case 0:
+      return `[[${target}]]`;
+    case 1:
+      return `[[${target}|${words(rng, 1)}]]`;
+    case 2:
+      return `![[${target}]]`;
+    default:
+      return `[[${target}#${words(rng, 1)}|${words(rng, 1)}]]`;
+  }
+}
+
+// Leaf inline generators — the classic serializer killers: adjacent marks,
+// nested marks, marks wrapping a wiki-link, inline math, date chips.
+const INLINE_LEAVES: Array<(rng: Rng) => string> = [
+  (rng) => words(rng, 1),
+  (rng) => `**${words(rng, 1)}**`,
+  (rng) => `_${words(rng, 1)}_`,
+  (rng) => `\`${words(rng, 1)}\``,
+  (rng) => `**_${words(rng, 1)}_**`, // nested bold+italic
+  (rng) => `_**${words(rng, 1)}**_`, // nested italic+bold
+  (rng) => `**${words(rng, 1)}**_${words(rng, 1)}_`, // adjacent, no separating space
+  (rng) => `**${words(rng, 1)}** **${words(rng, 1)}**`, // adjacent bold, separated
+  (rng) => wikiLink(rng),
+  (rng) => `_${wikiLink(rng)}_`, // marked wiki-link
+  (rng) => `**${wikiLink(rng)}**`,
+  (rng) =>
+    `$$${pick(
+      rng,
+      MATH_BODIES.map((b) => b.split(" ")[0] ?? b),
+    )}$$`, // inline math
+  (rng) => `<date value="2026-07-0${1 + int(rng, 9)}" />`,
+];
+
+function inlineText(rng: Rng, minWords = 3, maxWords = 10): string {
+  const n = minWords + int(rng, maxWords - minWords + 1);
+  const parts: string[] = [];
+  for (let i = 0; i < n; i++) {
+    parts.push(chance(rng, 0.4) ? pick(rng, INLINE_LEAVES)(rng) : words(rng, 1));
+  }
+  return parts.join(" ");
+}
+
+// --- block generators -----------------------------------------------------
+
+function heading(rng: Rng): string {
+  const level = 1 + int(rng, 6);
+  return `${"#".repeat(level)} ${inlineText(rng, 2, 5)}`;
+}
+
+function paragraph(rng: Rng): string {
+  return inlineText(rng, 4, 16);
+}
+
+function listBlock(rng: Rng): string {
+  const n = 2 + int(rng, 4);
+  const task = chance(rng, 0.4);
+  const lines: string[] = [];
+  for (let i = 0; i < n; i++) {
+    const marker = task ? (chance(rng, 0.5) ? "- [x] " : "- [ ] ") : "- ";
+    lines.push(`${marker}${inlineText(rng, 2, 6)}`);
+    if (!task && chance(rng, 0.3)) {
+      // nested sub-item
+      lines.push(`  - ${inlineText(rng, 2, 5)}`);
+    }
+  }
+  return lines.join("\n");
+}
+
+function tableRow(cells: string[]): string {
+  return `| ${cells.join(" | ")} |`;
+}
+
+function table(rng: Rng): string {
+  const cols = 2 + int(rng, 2);
+  const rows = 1 + int(rng, 3);
+  const cell = () => (chance(rng, 0.2) ? wikiLinkPlain(rng) : words(rng, 1));
+  const header = Array.from({ length: cols }, () => words(rng, 1));
+  const sep = Array.from({ length: cols }, () => "---");
+  const bodyRows = Array.from({ length: rows }, () => Array.from({ length: cols }, cell));
+  return [tableRow(header), tableRow(sep), ...bodyRows.map(tableRow)].join("\n");
+}
+
+function blockquote(rng: Rng): string {
+  if (chance(rng, 0.5)) {
+    const kind = pick(rng, ALERT_KINDS);
+    return `> [!${kind}]\n> ${inlineText(rng, 3, 8)}`;
+  }
+  return `> ${inlineText(rng, 3, 8)}`;
+}
+
+function codeFence(rng: Rng): string {
+  if (chance(rng, 0.4)) return "```mermaid\ngraph TD;\nA-->B;\n```";
+  const lines = 1 + int(rng, 3);
+  const body = Array.from(
+    { length: lines },
+    () => `const ${pick(rng, WORDS)} = ${int(rng, 100)};`,
+  ).join("\n");
+  return `\`\`\`\n${body}\n\`\`\``;
+}
+
+function mathBlock(rng: Rng): string {
+  return `$$\n${pick(rng, MATH_BODIES)}\n$$`;
+}
+
+function image(rng: Rng): string {
+  const alt = words(rng, 2);
+  const file = `${pick(rng, WORDS)}.png`;
+  return chance(rng, 0.5) ? `![${alt}](https://example.com/${file})` : `![${alt}](assets/${file})`;
+}
+
+function toggle(rng: Rng): string {
+  return `<toggle>\n  ${inlineText(rng, 3, 8)}\n</toggle>`;
+}
+
+function columns(rng: Rng): string {
+  const cols = Array.from(
+    { length: 2 },
+    () => `  <column>\n    ${inlineText(rng, 2, 6)}\n  </column>`,
+  );
+  return `<column_group>\n${cols.join("\n\n")}\n</column_group>`;
+}
+
+const BLOCK_GENERATORS: Array<(rng: Rng) => string> = [
+  heading,
+  paragraph,
+  paragraph, // weighted — prose dominates real documents
+  listBlock,
+  table,
+  blockquote,
+  codeFence,
+  mathBlock,
+  image,
+  toggle,
+  columns,
+];
+
+/** Generate a ~5-40 block vocabulary-legal document for seed `seed`. */
+export function generateDoc(seed: number): string {
+  const rng = mulberry32(seed);
+  const n = 5 + int(rng, 36);
+  const blocks: string[] = [];
+  for (let i = 0; i < n; i++) blocks.push(pick(rng, BLOCK_GENERATORS)(rng));
+  return `${blocks.join("\n\n")}\n`;
+}

--- a/apps/desktop/src/renderer/__tests__/markdown-roundtrip-property.test.ts
+++ b/apps/desktop/src/renderer/__tests__/markdown-roundtrip-property.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it } from "vitest";
+
+import { roundTrip, toCanonical } from "@renderer/editor/markdown/markdown-doc";
+import { generateDoc } from "./markdown-doc-generator";
+
+// Seeded property-based round-trip fuzzing over the vocabulary-composed
+// generator (markdown-doc-generator.ts) — complements the byte-pinned fixture
+// matrix (markdown-fixpoint.test.ts) and the adversarial byte/fragment fuzzer
+// (markdown-adversarial.test.ts) with structurally well-formed documents
+// built from the SAME node vocabulary the fixtures hand-pin. See plan 018.
+//
+// Invariant per generated doc `d`:
+//   1. toCanonical(d) reaches a fixpoint (does not throw) — the pipeline
+//      accepts every vocabulary-legal shape the generator can produce.
+//   2. serialize(parse(canonical)) === canonical — the canonical form is
+//      itself byte-stable (mirrors the canonical fixture class, generated
+//      instead of hand-written).
+//
+// All seeds run inside ONE test (like markdown-adversarial's report/hunt
+// loop) so per-seed vitest bookkeeping doesn't dominate the ~10s budget — only
+// the parse/serialize work does. On failure the message includes every
+// failing seed + a truncated doc excerpt, so it's replayable in isolation:
+// `ROUNDTRIP_SEED=<n> pnpm --filter @repo/desktop test markdown-roundtrip-property`.
+//
+// N: plan 018 targets 200 seeds, but each seed pays a full parse+serialize
+// (createSlateEditor is not cheap) — 200 measured at ~25s, over the ~10s
+// suite-time budget. Per the plan's own tuning order ("tune N down before
+// tuning doc size down"), N is cut instead of shrinking the ~5-40 block
+// generator range; 72 keeps this file at ~7s with margin.
+const BASE_SEED = 20260708; // plan-018 authoring date — arbitrary but fixed
+const N = 72;
+
+function seeds(): number[] {
+  const override = process.env.ROUNDTRIP_SEED;
+  if (override !== undefined && override !== "") return [Number(override)];
+  return Array.from({ length: N }, (_, i) => BASE_SEED + i);
+}
+
+// Seeds where the fuzzer found a genuine round-trip bug that isn't a
+// one-liner fix. Pinned here (skipped) rather than fixed — see NOTES in the
+// plan-018 executor report for the shape of each.
+const KNOWN_FAILURES = new Set<number>([]);
+
+function checkSeed(seed: number): string | null {
+  const doc = generateDoc(seed);
+  let canonical: string;
+  try {
+    canonical = toCanonical(doc);
+  } catch (error) {
+    return (
+      `seed=${seed} toCanonical did not reach a fixpoint: ${String(error)}\n` +
+      `doc (${doc.length}b, truncated to 2000):\n${doc.slice(0, 2000)}`
+    );
+  }
+  let out: string;
+  try {
+    out = roundTrip(canonical);
+  } catch (error) {
+    return (
+      `seed=${seed} canonical form failed to re-parse: ${String(error)}\n` +
+      `canonical (${canonical.length}b, truncated to 2000):\n${canonical.slice(0, 2000)}`
+    );
+  }
+  if (out !== canonical) {
+    return (
+      `seed=${seed} canonical form is not byte-stable\n` +
+      `canonical (${canonical.length}b, truncated to 2000):\n${canonical.slice(0, 2000)}`
+    );
+  }
+  return null;
+}
+
+describe("seeded property-based round-trip fuzzing", () => {
+  it(
+    `${N} generated documents reach a canonical fixpoint and re-serialize byte-stable`,
+    { timeout: 30_000 },
+    () => {
+      const failures: string[] = [];
+      for (const seed of seeds()) {
+        if (KNOWN_FAILURES.has(seed)) continue;
+        const failure = checkSeed(seed);
+        if (failure) failures.push(failure);
+      }
+      expect(failures).toEqual([]);
+    },
+  );
+
+  for (const seed of KNOWN_FAILURES) {
+    it.skip(`seed ${seed} (pinned — see plan-018 NOTES)`, () => {
+      expect(checkSeed(seed)).toBeNull();
+    });
+  }
+});


### PR DESCRIPTION
Plan 018 (hubble adoption): a deterministic seeded generator over the full node vocabulary + a 72-seed property test asserting toCanonical fixpoint + byte-exact round-trip, replayable via ROUNDTRIP_SEED. A 3,000-seed sweep found ZERO counterexamples — the round-trip pipeline holds. ~7s suite cost.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a deterministic, seeded Markdown doc generator and a property-based round‑trip test to validate the editor pipeline. Ensures `toCanonical` reaches a fixpoint and that canonical Markdown round‑trips byte‑exact, advancing Plan 018.

- **New Features**
  - Test-only generator composes vocabulary-legal docs (headings, nested/adjacent marks, lists, tables, alerts, code fences, math, wiki‑links, images, toggles, columns).
  - Property test runs 72 seeds by default (~7s), verifying `toCanonical(d)` and byte‑stable `roundTrip`; supports replay via `ROUNDTRIP_SEED` with failure output including the seed and a truncated excerpt.

<sup>Written for commit 1f63b5e309a494deb7b0e509d02ea454ef04b8d9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kyh/inteligir/pull/412?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

