### PR TITLE
feat(knowledge): #tag indexing — palette, agent tool, HTML-app broker

### DIFF
--- a/apps/desktop/dev/fixture-bridge.ts
+++ b/apps/desktop/dev/fixture-bridge.ts
@@ -128,6 +128,16 @@ nested:
 
 Edit the typed properties above; the yaml block round-trips byte-for-byte.
 `,
+  // Inline-tag note (plan 021): exercises the palette `#` flow. Its inline
+  // #meta unifies with frontmatter-note.md's frontmatter `tags: [meta, demo]`,
+  // so the tag list demos BOTH sources (meta count 2) and inline-only tags.
+  // Pre-canonical prose (the corpus test pins it canonical).
+  "tagged.md": `# Tagged note
+
+Inline tags: working on #project and #meta this week, with #ideas to chase.
+
+A nested tag #area/deep-dive lives here too.
+`,
   // WP2 vocabulary notes — every kit exercisable in the harness. All four are
   // CANONICAL (the corpus test pins that): editing them must never flip the
   // pane to Raw.
@@ -863,6 +873,8 @@ export function createFixtureBridge(): Bridge {
     getLinkGraph: async () => knowledge.graph(),
     searchVault: async ({ query, limit }) => knowledge.search(query, limit),
     listWikiTargets: async () => knowledge.wikiTargets(),
+    listTags: async () => knowledge.tags(),
+    getNotesByTag: async ({ tag }) => knowledge.notesWithTag(tag),
     onKnowledgeUpdated: knowledgeEvents.subscribe,
 
     // Delegation — no background agent, but the run is simulated against the

--- a/apps/desktop/resources/html-app-runtime/runtime.js
+++ b/apps/desktop/resources/html-app-runtime/runtime.js
@@ -72,9 +72,10 @@
 
   var files = {
     // list()                       → every doc as { path, name }
-    // list({ query, withProperties, limit }) → ranked hits (with snippets when
-    //   query is set) capped at `limit` (default 50, max 200); withProperties
-    //   attaches each hit's parsed frontmatter as `properties`.
+    // list({ query, tag, withProperties, limit }) → ranked hits (with snippets
+    //   when query is set) capped at `limit` (default 50, max 200); tag
+    //   restricts to notes carrying that tag; withProperties attaches each
+    //   hit's parsed frontmatter as `properties`.
     list: function (options) {
       return request("list", options === undefined ? [] : [options]);
     },

--- a/apps/desktop/src/renderer/__tests__/markdown-corpus.test.ts
+++ b/apps/desktop/src/renderer/__tests__/markdown-corpus.test.ts
@@ -47,6 +47,7 @@ const EXPECTED: Record<string, Classification> = {
   "kitchen-sink.md": "canonical",
   "legacy-web-clip.md": "raw:parse-error",
   "frontmatter-note.md": "canonical",
+  "tagged.md": "canonical",
   // WP2 vocabulary notes — canonical by construction (drafted, then pinned to
   // the pipeline's own round-trip output).
   "components-playground.md": "canonical",

--- a/apps/desktop/src/renderer/command/command-palette.tsx
+++ b/apps/desktop/src/renderer/command/command-palette.tsx
@@ -4,6 +4,7 @@ import {
   FilePlusIcon,
   FileTextIcon,
   FolderIcon,
+  HashIcon,
   LayoutTemplateIcon,
   MoonIcon,
   RefreshCwIcon,
@@ -26,18 +27,20 @@ import { useTheme } from "@renderer/lib/use-theme";
 import { useViewStore } from "@renderer/stores/view-store";
 import { useCreateFromTemplate, useOpenDailyNote } from "@renderer/workspace/use-note-templates";
 import { useVault } from "@renderer/workspace/vault-context";
-import type { SearchResult } from "@repo/core/knowledge/knowledge-index";
+import type { SearchResult, TagCount } from "@repo/core/knowledge/knowledge-index";
 
 const SEARCH_DEBOUNCE_MS = 150;
 const SEARCH_LIMIT = 8;
 
 /** Multi-step palette navigation. The root is search + commands; picking "New
  * note from template…" walks into template selection then note-naming, reusing
- * the same command input as the typed-name field. */
+ * the same command input as the typed-name field. Typing `#` at the root lists
+ * tags; selecting one walks into `browseTag` (that tag's notes). */
 type Phase =
   | { kind: "root" }
   | { kind: "pickTemplate" }
-  | { kind: "nameTemplate"; template: string };
+  | { kind: "nameTemplate"; template: string }
+  | { kind: "browseTag"; tag: string };
 
 /** Every whitespace-separated term must appear somewhere in the haystack —
  * the filename filter (filtering is ours: cmdk's scorer can't see the
@@ -79,6 +82,8 @@ export function CommandPalette({
   const [query, setQuery] = useState("");
   const [phase, setPhase] = useState<Phase>({ kind: "root" });
   const [hits, setHits] = useState<SearchResult[]>([]);
+  const [tags, setTags] = useState<TagCount[]>([]);
+  const [tagNotes, setTagNotes] = useState<string[]>([]);
   const inputRef = useRef<HTMLInputElement>(null);
 
   // Clear the filter AND reset navigation on every close, no matter the path —
@@ -89,9 +94,40 @@ export function CommandPalette({
     if (!open) {
       setQuery("");
       setHits([]);
+      setTagNotes([]);
       setPhase({ kind: "root" });
     }
   }, [open]);
+
+  // Load the tag list once per open — the `#` flow filters it client-side, and
+  // it's a small, cheap index read that the tag counts depend on.
+  useEffect(() => {
+    if (!open) return;
+    getBridge()
+      ?.listTags()
+      .then((result) => {
+        setTags(result);
+        return undefined;
+      })
+      .catch(() => {});
+  }, [open]);
+
+  // Fetch a tag's notes when stepping into the browse phase.
+  useEffect(() => {
+    if (phase.kind !== "browseTag") return;
+    const tag = phase.tag;
+    let live = true;
+    getBridge()
+      ?.getNotesByTag({ tag })
+      .then((paths) => {
+        if (live) setTagNotes(paths);
+        return undefined;
+      })
+      .catch(() => {});
+    return () => {
+      live = false;
+    };
+  }, [phase]);
 
   // Debounced full-text search; a stale response never lands over a newer
   // query (sequence check). Only the root phase searches notes — the sub-phases
@@ -100,7 +136,8 @@ export function CommandPalette({
   useEffect(() => {
     const trimmedQuery = query.trim();
     const seq = ++searchSeq.current;
-    if (!open || phase.kind !== "root" || trimmedQuery === "") {
+    // The root's `#`-prefixed query is a tag filter, not a full-text search.
+    if (!open || phase.kind !== "root" || trimmedQuery === "" || trimmedQuery.startsWith("#")) {
       setHits([]);
       return;
     }
@@ -141,6 +178,7 @@ export function CommandPalette({
       if (event.key !== "Escape" || phase.kind === "root") return;
       event.preventDefault();
       event.stopPropagation();
+      // browseTag / pickTemplate back out to root; nameTemplate to pickTemplate.
       goto({ kind: phase.kind === "nameTemplate" ? "pickTemplate" : "root" });
     },
     [phase.kind, goto],
@@ -224,6 +262,79 @@ export function CommandPalette({
               </CommandItem>
             </CommandGroup>
           )}
+        </CommandList>
+      </CommandDialog>
+    );
+  }
+
+  // ---- Tag flow: browse a tag's notes --------------------------------------
+  if (phase.kind === "browseTag") {
+    const tag = phase.tag;
+    const matches =
+      trimmed === "" ? tagNotes : tagNotes.filter((path) => matchesQuery(path, trimmed));
+    return (
+      <CommandDialog
+        open={open}
+        onOpenChange={(next) => (next ? onOpenChange(true) : close())}
+        initialFocus={inputRef}
+        shouldFilter={false}
+      >
+        <CommandInput
+          ref={inputRef}
+          value={query}
+          onValueChange={setQuery}
+          onKeyDown={handleInputKeyDown}
+          placeholder={`Notes tagged #${tag}…  (Esc to go back)`}
+        />
+        <CommandList>
+          <CommandEmpty>No notes with this tag.</CommandEmpty>
+          <CommandGroup heading={`#${tag}`}>
+            {matches.map((path) => (
+              <CommandItem key={path} value={path} onSelect={() => run(() => openFile(path))}>
+                <FileTextIcon />
+                <span className="truncate">{path}</span>
+              </CommandItem>
+            ))}
+          </CommandGroup>
+        </CommandList>
+      </CommandDialog>
+    );
+  }
+
+  // ---- Tag flow: list tags (typed `#` at the root) -------------------------
+  if (trimmed.startsWith("#")) {
+    const filter = trimmed.slice(1).toLowerCase();
+    const matches = filter === "" ? tags : tags.filter((t) => t.tag.toLowerCase().includes(filter));
+    return (
+      <CommandDialog
+        open={open}
+        onOpenChange={(next) => (next ? onOpenChange(true) : close())}
+        initialFocus={inputRef}
+        shouldFilter={false}
+      >
+        <CommandInput
+          ref={inputRef}
+          value={query}
+          onValueChange={setQuery}
+          placeholder="Filter tags…"
+        />
+        <CommandList>
+          <CommandEmpty>No tags.</CommandEmpty>
+          <CommandGroup heading="Tags">
+            {matches.map((t) => (
+              <CommandItem
+                key={t.tag}
+                value={`#${t.tag}`}
+                onSelect={() => goto({ kind: "browseTag", tag: t.tag })}
+              >
+                <HashIcon />
+                <span className="flex min-w-0 flex-1 items-center justify-between gap-2">
+                  <span className="truncate">{t.tag}</span>
+                  <span className="text-xs text-muted-foreground">{t.count}</span>
+                </span>
+              </CommandItem>
+            ))}
+          </CommandGroup>
         </CommandList>
       </CommandDialog>
     );

--- a/apps/desktop/src/renderer/workspace/html-app-broker.test.ts
+++ b/apps/desktop/src/renderer/workspace/html-app-broker.test.ts
@@ -10,13 +10,14 @@ import { handleBrokerRequest, type BrokerBridge, type BrokerDeps } from "./html-
 // the {query,limit} routing directly; `getBacklinks` returns the seeded map.
 function makeBridge(
   seed: Record<string, string> = {},
-  opts: { backlinks?: Record<string, BacklinkEntry[]> } = {},
+  opts: { backlinks?: Record<string, BacklinkEntry[]>; tags?: Record<string, string[]> } = {},
 ): {
   bridge: BrokerBridge;
   store: Map<string, string>;
   kinds: Map<string, VaultEntry["kind"]>;
   searchVault: ReturnType<typeof vi.fn>;
   getBacklinks: ReturnType<typeof vi.fn>;
+  getNotesByTag: ReturnType<typeof vi.fn>;
 } {
   const store = new Map<string, string>(Object.entries(seed));
   const kinds = new Map<string, VaultEntry["kind"]>();
@@ -28,6 +29,7 @@ function makeBridge(
     return typeof limit === "number" ? matches.slice(0, limit) : matches;
   });
   const getBacklinks = vi.fn(async ({ path }: { path: string }) => opts.backlinks?.[path] ?? []);
+  const getNotesByTag = vi.fn(async ({ tag }: { tag: string }) => opts.tags?.[tag] ?? []);
   const bridge: BrokerBridge = {
     listVault: async () =>
       [...store.keys()].map((path) => ({
@@ -46,8 +48,9 @@ function makeBridge(
     deleteVaultEntry: async ({ path }) => ({ removed: store.delete(path) }),
     searchVault,
     getBacklinks,
+    getNotesByTag,
   };
-  return { bridge, store, kinds, searchVault, getBacklinks };
+  return { bridge, store, kinds, searchVault, getBacklinks, getNotesByTag };
 }
 
 function makeDeps(bridge: BrokerBridge, over: Partial<BrokerDeps> = {}): BrokerDeps {
@@ -108,6 +111,48 @@ describe("handleBrokerRequest", () => {
     expect(result).toEqual([
       { path: "proj.md", name: "proj.md", snippet: "hit:proj", properties: { priority: 1 } },
     ]);
+  });
+
+  it("list with a tag routes through getNotesByTag as {path,name}", async () => {
+    const { bridge, getNotesByTag, searchVault } = makeBridge(
+      { "a.md": "x", "b.md": "y", "c.md": "z" },
+      { tags: { meta: ["a.md", "b.md"] } },
+    );
+    const result = await handleBrokerRequest("list", [{ tag: "meta" }], makeDeps(bridge));
+    expect(getNotesByTag).toHaveBeenCalledWith({ tag: "meta" });
+    expect(searchVault).not.toHaveBeenCalled();
+    expect(result).toEqual([
+      { path: "a.md", name: "a.md" },
+      { path: "b.md", name: "b.md" },
+    ]);
+  });
+
+  it("list with tag + query narrows the search within the tagged set", async () => {
+    const { bridge } = makeBridge(
+      { "projects/a.md": "x", "projects/b.md": "y", "other.md": "z" },
+      { tags: { meta: ["projects/a.md", "other.md"] } },
+    );
+    // searchVault matches by path substring "projects"; only projects/a.md is
+    // also tagged, so projects/b.md (matched query, untagged) drops.
+    const result = await handleBrokerRequest(
+      "list",
+      [{ tag: "meta", query: "projects" }],
+      makeDeps(bridge),
+    );
+    expect(result).toEqual([{ path: "projects/a.md", name: "a.md", snippet: "hit:projects" }]);
+  });
+
+  it("list with tag + withProperties attaches parsed frontmatter", async () => {
+    const { bridge } = makeBridge(
+      { "a.md": "---\nk: v\n---\nbody\n" },
+      { tags: { meta: ["a.md"] } },
+    );
+    const result = await handleBrokerRequest(
+      "list",
+      [{ tag: "meta", withProperties: true }],
+      makeDeps(bridge),
+    );
+    expect(result).toEqual([{ path: "a.md", name: "a.md", properties: { k: "v" } }]);
   });
 
   it("list defaults limit to 50 and hard-caps it at 200", async () => {

--- a/apps/desktop/src/renderer/workspace/html-app-broker.ts
+++ b/apps/desktop/src/renderer/workspace/html-app-broker.ts
@@ -37,6 +37,7 @@ export type BrokerBridge = Pick<
   | "deleteVaultEntry"
   | "searchVault"
   | "getBacklinks"
+  | "getNotesByTag"
 >;
 
 export type BrokerDeps = {
@@ -52,15 +53,18 @@ export type BrokerDeps = {
 const PathArg = Type.String({ minLength: 1 });
 
 // `list()` options (all optional — a bare `list()` stays the all-docs listing).
-// `query` routes through the lexical search; `withProperties` attaches each
-// hit's parsed frontmatter; `limit` bounds BOTH the search and the property
-// reads. The listing pipeline is capped so `withProperties` can never trigger
-// an unbounded read fan-out (see the cap-first/read-after step below).
+// `tag` restricts to notes carrying that tag (applied FIRST); `query` routes
+// through the lexical search (narrowing within the tag when both are given);
+// `withProperties` attaches each hit's parsed frontmatter; `limit` bounds BOTH
+// the search and the property reads. The listing pipeline is capped so
+// `withProperties` can never trigger an unbounded read fan-out (see the
+// cap-first/read-after step below).
 const LIST_DEFAULT_LIMIT = 50;
 const LIST_MAX_LIMIT = 200;
 const ListOptions = Type.Object(
   {
     query: Type.Optional(Type.String()),
+    tag: Type.Optional(Type.String()),
     withProperties: Type.Optional(Type.Boolean()),
     limit: Type.Optional(Type.Number({ minimum: 1 })),
   },
@@ -103,6 +107,11 @@ function requireDocInput(value: unknown): { body?: string; properties?: Record<s
 
 // ---- Dispatch --------------------------------------------------------------
 
+/** The leaf name of a vault path (its display `name` in list results). */
+function nameOf(path: string): string {
+  return path.split("/").pop() ?? path;
+}
+
 /** Handle one validated broker request. Throws on any invalid input, unknown
  * method, or downstream failure — the caller maps a throw to an error response.
  */
@@ -128,12 +137,28 @@ export async function handleBrokerRequest(
       const limit = Math.min(opts.limit ?? LIST_DEFAULT_LIMIT, LIST_MAX_LIMIT);
       // Compute the CAPPED hit set first — we never read more docs than `limit`.
       let hits: { path: string; name: string; snippet?: string }[];
-      if (opts.query !== undefined) {
+      if (opts.tag !== undefined) {
+        // Tag filter FIRST; a query then narrows WITHIN the tagged set.
+        const tagged = await bridge.getNotesByTag({ tag: opts.tag });
+        if (opts.query !== undefined) {
+          const taggedSet = new Set(tagged);
+          const results = await bridge.searchVault({ query: opts.query, limit });
+          hits = results
+            .filter((result) => taggedSet.has(result.path))
+            .map((result) => ({
+              path: result.path,
+              name: nameOf(result.path),
+              snippet: result.snippet,
+            }));
+        } else {
+          hits = tagged.slice(0, limit).map((path) => ({ path, name: nameOf(path) }));
+        }
+      } else if (opts.query !== undefined) {
         // Ranked lexical search; carry each hit's snippet through to the app.
         const results = await bridge.searchVault({ query: opts.query, limit });
         hits = results.map((result) => ({
           path: result.path,
-          name: result.path.split("/").pop() ?? result.path,
+          name: nameOf(result.path),
           snippet: result.snippet,
         }));
       } else {

--- a/packages/core/src/__tests__/tags.test.ts
+++ b/packages/core/src/__tests__/tags.test.ts
@@ -1,0 +1,137 @@
+import { describe, expect, it } from "vitest";
+
+import { KnowledgeIndex } from "../knowledge/knowledge-index";
+import { scanDoc } from "../knowledge/link-extract";
+import { TagIndex } from "../knowledge/tag-index";
+
+const tagsOf = (source: string): string[] => scanDoc(source).tags;
+
+describe("scanDoc — inline tag extraction", () => {
+  it("pulls `#tag` tokens from prose", () => {
+    expect(tagsOf("A note about #project and #ideas here.\n")).toEqual(["project", "ideas"]);
+  });
+
+  it("requires a letter first — excludes `#123` and fully-numeric hex", () => {
+    expect(tagsOf("issue #123 and #456789 not tags\n")).toEqual([]);
+  });
+
+  it("allows nested `a/b` tags and dashes, not a trailing separator", () => {
+    expect(tagsOf("#area/deep-dive and #foo/ and #bar-\n")).toEqual([
+      "area/deep-dive",
+      "foo",
+      "bar",
+    ]);
+  });
+
+  it("does not match `#` glued to a preceding word char (C#, ##h)", () => {
+    expect(tagsOf("C# rocks and a ##heading marker\n")).toEqual([]);
+  });
+
+  it("excludes tags inside inline code spans and fenced code", () => {
+    const src = "Text `#nope` inline.\n\n```\n#alsonope in a fence\n```\n\nBut #yes counts.\n";
+    expect(tagsOf(src)).toEqual(["yes"]);
+  });
+
+  it("excludes url fragments and link/image labels", () => {
+    const src =
+      "See <https://example.com/x#frag> and [a #label](out.md) and ![alt #nope](p.png), but #real here.\n";
+    expect(tagsOf(src)).toEqual(["real"]);
+  });
+
+  it("finds tags inside emphasis and headings", () => {
+    expect(tagsOf("## Topic #inheading\n\nBody with **#bold** tag.\n")).toEqual([
+      "inheading",
+      "bold",
+    ]);
+  });
+
+  it("keeps unicode letter tags", () => {
+    expect(tagsOf("café notes #café and #日本語\n")).toEqual(["café", "日本語"]);
+  });
+});
+
+describe("scanDoc — frontmatter tags", () => {
+  it("reads the frontmatter `tags` array, then inline tags in order", () => {
+    const src = "---\ntags:\n  - meta\n  - demo\n---\n\n# Note\n\nBody #inline here.\n";
+    expect(tagsOf(src)).toEqual(["meta", "demo", "inline"]);
+  });
+
+  it("tolerates and strips a leading `#` on frontmatter tags", () => {
+    const src = '---\ntags: ["#alpha", beta]\n---\n\nBody\n';
+    expect(tagsOf(src)).toEqual(["alpha", "beta"]);
+  });
+
+  it("ignores a non-array `tags` frontmatter value", () => {
+    expect(tagsOf("---\ntags: single\n---\n\nBody #inline\n")).toEqual(["inline"]);
+  });
+});
+
+describe("TagIndex", () => {
+  it("unifies case-insensitively, keeping the first-seen display case", () => {
+    const index = new TagIndex();
+    index.set("a.md", ["Meta"]);
+    index.set("b.md", ["meta"]);
+    expect(index.all()).toEqual([{ tag: "Meta", count: 2 }]);
+    expect(index.notesWithTag("META")).toEqual(["a.md", "b.md"]);
+  });
+
+  it("dedupes per-doc duplicates (frontmatter + inline of the same tag)", () => {
+    const index = new TagIndex();
+    index.set("a.md", ["meta", "Meta", "meta"]);
+    expect(index.all()).toEqual([{ tag: "meta", count: 1 }]);
+  });
+
+  it("orders by count desc, then alphabetically", () => {
+    const index = new TagIndex();
+    index.set("a.md", ["zebra", "alpha"]);
+    index.set("b.md", ["alpha"]);
+    expect(index.all()).toEqual([
+      { tag: "alpha", count: 2 },
+      { tag: "zebra", count: 1 },
+    ]);
+  });
+
+  it("removes a doc's contribution and drops now-empty tags", () => {
+    const index = new TagIndex();
+    index.set("a.md", ["shared", "onlya"]);
+    index.set("b.md", ["shared"]);
+    index.remove("a.md");
+    expect(index.all()).toEqual([{ tag: "shared", count: 1 }]);
+    expect(index.notesWithTag("onlya")).toEqual([]);
+  });
+
+  it("re-index replaces the prior tag set for a path", () => {
+    const index = new TagIndex();
+    index.set("a.md", ["old"]);
+    index.set("a.md", ["new"]);
+    expect(index.notesWithTag("old")).toEqual([]);
+    expect(index.notesWithTag("new")).toEqual(["a.md"]);
+  });
+});
+
+describe("KnowledgeIndex — tags", () => {
+  it("unions inline and frontmatter tags across docs", () => {
+    const index = new KnowledgeIndex();
+    index.setDoc("a.md", "---\ntags: [meta, demo]\n---\n\n# A\n");
+    index.setDoc("b.md", "# B\n\nInline #meta and #project.\n");
+    expect(index.tags()).toEqual([
+      { tag: "meta", count: 2 },
+      { tag: "demo", count: 1 },
+      { tag: "project", count: 1 },
+    ]);
+    expect(index.notesWithTag("meta")).toEqual(["a.md", "b.md"]);
+    expect(index.notesWithTag("project")).toEqual(["b.md"]);
+  });
+
+  it("drops tags when a doc is removed or becomes a non-doc", () => {
+    const index = new KnowledgeIndex();
+    index.setDoc("a.md", "#gone\n");
+    expect(index.notesWithTag("gone")).toEqual(["a.md"]);
+    index.remove("a.md");
+    expect(index.notesWithTag("gone")).toEqual([]);
+
+    index.setDoc("b.md", "#toother\n");
+    index.setOther("b.md");
+    expect(index.notesWithTag("toother")).toEqual([]);
+  });
+});

--- a/packages/core/src/knowledge/knowledge-index.ts
+++ b/packages/core/src/knowledge/knowledge-index.ts
@@ -17,7 +17,10 @@ import type { ExtractedLink, LinkKind } from "./link-extract";
 import { scanDoc, titleFromPath } from "./link-extract";
 import { buildResolver } from "./link-resolve";
 import { SearchIndex, tokenize } from "./search-index";
+import { TagIndex, type TagCount } from "./tag-index";
 import { basenamePath, extnamePath } from "./vault-path";
+
+export type { TagCount } from "./tag-index";
 
 // ---- Wire types (Bridge channel results) ------------------------------------
 
@@ -100,6 +103,7 @@ export class KnowledgeIndex {
   private readonly docs = new Map<string, DocRecord>();
   private readonly others = new Set<string>();
   private readonly searchIndex = new SearchIndex();
+  private readonly tagIndex = new TagIndex();
   private resolved: ResolvedState | null = null;
 
   /** Index (or re-index) a markdown doc. */
@@ -114,6 +118,7 @@ export class KnowledgeIndex {
       links: scan.links,
     });
     this.searchIndex.set(path, { title, headings: scan.headings, body: content });
+    this.tagIndex.set(path, scan.tags);
     this.resolved = null;
   }
 
@@ -122,6 +127,7 @@ export class KnowledgeIndex {
     if (this.docs.has(path)) {
       this.docs.delete(path);
       this.searchIndex.remove(path);
+      this.tagIndex.remove(path);
     }
     this.others.add(path);
     this.resolved = null;
@@ -130,7 +136,10 @@ export class KnowledgeIndex {
   /** Drop a file (doc or other) from the index. */
   remove(path: string): void {
     const wasDoc = this.docs.delete(path);
-    if (wasDoc) this.searchIndex.remove(path);
+    if (wasDoc) {
+      this.searchIndex.remove(path);
+      this.tagIndex.remove(path);
+    }
     const wasOther = this.others.delete(path);
     if (wasDoc || wasOther) this.resolved = null;
   }
@@ -139,6 +148,7 @@ export class KnowledgeIndex {
     this.docs.clear();
     this.others.clear();
     this.searchIndex.clear();
+    this.tagIndex.clear();
     this.resolved = null;
   }
 
@@ -240,6 +250,17 @@ export class KnowledgeIndex {
       snippet: this.searchSnippet(path, tokens),
       score,
     }));
+  }
+
+  /** Every tag in the vault with its note count (most-used first). Fed by both
+   * inline `#tags` and the frontmatter `tags` property, unified case-insensitively. */
+  tags(): TagCount[] {
+    return this.tagIndex.all();
+  }
+
+  /** Vault paths of notes carrying `tag` (case-insensitive), sorted. */
+  notesWithTag(tag: string): string[] {
+    return this.tagIndex.notesWithTag(tag);
   }
 
   // ---- Internals --------------------------------------------------------------

--- a/packages/core/src/knowledge/link-extract.ts
+++ b/packages/core/src/knowledge/link-extract.ts
@@ -23,6 +23,7 @@ import remarkGfm from "remark-gfm";
 import remarkParse from "remark-parse";
 import { unified } from "unified";
 
+import { parseProperties } from "../markdown/frontmatter";
 import { parseWikiBodyRange, remarkWikiLink } from "../markdown/remark-wiki-link";
 import { basenamePath, extnamePath } from "./vault-path";
 
@@ -59,6 +60,10 @@ export type DocScan = {
   /** Every heading's text, any depth, in document order. */
   headings: string[];
   links: ExtractedLink[];
+  /** The doc's tags, display case, deduped — frontmatter `tags` first (in
+   * declaration order), then inline `#tag` tokens in document order. Unified
+   * case-insensitively downstream by TagIndex. */
+  tags: string[];
 };
 
 const processor = unified()
@@ -67,10 +72,10 @@ const processor = unified()
   .use(remarkGfm)
   .use(remarkWikiLink);
 
-/** Parse a doc once and pull out title, headings, and note links. */
+/** Parse a doc once and pull out title, headings, note links, and tags. */
 export function scanDoc(source: string): DocScan {
   const tree = processor.parse(source);
-  const scan: DocScan = { title: null, headings: [], links: [] };
+  const scan: DocScan = { title: null, headings: [], links: [], tags: extractTags(tree) };
   walk(tree, (node) => {
     switch (node.type) {
       case "heading": {
@@ -132,6 +137,64 @@ function textOf(node: Nodes): string {
   if (node.type === "text" || node.type === "inlineCode") return node.value;
   if ("children" in node) return node.children.map(textOf).join("");
   return "";
+}
+
+// ---- Tags -------------------------------------------------------------------
+
+// An inline `#tag`: `#` at a word boundary (not glued to a preceding word char,
+// `#`, or `/` — so `C#`, `##h`, and url fragments don't count) followed by a
+// LETTER-first name (excludes `#123` and fully-numeric hex like `#123456`).
+// Nested `a/b/c` and dashes are allowed; a trailing `/` or `-` is not captured.
+// Unicode letters/numbers count — the pipeline already runs with the `u` flag
+// (search-index tokenizer), so it costs nothing here.
+const INLINE_TAG_RE = /(?<![\p{L}\p{N}_/#])#(\p{L}[\p{L}\p{N}_-]*(?:\/[\p{L}\p{N}_-]+)*)/gu;
+
+/** The doc's tags: frontmatter `tags` (declaration order) then inline `#tag`
+ * tokens (document order). Inline extraction is PARSE-AWARE — it scans only
+ * mdast `text` nodes, so code spans/fences (their own `inlineCode`/`code`
+ * nodes), link/image URLs (a node's `url`, never text), and link/image LABELS
+ * (their subtrees are suppressed) are all naturally excluded, no byte regex. */
+function extractTags(tree: Nodes): string[] {
+  const tags = [...frontmatterTags(tree)];
+  collectInlineTags(tree, tags, false);
+  return tags;
+}
+
+/** Parse the leading `yaml` node's `tags` property (017's typed tags: a string
+ * array). A leading `#` on a frontmatter tag is tolerated and stripped. */
+function frontmatterTags(tree: Nodes): string[] {
+  if (!("children" in tree)) return [];
+  const yaml = tree.children.find((child) => child.type === "yaml");
+  if (!yaml || yaml.type !== "yaml") return [];
+  const parsed = parseProperties(yaml.value);
+  if (parsed.kind !== "valid") return [];
+  const prop = parsed.properties.find((p) => p.key === "tags" && p.type === "tags");
+  if (!prop || prop.type !== "tags") return [];
+  return prop.value.map((tag) => tag.replace(/^#/, "").trim()).filter((tag) => tag !== "");
+}
+
+/** Walk `text` nodes for `#tag` tokens; suppress link/image subtrees so a
+ * `[label #not-a-tag](url)` label is never mistaken for a tag. */
+function collectInlineTags(node: Nodes, out: string[], suppressed: boolean): void {
+  if (node.type === "text") {
+    if (suppressed) return;
+    for (const match of node.value.matchAll(INLINE_TAG_RE)) {
+      // A trailing dash is captured by the name class but reads as punctuation,
+      // not part of the tag (`#bar-` → `bar`); a trailing `/` never is.
+      const tag = match[1]?.replace(/-+$/, "");
+      if (tag !== undefined && tag !== "") out.push(tag);
+    }
+    return;
+  }
+  const nextSuppressed =
+    suppressed ||
+    node.type === "link" ||
+    node.type === "linkReference" ||
+    node.type === "image" ||
+    node.type === "imageReference";
+  if ("children" in node) {
+    for (const child of node.children) collectInlineTags(child, out, nextSuppressed);
+  }
 }
 
 type NodePosition = { span: Span; line: number };

--- a/packages/core/src/knowledge/tag-index.ts
+++ b/packages/core/src/knowledge/tag-index.ts
@@ -1,0 +1,80 @@
+// ---------------------------------------------------------------------------
+// Tag index: tag → the notes carrying it, fed by BOTH inline `#tag` tokens and
+// the frontmatter `tags` property (the per-doc union is computed at extraction
+// time — see tagsOf in link-extract.ts). Tags unify case-insensitively: the
+// lowercased tag is the identity, and the display case of the FIRST occurrence
+// among the currently-indexed docs is what surfaces.
+//
+// Incremental like SearchIndex: set/remove touch one doc's tag set. Derived and
+// per-device — rebuilt locally, NEVER synced (the knowledge-index law).
+// ---------------------------------------------------------------------------
+
+/** A tag with the number of DISTINCT notes carrying it. `tag` is display case. */
+export type TagCount = { tag: string; count: number };
+
+type TagEntry = { display: string; paths: Set<string> };
+
+export class TagIndex {
+  /** lowercased tag → { display case, notes carrying it }. */
+  private readonly tags = new Map<string, TagEntry>();
+  /** path → the lowercased tag keys it contributed (the incremental diff basis). */
+  private readonly docTags = new Map<string, string[]>();
+
+  /** Index (or re-index) a doc's tags. Per-doc duplicates (`#Meta` + `#meta`,
+   * or a frontmatter tag that also appears inline) collapse to one, keeping the
+   * first-seen display case. */
+  set(path: string, tags: readonly string[]): void {
+    this.remove(path);
+    const keys: string[] = [];
+    const seen = new Set<string>();
+    for (const raw of tags) {
+      const display = raw.trim();
+      if (display === "") continue;
+      const key = display.toLowerCase();
+      if (seen.has(key)) continue;
+      seen.add(key);
+      keys.push(key);
+      let entry = this.tags.get(key);
+      if (!entry) {
+        entry = { display, paths: new Set() };
+        this.tags.set(key, entry);
+      }
+      entry.paths.add(path);
+    }
+    if (keys.length > 0) this.docTags.set(path, keys);
+  }
+
+  /** Drop a doc's tag contributions. A tag no note carries anymore vanishes. */
+  remove(path: string): void {
+    const keys = this.docTags.get(path);
+    if (!keys) return;
+    for (const key of keys) {
+      const entry = this.tags.get(key);
+      if (!entry) continue;
+      entry.paths.delete(path);
+      if (entry.paths.size === 0) this.tags.delete(key);
+    }
+    this.docTags.delete(path);
+  }
+
+  clear(): void {
+    this.tags.clear();
+    this.docTags.clear();
+  }
+
+  /** Every tag with its note count, most-used first (ties broken alphabetically,
+   * case-insensitively) — the palette's tag list ordering. */
+  all(): TagCount[] {
+    return [...this.tags.values()]
+      .map((entry): TagCount => ({ tag: entry.display, count: entry.paths.size }))
+      .toSorted(
+        (a, b) => b.count - a.count || (a.tag.toLowerCase() < b.tag.toLowerCase() ? -1 : 1),
+      );
+  }
+
+  /** The notes carrying `tag` (case-insensitive), by path. Empty when unknown. */
+  notesWithTag(tag: string): string[] {
+    const entry = this.tags.get(tag.trim().toLowerCase());
+    return entry ? [...entry.paths].toSorted() : [];
+  }
+}

--- a/packages/features/resources/agent/AGENTS.md
+++ b/packages/features/resources/agent/AGENTS.md
@@ -66,7 +66,7 @@ When notes aren't the right shape — a table, kanban, dashboard, tracker, books
 **The vault API** (`window.inteligir.files`, all async/Promise-based):
 
 - `list()` → `[{ path, name }]` — every markdown note in the vault.
-- `list({ query?, withProperties?, limit? })` → ranked hits — `query` runs a full-text search (each hit gains a `snippet`); `withProperties: true` attaches each hit's parsed frontmatter as `properties`; `limit` caps results (default 50, max 200). Use this for "notes tagged X sorted by Y" instead of `list()` + N reads.
+- `list({ query?, tag?, withProperties?, limit? })` → ranked hits — `query` runs a full-text search (each hit gains a `snippet`); `tag` restricts to notes carrying that tag (inline `#tag` or frontmatter `tags`, case-insensitive; combine with `query` to search within the tag); `withProperties: true` attaches each hit's parsed frontmatter as `properties`; `limit` caps results (default 50, max 200). Use this for "notes tagged X sorted by Y" instead of `list()` + N reads.
 - `read(path)` → `{ path, body, properties }` — `body` is the markdown after frontmatter; `properties` is the parsed frontmatter as an object.
 - `open(path)` — open a note in the editor.
 - `create(path, { body?, properties? })` — create a new note (errors if it exists).

--- a/packages/features/src/ipc-registry.ts
+++ b/packages/features/src/ipc-registry.ts
@@ -52,6 +52,7 @@ import type {
   ForwardLinkEntry,
   LinkGraph,
   SearchResult,
+  TagCount,
   WikiTarget,
 } from "@repo/core/knowledge/knowledge-index";
 import {
@@ -223,6 +224,8 @@ const KnowledgeSearchSchema = Type.Object(
   },
   { additionalProperties: false },
 );
+
+const KnowledgeTagSchema = Type.Object({ tag: Type.String() }, { additionalProperties: false });
 
 // Float32Array / ArrayBuffer / ArrayBufferView don't have a TypeBox primitive;
 // approximate with Type.Any plus a runtime instanceof guard at the handler.
@@ -415,6 +418,14 @@ export const IPC = {
    * then attachments (flagged `type: "asset"` so the picker groups them and
    * inserts `![[embeds]]`). */
   listWikiTargets: invokeVoid<WikiTarget[]>("knowledge:wiki-targets"),
+  /** Every tag in the vault with its note count (inline `#tags` ∪ frontmatter
+   * `tags`, unified case-insensitively) — the palette's `#` tag list. */
+  listTags: invokeVoid<TagCount[]>("knowledge:tags"),
+  /** Vault paths of the notes carrying a tag (case-insensitive). */
+  getNotesByTag: invoke<typeof KnowledgeTagSchema, string[]>(
+    "knowledge:notes-by-tag",
+    KnowledgeTagSchema,
+  ),
   /** Fired after every index refresh (revision is monotonic) so backlink
    * panes / graph views re-query. */
   onKnowledgeUpdated: event<{ revision: number }>("knowledge:updated"),

--- a/packages/features/src/server/__tests__/extension.test.ts
+++ b/packages/features/src/server/__tests__/extension.test.ts
@@ -27,6 +27,7 @@ function fakePorts(): AgentPorts {
     knowledge: {
       search: () => [],
       backlinks: () => [],
+      notesWithTag: () => [],
     },
   };
 }

--- a/packages/features/src/server/__tests__/knowledge-extension.test.ts
+++ b/packages/features/src/server/__tests__/knowledge-extension.test.ts
@@ -51,9 +51,11 @@ function backlink(sourcePath: string, line: number): BacklinkEntry {
   return { sourcePath, line, snippet: "", kind: "wiki", embed: false };
 }
 
+const emptyPort: KnowledgePort = { search: () => [], backlinks: () => [], notesWithTag: () => [] };
+
 describe("knowledge extension tools", () => {
   it("registers search_vault and get_backlinks with valid schemas", () => {
-    const tools = capture({ search: () => [], backlinks: () => [] });
+    const tools = capture(emptyPort);
     expect([...tools.keys()].toSorted()).toEqual(["get_backlinks", "search_vault"]);
     for (const [, tool] of tools) {
       expect(() => validateToolParametersSchema(tool, "knowledge")).not.toThrow();
@@ -62,20 +64,20 @@ describe("knowledge extension tools", () => {
 
   it("search_vault formats hits as 'path — snippet', one per line", async () => {
     const search = vi.fn(() => [searchResult("a.md", "alpha"), searchResult("b.md", "beta")]);
-    const tools = capture({ search, backlinks: () => [] });
+    const tools = capture({ ...emptyPort, search });
     const result = await tool(tools, "search_vault").execute("id", { query: "x" });
     expect(text(result)).toBe("a.md — alpha\nb.md — beta");
   });
 
   it("search_vault returns the No matches. sentinel on empty results", async () => {
-    const tools = capture({ search: () => [], backlinks: () => [] });
+    const tools = capture(emptyPort);
     const result = await tool(tools, "search_vault").execute("id", { query: "nope" });
     expect(text(result)).toBe("No matches.");
   });
 
   it("search_vault applies the default limit and hard-caps at 50", async () => {
     const search = vi.fn(() => []);
-    const tools = capture({ search, backlinks: () => [] });
+    const tools = capture({ ...emptyPort, search });
     const searchTool = tool(tools, "search_vault");
     await searchTool.execute("id", { query: "x" });
     expect(search).toHaveBeenLastCalledWith("x", 20);
@@ -85,15 +87,38 @@ describe("knowledge extension tools", () => {
     expect(search).toHaveBeenLastCalledWith("x", 3);
   });
 
+  it("search_vault with tag alone lists the tagged notes (sorted)", async () => {
+    const notesWithTag = vi.fn(() => ["b.md", "a.md"]);
+    const tools = capture({ ...emptyPort, notesWithTag });
+    const result = await tool(tools, "search_vault").execute("id", { tag: "meta" });
+    expect(notesWithTag).toHaveBeenCalledWith("meta");
+    expect(text(result)).toBe("a.md\nb.md");
+  });
+
+  it("search_vault with tag + query narrows within the tagged set", async () => {
+    const search = vi.fn(() => [searchResult("a.md", "alpha"), searchResult("c.md", "gamma")]);
+    const notesWithTag = vi.fn(() => ["a.md", "b.md"]);
+    const tools = capture({ ...emptyPort, search, notesWithTag });
+    const result = await tool(tools, "search_vault").execute("id", { tag: "meta", query: "x" });
+    // c.md matched the query but isn't tagged, so it drops.
+    expect(text(result)).toBe("a.md — alpha");
+  });
+
+  it("search_vault with an unknown tag returns No matches.", async () => {
+    const tools = capture(emptyPort);
+    const result = await tool(tools, "search_vault").execute("id", { tag: "nope" });
+    expect(text(result)).toBe("No matches.");
+  });
+
   it("get_backlinks lists unique source paths, one per line", async () => {
     const backlinks = vi.fn(() => [backlink("a.md", 1), backlink("a.md", 5), backlink("b.md", 2)]);
-    const tools = capture({ search: () => [], backlinks });
+    const tools = capture({ ...emptyPort, backlinks });
     const result = await tool(tools, "get_backlinks").execute("id", { path: "t.md" });
     expect(text(result)).toBe("a.md\nb.md");
   });
 
   it("get_backlinks returns the No backlinks. sentinel on empty results", async () => {
-    const tools = capture({ search: () => [], backlinks: () => [] });
+    const tools = capture(emptyPort);
     const result = await tool(tools, "get_backlinks").execute("id", { path: "t.md" });
     expect(text(result)).toBe("No backlinks.");
   });

--- a/packages/features/src/server/__tests__/knowledge-manager.test.ts
+++ b/packages/features/src/server/__tests__/knowledge-manager.test.ts
@@ -136,6 +136,28 @@ describe("KnowledgeManager", () => {
     expect(results.map((r) => r.path)).toEqual(["alpha.md", "beta.md"]);
   });
 
+  it("indexes tags from inline `#tags` and the frontmatter `tags` property", () => {
+    vault.writeText("a.md", "---\ntags: [meta, demo]\n---\n\n# A\n");
+    vault.writeText("b.md", "# B\n\nInline #meta and #project here.\n");
+    manager.refresh();
+    expect(manager.tags()).toEqual([
+      { tag: "meta", count: 2 },
+      { tag: "demo", count: 1 },
+      { tag: "project", count: 1 },
+    ]);
+    expect(manager.notesWithTag("META")).toEqual(["a.md", "b.md"]);
+    expect(manager.notesWithTag("project")).toEqual(["b.md"]);
+  });
+
+  it("drops a note's tags when it is deleted", () => {
+    vault.writeText("a.md", "# A\n\n#solo tag.\n");
+    manager.refresh();
+    expect(manager.notesWithTag("solo")).toEqual(["a.md"]);
+    vault.delete("a.md");
+    manager.refresh();
+    expect(manager.notesWithTag("solo")).toEqual([]);
+  });
+
   it("coalesces scheduleRefresh bursts through the debounce", () => {
     vi.useFakeTimers();
     try {

--- a/packages/features/src/server/agent/extension.ts
+++ b/packages/features/src/server/agent/extension.ts
@@ -45,6 +45,8 @@ export type ExecutorPort = {
 export type KnowledgePort = {
   search(query: string, limit?: number): SearchResult[];
   backlinks(path: string): BacklinkEntry[];
+  /** Vault paths of notes carrying a tag (case-insensitive). */
+  notesWithTag(tag: string): string[];
 };
 
 export type AgentPorts = {

--- a/packages/features/src/server/agent/knowledge/extension.ts
+++ b/packages/features/src/server/agent/knowledge/extension.ts
@@ -21,7 +21,18 @@ const SEARCH_DEFAULT_LIMIT = 20;
 const SEARCH_MAX_LIMIT = 50;
 
 const SearchVaultSchema = Type.Object({
-  query: Type.String({ description: "Search terms to match against note titles and body text." }),
+  query: Type.Optional(
+    Type.String({
+      description:
+        "Search terms to match against note titles and body text. Optional when `tag` is set (then it lists every note with that tag).",
+    }),
+  ),
+  tag: Type.Optional(
+    Type.String({
+      description:
+        "Restrict results to notes carrying this tag (case-insensitive; matches inline `#tag` and frontmatter `tags`). Combine with `query` to search within the tag.",
+    }),
+  ),
   limit: Type.Optional(
     Type.Number({
       description: `Max hits to return (default ${SEARCH_DEFAULT_LIMIT}, hard-capped at ${SEARCH_MAX_LIMIT}).`,
@@ -45,11 +56,27 @@ const knowledgeExtension: PiExtensionBundle = {
         label: "search_vault",
         description:
           "Full-text search over the user's vault (lexical, ranked). Returns matching " +
-          "note paths with snippets. Prefer this over grep for finding notes by topic.",
+          "note paths with snippets. Optionally filter by `tag` (inline `#tag` or " +
+          "frontmatter `tags`). Prefer this over grep for finding notes by topic.",
         parameters: SearchVaultSchema,
         execute: async (_toolCallId, params: Static<typeof SearchVaultSchema>) => {
           const limit = Math.min(params.limit ?? SEARCH_DEFAULT_LIMIT, SEARCH_MAX_LIMIT);
-          const hits = ports.knowledge.search(params.query, limit);
+          const query = params.query?.trim();
+          if (params.tag !== undefined) {
+            // Tag filter first, then the query narrows WITHIN the tagged set.
+            const tagged = new Set(ports.knowledge.notesWithTag(params.tag));
+            if (tagged.size === 0) return textResult("No matches.");
+            if (query === undefined || query === "") {
+              return textResult([...tagged].toSorted().slice(0, limit).join("\n"));
+            }
+            const hits = ports.knowledge.search(query, limit).filter((hit) => tagged.has(hit.path));
+            if (hits.length === 0) return textResult("No matches.");
+            return textResult(hits.map((hit) => `${hit.path} — ${hit.snippet}`).join("\n"));
+          }
+          if (query === undefined || query === "") {
+            return textResult("Provide a query or a tag to search.");
+          }
+          const hits = ports.knowledge.search(query, limit);
           if (hits.length === 0) return textResult("No matches.");
           return textResult(hits.map((hit) => `${hit.path} — ${hit.snippet}`).join("\n"));
         },

--- a/packages/features/src/server/handlers/knowledge-handlers.ts
+++ b/packages/features/src/server/handlers/knowledge-handlers.ts
@@ -7,4 +7,6 @@ export function registerKnowledgeHandlers(handle: HandlerRegistrar): void {
   handle("getLinkGraph", () => getKnowledgeManager().graph());
   handle("searchVault", ({ query, limit }) => getKnowledgeManager().search(query, limit));
   handle("listWikiTargets", () => getKnowledgeManager().wikiTargets());
+  handle("listTags", () => getKnowledgeManager().tags());
+  handle("getNotesByTag", ({ tag }) => getKnowledgeManager().notesWithTag(tag));
 }

--- a/packages/features/src/server/knowledge/knowledge-manager.ts
+++ b/packages/features/src/server/knowledge/knowledge-manager.ts
@@ -21,6 +21,7 @@ import type {
   ForwardLinkEntry,
   LinkGraph,
   SearchResult,
+  TagCount,
   WikiTarget,
 } from "@repo/core/knowledge/knowledge-index";
 
@@ -73,6 +74,16 @@ export class KnowledgeManager {
   wikiTargets(): WikiTarget[] {
     this.ensureBuilt();
     return this.index.wikiTargets();
+  }
+
+  tags(): TagCount[] {
+    this.ensureBuilt();
+    return this.index.tags();
+  }
+
+  notesWithTag(tag: string): string[] {
+    this.ensureBuilt();
+    return this.index.notesWithTag(tag);
   }
 
   // ---- Refresh ----------------------------------------------------------------

--- a/packages/features/src/server/lib/agent-lifecycle.ts
+++ b/packages/features/src/server/lib/agent-lifecycle.ts
@@ -62,6 +62,7 @@ export function getAgentPorts(): AgentPorts {
     knowledge: {
       search: (query, limit) => getKnowledgeManager().search(query, limit),
       backlinks: (path) => getKnowledgeManager().backlinks(path),
+      notesWithTag: (tag) => getKnowledgeManager().notesWithTag(tag),
     },
   };
 }


### PR DESCRIPTION
Plan 021, the final backlog item. TagIndex in core (case-unified, incremental, never synced) fed by the existing per-doc parse seam — inline `#tags` come from mdast text nodes so code spans/fences/links are structurally excluded (no regex-over-bytes), unioned with the typed frontmatter `tags` property (017). Unicode-aware, letter-first (`#123`/`C#` excluded).

Surfaces: `#` in the command palette lists tags with counts → phased note browser; `search_vault` gains an optional `tag` filter (query now optional); broker `list({tag})` append-only per ADR-0002. No editor rendering change (chips/panel deferred by plan).

26 new tests across core/features/desktop; 1,005 tests green; full canonical gate green; palette flow harness-verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Implements Plan 021: adds a vault-wide tag index and surfacing. Inline `#tags` and frontmatter `tags` are parsed once and indexed for fast tag browsing and tag-scoped search.

- **New Features**
  - Core (`@repo/core/knowledge`): new `TagIndex` with case-insensitive unification; extracts tags from markdown AST (ignores code/links), supports unicode, nested `a/b`, and dashes; exposed via `KnowledgeIndex.tags()` and `KnowledgeIndex.notesWithTag(tag)`.
  - IPC/Server: added `listTags` and `getNotesByTag` channels; `KnowledgeManager` wires through.
  - Palette: typing `#` lists tags with counts; selecting a tag shows its notes; supports filtering and back navigation.
  - Agent tool: `search_vault` accepts optional `tag`; query is optional when `tag` is set; when both are set, search narrows within the tag.
  - HTML-app broker: `files.list({ tag, query, withProperties, limit })` filters by `tag` first, then applies `query`; docs updated in `AGENTS.md`.

<sup>Written for commit 8045a83dc94cc6f651d98fec615dfecae2243c4f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kyh/inteligir/pull/420?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

