### PR TITLE
feat: agent-queryable HTML apps — broker gains query, properties, backlinks

### DIFF
--- a/apps/desktop/dev/fixture-bridge.ts
+++ b/apps/desktop/dev/fixture-bridge.ts
@@ -400,6 +400,42 @@ const SAMPLE_ASSETS: Record<string, string> = {
   // the same runtime injected). Exercises Alpine (the counter) + the injected
   // window.inteligir.files bridge (the note list). Not in SAMPLE_NOTES: it's not
   // a doc, so the markdown-corpus contract doesn't apply.
+  // Project cluster — typed frontmatter so the dashboard HTML app can query
+  // "project", pull each hit's properties, and sort a table by priority. All
+  // three link [[hub]] so `backlinks("wiki/hub.md")` returns a real, deduped set.
+  "projects/alpha.md": `---
+title: Project Alpha
+status: active
+priority: 1
+due: 2026-08-15
+---
+
+# Project Alpha
+
+The flagship project. Tracks against [[hub]].
+`,
+  "projects/beta.md": `---
+title: Project Beta
+status: paused
+priority: 3
+due: 2026-09-01
+---
+
+# Project Beta
+
+A secondary project effort, parked for now. See [[hub]].
+`,
+  "projects/gamma.md": `---
+title: Project Gamma
+status: active
+priority: 2
+due: 2026-07-20
+---
+
+# Project Gamma
+
+Exploratory project work, links back to [[hub]].
+`,
   "demo-app.html": `<!doctype html>
 <html>
   <head>
@@ -431,6 +467,76 @@ const SAMPLE_ASSETS: Record<string, string> = {
           notes: [],
           async load() {
             this.notes = await window.inteligir.files.list();
+          },
+          open(path) {
+            window.inteligir.files.open(path);
+          },
+        };
+      }
+    </script>
+  </body>
+</html>
+`,
+  "dashboard-demo.html": `<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <title>Project Dashboard</title>
+  </head>
+  <body>
+    <div x-data="dashboard()" x-init="load()" class="mx-auto max-w-2xl p-4">
+      <h1 class="mb-1 text-lg font-semibold">Project Dashboard</h1>
+      <p class="mb-4 text-sm" style="color: var(--muted)">
+        Notes matching "<span x-text="query"></span>", sorted by priority.
+      </p>
+      <table class="w-full text-sm" data-testid="project-table">
+        <thead>
+          <tr class="border-b text-left" style="border-color: var(--border)">
+            <th class="py-1 pr-3">Name</th>
+            <th class="py-1 pr-3">Status</th>
+            <th class="py-1 pr-3">Priority</th>
+            <th class="py-1 pr-3">Due</th>
+          </tr>
+        </thead>
+        <tbody>
+          <template x-for="row in rows" :key="row.path">
+            <tr class="border-b" style="border-color: var(--border)">
+              <td class="py-1 pr-3">
+                <button class="underline" x-on:click="open(row.path)" x-text="row.name"></button>
+              </td>
+              <td class="py-1 pr-3" x-text="prop(row, 'status')"></td>
+              <td class="py-1 pr-3" x-text="prop(row, 'priority')"></td>
+              <td class="py-1 pr-3" x-text="prop(row, 'due')"></td>
+            </tr>
+          </template>
+        </tbody>
+      </table>
+      <h2 class="mt-6 mb-1 text-sm font-semibold">Backlinks to hub</h2>
+      <ul class="space-y-1 text-sm" data-testid="backlink-list">
+        <template x-for="path in backlinks" :key="path">
+          <li x-text="path"></li>
+        </template>
+      </ul>
+    </div>
+    <script>
+      function dashboard() {
+        return {
+          query: "project",
+          rows: [],
+          backlinks: [],
+          async load() {
+            const hits = await window.inteligir.files.list({
+              query: this.query,
+              withProperties: true,
+              limit: 50,
+            });
+            this.rows = hits
+              .slice()
+              .sort((a, b) => (this.prop(a, "priority") ?? 0) - (this.prop(b, "priority") ?? 0));
+            this.backlinks = await window.inteligir.files.backlinks("wiki/hub.md");
+          },
+          prop(row, key) {
+            return row.properties ? row.properties[key] : undefined;
           },
           open(path) {
             window.inteligir.files.open(path);

--- a/apps/desktop/resources/html-app-runtime/runtime.js
+++ b/apps/desktop/resources/html-app-runtime/runtime.js
@@ -71,8 +71,12 @@
   }
 
   var files = {
-    list: function () {
-      return request("list", []);
+    // list()                       → every doc as { path, name }
+    // list({ query, withProperties, limit }) → ranked hits (with snippets when
+    //   query is set) capped at `limit` (default 50, max 200); withProperties
+    //   attaches each hit's parsed frontmatter as `properties`.
+    list: function (options) {
+      return request("list", options === undefined ? [] : [options]);
     },
     read: function (path) {
       return request("read", [path]);
@@ -89,9 +93,13 @@
     remove: function (path) {
       return request("remove", [path]);
     },
+    // Source paths of notes that link TO `path` (wiki + markdown links), deduped.
+    backlinks: function (path) {
+      return request("backlinks", [path]);
+    },
   };
   // Non-throwing variants: safeList, safeRead, … → { ok, value | error }.
-  ["list", "read", "open", "create", "update", "remove"].forEach(function (name) {
+  ["list", "read", "open", "create", "update", "remove", "backlinks"].forEach(function (name) {
     files["safe" + name.charAt(0).toUpperCase() + name.slice(1)] = makeSafe(files[name]);
   });
 

--- a/apps/desktop/src/renderer/workspace/html-app-broker.test.ts
+++ b/apps/desktop/src/renderer/workspace/html-app-broker.test.ts
@@ -1,18 +1,33 @@
 import { describe, expect, it, vi } from "vitest";
 
+import type { BacklinkEntry } from "@repo/core/knowledge/knowledge-index";
 import type { VaultEntry } from "@repo/features/ipc-registry";
 
 import { handleBrokerRequest, type BrokerBridge, type BrokerDeps } from "./html-app-broker";
 
-// A minimal in-memory Bridge slice standing in for the real host.
-function makeBridge(seed: Record<string, string> = {}): {
+// A minimal in-memory Bridge slice standing in for the real host. `searchVault`
+// is a substring stub (path OR content match), so tests seed paths and assert
+// the {query,limit} routing directly; `getBacklinks` returns the seeded map.
+function makeBridge(
+  seed: Record<string, string> = {},
+  opts: { backlinks?: Record<string, BacklinkEntry[]> } = {},
+): {
   bridge: BrokerBridge;
   store: Map<string, string>;
   kinds: Map<string, VaultEntry["kind"]>;
+  searchVault: ReturnType<typeof vi.fn>;
+  getBacklinks: ReturnType<typeof vi.fn>;
 } {
   const store = new Map<string, string>(Object.entries(seed));
   const kinds = new Map<string, VaultEntry["kind"]>();
   for (const path of store.keys()) kinds.set(path, path.endsWith(".md") ? "doc" : "other");
+  const searchVault = vi.fn(async ({ query, limit }: { query: string; limit?: number }) => {
+    const matches = [...store.keys()]
+      .filter((path) => (kinds.get(path) ?? "doc") === "doc" && path.includes(query))
+      .map((path) => ({ path, title: path, snippet: `hit:${query}`, score: 1 }));
+    return typeof limit === "number" ? matches.slice(0, limit) : matches;
+  });
+  const getBacklinks = vi.fn(async ({ path }: { path: string }) => opts.backlinks?.[path] ?? []);
   const bridge: BrokerBridge = {
     listVault: async () =>
       [...store.keys()].map((path) => ({
@@ -29,8 +44,10 @@ function makeBridge(seed: Record<string, string> = {}): {
       store.set(path, content);
     },
     deleteVaultEntry: async ({ path }) => ({ removed: store.delete(path) }),
+    searchVault,
+    getBacklinks,
   };
-  return { bridge, store, kinds };
+  return { bridge, store, kinds, searchVault, getBacklinks };
 }
 
 function makeDeps(bridge: BrokerBridge, over: Partial<BrokerDeps> = {}): BrokerDeps {
@@ -50,6 +67,101 @@ describe("handleBrokerRequest", () => {
       { path: "a.md", name: "a.md" },
       { path: "b.md", name: "b.md" },
     ]);
+  });
+
+  it("bare list() is unchanged: every doc, no cap, {path,name}", async () => {
+    const seed: Record<string, string> = {};
+    for (let i = 0; i < 120; i++) seed[`n${i}.md`] = "x";
+    const { bridge, searchVault } = makeBridge(seed);
+    const result = await handleBrokerRequest("list", [], makeDeps(bridge));
+    expect(result).toHaveLength(120);
+    expect(searchVault).not.toHaveBeenCalled();
+  });
+
+  it("list with a query routes through searchVault and keeps snippets", async () => {
+    const { bridge, searchVault } = makeBridge({
+      "projects/a.md": "x",
+      "projects/b.md": "y",
+      "other.md": "z",
+    });
+    const result = await handleBrokerRequest("list", [{ query: "projects" }], makeDeps(bridge));
+    expect(searchVault).toHaveBeenCalledWith({ query: "projects", limit: 50 });
+    expect(result).toEqual([
+      { path: "projects/a.md", name: "a.md", snippet: "hit:projects" },
+      { path: "projects/b.md", name: "b.md", snippet: "hit:projects" },
+    ]);
+  });
+
+  it("list withProperties (no query) attaches parsed frontmatter", async () => {
+    const { bridge } = makeBridge({ "a.md": "---\ntag: x\n---\nbody\n" });
+    const result = await handleBrokerRequest("list", [{ withProperties: true }], makeDeps(bridge));
+    expect(result).toEqual([{ path: "a.md", name: "a.md", properties: { tag: "x" } }]);
+  });
+
+  it("list withProperties + query carries BOTH snippet and properties", async () => {
+    const { bridge } = makeBridge({ "proj.md": "---\npriority: 1\n---\nbody\n" });
+    const result = await handleBrokerRequest(
+      "list",
+      [{ query: "proj", withProperties: true }],
+      makeDeps(bridge),
+    );
+    expect(result).toEqual([
+      { path: "proj.md", name: "proj.md", snippet: "hit:proj", properties: { priority: 1 } },
+    ]);
+  });
+
+  it("list defaults limit to 50 and hard-caps it at 200", async () => {
+    const { bridge, searchVault } = makeBridge();
+    await handleBrokerRequest("list", [{ query: "x" }], makeDeps(bridge));
+    expect(searchVault).toHaveBeenLastCalledWith({ query: "x", limit: 50 });
+    await handleBrokerRequest("list", [{ query: "x", limit: 999 }], makeDeps(bridge));
+    expect(searchVault).toHaveBeenLastCalledWith({ query: "x", limit: 200 });
+  });
+
+  it("list withProperties reads no more docs than the cap (cap-first)", async () => {
+    const seed: Record<string, string> = {};
+    for (let i = 0; i < 120; i++) seed[`n${i}.md`] = `---\ni: ${i}\n---\n`;
+    const { bridge } = makeBridge(seed);
+    const read = vi.spyOn(bridge, "readVaultDoc");
+    const result = await handleBrokerRequest(
+      "list",
+      [{ withProperties: true, limit: 10 }],
+      makeDeps(bridge),
+    );
+    expect(result).toHaveLength(10);
+    expect(read).toHaveBeenCalledTimes(10);
+  });
+
+  it("list rejects unknown option keys", async () => {
+    const { bridge } = makeBridge();
+    await expect(handleBrokerRequest("list", [{ bogus: 1 }], makeDeps(bridge))).rejects.toThrow(
+      /invalid list options/,
+    );
+  });
+
+  it("backlinks returns deduped source paths (mirrors get_backlinks)", async () => {
+    const { bridge } = makeBridge(
+      { "t.md": "x" },
+      {
+        backlinks: {
+          "t.md": [
+            { sourcePath: "a.md", line: 1, snippet: "", kind: "wiki", embed: false },
+            { sourcePath: "a.md", line: 5, snippet: "", kind: "wiki", embed: false },
+            { sourcePath: "b.md", line: 2, snippet: "", kind: "md", embed: false },
+          ],
+        },
+      },
+    );
+    const result = await handleBrokerRequest("backlinks", ["t.md"], makeDeps(bridge));
+    expect(result).toEqual(["a.md", "b.md"]);
+  });
+
+  it("backlinks rejects an unsafe path before the Bridge", async () => {
+    const { bridge, getBacklinks } = makeBridge();
+    await expect(handleBrokerRequest("backlinks", ["../x.md"], makeDeps(bridge))).rejects.toThrow(
+      /invalid vault path/,
+    );
+    expect(getBacklinks).not.toHaveBeenCalled();
   });
 
   it("read splits frontmatter into {path, body, properties}", async () => {

--- a/apps/desktop/src/renderer/workspace/html-app-broker.ts
+++ b/apps/desktop/src/renderer/workspace/html-app-broker.ts
@@ -31,7 +31,12 @@ import type { Bridge } from "@repo/features/ipc-registry";
 /** The Bridge slice the broker uses — nothing more. */
 export type BrokerBridge = Pick<
   Bridge,
-  "listVault" | "readVaultDoc" | "writeVaultDoc" | "deleteVaultEntry"
+  | "listVault"
+  | "readVaultDoc"
+  | "writeVaultDoc"
+  | "deleteVaultEntry"
+  | "searchVault"
+  | "getBacklinks"
 >;
 
 export type BrokerDeps = {
@@ -45,6 +50,23 @@ export type BrokerDeps = {
 // ---- Payload schemas -------------------------------------------------------
 
 const PathArg = Type.String({ minLength: 1 });
+
+// `list()` options (all optional — a bare `list()` stays the all-docs listing).
+// `query` routes through the lexical search; `withProperties` attaches each
+// hit's parsed frontmatter; `limit` bounds BOTH the search and the property
+// reads. The listing pipeline is capped so `withProperties` can never trigger
+// an unbounded read fan-out (see the cap-first/read-after step below).
+const LIST_DEFAULT_LIMIT = 50;
+const LIST_MAX_LIMIT = 200;
+const ListOptions = Type.Object(
+  {
+    query: Type.Optional(Type.String()),
+    withProperties: Type.Optional(Type.Boolean()),
+    limit: Type.Optional(Type.Number({ minimum: 1 })),
+  },
+  { additionalProperties: false },
+);
+
 const DocInput = Type.Object(
   {
     body: Type.Optional(Type.String()),
@@ -92,11 +114,45 @@ export async function handleBrokerRequest(
   const { bridge } = deps;
   switch (method) {
     case "list": {
-      const entries = await bridge.listVault();
-      // Docs only — an app edits notes, not binary assets.
-      return entries
-        .filter((entry) => entry.kind === "doc")
-        .map((entry) => ({ path: entry.path, name: entry.name }));
+      // Bare `list()` — unchanged: every doc as {path,name}. Kept byte-for-byte
+      // so existing apps that call `list()` with no args behave identically.
+      if (args[0] === undefined) {
+        const entries = await bridge.listVault();
+        // Docs only — an app edits notes, not binary assets.
+        return entries
+          .filter((entry) => entry.kind === "doc")
+          .map((entry) => ({ path: entry.path, name: entry.name }));
+      }
+      if (!Value.Check(ListOptions, args[0])) throw new Error("invalid list options");
+      const opts = args[0];
+      const limit = Math.min(opts.limit ?? LIST_DEFAULT_LIMIT, LIST_MAX_LIMIT);
+      // Compute the CAPPED hit set first — we never read more docs than `limit`.
+      let hits: { path: string; name: string; snippet?: string }[];
+      if (opts.query !== undefined) {
+        // Ranked lexical search; carry each hit's snippet through to the app.
+        const results = await bridge.searchVault({ query: opts.query, limit });
+        hits = results.map((result) => ({
+          path: result.path,
+          name: result.path.split("/").pop() ?? result.path,
+          snippet: result.snippet,
+        }));
+      } else {
+        const entries = await bridge.listVault();
+        hits = entries
+          .filter((entry) => entry.kind === "doc")
+          .slice(0, limit)
+          .map((entry) => ({ path: entry.path, name: entry.name }));
+      }
+      if (!opts.withProperties) return hits;
+      // Attach parsed properties — reads ONLY the already-capped set above.
+      return Promise.all(
+        hits.map(async (hit) => {
+          const { properties } = splitFrontmatter(await bridge.readVaultDoc({ path: hit.path }));
+          return hit.snippet === undefined
+            ? { path: hit.path, name: hit.name, properties }
+            : { path: hit.path, name: hit.name, snippet: hit.snippet, properties };
+        }),
+      );
     }
     case "read": {
       const path = requireSafePath(args[0]);
@@ -137,6 +193,14 @@ export async function handleBrokerRequest(
       if (!confirmed) return { removed: false };
       const result = await bridge.deleteVaultEntry({ path });
       return { removed: result.removed };
+    }
+    case "backlinks": {
+      const path = requireSafePath(args[0]);
+      const entries = await bridge.getBacklinks({ path });
+      // De-dupe by source path — a note may link the target on several lines,
+      // but an app only needs the SET of linking notes (mirrors the agent's
+      // get_backlinks tool).
+      return [...new Set(entries.map((entry) => entry.sourcePath))];
     }
     default:
       throw new Error(`unknown method: ${method}`);

--- a/apps/desktop/src/renderer/workspace/html-app-runtime.test.tsx
+++ b/apps/desktop/src/renderer/workspace/html-app-runtime.test.tsx
@@ -1,0 +1,96 @@
+// Runtime surface test — the vendored `resources/html-app-runtime/runtime.js`
+// is the app-facing half of the broker contract (ADR-0002). It's plain ES5-ish
+// vanilla JS with no module system, so we eval it into a jsdom window and drive
+// the postMessage RPC by hand: outbound requests are captured (window.parent ===
+// window in jsdom, so window.postMessage is the wire), inbound responses are
+// dispatched as message events. This pins the append-only additions from plan
+// 019 — `list(options)` forwarding and `backlinks` + `safeBacklinks`.
+
+import runtimeSource from "../../../resources/html-app-runtime/runtime.js?raw";
+import { afterEach, beforeAll, describe, expect, it, vi } from "vitest";
+
+type Posted = { type: string; id: string; token: string; method: string; args: unknown[] };
+
+const posted: Posted[] = [];
+
+// The methods we invoke are named (never undefined); the dynamic `files[name]`
+// lookups in the surface test read through the index signature (so they're
+// checked with `typeof`, never invoked).
+type BrokerFn = (...args: unknown[]) => Promise<unknown>;
+type FileApi = {
+  list(options?: unknown): Promise<unknown>;
+  backlinks(path: string): Promise<unknown>;
+  safeBacklinks(path: string): Promise<unknown>;
+} & Record<string, BrokerFn | undefined>;
+
+function fileApi(): FileApi {
+  // window.inteligir is installed by the evaluated runtime.
+  return (window as unknown as { inteligir: { files: FileApi } }).inteligir.files;
+}
+
+/** Resolve the most-recent outbound request by dispatching a response event. */
+function respondLatest(payload: { ok: boolean; value?: unknown; error?: string }): void {
+  const last = posted[posted.length - 1];
+  if (!last) throw new Error("no outbound request to respond to");
+  window.dispatchEvent(
+    new MessageEvent("message", {
+      data: { type: "inteligir:response", id: last.id, ...payload },
+      source: window,
+    }),
+  );
+}
+
+beforeAll(() => {
+  window.name = "tok";
+  // Capture outbound requests instead of letting jsdom deliver them — we drive
+  // the responses manually. window.parent === window here, so this is the wire.
+  vi.spyOn(window, "postMessage").mockImplementation((msg: unknown) => {
+    posted.push(msg as Posted);
+  });
+  // Evaluate the IIFE against the jsdom globals (window/document/setTimeout).
+  new Function(runtimeSource)();
+});
+
+afterEach(() => {
+  posted.length = 0;
+});
+
+describe("html-app runtime file API", () => {
+  it("exposes every method plus its safe* variant, including backlinks", () => {
+    const files = fileApi();
+    for (const name of ["list", "read", "open", "create", "update", "remove", "backlinks"]) {
+      expect(typeof files[name]).toBe("function");
+      const safe = "safe" + name.charAt(0).toUpperCase() + name.slice(1);
+      expect(typeof files[safe]).toBe("function");
+    }
+  });
+
+  it("list() sends no args; list(options) forwards the options object", () => {
+    void fileApi().list();
+    expect(posted[posted.length - 1]).toMatchObject({ method: "list", token: "tok", args: [] });
+    void fileApi().list({ query: "x", withProperties: true, limit: 10 });
+    expect(posted[posted.length - 1]).toMatchObject({
+      method: "list",
+      args: [{ query: "x", withProperties: true, limit: 10 }],
+    });
+  });
+
+  it("backlinks(path) forwards the path and resolves from the response", async () => {
+    const promise = fileApi().backlinks("wiki/hub.md");
+    expect(posted[posted.length - 1]).toMatchObject({
+      method: "backlinks",
+      args: ["wiki/hub.md"],
+    });
+    respondLatest({ ok: true, value: ["a.md", "b.md"] });
+    await expect(promise).resolves.toEqual(["a.md", "b.md"]);
+  });
+
+  it("safeBacklinks wraps a rejection into { ok:false, error }", async () => {
+    const promise = fileApi().safeBacklinks("wiki/hub.md");
+    // safe* defers the underlying call by a microtask, so let the request post
+    // before we answer it.
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    respondLatest({ ok: false, error: "boom" });
+    await expect(promise).resolves.toEqual({ ok: false, error: "boom" });
+  });
+});

--- a/packages/features/resources/agent/AGENTS.md
+++ b/packages/features/resources/agent/AGENTS.md
@@ -61,11 +61,13 @@ When notes aren't the right shape — a table, kanban, dashboard, tracker, books
 **The vault API** (`window.inteligir.files`, all async/Promise-based):
 
 - `list()` → `[{ path, name }]` — every markdown note in the vault.
+- `list({ query?, withProperties?, limit? })` → ranked hits — `query` runs a full-text search (each hit gains a `snippet`); `withProperties: true` attaches each hit's parsed frontmatter as `properties`; `limit` caps results (default 50, max 200). Use this for "notes tagged X sorted by Y" instead of `list()` + N reads.
 - `read(path)` → `{ path, body, properties }` — `body` is the markdown after frontmatter; `properties` is the parsed frontmatter as an object.
 - `open(path)` — open a note in the editor.
 - `create(path, { body?, properties? })` — create a new note (errors if it exists).
 - `update(path, { body?, properties? })` — patch a note. Omitted keys are left alone; a property set to `null` is DELETED; provided properties are added/replaced; a provided `body` replaces the body.
 - `remove(path)` — delete a note (asks the user to confirm first).
+- `backlinks(path)` → `[path, …]` — vault paths of notes that link TO `path` (deduped).
 
 Every method has a `safe*` variant (`safeRead`, `safeUpdate`, …) returning `{ ok, value }` or `{ ok, error }` instead of throwing. Paths are vault-relative (no `..`, no leading `/`). Build the UI, wire it to these calls, and the app reads and writes the user's real notes.
 


### PR DESCRIPTION
Plan 019 — connects the knowledge tools (013), HTML apps (015), and typed properties (017): `inteligir.files.list({query, withProperties, limit})` routes through the lexical search and attaches parsed properties (cap-first 50/200); new `files.backlinks(path)` mirrors the agent tool's dedup. Append-only per ADR-0002 — bare `list()` byte-identical, zero signature changes.

Live-verified in Electron against the real vault over `vault-app://` (query hits with snippets, property counts, backlinks) plus a property-sorted dashboard demo in the harness. 14 new tests; 435 desktop tests green; full gate green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enable HTML apps to query the vault, read typed properties in one call, and fetch backlinks. This makes dashboards fast and removes N+1 reads while keeping `list()` fully backwards compatible.

- New Features
  - Broker adds `list({ query?, withProperties?, limit? })`: runs ranked search with snippets, optionally attaches parsed frontmatter as `properties`; default limit 50, hard cap 200 (cap-first so we never read more than the limit).
  - Bare `list()` is unchanged and still returns every doc as `{ path, name }`.
  - `backlinks(path)` returns deduped source note paths linking to `path` (mirrors the agent tool); `safeBacklinks` included. Runtime now forwards `list(options)` and exposes `backlinks`/`safeBacklinks`. Docs updated and a small dashboard demo + unit tests added.

<sup>Written for commit 65f103ba3ab008d66d64128a23c637f27f52e476. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kyh/inteligir/pull/417?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

