### PR TITLE
chore: backport init template fixes (auth rate-limit, ui glob, nativewind)

### DIFF
--- a/apps/cloud/src/auth/auth.ts
+++ b/apps/cloud/src/auth/auth.ts
@@ -74,7 +74,9 @@ export function createAuth(env: Env, baseURL: string) {
     // throttles credential-stuffing against the auth routes. Cloudflare's WAF can
     // rate-limit at the edge too; this is defense-in-depth at the app layer.
     rateLimit: {
-      enabled: true,
+      // Off only when RATE_LIMIT_DISABLED === "true" (tests: the in-process test
+      // Worker shares one IP, so a multi-user suite would trip the limiter).
+      enabled: env.RATE_LIMIT_DISABLED !== "true",
       storage: "database",
       window: 60,
       max: 10,

--- a/apps/cloud/src/auth/auth.ts
+++ b/apps/cloud/src/auth/auth.ts
@@ -68,6 +68,17 @@ export function createAuth(env: Env, baseURL: string) {
     baseURL,
     plugins: [bearer()],
     emailAndPassword: { enabled: true },
+    // Persist rate-limit counters in D1. The default in-memory store keeps
+    // per-isolate counters, so across Workers isolates the effective limit
+    // multiplies and resets whenever an isolate recycles. 10 requests/60s per IP
+    // throttles credential-stuffing against the auth routes. Cloudflare's WAF can
+    // rate-limit at the edge too; this is defense-in-depth at the app layer.
+    rateLimit: {
+      enabled: true,
+      storage: "database",
+      window: 60,
+      max: 10,
+    },
     trustedOrigins: trustedOrigins(env),
     ...socialProviders(env),
   });

--- a/apps/cloud/src/db/schema.ts
+++ b/apps/cloud/src/db/schema.ts
@@ -78,6 +78,21 @@ export const verification = sqliteTable("verification", {
 });
 
 /**
+ * better-auth's database rate-limit store (`rateLimit.storage = "database"` in
+ * auth.ts). Keyed by IP+path; `key` is unique so the counter upsert is a single
+ * indexed lookup. `lastRequest` is an epoch-ms integer. Mirrors the sqlite shape
+ * `@better-auth/cli generate` emits for the rate-limit store — regenerate rather
+ * than hand-edit if the plugin set changes. Applied via `drizzle-kit push` (this
+ * repo has no migration files); no RLS on D1.
+ */
+export const rateLimit = sqliteTable("rate_limit", {
+  id: text("id").primaryKey(),
+  key: text("key").notNull().unique(),
+  count: integer("count").notNull(),
+  lastRequest: integer("last_request").notNull(),
+});
+
+/**
  * Vault ownership (first-writer-wins). `vaultId` is the primary key; the first
  * authenticated user to access a vault inserts a row claiming it. A later request
  * for the same vault by a different user is rejected (403).

--- a/apps/cloud/src/env.d.ts
+++ b/apps/cloud/src/env.d.ts
@@ -12,4 +12,10 @@ interface Env {
   /** Optional GitHub OAuth credentials — the provider is enabled only when both exist. */
   readonly GITHUB_CLIENT_ID?: string;
   readonly GITHUB_CLIENT_SECRET?: string;
+  /**
+   * Set to "true" ONLY in tests to disable auth rate limiting: the in-process
+   * test Worker serves every request from one IP, so a suite that signs up
+   * several users would otherwise trip the limiter. Unset in dev/prod → enabled.
+   */
+  readonly RATE_LIMIT_DISABLED?: string;
 }

--- a/apps/cloud/vitest.config.ts
+++ b/apps/cloud/vitest.config.ts
@@ -40,6 +40,9 @@ export default defineConfig({
         bindings: {
           TEST_SCHEMA,
           BETTER_AUTH_SECRET: "test-better-auth-secret-000000000000",
+          // Tests hit the in-process Worker from one IP; keep the auth limiter
+          // off so multi-user suites don't 429. Rate limiting is covered in prod.
+          RATE_LIMIT_DISABLED: "true",
         },
       },
     }),

--- a/packages/ui/src/styles/globals.css
+++ b/packages/ui/src/styles/globals.css
@@ -48,7 +48,10 @@
   font-weight: 600;
 }
 
-@source "../../../../apps/**/*.{ts,tsx}";
+/* This package's own components only. Tailwind cannot auto-detect them through
+   the node_modules symlink, but each app's sources are auto-detected from its
+   own build root — scanning apps/** from here would make every app ship every
+   other app's classes. */
 @source "../**/*.{ts,tsx}";
 
 @custom-variant dark (&:is(.dark *));

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -97,8 +97,8 @@ catalogs:
       specifier: ^1.24.0
       version: 1.24.0
     nativewind:
-      specifier: 5.0.0-preview.3
-      version: 5.0.0-preview.3
+      specifier: 5.0.0-preview.4
+      version: 5.0.0-preview.4
     react:
       specifier: ^19.2.7
       version: 19.2.7
@@ -483,7 +483,7 @@ importers:
         version: 57.0.0(expo@57.0.4)(react-native@0.86.0(@babel/core@7.29.7)(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.2.17)(react@19.2.7))
       nativewind:
         specifier: 'catalog:'
-        version: 5.0.0-preview.3(react-native-css@3.0.7(@expo/metro-config@57.0.3(expo@57.0.4)(typescript@7.0.2))(lightningcss@1.30.1)(react-native@0.86.0(@babel/core@7.29.7)(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.2.17)(react@19.2.7))(react@19.2.7))(tailwindcss@4.3.2)
+        version: 5.0.0-preview.4(react-native-css@3.0.7(@expo/metro-config@57.0.3(expo@57.0.4)(typescript@7.0.2))(lightningcss@1.30.1)(react-native@0.86.0(@babel/core@7.29.7)(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.2.17)(react@19.2.7))(react@19.2.7))(tailwindcss@4.3.2)
       react:
         specifier: 'catalog:'
         version: 19.2.7
@@ -7921,8 +7921,8 @@ packages:
     resolution: {integrity: sha512-i0tloweeudshAEuddpDxcg9Ik6pkPfVsHIgKyf143JrgG7/MOh0+q7BypdLXZPoOP7fOYt1eTcwGkyiVmhJFkA==}
     engines: {node: ^20.0.0 || >=22.0.0}
 
-  nativewind@5.0.0-preview.3:
-    resolution: {integrity: sha512-cbl1GzzY55NL2IG35AaAVfrL4+bCh77sa39aST5/o7xy3TLPthAtzhNPstnrCn+DtIglTnXOlOJGFrX2WdhI6w==}
+  nativewind@5.0.0-preview.4:
+    resolution: {integrity: sha512-eLsFGczxIsWADoD18EbEyt01aWgw4uP1/t/O7JIsp/OEbSgVYVobW97e2DDTOxxiiqSu0RexC1KSo5d7tes9uQ==}
     engines: {node: '>=20'}
     peerDependencies:
       react-native-css: ^3.0.1
@@ -17942,7 +17942,7 @@ snapshots:
 
   nanostores@1.4.0: {}
 
-  nativewind@5.0.0-preview.3(react-native-css@3.0.7(@expo/metro-config@57.0.3(expo@57.0.4)(typescript@7.0.2))(lightningcss@1.30.1)(react-native@0.86.0(@babel/core@7.29.7)(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.2.17)(react@19.2.7))(react@19.2.7))(tailwindcss@4.3.2):
+  nativewind@5.0.0-preview.4(react-native-css@3.0.7(@expo/metro-config@57.0.3(expo@57.0.4)(typescript@7.0.2))(lightningcss@1.30.1)(react-native@0.86.0(@babel/core@7.29.7)(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.2.17)(react@19.2.7))(react@19.2.7))(tailwindcss@4.3.2):
     dependencies:
       react-native-css: 3.0.7(@expo/metro-config@57.0.3(expo@57.0.4)(typescript@7.0.2))(lightningcss@1.30.1)(react-native@0.86.0(@babel/core@7.29.7)(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.2.17)(react@19.2.7))(react@19.2.7)
       tailwindcss: 4.3.2

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -34,7 +34,7 @@ catalog:
   expo-system-ui: ~57.0.0
   expo-web-browser: ~57.0.0
   lucide-react: ^1.24.0
-  nativewind: 5.0.0-preview.3
+  nativewind: 5.0.0-preview.4
   react: ^19.2.7
   react-dom: ^19.2.7
   react-native: ~0.86.0


### PR DESCRIPTION
Backports three recent `init` template fixes into this diverged fork. Structure differs (no `api`/`db` packages — `apps/cloud` is the Worker + better-auth over D1), so each fix was re-homed to the fork's layout.

## Fixes

- [x] **feat(auth): database-backed rate limiting** — init `448b92aeae97` (SECURITY)
  - `apps/cloud/src/auth/auth.ts`: added `rateLimit: { enabled: true, storage: "database", window: 60, max: 10 }` to `betterAuth()`.
  - `apps/cloud/src/db/schema.ts`: added the `rate_limit` table (sqlite/D1 shape — `id`, `key` unique, `count`, `last_request`).
  - init used pg (`bigint`, `.enableRLS()`); adapted to sqlite (`integer`, no RLS on D1).
  - **No migration file generated** — this repo uses `drizzle-kit push` (no `migrations/` dir). Apply with `pnpm db:push:local` / `db:push:remote`.
  - **WAF note:** Cloudflare's WAF can rate-limit auth routes at the edge; this is defense-in-depth at the app layer (persistent counters that survive isolate recycling).

- [x] **perf(ui): stop scanning `apps/**` from the shared stylesheet** — init `54a7422bfad4`
  - `packages/ui/src/styles/globals.css`: removed `@source "../../../../apps/**/*.{ts,tsx}";`.
  - Verified both consumers (`apps/web`, `apps/desktop`) only `@import "@repo/ui/globals.css"` and rely on Tailwind v4 auto-detection from their own build roots — matching init's `apps/web` exactly. Confirmed real builds still pass (see below).

- [x] **chore(mobile): bump nativewind `5.0.0-preview.3` → `preview.4`** — init `b6b2b20f219f`
  - Bumped the `pnpm-workspace.yaml` catalog entry (fork centralizes it there; `apps/mobile` uses `catalog:`). Ran `pnpm install`; lockfile refreshed.

## Skipped

- **test(ui): vitest scaffolding** — init `6b9805ffb8ba`. That commit *removed* dead vitest scaffolding from `packages/ui` (no tests ever ran). This fork's `packages/ui` already has **no** vitest config or `test` script — it's already at the commit's end-state. Adding vitest (the task's framing) would contradict the referenced commit and `vitest run` would fail with no tests. Nothing to do.
- **90-mobile-styles** — the fork's class-based dark mode is an intentional divergence, not a regression. Left untouched.

## Verification

- `pnpm install` — clean (peer warnings for vite 8 / typescript 7 are pre-existing).
- `pnpm --filter @repo/cloud typecheck` — pass (better-auth accepts the `rateLimit` config; schema compiles).
- `pnpm --filter @repo/ui typecheck` — pass.
- `pnpm --filter @repo/web build` — pass.
- `pnpm --filter @repo/desktop build` — pass.
- `pnpm --filter @repo/mobile typecheck` — pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Backported three init template fixes: database-backed auth rate limiting in `apps/cloud` (10 requests per 60s, stored in D1), narrowed the shared UI stylesheet scan to only its own sources, and bumped `nativewind` to `5.0.0-preview.4`. Rate limiting is gated by `RATE_LIMIT_DISABLED` and is disabled in tests to prevent 429s; production remains protected.

- **Migration**
  - Create the rate-limit table via `drizzle-kit`: run `pnpm db:push:local` and `pnpm db:push:remote` (no migration files in this repo).

<sup>Written for commit 50ffc8bdbb92e4cefa48bd04e791b792501f8d98. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kyh/inteligir/pull/454?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

