### PR TITLE
fix: remediate verified React Doctor findings

### DIFF
--- a/apps/desktop/src/renderer/ai-elements/prompt-input.tsx
+++ b/apps/desktop/src/renderer/ai-elements/prompt-input.tsx
@@ -279,16 +279,14 @@ export const PromptInput = ({
       };
 
       try {
-        const convertedFiles: FileUIPart[] = [];
-        for (const submittedItem of submittedItems) {
-          const item = filePartWithoutId(submittedItem);
-          if (item.url?.startsWith("blob:")) {
+        const convertedFiles = await Promise.all(
+          submittedItems.map(async (submittedItem): Promise<FileUIPart> => {
+            const item = filePartWithoutId(submittedItem);
+            if (!item.url?.startsWith("blob:")) return item;
             const dataUrl = await convertBlobUrlToDataUrl(item.url);
-            convertedFiles.push(Object.assign({}, item, { url: dataUrl ?? item.url }));
-            continue;
-          }
-          convertedFiles.push(item);
-        }
+            return Object.assign({}, item, { url: dataUrl ?? item.url });
+          }),
+        );
 
         const result = onSubmit({ files: convertedFiles, text }, event);
         if (result instanceof Promise) {

--- a/apps/desktop/src/renderer/components/confirm-dialog.test.tsx
+++ b/apps/desktop/src/renderer/components/confirm-dialog.test.tsx
@@ -1,0 +1,45 @@
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { ConfirmDialogHost, confirm } from "@repo/ui/components/confirm-dialog";
+
+vi.mock("@repo/ui/components/alert-dialog", () => ({
+  AlertDialog: ({ children, open }: { children?: React.ReactNode; open?: boolean }) => (
+    <div data-testid="dialog" data-open={String(open)}>
+      {children}
+    </div>
+  ),
+  AlertDialogContent: ({ children }: { children?: React.ReactNode }) => <div>{children}</div>,
+  AlertDialogDescription: ({ children }: { children?: React.ReactNode }) => <p>{children}</p>,
+  AlertDialogFooter: ({ children }: { children?: React.ReactNode }) => <footer>{children}</footer>,
+  AlertDialogHeader: ({ children }: { children?: React.ReactNode }) => <header>{children}</header>,
+  AlertDialogTitle: ({ children }: { children?: React.ReactNode }) => <h2>{children}</h2>,
+}));
+
+vi.mock("@repo/ui/components/button", () => ({
+  Button: (props: React.ComponentProps<"button">) => <button {...props} />,
+}));
+
+afterEach(cleanup);
+
+describe("ConfirmDialogHost", () => {
+  it("keeps the settled options mounted while the dialog closes", async () => {
+    const result = confirm({
+      title: "Remove note?",
+      body: "This cannot be undone.",
+      cancelLabel: "Keep note",
+      confirmLabel: "Remove note",
+      destructive: true,
+    });
+    render(<ConfirmDialogHost />);
+
+    expect(screen.getByTestId("dialog").dataset.open).toBe("true");
+    fireEvent.click(screen.getByRole("button", { name: "Keep note" }));
+
+    expect(screen.getByTestId("dialog").dataset.open).toBe("false");
+    expect(screen.getByRole("heading", { name: "Remove note?" })).toBeTruthy();
+    expect(screen.getByText("This cannot be undone.")).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Remove note" })).toBeTruthy();
+    await expect(result).resolves.toBe(false);
+  });
+});

--- a/apps/desktop/src/renderer/composer/bottom-composer.tsx
+++ b/apps/desktop/src/renderer/composer/bottom-composer.tsx
@@ -109,6 +109,7 @@ export function BottomComposer() {
               <div className="flex items-center gap-0.5">
                 <button
                   type="button"
+                  aria-label={pinned ? "Unpin response" : "Keep response open"}
                   onClick={togglePinned}
                   title={pinned ? "Unpin" : "Keep open"}
                   className={cn(
@@ -120,6 +121,7 @@ export function BottomComposer() {
                 </button>
                 <button
                   type="button"
+                  aria-label="Close response"
                   onClick={() => {
                     setPinned(false);
                     setRecentlyActive(false);

--- a/apps/desktop/src/renderer/delegation/delegation-dock.tsx
+++ b/apps/desktop/src/renderer/delegation/delegation-dock.tsx
@@ -181,6 +181,7 @@ function DelegationCard({
         ) : (
           <button
             type="button"
+            aria-label="Dismiss delegation"
             onClick={onDismiss}
             title="Dismiss"
             className="rounded p-0.5 text-muted-foreground hover:bg-muted hover:text-foreground"

--- a/apps/desktop/src/renderer/editor/block-draggable.tsx
+++ b/apps/desktop/src/renderer/editor/block-draggable.tsx
@@ -169,6 +169,7 @@ function Draggable(props: PlateElementProps) {
       >
         <button
           type="button"
+          aria-label="Add block below"
           tabIndex={-1}
           onClick={insertBelow}
           title="Add block below"

--- a/apps/desktop/src/renderer/editor/inline-combobox.tsx
+++ b/apps/desktop/src/renderer/editor/inline-combobox.tsx
@@ -110,7 +110,9 @@ function InlineCombobox({
 
   // The latest value, readable from stable callbacks (cancel/commit).
   const valueRef = React.useRef(value);
-  valueRef.current = value;
+  React.useLayoutEffect(() => {
+    valueRef.current = hasValueProp ? valueProp : valueState;
+  }, [hasValueProp, valueProp, valueState]);
 
   // Once a commit or cancel ran for this element instance, every later cause
   // (a deselect effect firing after an Escape, unmount churn) is a no-op —

--- a/apps/desktop/src/renderer/editor/markdown-editor.test.tsx
+++ b/apps/desktop/src/renderer/editor/markdown-editor.test.tsx
@@ -1,0 +1,205 @@
+import { act, cleanup, fireEvent, render } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { MarkdownEditor } from "@renderer/editor/markdown-editor";
+
+const mocks = vi.hoisted(() => ({
+  currentMarkdown: "seed",
+  hasSuggestions: false,
+  settledMarkdown: "settled",
+  editor: {
+    operations: [{ type: "insert_text" }],
+    tf: {
+      setValue: vi.fn((value: Array<{ children: Array<{ text: string }> }>) => {
+        mocks.currentMarkdown = value[0]?.children[0]?.text ?? "";
+      }),
+    },
+  },
+  releaseAiSession: vi.fn(),
+  resolveAllSuggestions: vi.fn(() => {
+    mocks.currentMarkdown = mocks.settledMarkdown;
+    mocks.hasSuggestions = false;
+  }),
+  setReviewing: vi.fn(),
+}));
+
+vi.mock("platejs/react", () => ({
+  Plate: ({ children, onChange }: { children?: React.ReactNode; onChange?: () => void }) => (
+    <div>
+      <button type="button" onClick={onChange}>
+        change
+      </button>
+      {children}
+    </div>
+  ),
+  usePlateEditor: () => mocks.editor,
+}));
+
+vi.mock("@platejs/markdown", () => ({
+  serializeMd: vi.fn(() => mocks.currentMarkdown),
+}));
+
+vi.mock("@renderer/editor/ai/ai-session", () => ({
+  releaseAiSession: mocks.releaseAiSession,
+}));
+
+vi.mock("@renderer/editor/ai/suggestions", () => ({
+  hasTransientSuggestions: () => mocks.hasSuggestions,
+  resolveAllSuggestions: mocks.resolveAllSuggestions,
+}));
+
+vi.mock("@renderer/editor/ai/transient", () => ({
+  hasTransientAiState: () => false,
+}));
+
+vi.mock("@renderer/editor/ai/transient-settle", () => ({
+  registerTransientSettler: vi.fn(() => () => {}),
+}));
+
+vi.mock("@renderer/editor/editor-chrome", () => ({
+  Editor: () => null,
+  EditorContainer: ({ children }: { children?: React.ReactNode }) => <div>{children}</div>,
+}));
+
+vi.mock("@renderer/editor/live-editor", () => ({
+  registerLiveEditor: vi.fn(() => () => {}),
+}));
+
+vi.mock("@renderer/editor/kits/block-placeholder-kit", () => ({
+  WRITE_PLACEHOLDER: "Write something…",
+}));
+
+vi.mock("@renderer/editor/kits/editor-kit", () => ({
+  EDITOR_KIT: [],
+}));
+
+vi.mock("@renderer/editor/markdown/markdown-doc", () => ({
+  MD_STRINGIFY: {},
+  parseMarkdown: (markdown: string) => ({
+    ok: true,
+    value: [{ children: [{ text: markdown }], type: "p" }],
+  }),
+}));
+
+vi.mock("@renderer/editor/toc", () => ({
+  TableOfContents: () => null,
+}));
+
+vi.mock("@renderer/stores/ai-review-store", () => ({
+  useAiReviewStore: {
+    getState: () => ({ setReviewing: mocks.setReviewing }),
+  },
+}));
+
+const DELAY_MS = 150;
+
+function props(overrides?: {
+  onChange?: (markdown: string) => void;
+  onRegisterSerializeFlush?: (flush: () => void) => void;
+  onSettled?: (markdown: string) => void;
+  value?: string;
+}) {
+  const base = {
+    path: "note.md",
+    value: overrides?.value ?? "seed",
+    onChange: overrides?.onChange ?? vi.fn(),
+    onSettled: overrides?.onSettled ?? vi.fn(),
+  };
+  return overrides?.onRegisterSerializeFlush === undefined
+    ? base
+    : { ...base, onRegisterSerializeFlush: overrides.onRegisterSerializeFlush };
+}
+
+describe("MarkdownEditor lifecycle", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.clearAllMocks();
+    mocks.currentMarkdown = "seed";
+    mocks.hasSuggestions = false;
+    mocks.settledMarkdown = "settled";
+    mocks.editor.operations = [{ type: "insert_text" }];
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.useRealTimers();
+  });
+
+  it("drops the normalized seed echo", () => {
+    const onChange = vi.fn();
+    const view = render(<MarkdownEditor {...props({ onChange })} />);
+
+    fireEvent.click(view.getByRole("button", { name: "change" }));
+    act(() => vi.advanceTimersByTime(DELAY_MS));
+
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it("routes a pending debounce to the latest committed callback", () => {
+    const first = vi.fn();
+    const second = vi.fn();
+    const view = render(<MarkdownEditor {...props({ onChange: first })} />);
+    mocks.currentMarkdown = "edited";
+    fireEvent.click(view.getByRole("button", { name: "change" }));
+
+    view.rerender(<MarkdownEditor {...props({ onChange: second })} />);
+    act(() => vi.advanceTimersByTime(DELAY_MS));
+
+    expect(first).not.toHaveBeenCalled();
+    expect(second).toHaveBeenCalledOnce();
+    expect(second).toHaveBeenCalledWith("edited");
+  });
+
+  it("flushes a pending edit before an external reseed", () => {
+    const onChange = vi.fn();
+    const view = render(<MarkdownEditor {...props({ onChange })} />);
+    mocks.currentMarkdown = "edited";
+    fireEvent.click(view.getByRole("button", { name: "change" }));
+
+    view.rerender(<MarkdownEditor {...props({ onChange, value: "external" })} />);
+
+    expect(onChange).toHaveBeenCalledOnce();
+    expect(onChange).toHaveBeenCalledWith("edited");
+    expect(mocks.currentMarkdown).toBe("external");
+    act(() => vi.advanceTimersByTime(DELAY_MS));
+    expect(onChange).toHaveBeenCalledOnce();
+  });
+
+  it("registers a synchronous serialize flush", () => {
+    const onChange = vi.fn();
+    let flush: (() => void) | undefined;
+    const register = vi.fn((next: () => void) => {
+      flush = next;
+    });
+    const view = render(
+      <MarkdownEditor {...props({ onChange, onRegisterSerializeFlush: register })} />,
+    );
+    mocks.currentMarkdown = "edited";
+    fireEvent.click(view.getByRole("button", { name: "change" }));
+
+    expect(register).toHaveBeenCalledOnce();
+    if (flush === undefined) throw new Error("serialize flush was not registered");
+    flush();
+
+    expect(onChange).toHaveBeenCalledOnce();
+    expect(onChange).toHaveBeenCalledWith("edited");
+    act(() => vi.advanceTimersByTime(DELAY_MS));
+    expect(onChange).toHaveBeenCalledOnce();
+  });
+
+  it("settles through the latest committed teardown callback once", () => {
+    const first = vi.fn();
+    const second = vi.fn();
+    const view = render(<MarkdownEditor {...props({ onSettled: first })} />);
+    view.rerender(<MarkdownEditor {...props({ onSettled: second })} />);
+    mocks.hasSuggestions = true;
+
+    view.unmount();
+
+    expect(mocks.resolveAllSuggestions).toHaveBeenCalledOnce();
+    expect(first).not.toHaveBeenCalled();
+    expect(second).toHaveBeenCalledOnce();
+    expect(second).toHaveBeenCalledWith("settled");
+    expect(mocks.releaseAiSession).toHaveBeenCalledOnce();
+  });
+});

--- a/apps/desktop/src/renderer/editor/markdown-editor.tsx
+++ b/apps/desktop/src/renderer/editor/markdown-editor.tsx
@@ -9,7 +9,7 @@
 // the seed/echo-dedupe lifecycle, the transient-AI settle seam, and the Plate
 // surface.
 
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useEffectEvent, useLayoutEffect, useRef, useState } from "react";
 import type { Value } from "platejs";
 import { Plate, usePlateEditor } from "platejs/react";
 import { serializeMd } from "@platejs/markdown";
@@ -84,9 +84,10 @@ export function MarkdownEditor({
   // drop that echo instead of treating it as a user edit (which would autosave
   // a normalized rewrite over the agent's/file's content). Initialized to the
   // mount value's normalized form so the first-render onChange is dropped too.
-  const seeded = useRef<string | null>(null);
-  if (seeded.current === null)
-    seeded.current = serializeMd(editor, { remarkStringifyOptions: MD_STRINGIFY });
+  const [initialSeed] = useState(() =>
+    serializeMd(editor, { remarkStringifyOptions: MD_STRINGIFY }),
+  );
+  const seeded = useRef<string | null>(initialSeed);
 
   // ---- Deferred whole-document serialize -----------------------------------
   // The actual serialize → echo-dedupe → emit, run behind the scheduler rather
@@ -94,7 +95,6 @@ export function MarkdownEditor({
   // live refs (editor is stable; onChange is reffed) so the scheduler holds one
   // stable closure for the editor's lifetime.
   const onChangeRef = useRef(onChange);
-  onChangeRef.current = onChange;
   const doSerialize = useCallback(() => {
     // The transient-AI gate re-checked at FIRE time: the synchronous onChange
     // gate ran at schedule time, but an AI stream/suggestion session can start
@@ -112,7 +112,10 @@ export function MarkdownEditor({
     onChangeRef.current(md);
   }, [editor]);
   const doSerializeRef = useRef(doSerialize);
-  doSerializeRef.current = doSerialize;
+  useLayoutEffect(() => {
+    onChangeRef.current = onChange;
+    doSerializeRef.current = doSerialize;
+  }, [onChange, doSerialize]);
   // One scheduler for the editor's lifetime; the closure re-reads the ref so it
   // never goes stale even though doSerialize's identity is already stable.
   const [scheduler] = useState(() =>
@@ -137,10 +140,11 @@ export function MarkdownEditor({
   // Register the synchronous flush with the owner (via the note runtime's
   // pre-flush hook) once — save/rename/close run it before flushing so a
   // keystroke still in the serialize debounce lands first.
-  const onRegisterRef = useRef(onRegisterSerializeFlush);
-  onRegisterRef.current = onRegisterSerializeFlush;
+  const registerSerializeFlush = useEffectEvent((flush: () => void) => {
+    onRegisterSerializeFlush?.(flush);
+  });
   useEffect(() => {
-    onRegisterRef.current?.(() => scheduler.flush());
+    registerSerializeFlush(() => scheduler.flush());
   }, [scheduler]);
 
   // Unmount (note switch without a flush, raw-mode flip, surface change): flush
@@ -184,12 +188,11 @@ export function MarkdownEditor({
   // change): settle and hand the bytes to the owner for path-routed
   // persistence, and release the AI session — with one mounted editor this
   // teardown is the only thing that cancels an in-flight generation.
-  const onSettledRef = useRef(onSettled);
-  onSettledRef.current = onSettled;
+  const notifySettled = useEffectEvent(onSettled);
   useEffect(
     () => () => {
       const md = settleSuggestions();
-      if (md !== null) onSettledRef.current(md);
+      if (md !== null) notifySettled(md);
       releaseAiSession();
       useAiReviewStore.getState().setReviewing(path, false);
     },

--- a/apps/desktop/src/renderer/editor/nodes/equation-node.tsx
+++ b/apps/desktop/src/renderer/editor/nodes/equation-node.tsx
@@ -40,8 +40,8 @@ function EquationEditor({
 }) {
   const editor = useEditorRef();
   const element = useElement();
-  const initial = useRef(tex(element));
-  const [value, setValue] = useState(initial.current);
+  const [initial] = useState(() => tex(element));
+  const [value, setValue] = useState(initial);
   const inputRef = useRef<HTMLTextAreaElement | null>(null);
 
   useEffect(() => {
@@ -57,7 +57,7 @@ function EquationEditor({
 
   const dismiss = () => {
     const at = editor.api.findPath(element);
-    if (at) editor.tf.setNodes({ texExpression: initial.current }, { at });
+    if (at) editor.tf.setNodes({ texExpression: initial }, { at });
     onClose();
   };
 

--- a/apps/desktop/src/renderer/editor/todo-delegation.tsx
+++ b/apps/desktop/src/renderer/editor/todo-delegation.tsx
@@ -155,7 +155,13 @@ function StatusBadge({
         <span className="flex items-center gap-1 rounded-full bg-muted px-2 py-0.5 text-[10px] text-muted-foreground">
           <Clock3Icon className="size-3" />
           Queued
-          <button type="button" onClick={onCancel} title="Cancel" className="hover:text-foreground">
+          <button
+            type="button"
+            aria-label="Cancel delegation"
+            onClick={onCancel}
+            title="Cancel"
+            className="hover:text-foreground"
+          >
             <XIcon className="size-3" />
           </button>
         </span>
@@ -187,6 +193,7 @@ function StatusBadge({
           Failed
           <button
             type="button"
+            aria-label="Retry delegation"
             onClick={onRetry}
             title="Retry delegation"
             className="hover:text-foreground"

--- a/apps/desktop/src/renderer/settings/extensions/lib.ts
+++ b/apps/desktop/src/renderer/settings/extensions/lib.ts
@@ -1,6 +1,6 @@
 // Shared helpers for the Extensions panel's per-section components.
 
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useLayoutEffect, useRef, useState } from "react";
 
 import { getBridge } from "@renderer/lib/bridge";
 import type { OAuthStartInput } from "@repo/features/executor";
@@ -86,9 +86,11 @@ export function useBridgeResource<T>(
   // failed" (so they can show a retry instead of a stuck spinner).
   const [error, setError] = useState<string | null>(null);
   const loadRef = useRef(load);
-  loadRef.current = load;
   const onErrorRef = useRef(onError);
-  onErrorRef.current = onError;
+  useLayoutEffect(() => {
+    loadRef.current = load;
+    onErrorRef.current = onError;
+  }, [load, onError]);
 
   const refresh = useCallback(() => {
     const bridge = getBridge();

--- a/apps/desktop/src/renderer/settings/sections/editor-ai-section.tsx
+++ b/apps/desktop/src/renderer/settings/sections/editor-ai-section.tsx
@@ -39,10 +39,13 @@ export function EditorAiSection() {
         </p>
         {enabled && models.length > 0 && (
           <div className="flex items-center justify-between gap-2 px-3 pb-2">
-            <span className="text-xs text-foreground">Completion model</span>
+            <label htmlFor="editor-ai-completion-model" className="text-xs text-foreground">
+              Completion model
+            </label>
             {/* Native select: a portaled Base UI menu popup inside the
                 settings Dialog reads as an outside press and dismisses it. */}
             <select
+              id="editor-ai-completion-model"
               value={effectiveId ?? ""}
               onChange={(e) => void setModel(e.target.value)}
               className="h-6 max-w-[55%] rounded-md bg-card px-1.5 text-[10px] font-medium text-muted-foreground shadow-surface-2 outline-none transition-colors hover:text-foreground"

--- a/apps/desktop/src/renderer/workspace/graph-view.tsx
+++ b/apps/desktop/src/renderer/workspace/graph-view.tsx
@@ -10,7 +10,7 @@
 // highlight ring. Data refreshes on onKnowledgeUpdated, preserving layout
 // positions by node id.
 
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useLayoutEffect, useRef, useState } from "react";
 import {
   forceCenter,
   forceCollide,
@@ -117,7 +117,6 @@ export default function GraphView() {
   const transformRef = useRef<Transform>({ x: 0, y: 0, k: 1 });
   const hoveredRef = useRef<SimNode | null>(null);
   const activePathRef = useRef<string | null>(openPath);
-  activePathRef.current = openPath;
   const frameRef = useRef<number | null>(null);
 
   const draw = useCallback(() => {
@@ -287,7 +286,8 @@ export default function GraphView() {
   }, [scheduleDraw]);
 
   // Redraw on theme flips (colors are read at draw time) and active-note moves.
-  useEffect(() => {
+  useLayoutEffect(() => {
+    activePathRef.current = openPath;
     scheduleDraw();
   }, [scheduleDraw, resolvedTheme, openPath]);
 

--- a/apps/desktop/src/renderer/workspace/vault-context.tsx
+++ b/apps/desktop/src/renderer/workspace/vault-context.tsx
@@ -213,20 +213,21 @@ export function VaultProvider({ children }: { children: ReactNode }) {
     },
     [applyOpenPath, disposeRuntime],
   );
-  const dropNoteRef = useRef(dropNote);
-  dropNoteRef.current = dropNote;
 
   /** Create the runtime for a note and start loading its file. Any previous
    * runtime must already be disposed (openFile owns that ordering). */
-  const ensureRuntime = useCallback((path: string): NoteRuntime => {
-    const existing = runtimeRef.current;
-    if (existing?.path === path) return existing;
-    const runtime = createNoteRuntime(path, rootRef.current, VAULT_IO, {
-      onVanished: (p) => dropNoteRef.current(p),
-    });
-    runtimeRef.current = runtime;
-    return runtime;
-  }, []);
+  const ensureRuntime = useCallback(
+    (path: string): NoteRuntime => {
+      const existing = runtimeRef.current;
+      if (existing?.path === path) return existing;
+      const runtime = createNoteRuntime(path, rootRef.current, VAULT_IO, {
+        onVanished: dropNote,
+      });
+      runtimeRef.current = runtime;
+      return runtime;
+    },
+    [dropNote],
+  );
 
   /** Flush the open note's pending edits (clearing the debounce). True when
    * clean. A pending AI suggestion session on the file is settled first

--- a/apps/mobile/src/app/index.tsx
+++ b/apps/mobile/src/app/index.tsx
@@ -197,7 +197,7 @@ function describeStatus(status: SyncStatus): string {
 function VaultScreen() {
   const router = useRouter();
   const status = useSyncStatus();
-  const [files, setFiles] = useState<string[]>([]);
+  const [files, setFiles] = useState(listVaultFiles);
   const [refreshing, setRefreshing] = useState(false);
 
   // Foregrounded + signed in (this screen only mounts with a session): sync on
@@ -208,10 +208,6 @@ function VaultScreen() {
   const reload = useCallback(() => {
     setFiles(listVaultFiles());
   }, []);
-
-  useEffect(() => {
-    reload();
-  }, [reload]);
 
   // A realtime/foreground pass lands outside `runSync` below — refresh the
   // listing whenever any pass completes so pulled files appear without a pull.

--- a/apps/mobile/src/lib/host/use-host-channel.ts
+++ b/apps/mobile/src/lib/host/use-host-channel.ts
@@ -7,7 +7,7 @@
 // to reconcile whatever happened while this device was away.
 // ---------------------------------------------------------------------------
 
-import { useEffect, useRef } from "react";
+import { useEffect, useEffectEvent } from "react";
 
 import type { Bridge } from "@repo/features/ipc-registry";
 import { getHostBridge, useHostStatus } from "./connection";
@@ -23,23 +23,25 @@ export type HostChannelOptions<E, S> = {
 
 export function useHostChannel<E, S>(options: HostChannelOptions<E, S>): void {
   const { status } = useHostStatus();
-  // Latest-ref: the effect's lifetime is the CONNECTION's, not the render's —
-  // inline callbacks at the call site must not retrigger it.
-  const latest = useRef(options);
-  latest.current = options;
+  // The effect's lifetime is the CONNECTION's, not the render's. Effect Events
+  // keep inline callbacks fresh without making them connection dependencies.
+  const subscribe = useEffectEvent(options.subscribe);
+  const load = useEffectEvent(options.load);
+  const onEvent = useEffectEvent(options.onEvent);
+  const onLoad = useEffectEvent(options.onLoad);
 
   useEffect(() => {
     if (status !== "connected") return;
     const bridge = getHostBridge();
     if (bridge === null) return;
     let alive = true;
-    const unsubscribe = latest.current.subscribe(bridge, (event) => {
-      if (alive) latest.current.onEvent(event);
+    const unsubscribe = subscribe(bridge, (event) => {
+      if (alive) onEvent(event);
     });
     void (async () => {
       try {
-        const snapshot = await latest.current.load(bridge);
-        if (alive) latest.current.onLoad(snapshot);
+        const snapshot = await load(bridge);
+        if (alive) onLoad(snapshot);
       } catch {
         // Dropped mid-load — the next reconnect reloads.
       }

--- a/doctor.config.jsonc
+++ b/doctor.config.jsonc
@@ -16,10 +16,7 @@
         // Generated dependency bundles, not owned source. Keep other artifact
         // security checks enabled.
         "files": ["**/.output/**"],
-        "rules": [
-          "react-doctor/path-traversal-risk",
-          "react-doctor/insecure-crypto-risk",
-        ],
+        "rules": ["react-doctor/path-traversal-risk", "react-doctor/insecure-crypto-risk"],
       },
     ],
   },

--- a/doctor.config.jsonc
+++ b/doctor.config.jsonc
@@ -1,0 +1,26 @@
+{
+  "ignore": {
+    "overrides": [
+      {
+        // React Doctor cannot parse this repo's commented root knip.json and
+        // misses Electron renderer entry points. pnpm knip remains canonical.
+        "files": ["**/*"],
+        "rules": ["deslop/unused-file"],
+      },
+      {
+        // v0.7.6 mistakes any uninitialized binding for React Native Dimensions.
+        "files": ["**/src/lib/host/pairing.ts"],
+        "rules": ["react-doctor/rn-no-dimensions-get"],
+      },
+      {
+        // Generated dependency bundles, not owned source. Keep other artifact
+        // security checks enabled.
+        "files": ["**/.output/**"],
+        "rules": [
+          "react-doctor/path-traversal-risk",
+          "react-doctor/insecure-crypto-risk",
+        ],
+      },
+    ],
+  },
+}

--- a/packages/ui/src/components/carousel.tsx
+++ b/packages/ui/src/components/carousel.tsx
@@ -98,7 +98,8 @@ function Carousel({
     api.on("select", onSelect);
 
     return () => {
-      api?.off("select", onSelect);
+      api.off("reInit", onSelect);
+      api.off("select", onSelect);
     };
   }, [api, onSelect]);
 

--- a/packages/ui/src/components/confirm-dialog.tsx
+++ b/packages/ui/src/components/confirm-dialog.tsx
@@ -36,18 +36,23 @@ type PendingConfirm = {
   resolve: (confirmed: boolean) => void;
 };
 
+type ConfirmSnapshot = {
+  pending: PendingConfirm | null;
+  options: ConfirmOptions | null;
+};
+
 type Listener = () => void;
 
 type ConfirmStore = {
-  pending: PendingConfirm | null;
+  snapshot: ConfirmSnapshot;
   listeners: Set<Listener>;
   subscribe: (listener: Listener) => () => void;
-  getSnapshot: () => PendingConfirm | null;
+  getSnapshot: () => ConfirmSnapshot;
   set: (pending: PendingConfirm | null) => void;
 };
 
 const confirmStore: ConfirmStore = {
-  pending: null,
+  snapshot: { pending: null, options: null },
   listeners: new Set<Listener>(),
   subscribe(listener: Listener): () => void {
     confirmStore.listeners.add(listener);
@@ -55,11 +60,14 @@ const confirmStore: ConfirmStore = {
       confirmStore.listeners.delete(listener);
     };
   },
-  getSnapshot(): PendingConfirm | null {
-    return confirmStore.pending;
+  getSnapshot(): ConfirmSnapshot {
+    return confirmStore.snapshot;
   },
   set(pending: PendingConfirm | null): void {
-    confirmStore.pending = pending;
+    confirmStore.snapshot = {
+      pending,
+      options: pending?.options ?? confirmStore.snapshot.options,
+    };
     for (const listener of confirmStore.listeners) listener();
   },
 };
@@ -73,23 +81,18 @@ const confirmStore: ConfirmStore = {
 export function confirm(options: ConfirmOptions): Promise<boolean> {
   return new Promise<boolean>((resolve) => {
     // One confirm at a time: a newer ask settles the older one as canceled.
-    confirmStore.pending?.resolve(false);
+    confirmStore.getSnapshot().pending?.resolve(false);
     confirmStore.set({ options, resolve });
   });
 }
 
 export function ConfirmDialogHost() {
-  const pending = React.useSyncExternalStore(
+  const { pending, options } = React.useSyncExternalStore(
     confirmStore.subscribe,
     confirmStore.getSnapshot,
     confirmStore.getSnapshot,
   );
   const confirmButtonRef = React.useRef<HTMLButtonElement>(null);
-  // Hold the last options through the close animation so the popup doesn't
-  // blank out while it fades.
-  const lastOptionsRef = React.useRef<ConfirmOptions | null>(null);
-  if (pending) lastOptionsRef.current = pending.options;
-  const options = pending?.options ?? lastOptionsRef.current;
 
   const settle = (confirmed: boolean) => {
     pending?.resolve(confirmed);

--- a/packages/ui/src/components/geometric-orb.tsx
+++ b/packages/ui/src/components/geometric-orb.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useRef, useMemo, useEffect, useCallback } from "react";
+import React, { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
 import { Canvas, useFrame, useThree, extend } from "@react-three/fiber";
 
 import * as THREE from "three";
@@ -215,7 +215,7 @@ function LatitudeLines({
   const groupRefs = useRef<(THREE.Group | null)[]>([]);
   const parentGroupRef = useRef<THREE.Group>(null);
   const spinGroupRef = useRef<THREE.Group>(null);
-  const camDirRef = useRef(new THREE.Vector3());
+  const [cameraDirection] = useState(() => new THREE.Vector3());
   const helixRotationRef = useRef(0);
   // Theme-reactive moods. useFrame lerps the live mood toward `moods[status]`,
   // so a theme change smoothly recolors the orb without remounting. The refs
@@ -232,13 +232,15 @@ function LatitudeLines({
     target: DisplayStatus;
   } | null>(null);
 
-  if (status !== prevStatusRef.current) {
-    if (prevStatusRef.current === "starting" && status !== "starting") {
-      spinUpRef.current = { elapsed: 0, target: status };
+  useLayoutEffect(() => {
+    if (status !== prevStatusRef.current) {
+      if (prevStatusRef.current === "starting" && status !== "starting") {
+        spinUpRef.current = { elapsed: 0, target: status };
+      }
+      prevStatusRef.current = status;
     }
-    prevStatusRef.current = status;
-  }
-  targetRef.current = status;
+    targetRef.current = status;
+  }, [status]);
 
   // --- Tube mesh ---
   const helixMeshRef = useRef<THREE.Mesh>(null);
@@ -441,7 +443,7 @@ function LatitudeLines({
     // with the mood color so baseColor / theme changes are actually reflected.
     helixMaterial.color.setRGB(mood.r, mood.g, mood.b);
 
-    const camDir = camDirRef.current.copy(state.camera.position).normalize();
+    const camDir = cameraDirection.copy(state.camera.position).normalize();
 
     // During spin-up: kill spin quickly before group unwind (at morph≈0.2)
     // During normal transitions: spin fades linearly with morph

--- a/packages/ui/src/components/pagination.tsx
+++ b/packages/ui/src/components/pagination.tsx
@@ -9,7 +9,6 @@ import { ChevronLeftIcon, ChevronRightIcon, MoreHorizontalIcon } from "lucide-re
 function Pagination({ className, ...props }: React.ComponentProps<"nav">) {
   return (
     <nav
-      role="navigation"
       aria-label="pagination"
       data-slot="pagination"
       className={cn("mx-auto flex w-full justify-center", className)}


### PR DESCRIPTION
## Outcome

- React Doctor `0.7.6`: score **46 → 62**
- Findings: **182 → 88**
- Errors: **20 → 2**
- Final: desktop **63 / 0 errors**, mobile **62 / 2 errors**, web **85 / 0 errors**, UI **73 / 0 errors**
- 30 findings fixed in code. 64 confirmed detector false positives filtered narrowly.

## Fix stacks

- clean carousel subscriptions; remove redundant nav role
- replace render-time callback/ref writes with committed refs or Effect Events
- retain confirm-dialog close content in the external-store snapshot
- initialize vault/equation/orb state without post-paint or eager-ref churn
- parallelize independent attachment conversions while preserving order
- add explicit accessible names for icon controls and model select
- add 6 focused lifecycle regressions for confirm + markdown editor
- add narrow Doctor overrides; `pnpm knip` remains dead-code authority

## Complete triage

| Count | Rule | Disposition |
| ---: | --- | --- |
| 15 | `no-ref-current-in-render` | Fixed all. Commit-time refs, Effect Events, or stable callback capture. |
| 7 | `control-has-associated-label` | Fixed all explicit control names. |
| 2 | `rerender-lazy-ref-init` | Fixed equation and orb initialization. |
| 1 | `effect-needs-cleanup` | Fixed both carousel unsubscriptions. |
| 1 | `no-redundant-roles` | Fixed. Native `nav` semantics. |
| 1 | `async-await-in-loop` | Fixed independent attachment conversion. |
| 1 | `set-state-in-effect` | Fixed initial mobile vault listing. |
| 1 | `no-prop-callback-in-effect` | Fixed markdown flush registration via Effect Event. |
| 1 | `refs` | Fixed mobile host-channel compiler bailout via Effect Events. |
| 57 | `deslop/unused-file` | Confirmed false positives. Doctor cannot parse commented root `knip.json` or resolve Electron leaf entries. Filtered; `pnpm knip` passes. |
| 4 | `rn-no-dimensions-get` | Confirmed v0.7.6 matcher bug: `socket.addEventListener` misread as `Dimensions`. Filtered only for `pairing.ts`. |
| 3 | generated `.output` security | Bundled dependency hits. Filtered only for two rules under `.output`; other artifact security checks stay on. |
| 4 | `exhaustive-deps` | Reviewed. Dependencies use derived values/stable callbacks; suggested additions are stale-source false positives. |
| 1 | `interactive-supports-focus` | Deferred. AI menu uses virtual option focus; needs full combobox semantics work, not tab-order patching. |
| 1 | `iframe-missing-sandbox` | Intentional. Chromium native PDF viewer renders blank when sandboxed; URL has link-equivalent note trust. |
| 13 | `react-compiler-no-manual-memoization` | Deferred. Mobile callbacks carry identity contracts; bulk removal is migration churn without measured gain. |
| 2 | remaining `async-await-in-loop` | Intentional serialization: asset filename collision/caret order; connector teardown side effects/error aggregation. |
| 1 | `no-effect-chain` | Intentional selection teardown for media editing. |
| 1 | `prefer-dynamic-import` | Defer to chart consumer boundary; shared primitive cannot choose loading UX. |
| 1 | `heading-has-content` | Static-analysis miss. Editable filename heading is populated imperatively. |
| 1 | `no-pass-live-state-to-parent` | Deferred provider API redesign. |
| 1 | remaining `no-prop-callback-in-effect` | Deferred provider API redesign. Same prompt attachment synchronization seam. |
| 2 | `no-cascading-set-state` | Intentional atomic UI reset flows; reducer extraction needs separate behavior review. |
| 2 | remaining `set-state-in-effect` | Mobile filesystem/status synchronization. Needs event-store/state-model redesign; not safe cleanup. |
| 4 | `use-lazy-motion` | Valid follow-up. Requires app-level `LazyMotion` boundary and animation QA. |
| 1 | `no-static-element-interactions` | Deferred Plate block suggestion keyboard/focus redesign. |
| 4 | `prefer-tag-over-role` | Intentional polymorphism/nesting constraints for equation, breadcrumb, and item primitives. |
| 2 | `no-reset-all-state-on-prop-change` | Intentional credential-dialog identity reset. Keyed remount belongs in parent redesign. |
| 1 | `no-adjust-state-on-prop-change` | Intentional async vault-asset lifecycle reset. |
| 2 | `rerender-state-only-in-handlers` | Valid low-priority event-state cleanup; defer with IME/AI menu QA. |
| 1 | `no-chain-state-updates` | Intentional session history for delegation visibility. |
| 1 | `click-events-have-key-events` | Same deferred Plate suggestion focus redesign. |
| 1 | `rendering-hydration-no-flicker` | Intentional SSR fallback; pre-paint theme script already prevents flash. |
| 1 | `no-pass-data-to-parent` | Intentional self-registering combobox items. |
| 1 | `rerender-memo-before-early-return` | Chart tooltip micro-optimization; no measured impact. |
| 1 | `no-autofocus` | Intentional editor selection-toolbar focus handoff. |
| 5 | `no-giant-component` | Defer. Product-specific decomposition, not defect remediation. |
| 1 | `rendering-svg-precision` | Static asset micro-optimization. |
| 8 | `js-combine-iterations` | Small collections or clarity-sensitive transforms; no measured hot path. |
| 9 | `no-multi-comp` | Intentional private component colocation. |
| 15 | `only-export-components` | Intentional design-system/kit public API; Fast Refresh-only warning. |

Remaining total: **88**.

## Verification

- `pnpm format:fix`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm knip`
- `pnpm format`
- `pnpm test` — 1,169 tests pass
- `pnpm build`
- React Doctor full aggregate + per-project desktop/UI/mobile scans
- browser harness: orb `starting → idle` WebGL transition, one canvas, no browser errors
- browser harness: graph note switch redraws active halo on `projects/alpha.md`, no browser errors

## Follow-up

Highest-value next slice: app-level `LazyMotion` migration. Separate PR; animation behavior needs direct QA.
