### PR TITLE
feat(editor): typed file-properties panel over frontmatter

### DIFF
--- a/apps/desktop/dev/fixture-bridge.ts
+++ b/apps/desktop/dev/fixture-bridge.ts
@@ -112,12 +112,21 @@ Latency is <50ms on a good day.
 `,
   "frontmatter-note.md": `---
 title: Frontmatter note
-tags: [meta, demo]
+published: true
+draft: false
+priority: 2
+due: 2026-07-01
+status: on
+tags:
+  - meta
+  - demo
+nested:
+  keep: me
 ---
 
 # Frontmatter note
 
-The yaml block above survives Rich edits byte-for-byte; edit it via Raw.
+Edit the typed properties above; the yaml block round-trips byte-for-byte.
 `,
   // WP2 vocabulary notes — every kit exercisable in the harness. All four are
   // CANONICAL (the corpus test pins that): editing them must never flip the

--- a/apps/desktop/src/renderer/__tests__/fixtures/roundtrip/canonical/frontmatter-invalid.md
+++ b/apps/desktop/src/renderer/__tests__/fixtures/roundtrip/canonical/frontmatter-invalid.md
@@ -1,0 +1,9 @@
+---
+title: Broken
+tags: [unclosed
+::: not: valid
+---
+
+# Broken frontmatter
+
+The YAML above is not a valid property list, but it round-trips byte-for-byte.

--- a/apps/desktop/src/renderer/__tests__/fixtures/roundtrip/canonical/frontmatter-properties.md
+++ b/apps/desktop/src/renderer/__tests__/fixtures/roundtrip/canonical/frontmatter-properties.md
@@ -1,0 +1,18 @@
+---
+title: Field notes
+published: true
+draft: false
+count: 3
+due: 2026-07-01
+maybe: yes
+tags:
+  - alpha
+  - beta
+nested:
+  a: 1
+  b: 2
+---
+
+# Field notes
+
+Every property type plus an unsupported nested map, all byte-stable here.

--- a/apps/desktop/src/renderer/__tests__/properties-edit.test.ts
+++ b/apps/desktop/src/renderer/__tests__/properties-edit.test.ts
@@ -1,0 +1,129 @@
+// The properties panel's edit → serialize flow, driven headlessly against the
+// real EDITOR_KIT (the same pipeline the live editor serializes through). It
+// proves the one-write-path contract: a property edit becomes a frontmatter-
+// node write, and the ordinary Plate serialize emits the note bytes — with
+// unsupported YAML preserved byte-for-byte.
+
+import { describe, expect, it } from "vitest";
+import { createSlateEditor } from "platejs";
+import { serializeMd } from "@platejs/markdown";
+
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+import {
+  type TypedProperty,
+  parseProperties,
+  serializeProperties,
+  typeNewProperty,
+} from "@repo/core/markdown/frontmatter";
+
+import { EDITOR_KIT } from "@renderer/editor/kits/editor-kit";
+import { MD_STRINGIFY, parseMarkdown } from "@renderer/editor/markdown/markdown-doc";
+import {
+  readFrontmatterRaw,
+  writeFrontmatterRaw,
+} from "@renderer/editor/properties/properties-node";
+
+function seed(md: string) {
+  const parsed = parseMarkdown(md);
+  if (!parsed.ok) throw new Error("fixture must parse");
+  return createSlateEditor({ plugins: EDITOR_KIT, value: parsed.value });
+}
+function serialize(editor: ReturnType<typeof seed>): string {
+  return serializeMd(editor, { remarkStringifyOptions: MD_STRINGIFY });
+}
+
+// The panel's exact edit step: re-type one property, then write it back.
+function editProperty(
+  editor: ReturnType<typeof seed>,
+  mutate: (props: TypedProperty[]) => TypedProperty[],
+) {
+  const raw = readFrontmatterRaw(editor) ?? "";
+  const parsed = parseProperties(raw);
+  if (parsed.kind !== "valid") throw new Error(`expected valid, got ${parsed.kind}`);
+  writeFrontmatterRaw(editor, serializeProperties(mutate(parsed.properties), raw));
+}
+
+const DOC =
+  "---\ntitle: Note\ndone: false\ntags:\n  - a\n  - b\nnested:\n  x: 1\n  y: 2\n---\n\n# Body\n\ntext\n";
+
+describe("properties panel edit → serialize", () => {
+  it("reads the frontmatter node's raw yaml", () => {
+    const editor = seed(DOC);
+    expect(readFrontmatterRaw(editor)).toBe(
+      "title: Note\ndone: false\ntags:\n  - a\n  - b\nnested:\n  x: 1\n  y: 2",
+    );
+  });
+
+  it("editing a checkbox flips only that key; the unsupported map is untouched", () => {
+    const editor = seed(DOC);
+    editProperty(editor, (props) =>
+      props.map((p) => (p.key === "done" ? { key: "done", type: "checkbox", value: true } : p)),
+    );
+    expect(serialize(editor)).toBe(
+      "---\ntitle: Note\ndone: true\ntags:\n  - a\n  - b\nnested:\n  x: 1\n  y: 2\n---\n\n# Body\n\ntext\n",
+    );
+  });
+
+  it("editing a text value serializes the new bytes", () => {
+    const editor = seed(DOC);
+    editProperty(editor, (props) =>
+      props.map((p) => (p.key === "title" ? { key: "title", type: "text", value: "Renamed" } : p)),
+    );
+    expect(serialize(editor)).toContain("title: Renamed\n");
+  });
+
+  it("adding a property to a note with no frontmatter inserts a block", () => {
+    const editor = seed("# Body\n\ntext\n");
+    expect(readFrontmatterRaw(editor)).toBeNull();
+    writeFrontmatterRaw(editor, serializeProperties([typeNewProperty("title", "Hello")], ""));
+    const out = serialize(editor);
+    expect(out.startsWith("---\ntitle: Hello\n---\n")).toBe(true);
+    expect(out).toContain("# Body");
+    // The inserted block is itself parseable as a valid property.
+    expect(parseProperties(readFrontmatterRaw(editor) ?? "")).toEqual({
+      kind: "valid",
+      properties: [{ key: "title", type: "text", value: "Hello" }],
+    });
+  });
+
+  it("clearing every property removes the frontmatter block", () => {
+    const editor = seed(DOC);
+    writeFrontmatterRaw(editor, serializeProperties([], readFrontmatterRaw(editor) ?? ""));
+    const out = serialize(editor);
+    expect(out.startsWith("---")).toBe(false);
+    expect(out).toContain("# Body");
+  });
+});
+
+// Tie the byte-pinned round-trip fixtures to the typing layer: the properties-
+// rich note types cleanly, the invalid-frontmatter note reports `invalid` (so
+// the panel shows "properties unavailable" and never rewrites the block).
+const FIXTURES = fileURLToPath(new URL("fixtures/roundtrip/canonical/", import.meta.url));
+function fixtureProps(name: string) {
+  const text = readFileSync(`${FIXTURES}${name}`, "utf8");
+  const match = /^---[ \t]*\r?\n([\s\S]*?)\r?\n---/.exec(text);
+  return parseProperties(match?.[1] ?? "");
+}
+
+describe("round-trip fixtures ↔ typing", () => {
+  it("frontmatter-properties.md types every supported kind", () => {
+    const parsed = fixtureProps("frontmatter-properties.md");
+    if (parsed.kind !== "valid") throw new Error("expected valid");
+    expect(parsed.properties.map((p) => [p.key, p.type])).toEqual([
+      ["title", "text"],
+      ["published", "checkbox"],
+      ["draft", "checkbox"],
+      ["count", "number"],
+      ["due", "date"],
+      ["maybe", "text"],
+      ["tags", "tags"],
+      ["nested", "unsupported"],
+    ]);
+  });
+
+  it("frontmatter-invalid.md is invalid (preserved, never rewritten)", () => {
+    expect(fixtureProps("frontmatter-invalid.md").kind).toBe("invalid");
+  });
+});

--- a/apps/desktop/src/renderer/editor/kits/frontmatter-kit.tsx
+++ b/apps/desktop/src/renderer/editor/kits/frontmatter-kit.tsx
@@ -40,19 +40,14 @@ const FrontmatterBasePlugin = createSlatePlugin({
 
 export const FrontmatterBaseKit = [FrontmatterBasePlugin];
 
+// The frontmatter's user-facing surface is now the typed properties panel
+// (editor/properties/), rendered above the document. The node itself stays in
+// the value (it serializes the `---` block byte-for-byte) but renders
+// invisibly — zero-height and non-interactive, so it keeps its DOM point for
+// Slate while the caret and block chrome skip past it.
 function FrontmatterElement(props: PlateElementProps) {
-  const value = typeof props.element.value === "string" ? props.element.value : "";
   return (
-    <PlateElement {...props} className="mb-4">
-      <div
-        contentEditable={false}
-        className="rounded-md border border-border bg-muted/30 px-3 py-2 font-mono text-xs text-muted-foreground select-text"
-        title="Frontmatter is read-only in Rich mode — edit it in Raw"
-      >
-        <div className="mb-1 opacity-50 select-none">---</div>
-        <pre className="whitespace-pre-wrap">{value}</pre>
-        <div className="mt-1 opacity-50 select-none">---</div>
-      </div>
+    <PlateElement {...props} className="h-0 overflow-hidden select-none">
       {props.children}
     </PlateElement>
   );

--- a/apps/desktop/src/renderer/editor/markdown-editor.tsx
+++ b/apps/desktop/src/renderer/editor/markdown-editor.tsx
@@ -22,6 +22,7 @@ import { Editor, EditorContainer } from "@renderer/editor/editor-chrome";
 import { WRITE_PLACEHOLDER } from "@renderer/editor/kits/block-placeholder-kit";
 import { EDITOR_KIT } from "@renderer/editor/kits/editor-kit";
 import { MD_STRINGIFY, parseMarkdown } from "@renderer/editor/markdown/markdown-doc";
+import { PropertiesPanel } from "@renderer/editor/properties/properties-panel";
 import { createSerializeScheduler } from "@renderer/editor/serialize-scheduler";
 import { TableOfContents } from "@renderer/editor/toc";
 import { useAiReviewStore } from "@renderer/stores/ai-review-store";
@@ -214,6 +215,10 @@ export function MarkdownEditor({
       {/* EditorContainer is the relative wrapper the cursor overlay's
           selection ghost and the floating toolbar (afterEditable renders)
           position against. The toolbar itself renders from FloatingToolbarKit. */}
+      {/* Typed file-properties over the note's frontmatter, above the document.
+          It edits the frontmatter NODE, so its changes ride this same Plate
+          instance's serialize path to disk — no second write path. */}
+      <PropertiesPanel />
       <EditorContainer>
         {/* The editor-level placeholder covers the pristine-empty doc —
             BlockPlaceholderPlugin deliberately skips that state (its

--- a/apps/desktop/src/renderer/editor/properties/properties-node.ts
+++ b/apps/desktop/src/renderer/editor/properties/properties-node.ts
@@ -1,0 +1,38 @@
+// The one seam between the file-properties panel and the document: the panel
+// edits the FRONTMATTER NODE, and Plate's normal serialize → onChange → editNote
+// path persists it — there is no second write path to the file. These helpers
+// read and write the frontmatter node's raw yaml `value` (see kits/frontmatter-
+// kit.tsx: a void element pinned to path [0], serialized back byte-for-byte).
+//
+// Pure (no React): the panel calls them from event handlers, and the edit→
+// serialize tests drive them headlessly against a createSlateEditor.
+
+import { ElementApi, type SlateEditor, type TElement } from "platejs";
+
+/** The frontmatter node's raw yaml (fences excluded, no trailing newline —
+ * matching remark-frontmatter's node `value`), or `null` when the document has
+ * no frontmatter block at all. `""` means an empty block (`---\n---`). */
+export function readFrontmatterRaw(editor: SlateEditor): string | null {
+  const first = editor.children[0];
+  if (ElementApi.isElement(first) && first.type === "frontmatter") {
+    return typeof first.value === "string" ? first.value : "";
+  }
+  return null;
+}
+
+/** Set the frontmatter block's raw yaml. Empty `raw` removes the block; when
+ * none exists yet a node is inserted at [0] (the kit normalizer pins it there).
+ * A single edit runs through Slate, so the editor's serialize path emits it. */
+export function writeFrontmatterRaw(editor: SlateEditor, raw: string): void {
+  const hasNode = readFrontmatterRaw(editor) !== null;
+  if (raw === "") {
+    if (hasNode) editor.tf.removeNodes({ at: [0] });
+    return;
+  }
+  if (hasNode) {
+    editor.tf.setNodes({ value: raw }, { at: [0] });
+    return;
+  }
+  const node: TElement = { children: [{ text: "" }], type: "frontmatter", value: raw };
+  editor.tf.insertNodes(node, { at: [0], select: false });
+}

--- a/apps/desktop/src/renderer/editor/properties/properties-panel.tsx
+++ b/apps/desktop/src/renderer/editor/properties/properties-panel.tsx
@@ -1,0 +1,271 @@
+// The file-properties panel — typed controls over the open note's YAML
+// frontmatter, rendered above the document. The markdown file is the ONLY
+// property store (hubble ADR-0003): there is no metadata DB. Edits flow through
+// the frontmatter NODE (properties-node.ts) and out the editor's normal
+// serialize path, so a property edit and a body edit take the exact same route
+// to disk. Unsupported / invalid YAML is shown read-only and preserved
+// byte-for-byte — the panel never destroys what it can't read.
+
+import { type KeyboardEvent, useCallback, useMemo, useState } from "react";
+import { PlusIcon } from "lucide-react";
+import { useEditorRef, useEditorSelector } from "platejs/react";
+
+import {
+  type ParsedProperties,
+  type PropertyType,
+  type TypedProperty,
+  parseProperties,
+  serializeProperties,
+  typeNewProperty,
+} from "@repo/core/markdown/frontmatter";
+import { Input } from "@repo/ui/components/input";
+import { cn } from "@repo/ui/lib/utils";
+
+import { EDITOR_COLUMN_PX } from "@renderer/editor/editor-chrome";
+import {
+  readFrontmatterRaw,
+  writeFrontmatterRaw,
+} from "@renderer/editor/properties/properties-node";
+import {
+  CheckboxField,
+  NumberField,
+  TagsField,
+  TextField,
+  UnsupportedField,
+} from "@renderer/editor/properties/property-fields";
+
+// Which interpretations a value can be forced into WITHOUT changing its bytes.
+// Only string values are ambiguous (text vs date — both serialize the string
+// verbatim); everything else has a single honest type. Overrides are
+// session-only and never written to the file (they don't change the value).
+function overrideOptions(prop: TypedProperty): PropertyType[] {
+  return prop.type === "text" || prop.type === "date" ? ["text", "date"] : [prop.type];
+}
+
+const TYPE_LABEL: Record<PropertyType, string> = {
+  text: "Text",
+  number: "Number",
+  checkbox: "Checkbox",
+  date: "Date",
+  tags: "Tags",
+  unsupported: "Unsupported",
+};
+
+function Field({
+  prop,
+  onChange,
+}: {
+  prop: TypedProperty;
+  onChange: (next: TypedProperty) => void;
+}) {
+  switch (prop.type) {
+    case "checkbox":
+      return <CheckboxField prop={prop} onChange={onChange} />;
+    case "number":
+      return <NumberField prop={prop} onChange={onChange} />;
+    case "tags":
+      return <TagsField prop={prop} onChange={onChange} />;
+    case "unsupported":
+      return <UnsupportedField prop={prop} />;
+    case "text":
+    case "date":
+      return <TextField prop={prop} onChange={onChange} />;
+  }
+}
+
+function PropertyRow({
+  prop,
+  onChange,
+  onDelete,
+  onOverrideType,
+}: {
+  prop: TypedProperty;
+  onChange: (next: TypedProperty) => void;
+  onDelete: () => void;
+  onOverrideType: (type: PropertyType) => void;
+}) {
+  const options = overrideOptions(prop);
+  return (
+    <div className="group grid grid-cols-[9rem_1fr] items-start gap-2">
+      <div className="flex flex-col gap-0.5 pt-1">
+        <span className="truncate text-sm text-muted-foreground" title={prop.key}>
+          {prop.key}
+        </span>
+        {options.length > 1 && (
+          // Session-only reinterpretation of a string value (text ↔ date).
+          <select
+            value={prop.type}
+            onChange={(e) => {
+              const type = e.target.value;
+              if (type === "text" || type === "date") onOverrideType(type);
+            }}
+            aria-label={`${prop.key} type`}
+            className="w-fit rounded-[4px] bg-transparent text-[10px] text-muted-foreground/70 outline-none hover:text-foreground"
+          >
+            {options.map((type) => (
+              <option key={type} value={type}>
+                {TYPE_LABEL[type]}
+              </option>
+            ))}
+          </select>
+        )}
+      </div>
+      <div className="flex items-start gap-1">
+        <div className="min-w-0 flex-1">
+          <Field prop={prop} onChange={onChange} />
+        </div>
+        <button
+          type="button"
+          aria-label={`Remove ${prop.key}`}
+          onClick={onDelete}
+          className="mt-1 rounded-[4px] px-1 text-xs text-muted-foreground opacity-0 transition-opacity hover:text-destructive group-hover:opacity-100"
+        >
+          Remove
+        </button>
+      </div>
+    </div>
+  );
+}
+
+function AddProperty({ onAdd }: { onAdd: (key: string, value: string) => void }) {
+  const [open, setOpen] = useState(false);
+  const [key, setKey] = useState("");
+  const [value, setValue] = useState("");
+
+  const reset = () => {
+    setOpen(false);
+    setKey("");
+    setValue("");
+  };
+  const submit = () => {
+    const trimmed = key.trim();
+    if (trimmed === "") {
+      reset();
+      return;
+    }
+    onAdd(trimmed, value);
+    reset();
+  };
+  const onKeyDown = (e: KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === "Enter") {
+      e.preventDefault();
+      submit();
+    } else if (e.key === "Escape") {
+      e.preventDefault();
+      reset();
+    }
+  };
+
+  if (!open) {
+    return (
+      <button
+        type="button"
+        onClick={() => setOpen(true)}
+        className="flex items-center gap-1 rounded-[6px] px-1.5 py-1 text-sm text-muted-foreground transition-colors hover:bg-hover hover:text-foreground"
+      >
+        <PlusIcon className="size-3.5" />
+        Add property
+      </button>
+    );
+  }
+  return (
+    <div className="grid grid-cols-[9rem_1fr] items-center gap-2">
+      <Input
+        autoFocus
+        value={key}
+        onChange={(e) => setKey(e.target.value)}
+        onKeyDown={onKeyDown}
+        placeholder="Property"
+        spellCheck={false}
+        className="h-7 px-1.5 text-sm"
+      />
+      <Input
+        value={value}
+        onChange={(e) => setValue(e.target.value)}
+        onKeyDown={onKeyDown}
+        onBlur={submit}
+        placeholder="Value"
+        spellCheck={false}
+        className="h-7 px-1.5 text-sm"
+      />
+    </div>
+  );
+}
+
+export function PropertiesPanel() {
+  const editor = useEditorRef();
+  const raw = useEditorSelector(() => readFrontmatterRaw(editor), []);
+  const parsed = useMemo<ParsedProperties | null>(
+    () => (raw === null ? null : parseProperties(raw)),
+    [raw],
+  );
+  // Session-only type overrides (never written to the file), keyed by property.
+  const [overrides, setOverrides] = useState<Record<string, PropertyType>>({});
+
+  const properties = parsed?.kind === "valid" ? parsed.properties : [];
+  const invalid = parsed?.kind === "invalid";
+
+  const commit = useCallback(
+    (next: TypedProperty[]) => {
+      writeFrontmatterRaw(editor, serializeProperties(next, raw ?? ""));
+    },
+    [editor, raw],
+  );
+
+  // Re-type a property under its session override before rendering its field,
+  // so a "text as date" reinterpretation edits (and serializes) as a date.
+  const applyOverride = (prop: TypedProperty): TypedProperty => {
+    const forced = overrides[prop.key];
+    if (forced === undefined || forced === prop.type) return prop;
+    if (
+      (prop.type === "text" || prop.type === "date") &&
+      (forced === "text" || forced === "date")
+    ) {
+      return { key: prop.key, type: forced, value: prop.value };
+    }
+    return prop;
+  };
+
+  const handleChange = (index: number, nextProp: TypedProperty) => {
+    const next = properties.slice();
+    next[index] = nextProp;
+    commit(next);
+  };
+  const handleDelete = (index: number) => {
+    commit(properties.filter((_, i) => i !== index));
+  };
+  const handleAdd = (key: string, value: string) => {
+    // A duplicate key would make the whole block invalid — ignore it.
+    if (properties.some((p) => p.key === key)) return;
+    commit([...properties, typeNewProperty(key, value)]);
+  };
+
+  if (invalid) {
+    return (
+      <div className={cn(EDITOR_COLUMN_PX, "mb-4")}>
+        <p className="rounded-[8px] bg-muted/50 px-2.5 py-1.5 text-xs text-muted-foreground">
+          Properties unavailable — this note&rsquo;s frontmatter isn&rsquo;t a valid property list.
+          Edit it in Raw mode; it&rsquo;s preserved untouched.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className={cn(EDITOR_COLUMN_PX, "mb-4 flex flex-col gap-0.5")}>
+      {properties.map((prop, index) => {
+        const shown = applyOverride(prop);
+        return (
+          <PropertyRow
+            key={prop.key}
+            prop={shown}
+            onChange={(nextProp) => handleChange(index, nextProp)}
+            onDelete={() => handleDelete(index)}
+            onOverrideType={(type) => setOverrides((prev) => ({ ...prev, [prop.key]: type }))}
+          />
+        );
+      })}
+      <AddProperty onAdd={handleAdd} />
+    </div>
+  );
+}

--- a/apps/desktop/src/renderer/editor/properties/property-fields.tsx
+++ b/apps/desktop/src/renderer/editor/properties/property-fields.tsx
@@ -1,0 +1,165 @@
+// Per-type controls for the file-properties panel. Each field renders one
+// TypedProperty and reports edits back as a new TypedProperty (the panel turns
+// that into a frontmatter-node write). Plain inputs only (v1): no date picker,
+// no tag autocomplete. Text-like fields buffer locally and commit on blur/Enter
+// so the document isn't re-serialized on every keystroke; checkbox and tags
+// commit immediately.
+
+import { type KeyboardEvent, useEffect, useState } from "react";
+import { XIcon } from "lucide-react";
+
+import type { TypedProperty } from "@repo/core/markdown/frontmatter";
+import { Checkbox } from "@repo/ui/components/checkbox";
+import { Input } from "@repo/ui/components/input";
+import { cn } from "@repo/ui/lib/utils";
+
+const FIELD_CLASS =
+  "h-7 border-transparent bg-transparent px-1.5 text-sm shadow-none hover:bg-hover focus-visible:bg-card focus-visible:ring-1";
+
+// A text-like value buffered locally; commit only real changes, on blur/Enter.
+function useBuffer(value: string, commit: (next: string) => void) {
+  const [local, setLocal] = useState(value);
+  useEffect(() => setLocal(value), [value]);
+  return {
+    value: local,
+    onChange: (e: { target: { value: string } }) => setLocal(e.target.value),
+    onBlur: () => {
+      if (local !== value) commit(local);
+    },
+    onKeyDown: (e: KeyboardEvent<HTMLInputElement>) => {
+      if (e.key === "Enter") {
+        e.preventDefault();
+        e.currentTarget.blur();
+      } else if (e.key === "Escape") {
+        setLocal(value);
+        e.currentTarget.blur();
+      }
+    },
+  };
+}
+
+export function TextField({
+  prop,
+  onChange,
+}: {
+  prop: Extract<TypedProperty, { type: "text" | "date" }>;
+  onChange: (next: TypedProperty) => void;
+}) {
+  const buffer = useBuffer(prop.value, (value) => onChange({ ...prop, value }));
+  return (
+    <Input
+      {...buffer}
+      spellCheck={false}
+      placeholder={prop.type === "date" ? "YYYY-MM-DD" : "Empty"}
+      className={FIELD_CLASS}
+      aria-label={prop.key}
+    />
+  );
+}
+
+export function NumberField({
+  prop,
+  onChange,
+}: {
+  prop: Extract<TypedProperty, { type: "number" }>;
+  onChange: (next: TypedProperty) => void;
+}) {
+  const buffer = useBuffer(String(prop.value), (raw) => {
+    const value = Number(raw);
+    if (raw.trim() !== "" && Number.isFinite(value)) onChange({ ...prop, value });
+  });
+  return <Input {...buffer} type="number" className={FIELD_CLASS} aria-label={prop.key} />;
+}
+
+export function CheckboxField({
+  prop,
+  onChange,
+}: {
+  prop: Extract<TypedProperty, { type: "checkbox" }>;
+  onChange: (next: TypedProperty) => void;
+}) {
+  return (
+    <div className="flex h-7 items-center px-1.5">
+      <Checkbox
+        checked={prop.value}
+        onCheckedChange={(value) => onChange({ ...prop, value: value === true })}
+        aria-label={prop.key}
+      />
+    </div>
+  );
+}
+
+export function TagsField({
+  prop,
+  onChange,
+}: {
+  prop: Extract<TypedProperty, { type: "tags" }>;
+  onChange: (next: TypedProperty) => void;
+}) {
+  const [draft, setDraft] = useState("");
+  const commitTag = () => {
+    const tag = draft.trim();
+    if (tag === "" || prop.value.includes(tag)) {
+      setDraft("");
+      return;
+    }
+    onChange({ ...prop, value: [...prop.value, tag] });
+    setDraft("");
+  };
+  return (
+    <div className="flex min-h-7 flex-wrap items-center gap-1 px-1.5 py-0.5">
+      {prop.value.map((tag) => (
+        <span
+          key={tag}
+          className="inline-flex items-center gap-0.5 rounded-[6px] bg-muted px-1.5 py-0.5 text-xs text-foreground"
+        >
+          {tag}
+          <button
+            type="button"
+            aria-label={`Remove ${tag}`}
+            onClick={() => onChange({ ...prop, value: prop.value.filter((t) => t !== tag) })}
+            className="text-muted-foreground hover:text-foreground"
+          >
+            <XIcon className="size-3" />
+          </button>
+        </span>
+      ))}
+      <input
+        value={draft}
+        onChange={(e) => setDraft(e.target.value)}
+        onBlur={commitTag}
+        onKeyDown={(e) => {
+          if (e.key === "Enter" || e.key === ",") {
+            e.preventDefault();
+            commitTag();
+          } else if (e.key === "Backspace" && draft === "" && prop.value.length > 0) {
+            onChange({ ...prop, value: prop.value.slice(0, -1) });
+          }
+        }}
+        placeholder={prop.value.length === 0 ? "Add tag" : ""}
+        aria-label={`${prop.key} tags`}
+        className="min-w-16 flex-1 bg-transparent text-sm outline-none placeholder:text-muted-foreground/60"
+      />
+    </div>
+  );
+}
+
+export function UnsupportedField({
+  prop,
+}: {
+  prop: Extract<TypedProperty, { type: "unsupported" }>;
+}) {
+  return (
+    <div className="flex min-h-7 items-center px-1.5">
+      <pre
+        title="Unsupported YAML — preserved byte-for-byte. Edit it in Raw mode."
+        className={cn(
+          "max-w-full overflow-x-auto rounded-[6px] bg-muted/60 px-1.5 py-0.5",
+          "font-mono text-xs whitespace-pre text-muted-foreground",
+        )}
+      >
+        {prop.rawYaml === "" ? "—" : prop.rawYaml}
+      </pre>
+    </div>
+  );
+}

--- a/packages/core/src/markdown/frontmatter-typing.test.ts
+++ b/packages/core/src/markdown/frontmatter-typing.test.ts
@@ -1,0 +1,175 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  type TypedProperty,
+  parseProperties,
+  serializeProperties,
+} from "@repo/core/markdown/frontmatter";
+
+// Every typing rule from plan 017 (hubble ADR-0003), exhaustively. The rules
+// ARE the feature: conservative YAML 1.2 core-schema typing that never coerces
+// and never destroys what it can't represent.
+
+function props(yaml: string): TypedProperty[] {
+  const parsed = parseProperties(yaml);
+  if (parsed.kind !== "valid") throw new Error(`expected valid, got ${parsed.kind}`);
+  return parsed.properties;
+}
+
+describe("parseProperties — kinds", () => {
+  it("empty / whitespace yaml is `none`", () => {
+    expect(parseProperties("").kind).toBe("none");
+    expect(parseProperties("   \n  ").kind).toBe("none");
+  });
+
+  it("malformed yaml is `invalid`", () => {
+    expect(parseProperties("a: [1, 2\nb: :\n").kind).toBe("invalid");
+  });
+
+  it("duplicate keys are `invalid` (never guessed)", () => {
+    expect(parseProperties("a: 1\na: 2\n").kind).toBe("invalid");
+  });
+
+  it("a non-mapping root (sequence / scalar) is `invalid`", () => {
+    expect(parseProperties("- a\n- b\n").kind).toBe("invalid");
+    expect(parseProperties("just a string\n").kind).toBe("invalid");
+  });
+});
+
+describe("parseProperties — typing rules", () => {
+  it("true/false → checkbox", () => {
+    expect(props("a: true\nb: false\n")).toEqual([
+      { key: "a", type: "checkbox", value: true },
+      { key: "b", type: "checkbox", value: false },
+    ]);
+  });
+
+  it("yes/no/on/off STAY text (no coercion)", () => {
+    expect(props("a: yes\nb: no\nc: on\nd: off\n")).toEqual([
+      { key: "a", type: "text", value: "yes" },
+      { key: "b", type: "text", value: "no" },
+      { key: "c", type: "text", value: "on" },
+      { key: "d", type: "text", value: "off" },
+    ]);
+  });
+
+  it("explicit YYYY-MM-DD strings → date; other date-ish strings stay text", () => {
+    expect(props("a: 2026-07-01\n")).toEqual([{ key: "a", type: "date", value: "2026-07-01" }]);
+    // A timestamp with a time component is not the recognized shape → text.
+    expect(props("a: 2026-07-01T10:00\n")).toEqual([
+      { key: "a", type: "text", value: "2026-07-01T10:00" },
+    ]);
+    // A quoted date is still just a string with the date shape → date.
+    expect(props('a: "2026-07-01"\n')).toEqual([{ key: "a", type: "date", value: "2026-07-01" }]);
+  });
+
+  it("numbers → number", () => {
+    expect(props("a: 42\nb: 3.14\nc: -7\n")).toEqual([
+      { key: "a", type: "number", value: 42 },
+      { key: "b", type: "number", value: 3.14 },
+      { key: "c", type: "number", value: -7 },
+    ]);
+  });
+
+  it("plain strings → text", () => {
+    expect(props("title: Hello World\n")).toEqual([
+      { key: "title", type: "text", value: "Hello World" },
+    ]);
+  });
+
+  it("string arrays → tags (block or flow)", () => {
+    expect(props("tags:\n  - a\n  - b\n")).toEqual([
+      { key: "tags", type: "tags", value: ["a", "b"] },
+    ]);
+    expect(props("tags: [a, b]\n")).toEqual([{ key: "tags", type: "tags", value: ["a", "b"] }]);
+    expect(props("tags: []\n")).toEqual([{ key: "tags", type: "tags", value: [] }]);
+  });
+
+  it("nested maps, mixed / non-string arrays and nulls → unsupported", () => {
+    const parsed = props("nested:\n  a: 1\n  b: 2\nmixed: [1, two]\nnums: [1, 2]\nempty:\n");
+    expect(parsed.map((p) => [p.key, p.type])).toEqual([
+      ["nested", "unsupported"],
+      ["mixed", "unsupported"],
+      ["nums", "unsupported"],
+      ["empty", "unsupported"],
+    ]);
+    // The nested map's raw source bytes are captured for the read-only display.
+    const nested = parsed[0];
+    if (nested?.type !== "unsupported") throw new Error("expected unsupported");
+    expect(nested.rawYaml).toBe("a: 1\n  b: 2");
+  });
+
+  it("preserves key order", () => {
+    expect(props("z: 1\na: 2\nm: 3\n").map((p) => p.key)).toEqual(["z", "a", "m"]);
+  });
+});
+
+describe("serializeProperties", () => {
+  const prior =
+    "title: My Note\ndone: false\ntags:\n  - alpha\n  - beta\nnested:\n  a: 1\n  b: 2\n";
+
+  function edit(mutate: (p: TypedProperty[]) => TypedProperty[]): string {
+    return serializeProperties(mutate(props(prior)), prior.trimEnd());
+  }
+
+  it("editing one property is a minimal diff; unsupported keys stay byte-exact", () => {
+    const out = edit((p) =>
+      p.map((prop) =>
+        prop.key === "done" ? { key: "done", type: "checkbox", value: true } : prop,
+      ),
+    );
+    expect(out).toBe(
+      "title: My Note\ndone: true\ntags:\n  - alpha\n  - beta\nnested:\n  a: 1\n  b: 2",
+    );
+  });
+
+  it("no edit → identical bytes back", () => {
+    expect(edit((p) => p)).toBe(prior.trimEnd());
+  });
+
+  it("does NOT coerce a string that looks boolean/numeric (quotes on write)", () => {
+    const out = serializeProperties(
+      [
+        { key: "a", type: "text", value: "true" },
+        { key: "b", type: "text", value: "42" },
+        { key: "c", type: "text", value: "yes" },
+      ],
+      "",
+    );
+    // `true`/`42` are quoted so they re-parse as strings; `yes` needs none
+    // (it is already a string under the core schema).
+    expect(out).toBe('a: "true"\nb: "42"\nc: yes');
+    expect(props(out + "\n")).toEqual([
+      { key: "a", type: "text", value: "true" },
+      { key: "b", type: "text", value: "42" },
+      { key: "c", type: "text", value: "yes" },
+    ]);
+  });
+
+  it("a date string stays plain (re-parses as date)", () => {
+    const out = serializeProperties([{ key: "due", type: "date", value: "2026-12-25" }], "");
+    expect(out).toBe("due: 2026-12-25");
+    expect(props(out + "\n")).toEqual([{ key: "due", type: "date", value: "2026-12-25" }]);
+  });
+
+  it("adding a key appends it; deleting removes only it", () => {
+    const added = edit((p) => [...p, { key: "priority", type: "number", value: 1 }]);
+    expect(added).toBe(
+      "title: My Note\ndone: false\ntags:\n  - alpha\n  - beta\nnested:\n  a: 1\n  b: 2\npriority: 1",
+    );
+    const removed = edit((p) => p.filter((prop) => prop.key !== "done"));
+    expect(removed).toBe("title: My Note\ntags:\n  - alpha\n  - beta\nnested:\n  a: 1\n  b: 2");
+  });
+
+  it("clearing every property empties the block", () => {
+    expect(serializeProperties([], prior)).toBe("");
+  });
+
+  it("round-trips tags edits", () => {
+    const out = serializeProperties(
+      [{ key: "tags", type: "tags", value: ["x", "y", "z"] }],
+      "tags:\n  - a\n",
+    );
+    expect(props(out + "\n")).toEqual([{ key: "tags", type: "tags", value: ["x", "y", "z"] }]);
+  });
+});

--- a/packages/core/src/markdown/frontmatter.ts
+++ b/packages/core/src/markdown/frontmatter.ts
@@ -11,7 +11,13 @@
 // worker, or RN like the rest of @repo/core.
 // ---------------------------------------------------------------------------
 
-import { parse as parseYaml, stringify as stringifyYaml } from "yaml";
+import {
+  isMap,
+  isScalar,
+  parse as parseYaml,
+  parseDocument,
+  stringify as stringifyYaml,
+} from "yaml";
 
 /** A doc's frontmatter as a parsed top-level mapping. */
 export type Properties = Record<string, unknown>;
@@ -76,4 +82,156 @@ export function applyPropertiesPatch(current: Properties, patch: PropertiesPatch
     else next[key] = value;
   }
   return next;
+}
+
+// ---------------------------------------------------------------------------
+// Typed properties — the file-properties panel's parse/serialize contract
+// (plan 017, hubble ADR-0003: the markdown file is the ONLY property store).
+// This sits ONE layer above splitFrontmatter: the panel already holds the
+// frontmatter block's raw yaml (the Plate frontmatter node's `value`), so these
+// helpers work on that yaml text directly. Kept here beside the split seam so
+// there is a single core home for frontmatter/YAML knowledge — the broker's
+// `read → properties` and the panel never fork a second YAML parser.
+//
+// Conservative typing (YAML 1.2 core schema, the `yaml` package's default):
+// `true`/`false` are the ONLY booleans, so `yes/no/on/off` stay text; the core
+// schema has no timestamp tag, so dates are recognized ONLY from explicit
+// `YYYY-MM-DD` strings; anything the panel can't safely round-trip (nested
+// maps, mixed/non-string arrays, nulls, anchors) is "unsupported" — displayed
+// read-only and preserved byte-for-byte on save via the Document API.
+// ---------------------------------------------------------------------------
+
+export type PropertyType = "text" | "number" | "checkbox" | "date" | "tags" | "unsupported";
+
+/** A frontmatter key parsed into a typed control. The ADT keeps illegal
+ * states unrepresentable: each type carries exactly the value shape its field
+ * edits, and `unsupported` carries the raw source bytes it must preserve. */
+export type TypedProperty =
+  | { key: string; type: "text"; value: string }
+  | { key: string; type: "number"; value: number }
+  | { key: string; type: "checkbox"; value: boolean }
+  | { key: string; type: "date"; value: string }
+  | { key: string; type: "tags"; value: string[] }
+  | { key: string; type: "unsupported"; rawYaml: string };
+
+/** The result of typing a frontmatter block:
+ *  - `none`    — the block is empty (no properties to show).
+ *  - `invalid` — malformed yaml, duplicate keys, or a non-mapping root. The
+ *                panel shows "properties unavailable" and NEVER rewrites the
+ *                block: what it can't read, it can't destroy.
+ *  - `valid`   — a top-level mapping, each key classified. */
+export type ParsedProperties =
+  | { kind: "valid"; properties: TypedProperty[] }
+  | { kind: "invalid" }
+  | { kind: "none" };
+
+// Explicit calendar-date shape only — no month/day range check, so an
+// out-of-range `2026-13-40` still edits as a (plain-text) date field rather
+// than being silently reclassified; the point is byte-safety, not validation.
+const DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
+
+function isStringArray(value: unknown): value is string[] {
+  return Array.isArray(value) && value.every((item) => typeof item === "string");
+}
+
+function classify(key: string, value: unknown, rawYaml: string): TypedProperty {
+  if (typeof value === "boolean") return { key, type: "checkbox", value };
+  if (typeof value === "number" && Number.isFinite(value)) return { key, type: "number", value };
+  if (typeof value === "string") {
+    return DATE_RE.test(value) ? { key, type: "date", value } : { key, type: "text", value };
+  }
+  if (isStringArray(value)) return { key, type: "tags", value };
+  return { key, type: "unsupported", rawYaml };
+}
+
+/** Type a frontmatter block's raw yaml into editable properties. Never throws:
+ * a parse failure (or non-mapping root) is reported as `invalid`, leaving the
+ * caller to preserve the raw block untouched. */
+export function parseProperties(yamlText: string): ParsedProperties {
+  if (yamlText.trim() === "") return { kind: "none" };
+  let doc;
+  try {
+    doc = parseDocument(yamlText);
+  } catch {
+    return { kind: "invalid" };
+  }
+  // Duplicate keys and malformed yaml both surface as document errors.
+  if (doc.errors.length > 0) return { kind: "invalid" };
+  const contents = doc.contents;
+  if (!isMap(contents)) return { kind: "invalid" };
+  const properties: TypedProperty[] = [];
+  for (const item of contents.items) {
+    const keyNode = item.key;
+    const key = isScalar(keyNode) ? String(keyNode.value) : String(keyNode);
+    const valueNode = item.value;
+    // Slice the value's source bytes for the unsupported read-only display;
+    // range[0..1] is the value span (excludes the key and trailing node gap).
+    const range = valueNode?.range;
+    const rawYaml = range ? yamlText.slice(range[0], range[1]).trimEnd() : "";
+    const value = valueNode == null ? null : valueNode.toJSON();
+    properties.push(classify(key, value, rawYaml));
+  }
+  return { kind: "valid", properties };
+}
+
+/** Type a single new key from a user-entered raw value (the panel's "Add
+ * property" flow): the value is read as a YAML scalar so `true`, `42`,
+ * `2026-07-01`, `[a, b]` type naturally, exactly as if it had been typed into
+ * the block. An empty value is an empty text property. */
+export function typeNewProperty(key: string, rawValue: string): TypedProperty {
+  if (rawValue.trim() === "") return { key, type: "text", value: "" };
+  let value: unknown;
+  try {
+    value = parseYaml(rawValue);
+  } catch {
+    value = rawValue;
+  }
+  return classify(key, value, rawValue);
+}
+
+function typedValue(prop: TypedProperty): unknown {
+  return prop.type === "unsupported" ? undefined : prop.value;
+}
+
+function valueEqual(a: unknown, b: unknown): boolean {
+  if (Array.isArray(a) && Array.isArray(b)) {
+    return a.length === b.length && a.every((item, i) => item === b[i]);
+  }
+  return a === b;
+}
+
+/** Recombine typed properties back into a frontmatter block's raw yaml (no
+ * fences, no trailing newline — matching remark-frontmatter's node `value`).
+ * Works over the `yaml` Document parsed from `priorRaw` so untouched keys —
+ * crucially every `unsupported` one — keep their exact source bytes, comments
+ * included; key ORDER is preserved and new keys append. Only keys whose value
+ * actually changed are re-set, so an edit to one property yields a minimal
+ * diff. An empty property list clears the block entirely (returns ""). */
+export function serializeProperties(properties: TypedProperty[], priorRaw: string): string {
+  if (properties.length === 0) return "";
+  const doc = parseDocument(priorRaw);
+  let parsedPrior: unknown = null;
+  try {
+    if (priorRaw.trim() !== "") parsedPrior = parseYaml(priorRaw);
+  } catch {
+    parsedPrior = null;
+  }
+  const priorValues: Properties = isPlainRecord(parsedPrior) ? parsedPrior : {};
+  if (isMap(doc.contents)) {
+    const desired = new Set(properties.map((prop) => prop.key));
+    const removable = doc.contents.items
+      .map((item) => (isScalar(item.key) ? String(item.key.value) : String(item.key)))
+      .filter((key) => !desired.has(key));
+    for (const key of removable) doc.delete(key);
+  }
+  for (const prop of properties) {
+    // Unsupported keys are never re-set — the Document keeps their raw bytes.
+    if (prop.type === "unsupported") continue;
+    const next = typedValue(prop);
+    const had = Object.prototype.hasOwnProperty.call(priorValues, prop.key);
+    if (!had || !valueEqual(priorValues[prop.key], next)) doc.set(prop.key, next);
+  }
+  // A mapping always stringifies with a single trailing newline; the frontmatter
+  // node value carries none, so drop exactly one.
+  return doc.toString().replace(/\n$/, "");
 }


### PR DESCRIPTION
Plan 017 / hubble ADR-0003 adoption: a typed properties panel above the note — the file stays the ONLY store. Conservative typing (true/false→checkbox, yes/no/on/off stay text, dates only YYYY-MM-DD, numbers/tags), unsupported/invalid YAML preserved byte-exactly and shown read-only, session-only type overrides. Typing helpers live in @repo/core beside 015's frontmatter split so the panel and the HTML-app broker share ONE parse path. Discriminated-union TypedProperty ADT. yaml Document API for byte-preserving edits (harness-verified minimal diffs). 19 new typing tests + 7 edit-flow tests + 2 pipeline-generated fixtures; zero existing fixture changes; full gate green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a typed file-properties panel above the editor that edits YAML frontmatter in place, keeping the markdown file as the single source of truth and preserving unsupported/invalid YAML byte-for-byte. Fulfills ADR-0003 by using one parse/write path with minimal diffs.

- New Features
  - Typed properties panel for text, number, checkbox, date, and tags; add/remove; session-only text/date override.
  - Edits write to the frontmatter node and flow through the existing serialize path; frontmatter block now renders invisible.
  - Invalid frontmatter shows a read-only notice; unsupported values (nested maps, mixed arrays, nulls) display read-only and are preserved byte-for-byte.

- Refactors
  - Shared helpers in `@repo/core`: `parseProperties`, `serializeProperties`, `typeNewProperty` with conservative YAML 1.2 typing (true/false only; yes/no/on/off stay text; dates only YYYY-MM-DD).
  - YAML Document API preserves comments and key order; only changed keys are updated for minimal diffs; unsupported keys retain exact bytes.
  - Added edit→serialize tests and byte-pinned fixtures to guarantee round-trip stability.

<sup>Written for commit daf67a091fea8c5769e4be310363bf0e6900af50. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kyh/inteligir/pull/413?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

