### PR TITLE
Add rename_note agent tool (closes #450)

### DIFF
--- a/packages/features/resources/agent/AGENTS.md
+++ b/packages/features/resources/agent/AGENTS.md
@@ -37,6 +37,7 @@ The user's notes are edited with your raw file tools (`read`, `edit`, `write`) a
 The user's persistent knowledge lives in `./vault` (a folder they chose, symlinked into your workspace). This is your long-term memory and the user's data store — notes, plans, research, structured records. It survives across sessions.
 
 - Read and write it with your normal file tools (`read`, `edit`, `write`, `bash`), e.g. `read ./vault/projects/roadmap.md`.
+- To rename or move a note, use the `rename_note` tool — never `bash mv`, and never write-to-a-new-path + delete. Only `rename_note` rewrites the vault's inbound `[[links]]` and records the old title as an alias; a raw move silently dangles every link pointing at the file.
 - It's GitHub-flavored markdown. Write clean, conventional markdown (`-` bullets, `#` headings, `- [ ]` task checkboxes) and keep edits minimal — the user's editor shows a live diff, so churn in untouched parts is noise.
 - Prefer the vault over re-asking the user or losing context. When you learn something durable, write it there.
 - The user is looking at these files in their editor, so an edit you make shows up live on their screen. Don't reorganize or delete their files without asking.

--- a/packages/features/src/server/__tests__/extension.test.ts
+++ b/packages/features/src/server/__tests__/extension.test.ts
@@ -28,6 +28,7 @@ function fakePorts(): AgentPorts {
       search: () => [],
       backlinks: () => [],
       notesWithTag: () => [],
+      rename: () => ({ ok: false, reason: "not wired in this test" }),
     },
     privacy: {
       probe: () => "indeterminate",

--- a/packages/features/src/server/__tests__/knowledge-extension.test.ts
+++ b/packages/features/src/server/__tests__/knowledge-extension.test.ts
@@ -59,9 +59,9 @@ const emptyPort: KnowledgePort = {
 };
 
 describe("knowledge extension tools", () => {
-  it("registers search_vault and get_backlinks with valid schemas", () => {
+  it("registers search_vault, get_backlinks, and rename_note with valid schemas", () => {
     const tools = capture(emptyPort);
-    expect([...tools.keys()].toSorted()).toEqual(["get_backlinks", "search_vault"]);
+    expect([...tools.keys()].toSorted()).toEqual(["get_backlinks", "rename_note", "search_vault"]);
     for (const [, tool] of tools) {
       expect(() => validateToolParametersSchema(tool, "knowledge")).not.toThrow();
     }
@@ -126,5 +126,44 @@ describe("knowledge extension tools", () => {
     const tools = capture(emptyPort);
     const result = await tool(tools, "get_backlinks").execute("id", { path: "t.md" });
     expect(text(result)).toBe("No backlinks.");
+  });
+
+  it("rename_note passes both paths to the port and reports the rewrite count", async () => {
+    const rename = vi.fn(() => ({
+      ok: true as const,
+      from: "a.md",
+      to: "b/c.md",
+      linksRewritten: 2,
+    }));
+    const tools = capture({ ...emptyPort, rename });
+    const result = await tool(tools, "rename_note").execute("id", { from: "a.md", to: "b/c.md" });
+    expect(rename).toHaveBeenCalledWith("a.md", "b/c.md");
+    expect(text(result)).toBe("Renamed a.md to b/c.md. Rewrote links in 2 notes.");
+  });
+
+  it("rename_note text is grammatical for one rewrite and honest for zero", async () => {
+    const one = capture({
+      ...emptyPort,
+      rename: () => ({ ok: true, from: "a.md", to: "b.md", linksRewritten: 1 }),
+    });
+    expect(text(await tool(one, "rename_note").execute("id", { from: "a.md", to: "b.md" }))).toBe(
+      "Renamed a.md to b.md. Rewrote links in 1 note.",
+    );
+    const zero = capture({
+      ...emptyPort,
+      rename: () => ({ ok: true, from: "a.md", to: "b.md", linksRewritten: 0 }),
+    });
+    expect(text(await tool(zero, "rename_note").execute("id", { from: "a.md", to: "b.md" }))).toBe(
+      "Renamed a.md to b.md. No link rewrites were needed.",
+    );
+  });
+
+  it("rename_note surfaces a refusal reason verbatim", async () => {
+    const tools = capture({
+      ...emptyPort,
+      rename: () => ({ ok: false, reason: "taken.md already exists" }),
+    });
+    const result = await tool(tools, "rename_note").execute("id", { from: "a.md", to: "taken.md" });
+    expect(text(result)).toBe("Rename failed: taken.md already exists");
   });
 });

--- a/packages/features/src/server/__tests__/knowledge-extension.test.ts
+++ b/packages/features/src/server/__tests__/knowledge-extension.test.ts
@@ -51,7 +51,12 @@ function backlink(sourcePath: string, line: number): BacklinkEntry {
   return { sourcePath, line, snippet: "", kind: "wiki", embed: false };
 }
 
-const emptyPort: KnowledgePort = { search: () => [], backlinks: () => [], notesWithTag: () => [] };
+const emptyPort: KnowledgePort = {
+  search: () => [],
+  backlinks: () => [],
+  notesWithTag: () => [],
+  rename: () => ({ ok: false, reason: "not wired in this test" }),
+};
 
 describe("knowledge extension tools", () => {
   it("registers search_vault and get_backlinks with valid schemas", () => {

--- a/packages/features/src/server/__tests__/knowledge-privacy.test.ts
+++ b/packages/features/src/server/__tests__/knowledge-privacy.test.ts
@@ -50,7 +50,15 @@ function diskProbe(overrides: Record<string, string> = {}): (rel: string) => Pri
 
 function buildPort(overrides: Record<string, string> = {}): KnowledgePort {
   const index = seededIndex();
-  return buildAgentKnowledgePort({ queries: () => index, probe: diskProbe(overrides) });
+  return buildAgentKnowledgePort({
+    queries: () => index,
+    probe: diskProbe(overrides),
+    // These tests are fs-free; rename (which writes through the real
+    // VaultManager) is covered by knowledge-rename-port.test.ts.
+    vault: () => {
+      throw new Error("rename is not under test in knowledge-privacy tests");
+    },
+  });
 }
 
 // Capture the extension's registered tools so their execute() closures run

--- a/packages/features/src/server/__tests__/knowledge-privacy.test.ts
+++ b/packages/features/src/server/__tests__/knowledge-privacy.test.ts
@@ -58,6 +58,9 @@ function buildPort(overrides: Record<string, string> = {}): KnowledgePort {
     vault: () => {
       throw new Error("rename is not under test in knowledge-privacy tests");
     },
+    afterRename: () => {
+      throw new Error("rename is not under test in knowledge-privacy tests");
+    },
   });
 }
 

--- a/packages/features/src/server/__tests__/knowledge-rename-port.test.ts
+++ b/packages/features/src/server/__tests__/knowledge-rename-port.test.ts
@@ -1,0 +1,149 @@
+// ---------------------------------------------------------------------------
+// KnowledgePort.rename — the capability behind the agent's rename_note tool.
+// Drives buildAgentKnowledgePort over a REAL VaultManager (same scaffolding
+// as rename-rewrite.test.ts) and pins that the agent's rename takes the SAME
+// pipeline as the user-facing renameVaultEntry handler: destination-basename
+// note-name gate, snapshot-verified vault-wide link rewrite, old-title alias
+// recording — plus the port's own live-disk privacy re-probe on the source
+// (the tool gate's unknown-tool arg screen is index-lagged; this closes it).
+// ---------------------------------------------------------------------------
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import { notePrivacy } from "@repo/core/markdown/frontmatter";
+
+import { buildAgentKnowledgePort } from "../lib/agent-knowledge-port";
+import { VaultManager } from "../vault/vault";
+import type { KnowledgePort, PrivacyProbe } from "../agent/extension";
+
+let tmp: string;
+let root: string;
+let vault: VaultManager;
+let port: KnowledgePort;
+
+/** Mirror of agent-lifecycle's probeVaultPrivacy over the test vault: live
+ * disk read, any failure short of a real verdict reads "absent" (none of
+ * these tests hinge on the absent/indeterminate error split). */
+const probe = (rel: string): PrivacyProbe => {
+  try {
+    return notePrivacy(vault.readText(rel));
+  } catch {
+    return "absent";
+  }
+};
+
+beforeEach(() => {
+  tmp = fs.mkdtempSync(path.join(os.tmpdir(), "knowledge-rename-port-test-"));
+  root = path.join(tmp, "vault");
+  vault = new VaultManager({
+    settingsPath: path.join(tmp, "settings.json"),
+    defaultRoot: root,
+    manageAgentLink: false,
+  });
+  vault.ensureReady();
+  port = buildAgentKnowledgePort({
+    // rename never touches the queries; give it an inert set.
+    queries: () => ({ search: () => [], backlinks: () => [], notesWithTag: () => [] }),
+    probe,
+    vault: () => vault,
+  });
+});
+
+afterEach(() => {
+  vault.close();
+  fs.rmSync(tmp, { recursive: true, force: true });
+});
+
+describe("KnowledgePort.rename — link rewrite + alias, user-rename parity", () => {
+  it("rewrites inbound links, records the old-title alias, and reports the count", () => {
+    vault.writeText("a.md", "See [[B]].\n");
+    vault.writeText("B.md", "# B\n");
+
+    expect(port.rename("B.md", "C.md")).toEqual({
+      ok: true,
+      from: "B.md",
+      to: "C.md",
+      linksRewritten: 1,
+    });
+    expect(fs.existsSync(path.join(root, "B.md"))).toBe(false);
+    expect(vault.readText("a.md")).toBe("See [[C]].\n");
+    expect(vault.readText("C.md")).toBe("---\naliases:\n  - B\n---\n# B\n");
+  });
+
+  it("moves across directories — the name gate is basename-only, like the handler", () => {
+    vault.writeText("a.md", "See [[B]].\n");
+    vault.writeText("B.md", "# B\n");
+
+    // Wiki links are location-independent, so a dir-only move rewrites
+    // nothing and records no alias (the stem didn't change).
+    expect(port.rename("B.md", "sub/B.md")).toEqual({
+      ok: true,
+      from: "B.md",
+      to: "sub/B.md",
+      linksRewritten: 0,
+    });
+    expect(vault.readText("sub/B.md")).toBe("# B\n");
+    expect(vault.readText("a.md")).toBe("See [[B]].\n");
+  });
+
+  it.each([["con.md"], ["bad:name.md"], ["sub/nul.md"]])(
+    "refuses an invalid destination name (%s) and changes nothing",
+    (to) => {
+      vault.writeText("B.md", "# B\n");
+      const result = port.rename("B.md", to);
+      expect(result.ok).toBe(false);
+      expect(vault.readText("B.md")).toBe("# B\n");
+    },
+  );
+
+  it("refuses an occupied destination (renameWithLinkRewrite's own refusal)", () => {
+    vault.writeText("B.md", "# B\n");
+    vault.writeText("taken.md", "occupied\n");
+
+    expect(port.rename("B.md", "taken.md")).toEqual({
+      ok: false,
+      reason: "taken.md already exists",
+    });
+    expect(vault.readText("B.md")).toBe("# B\n");
+    expect(vault.readText("taken.md")).toBe("occupied\n");
+  });
+
+  it("refuses a missing source with the honest not-found reason", () => {
+    expect(port.rename("ghost.md", "new.md")).toEqual({
+      ok: false,
+      reason: "Not found: ghost.md",
+    });
+  });
+});
+
+describe("KnowledgePort.rename — live privacy re-probe (index-lag closer)", () => {
+  it("refuses to rename a private note; the reason names the path, never content", () => {
+    const secret = "---\nprivate: true\n---\n# Umbrella\n\nTOP-SECRET body\n";
+    vault.writeText("secret.md", secret);
+
+    const result = port.rename("secret.md", "renamed.md");
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.reason).toContain("secret.md");
+      expect(result.reason).toContain("private");
+      expect(result.reason).not.toContain("TOP-SECRET");
+      expect(result.reason).not.toContain("Umbrella");
+    }
+    expect(vault.readText("secret.md")).toBe(secret);
+    expect(fs.existsSync(path.join(root, "renamed.md"))).toBe(false);
+  });
+
+  it("refuses an unreadable-frontmatter source — fail-closed, like the file tools", () => {
+    // The same proven-indeterminate frontmatter knowledge-privacy.test.ts pins.
+    const invalid = "---\n[not: valid: yaml\n---\nbody\n";
+    vault.writeText("weird.md", invalid);
+
+    const result = port.rename("weird.md", "renamed.md");
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.reason).toContain("fail-closed");
+    expect(vault.readText("weird.md")).toBe(invalid);
+  });
+});

--- a/packages/features/src/server/__tests__/knowledge-rename-port.test.ts
+++ b/packages/features/src/server/__tests__/knowledge-rename-port.test.ts
@@ -23,6 +23,7 @@ let tmp: string;
 let root: string;
 let vault: VaultManager;
 let port: KnowledgePort;
+let afterRenameCalls: Array<[string, string]>;
 
 /** Mirror of agent-lifecycle's probeVaultPrivacy over the test vault: live
  * disk read, any failure short of a real verdict reads "absent" (none of
@@ -44,11 +45,13 @@ beforeEach(() => {
     manageAgentLink: false,
   });
   vault.ensureReady();
+  afterRenameCalls = [];
   port = buildAgentKnowledgePort({
     // rename never touches the queries; give it an inert set.
     queries: () => ({ search: () => [], backlinks: () => [], notesWithTag: () => [] }),
     probe,
     vault: () => vault,
+    afterRename: (from, to) => afterRenameCalls.push([from, to]),
   });
 });
 
@@ -116,6 +119,22 @@ describe("KnowledgePort.rename — link rewrite + alias, user-rename parity", ()
       ok: false,
       reason: "Not found: ghost.md",
     });
+  });
+
+  it("runs the metadata remap on success, and NOT on any refusal", () => {
+    vault.writeText("B.md", "# B\n");
+    // Success → the delegation/checkpoint remap fires with the exact paths.
+    expect(port.rename("B.md", "C.md").ok).toBe(true);
+    expect(afterRenameCalls).toEqual([["B.md", "C.md"]]);
+
+    // Every refusal path leaves the remap untouched (no stale repoint).
+    afterRenameCalls = [];
+    port.rename("ghost.md", "new.md"); // missing source
+    port.rename("C.md", "con.md"); // invalid name
+    // The live probe reads this file's frontmatter → private → refused.
+    vault.writeText("secret.md", "---\nprivate: true\n---\n");
+    port.rename("secret.md", "x.md"); // private
+    expect(afterRenameCalls).toEqual([]);
   });
 });
 

--- a/packages/features/src/server/__tests__/privacy-gate.test.ts
+++ b/packages/features/src/server/__tests__/privacy-gate.test.ts
@@ -280,6 +280,21 @@ describe("privacy gate — bash/execute/browser/peekaboo (best-effort ONLY)", ()
     expect(decide("resume", { executionId: "x", action: "accept" })).toEqual({ allow: true });
   });
 
+  it("rename_note is covered by the unknown-tool arg screen — a private-note rename blocks", () => {
+    // rename_note is deliberately NOT in the curated KNOWLEDGE_TOOLS set: its
+    // args are real vault paths, so the opaque literal-path screen must apply.
+    // Both sides screen — renaming a private note away, or onto its path.
+    for (const from of ["./vault/notes/secret.md", "vault/notes/secret.md", "notes/secret.md"]) {
+      expect(decide("rename_note", { from, to: "renamed.md" }).allow, from).toBe(false);
+    }
+    expect(decide("rename_note", { from: "public.md", to: "notes/secret.md" }).allow).toBe(false);
+    // A rename touching no indexed private note passes the gate; the
+    // KnowledgePort still live-probes the source (knowledge-rename-port.test).
+    expect(decide("rename_note", { from: "./vault/public.md", to: "renamed.md" })).toEqual({
+      allow: true,
+    });
+  });
+
   it("screens an UNKNOWN tool's args for a private path (no silent fail-open)", () => {
     // A future/connector tool the dispatch doesn't name gets the same
     // best-effort screen bash does, not a blanket allow.

--- a/packages/features/src/server/__tests__/rename-rewrite.test.ts
+++ b/packages/features/src/server/__tests__/rename-rewrite.test.ts
@@ -41,7 +41,10 @@ describe("renameWithLinkRewrite", () => {
     vault.writeText("hub.md", hub);
     vault.writeText("old note.md", "# The note\n");
 
-    expect(renameWithLinkRewrite(vault, "old note.md", "sub/new note.md")).toEqual({ ok: true });
+    expect(renameWithLinkRewrite(vault, "old note.md", "sub/new note.md")).toEqual({
+      ok: true,
+      docsRewritten: 1,
+    });
 
     expect(fs.existsSync(path.join(root, "old note.md"))).toBe(false);
     // Phase 3: the old title is recorded as an alias on the moved doc.
@@ -66,7 +69,10 @@ describe("renameWithLinkRewrite", () => {
     vault.writeText("hub.md", "shot ![the alt](pic.png), embed ![[pic.png]]\n");
     fs.writeFileSync(path.join(root, "pic.png"), "binary-ish");
 
-    expect(renameWithLinkRewrite(vault, "pic.png", "assets/photo.png")).toEqual({ ok: true });
+    expect(renameWithLinkRewrite(vault, "pic.png", "assets/photo.png")).toEqual({
+      ok: true,
+      docsRewritten: 1,
+    });
 
     expect(fs.existsSync(path.join(root, "pic.png"))).toBe(false);
     expect(fs.readFileSync(path.join(root, "assets/photo.png"), "utf8")).toBe("binary-ish");
@@ -79,7 +85,10 @@ describe("renameWithLinkRewrite", () => {
     vault.writeText("a/doc.md", "self [[doc]] plus [sibling](sib.md)\n");
     vault.writeText("a/sib.md", "# Sib\n");
 
-    expect(renameWithLinkRewrite(vault, "a/doc.md", "b/doc.md")).toEqual({ ok: true });
+    expect(renameWithLinkRewrite(vault, "a/doc.md", "b/doc.md")).toEqual({
+      ok: true,
+      docsRewritten: 1,
+    });
     expect(vault.readText("b/doc.md")).toBe("self [[doc]] plus [sibling](../a/sib.md)\n");
   });
 
@@ -111,7 +120,10 @@ describe("renameWithLinkRewrite", () => {
     try {
       racy.writeText("hub.md", "[[old]]\n");
       racy.writeText("old.md", "");
-      expect(renameWithLinkRewrite(racy, "old.md", "new.md")).toEqual({ ok: true });
+      expect(renameWithLinkRewrite(racy, "old.md", "new.md")).toEqual({
+        ok: true,
+        docsRewritten: 0,
+      });
       // The concurrent edit is preserved; the stale rewrite was dropped.
       expect(racy.readText("hub.md")).toBe("concurrent edit\n");
       // The alias still records — the skipped stale [[old]] link is exactly
@@ -126,7 +138,10 @@ describe("renameWithLinkRewrite", () => {
 describe("renameWithLinkRewrite — old-title alias (phase 3)", () => {
   it("records the old stem on a retitle even when no links needed rewriting", () => {
     vault.writeText("Meeting Notes.md", "# Meeting Notes\n\nBody.\n");
-    expect(renameWithLinkRewrite(vault, "Meeting Notes.md", "Retro.md")).toEqual({ ok: true });
+    expect(renameWithLinkRewrite(vault, "Meeting Notes.md", "Retro.md")).toEqual({
+      ok: true,
+      docsRewritten: 0,
+    });
     expect(vault.readText("Retro.md")).toBe(
       "---\naliases:\n  - Meeting Notes\n---\n# Meeting Notes\n\nBody.\n",
     );
@@ -134,31 +149,43 @@ describe("renameWithLinkRewrite — old-title alias (phase 3)", () => {
 
   it("appends to an existing alias list and skips a duplicate", () => {
     vault.writeText("a.md", "---\naliases:\n  - Existing\n---\nbody\n");
-    expect(renameWithLinkRewrite(vault, "a.md", "b.md")).toEqual({ ok: true });
+    expect(renameWithLinkRewrite(vault, "a.md", "b.md")).toEqual({ ok: true, docsRewritten: 0 });
     expect(vault.readText("b.md")).toBe("---\naliases:\n  - Existing\n  - a\n---\nbody\n");
     // Rename back and forth: "b" gets recorded, then the re-rename to b.md
     // would record "a" again — the ci-duplicate check keeps the list clean.
-    expect(renameWithLinkRewrite(vault, "b.md", "a.md")).toEqual({ ok: true });
-    expect(renameWithLinkRewrite(vault, "a.md", "b.md")).toEqual({ ok: true });
+    expect(renameWithLinkRewrite(vault, "b.md", "a.md")).toEqual({ ok: true, docsRewritten: 0 });
+    expect(renameWithLinkRewrite(vault, "a.md", "b.md")).toEqual({ ok: true, docsRewritten: 0 });
     expect(vault.readText("b.md")).toBe("---\naliases:\n  - Existing\n  - a\n  - b\n---\nbody\n");
   });
 
   it("skips case-only retitles and dir-only moves", () => {
     vault.writeText("note.md", "# N\n");
-    expect(renameWithLinkRewrite(vault, "note.md", "Note.md")).toEqual({ ok: true });
+    expect(renameWithLinkRewrite(vault, "note.md", "Note.md")).toEqual({
+      ok: true,
+      docsRewritten: 0,
+    });
     expect(vault.readText("Note.md")).toBe("# N\n");
-    expect(renameWithLinkRewrite(vault, "Note.md", "sub/Note.md")).toEqual({ ok: true });
+    expect(renameWithLinkRewrite(vault, "Note.md", "sub/Note.md")).toEqual({
+      ok: true,
+      docsRewritten: 0,
+    });
     expect(vault.readText("sub/Note.md")).toBe("# N\n");
   });
 
   it("skips non-docs and unreadable frontmatter (bytes = plain rename)", () => {
     fs.writeFileSync(path.join(root, "pic.png"), "bytes");
-    expect(renameWithLinkRewrite(vault, "pic.png", "photo.png")).toEqual({ ok: true });
+    expect(renameWithLinkRewrite(vault, "pic.png", "photo.png")).toEqual({
+      ok: true,
+      docsRewritten: 0,
+    });
     expect(fs.readFileSync(path.join(root, "photo.png"), "utf8")).toBe("bytes");
 
     const invalid = "---\ndup: 1\ndup: 2\n---\nbody\n";
     vault.writeText("weird.md", invalid);
-    expect(renameWithLinkRewrite(vault, "weird.md", "renamed weird.md")).toEqual({ ok: true });
+    expect(renameWithLinkRewrite(vault, "weird.md", "renamed weird.md")).toEqual({
+      ok: true,
+      docsRewritten: 0,
+    });
     expect(vault.readText("renamed weird.md")).toBe(invalid);
   });
 });

--- a/packages/features/src/server/agent/extension.ts
+++ b/packages/features/src/server/agent/extension.ts
@@ -42,7 +42,9 @@ export type ExecutorPort = {
 };
 
 /** Knowledge-engine access (derived indexes live OUTSIDE the vault, so the
- * agent's file tools can't reach them — hence a port). Read-only.
+ * agent's file tools can't reach them — hence a port). Read-only queries plus
+ * `rename` — the one mutation, and it exists precisely because the agent's
+ * raw file tools CAN move a file but can't rewrite the vault's links to it.
  *
  * PRIVACY CONTRACT: results are privacy-FILTERED — a `private: true` note
  * never appears (no path, no snippet; a private backlinks target reads as
@@ -54,7 +56,22 @@ export type KnowledgePort = {
   backlinks(path: string): BacklinkEntry[];
   /** Vault paths of notes carrying a tag (case-insensitive). */
   notesWithTag(tag: string): string[];
+  /** Rename/move a vault file through the SAME pipeline the user-facing
+   * renameVaultEntry handler runs: note-name gate on the destination
+   * basename, then snapshot-verified vault-wide link rewrite + old-title
+   * alias recording (knowledge/rename-rewrite.ts). Refusals are VALUES,
+   * never throws (guarded-edit style). */
+  rename(from: string, to: string): RenameNoteResult;
 };
+
+/** KnowledgePort.rename outcome. `linksRewritten` counts the NOTES whose
+ * links were rewritten to follow the move (0 when nothing pointed at the
+ * file, or when wiki-links were already location-independent). A failure
+ * `reason` is one model-safe sentence: invalid destination name, missing
+ * source, occupied destination, or a private/unreadable source. */
+export type RenameNoteResult =
+  | { ok: true; from: string; to: string; linksRewritten: number }
+  | { ok: false; reason: string };
 
 /** A note's live-disk privacy verdict: notePrivacy's three states plus
  * `absent` (no such file). Anything that can't be read/typed probes

--- a/packages/features/src/server/agent/knowledge/extension.ts
+++ b/packages/features/src/server/agent/knowledge/extension.ts
@@ -1,12 +1,15 @@
 /**
  * Knowledge extension — exposes the derived knowledge indexes (lexical search,
- * backlinks) as agent tools. These indexes live OUTSIDE the vault (rebuilt per
- * device, never synced), so the agent's native file tools can't reach them —
- * the capability arrives through `ports.knowledge` (built main-side in
- * agent-lifecycle.ts). Pure in-process: no CLI, no setup().
+ * backlinks) and the link-aware rename as agent tools. The indexes live
+ * OUTSIDE the vault (rebuilt per device, never synced), so the agent's native
+ * file tools can't reach them — and a raw `bash mv` can't rewrite the links
+ * they track — hence the capabilities arrive through `ports.knowledge` (built
+ * main-side in agent-lifecycle.ts). Pure in-process: no CLI, no setup().
  *
- * Both tools are read-only, so there is no confirmation gating (mirrors how
- * the browser/executor tools leave non-mutating calls ungated).
+ * search_vault / get_backlinks are read-only, so there is no confirmation
+ * gating (mirrors how the browser/executor tools leave non-mutating calls
+ * ungated). rename_note mutates, but only via the same reversible pipeline a
+ * user rename takes — no gating there either.
  */
 
 import { Type, type Static } from "@sinclair/typebox";
@@ -43,6 +46,17 @@ const SearchVaultSchema = Type.Object({
 const GetBacklinksSchema = Type.Object({
   path: Type.String({
     description: "Vault-relative note path (e.g. 'notes/ideas.md') to find links pointing to it.",
+  }),
+});
+
+const RenameNoteSchema = Type.Object({
+  from: Type.String({
+    description: "Current vault-relative path of the file to rename or move (e.g. 'notes/old.md').",
+  }),
+  to: Type.String({
+    description:
+      "New vault-relative path (e.g. 'notes/new.md', or 'archive/old.md' to move it). " +
+      "The destination file name must be a valid note name.",
   }),
 });
 
@@ -95,6 +109,34 @@ const knowledgeExtension: PiExtensionBundle = {
           // lines, but the agent only needs the set of linking notes.
           const paths = [...new Set(hits.map((hit) => hit.sourcePath))];
           return textResult(paths.join("\n"));
+        },
+      });
+
+      // The one mutating tool here. Privacy: rename_note is deliberately NOT
+      // in the gate's curated KNOWLEDGE_TOOLS set — it falls through to the
+      // unknown-tool arg screen (privacy/gate.ts decideOpaqueInput), so an
+      // argument naming an indexed private note blocks the call before this
+      // execute runs; the port re-probes the source against live disk on top
+      // (agent-knowledge-port.ts renameNote). Do not add it to the curated
+      // set without giving the gate a real per-path decision for it.
+      pi.registerTool({
+        name: "rename_note",
+        label: "rename_note",
+        description:
+          "Rename or move a vault file, rewriting every [[wiki-link]] and markdown link " +
+          "that pointed at it across the whole vault and recording the old title as a " +
+          "frontmatter alias so stale references still resolve. ALWAYS use this to " +
+          "rename/move notes — never `bash mv` and never write-to-a-new-path + delete, " +
+          "because those bypass the link rewrite and dangle every inbound link.",
+        parameters: RenameNoteSchema,
+        execute: async (_toolCallId, params: Static<typeof RenameNoteSchema>) => {
+          const result = ports.knowledge.rename(params.from, params.to);
+          if (!result.ok) return textResult(`Rename failed: ${result.reason}`);
+          const links =
+            result.linksRewritten === 0
+              ? "No link rewrites were needed."
+              : `Rewrote links in ${result.linksRewritten} note${result.linksRewritten === 1 ? "" : "s"}.`;
+          return textResult(`Renamed ${result.from} to ${result.to}. ${links}`);
         },
       });
     },

--- a/packages/features/src/server/handlers/vault-handlers.ts
+++ b/packages/features/src/server/handlers/vault-handlers.ts
@@ -1,5 +1,4 @@
-import { getDelegationManager } from "../delegation/delegation-manager";
-import { getSnapshotStore } from "../snapshots/snapshot-store";
+import { remapNoteMetadata } from "../vault/rename-metadata";
 import { renameWithLinkRewrite } from "../knowledge/rename-rewrite";
 import { probeVaultPrivacy } from "../lib/agent-lifecycle";
 import { getPlatform } from "../platform-instance";
@@ -113,21 +112,10 @@ export function registerVaultHandlers(handle: HandlerRegistrar): void {
     // Rename, then rewrite [[wiki]] / relative md links vault-wide so nothing
     // dangles (snapshot-verified byte surgery — see knowledge/rename-rewrite).
     const result = renameWithLinkRewrite(getVaultManager(), from, to);
-    // Repoint any delegations so badges keep matching and queued runs target the
-    // new path (rename preserves content, so their positional anchors hold). The
-    // disk rename is the source of truth — if this best-effort metadata remap
-    // throws, log it but still report the rename that actually happened, rather
-    // than tell the renderer it failed and leave the two views inconsistent.
-    if (result.ok) {
-      try {
-        getDelegationManager().renameSource(from, to);
-        // Same story for AI-write snapshots: a chat checkpoint's entry path
-        // is its restore target, so undo must follow the moved file.
-        getSnapshotStore().renamePath(from, to);
-      } catch (err) {
-        console.warn("[vault] delegation remap after rename failed:", err);
-      }
-    }
+    // Repoint delegations + AI-write checkpoints at the new path — the single
+    // shared remap the agent's rename_note tool uses too, so the two rename
+    // paths can't drift.
+    if (result.ok) remapNoteMetadata(from, to);
     return result;
   });
 

--- a/packages/features/src/server/knowledge/rename-rewrite.ts
+++ b/packages/features/src/server/knowledge/rename-rewrite.ts
@@ -31,11 +31,14 @@ import { addFrontmatterAlias } from "@repo/core/markdown/frontmatter";
 
 import type { VaultManager } from "../vault/vault";
 
+/** `docsRewritten` counts the docs the rewrite loop actually wrote — the
+ * notes whose links were retargeted (a standalone alias-only write on the
+ * moved doc is not a link rewrite and is not counted). */
 export function renameWithLinkRewrite(
   vault: VaultManager,
   from: string,
   to: string,
-): { ok: true } | { ok: false; error: string } {
+): { ok: true; docsRewritten: number } | { ok: false; error: string } {
   // Snapshot before the rename; a failure here degrades to a plain rename.
   let snapshot: { docs: Map<string, string>; files: string[] } | null = null;
   try {
@@ -55,7 +58,8 @@ export function renameWithLinkRewrite(
   }
 
   const result = vault.rename(from, to);
-  if (!result.ok || snapshot === null) return result;
+  if (!result.ok) return result;
+  if (snapshot === null) return { ok: true, docsRewritten: 0 };
 
   // Phase 3 precondition: record the old stem as an alias only for a doc
   // whose resolvable NAME actually changed — never for dir-only moves (stem
@@ -68,6 +72,7 @@ export function renameWithLinkRewrite(
     oldStem !== "" &&
     oldStem.toLowerCase() !== titleFromPath(to).toLowerCase();
 
+  let docsRewritten = 0;
   try {
     const edits = computeRenameEdits(snapshot.docs, snapshot.files, from, to);
     for (const [postPath, content] of edits) {
@@ -91,6 +96,7 @@ export function renameWithLinkRewrite(
           ? (addFrontmatterAlias(content, oldStem) ?? content)
           : content;
       vault.writeText(postPath, next);
+      docsRewritten++;
     }
     if (recordAlias && !edits.has(to)) {
       // No rewrite touched the moved doc — read it, snapshot-verify (its
@@ -102,7 +108,7 @@ export function renameWithLinkRewrite(
     // leaves stale links (repairable), never inconsistent views.
     console.warn("[knowledge] link rewrite after rename failed:", err);
   }
-  return result;
+  return { ok: true, docsRewritten };
 }
 
 function recordAliasStandalone(

--- a/packages/features/src/server/lib/agent-knowledge-port.ts
+++ b/packages/features/src/server/lib/agent-knowledge-port.ts
@@ -56,6 +56,10 @@ export function buildAgentKnowledgePort(deps: {
   /** Live VaultManager accessor (defer-to-singleton, like `queries`) — the
    * rename capability writes through it. */
   vault: () => VaultManager;
+  /** Best-effort metadata remap run after a successful rename (delegations +
+   * AI-write checkpoints repointed at the new path) — the SAME remap the
+   * user-facing rename handler uses, injected so the two paths can't drift. */
+  afterRename: (from: string, to: string) => void;
 }): KnowledgePort {
   const isPublicNow = (rel: string): boolean => deps.probe(rel) === "public";
   return {
@@ -88,7 +92,11 @@ export function buildAgentKnowledgePort(deps: {
  * the same refusal wording family the file tools use. Refusals are values,
  * never throws. */
 function renameNote(
-  deps: { probe: (rel: string) => PrivacyProbe; vault: () => VaultManager },
+  deps: {
+    probe: (rel: string) => PrivacyProbe;
+    vault: () => VaultManager;
+    afterRename: (from: string, to: string) => void;
+  },
   from: string,
   to: string,
 ): RenameNoteResult {
@@ -116,5 +124,7 @@ function renameNote(
   }
   const result = renameWithLinkRewrite(deps.vault(), from, to);
   if (!result.ok) return { ok: false, reason: result.error };
+  // Parity with the user-facing rename: repoint delegations + checkpoints.
+  deps.afterRename(from, to);
   return { ok: true, from, to, linksRewritten: result.docsRewritten };
 }

--- a/packages/features/src/server/lib/agent-knowledge-port.ts
+++ b/packages/features/src/server/lib/agent-knowledge-port.ts
@@ -1,8 +1,10 @@
 // ---------------------------------------------------------------------------
 // The agent-facing KnowledgePort — the ONE choke point where index results
-// become model-visible text (search_vault / get_backlinks). SECURITY-CRITICAL:
-// a private note's PATH and SNIPPET are both leaks, so non-public hits are
-// dropped ENTIRELY, never annotated.
+// become model-visible text (search_vault / get_backlinks), plus the port's
+// single mutation, rename (rename_note — same rewrite pipeline as user
+// renames; see renameNote below). SECURITY-CRITICAL: a private note's PATH
+// and SNIPPET are both leaks, so non-public hits are dropped ENTIRELY, never
+// annotated.
 //
 // Two layers, both required:
 //  (1) index prefilter — every query runs with { excludePrivate: true } (the
@@ -29,8 +31,12 @@
 
 import type { BacklinkEntry, SearchResult } from "@repo/core/knowledge/knowledge-index";
 import type { PrivacyOpts } from "@repo/core/knowledge/link-graph-index";
+import { checkNoteName, noteNameErrorMessage } from "@repo/core/knowledge/note-name";
+import { basenamePath } from "@repo/core/knowledge/vault-path";
 
-import type { KnowledgePort, PrivacyProbe } from "../agent/extension";
+import { renameWithLinkRewrite } from "../knowledge/rename-rewrite";
+import type { KnowledgePort, PrivacyProbe, RenameNoteResult } from "../agent/extension";
+import type { VaultManager } from "../vault/vault";
 
 /** The queries the port wraps — KnowledgeManager (production) and core's
  * KnowledgeIndex (tests) both satisfy it structurally. */
@@ -47,6 +53,9 @@ export function buildAgentKnowledgePort(deps: {
   /** LIVE disk probe (agent-lifecycle's vault-backed one). Only "public"
    * passes — absent/indeterminate/private all drop, fail-closed. */
   probe: (rel: string) => PrivacyProbe;
+  /** Live VaultManager accessor (defer-to-singleton, like `queries`) — the
+   * rename capability writes through it. */
+  vault: () => VaultManager;
 }): KnowledgePort {
   const isPublicNow = (rel: string): boolean => deps.probe(rel) === "public";
   return {
@@ -65,5 +74,47 @@ export function buildAgentKnowledgePort(deps: {
         .filter((entry) => isPublicNow(entry.sourcePath));
     },
     notesWithTag: (tag) => deps.queries().notesWithTag(tag, EXCLUDE).filter(isPublicNow),
+    rename: (from, to) => renameNote(deps, from, to),
   };
+}
+
+/** The agent's rename — the SAME pipeline as the renameVaultEntry handler
+ * (handlers/vault-handlers.ts): the note-name gate on the destination
+ * BASENAME only (directory moves pass through), then renameWithLinkRewrite's
+ * snapshot-verified link surgery + old-title alias recording. On top, the
+ * port's usual live-disk privacy re-probe on the SOURCE: the tool gate
+ * already blocks rename_note args naming an INDEXED private note (gate.ts's
+ * unknown-tool arg screen), and this probe closes its index-lag window with
+ * the same refusal wording family the file tools use. Refusals are values,
+ * never throws. */
+function renameNote(
+  deps: { probe: (rel: string) => PrivacyProbe; vault: () => VaultManager },
+  from: string,
+  to: string,
+): RenameNoteResult {
+  const verdict = checkNoteName(basenamePath(to));
+  if (!verdict.ok) return { ok: false, reason: noteNameErrorMessage(verdict.reason) };
+  // "absent" passes through — vault.rename's own "Not found" is the honest
+  // reply; "private"/"indeterminate" refuse, fail-closed (path only, no
+  // content, matching the gate's outbound-payload rule).
+  const probe = deps.probe(from);
+  if (probe === "private") {
+    return {
+      ok: false,
+      reason:
+        `./vault/${from} is marked private (frontmatter \`private: true\`) and cannot be ` +
+        `renamed by AI tools. Tell the user the note is private.`,
+    };
+  }
+  if (probe === "indeterminate") {
+    return {
+      ok: false,
+      reason:
+        `./vault/${from} has unreadable frontmatter and is treated as private (fail-closed), ` +
+        `so it cannot be renamed. Tell the user the note could not be read.`,
+    };
+  }
+  const result = renameWithLinkRewrite(deps.vault(), from, to);
+  if (!result.ok) return { ok: false, reason: result.error };
+  return { ok: true, from, to, linksRewritten: result.docsRewritten };
 }

--- a/packages/features/src/server/lib/agent-lifecycle.ts
+++ b/packages/features/src/server/lib/agent-lifecycle.ts
@@ -65,14 +65,16 @@ export function getAgentPorts(): AgentPorts {
       execute: executeEnsuringDaemon,
       resume: resumeEnsuringDaemon,
     },
-    // Read-only knowledge queries, PRIVACY-FILTERED (agent-knowledge-port.ts):
+    // Knowledge queries + rename, PRIVACY-FILTERED (agent-knowledge-port.ts):
     // private notes are excluded at the index and every survivor is re-probed
-    // against live disk — a private path/snippet never reaches the model.
-    // Defers to the live singleton so a logout/login vault reset stays
-    // transparent (mirrors executor above).
+    // against live disk — a private path/snippet never reaches the model —
+    // and rename routes through the SAME renameWithLinkRewrite pipeline the
+    // renameVaultEntry handler runs. Defers to the live singletons so a
+    // logout/login vault reset stays transparent (mirrors executor above).
     knowledge: buildAgentKnowledgePort({
       queries: () => getKnowledgeManager(),
       probe: probeVaultPrivacy,
+      vault: getVaultManager,
     }),
     // Vault-privacy capability for the tool gate (agent/privacy). probe reads
     // LIVE disk through VaultManager (resolve() confinement included): a path

--- a/packages/features/src/server/lib/agent-lifecycle.ts
+++ b/packages/features/src/server/lib/agent-lifecycle.ts
@@ -42,6 +42,7 @@ import {
   resumeVaultWrites,
   suspendVaultWrites,
 } from "../vault/vault";
+import { remapNoteMetadata } from "../vault/rename-metadata";
 import type { SetupProgress } from "@repo/features/ipc";
 
 /** Bundled agent assets (skills/, AGENTS.md), resolved by the shell. */
@@ -75,6 +76,7 @@ export function getAgentPorts(): AgentPorts {
       queries: () => getKnowledgeManager(),
       probe: probeVaultPrivacy,
       vault: getVaultManager,
+      afterRename: remapNoteMetadata,
     }),
     // Vault-privacy capability for the tool gate (agent/privacy). probe reads
     // LIVE disk through VaultManager (resolve() confinement included): a path

--- a/packages/features/src/server/vault/rename-metadata.ts
+++ b/packages/features/src/server/vault/rename-metadata.ts
@@ -1,0 +1,28 @@
+// ---------------------------------------------------------------------------
+// The metadata remap that must follow ANY note rename — the single authority
+// shared by the user-facing `renameVaultEntry` handler and the agent's
+// `rename_note` tool, so the two rename paths can never drift.
+//
+// A rename preserves content, so delegation positional anchors and checkpoint
+// restore targets stay valid — they just need repointing at the new path.
+// This is BEST-EFFORT on top of the disk rename (the source of truth): if a
+// manager throws, we log and move on rather than fail a rename that already
+// happened and leave the two views inconsistent.
+// ---------------------------------------------------------------------------
+
+import { getDelegationManager } from "../delegation/delegation-manager";
+import { getSnapshotStore } from "../snapshots/snapshot-store";
+
+/** Repoint delegations and AI-write checkpoints from `from` to `to` after a
+ * successful note rename. Best-effort; never throws. */
+export function remapNoteMetadata(from: string, to: string): void {
+  try {
+    // Delegations: badges keep matching and queued runs target the new path.
+    getDelegationManager().renameSource(from, to);
+    // AI-write snapshots: a chat checkpoint's entry path is its restore
+    // target, so undo must follow the moved file.
+    getSnapshotStore().renamePath(from, to);
+  } catch (err) {
+    console.warn("[vault] delegation/snapshot remap after rename failed:", err);
+  }
+}


### PR DESCRIPTION
Closes #450.

## Problem
When a **user** renames a note it routes through `renameVaultEntry` → `renameWithLinkRewrite`: inbound `[[links]]` are rewritten vault-wide and the old title is recorded as an alias. When the **agent** renames (via `bash mv` or write-to-new-path), none of that happens — every inbound link silently dangles and no alias is recorded. The agent can rot the graph unprompted.

## Fix
A first-class `rename_note(from, to)` agent tool in the knowledge bundle, routed through the **same** `renameWithLinkRewrite` path via the injected `KnowledgePort` (the `agent/` boundary never imports `main/`).

- **Result is a value, never a throw:** `{ok:true, from, to, linksRewritten}` | `{ok:false, reason}`.
- **Name validation:** destination basename through `checkNoteName` (directory moves pass through, mirroring the user handler); occupied-destination and missing-source refusals surfaced verbatim.
- **Privacy:** the gate was **not** touched — `rename_note` is an unknown tool, so its args already hit the gate's opaque-input private-path screen (blocked on a private `from`/`to`); the port adds a live-disk re-probe on top (defense-in-depth, closes the index-lag window). Both pinned by tests, incl. no-content-leak assertions.
- **AGENTS.md** steers the agent to use `rename_note`, never `bash mv`.

## Parity fix (found during the build)
The user handler also repoints delegations + AI-write checkpoints after a rename; the tool initially didn't, so an agent rename of a note with active delegations/checkpoints would leave that metadata stale. Extracted a single `remapNoteMetadata()` called by the handler **and** injected into the port as `afterRename` — one remap authority, so the two rename paths can't drift. Pinned by a test that asserts the remap fires on success and on no refusal path.

## Verification
Full gate suite green (typecheck/lint/knip/format/test/build). The port is exercised over a real `VaultManager` on disk. **Not driven:** a live Electron agent actually invoking the tool — needs provider OAuth on-device.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a `rename_note` agent tool that renames/moves notes through the same link-rewrite and alias pipeline as user renames, preventing dangling links. Unifies post-rename metadata remapping and surfaces how many notes were updated.

- **New Features**
  - `rename_note` via `KnowledgePort.rename(from, to)` routes through `renameWithLinkRewrite` and returns `{ ok, from, to, linksRewritten }`.
  - Validates destination name and refuses private or unreadable sources with clear reasons.
  - Gate screens args by path; `AGENTS.md` instructs using `rename_note` instead of `bash mv`.

- **Bug Fixes**
  - Extracted `remapNoteMetadata()` and call it from both user and agent rename paths to repoint delegations and AI-write checkpoints.
  - `renameWithLinkRewrite` now reports `docsRewritten` so the tool can report link-rewrite counts.

<sup>Written for commit 064b1624b1d502757fe36a1e89d5113200d0c289. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kyh/inteligir/pull/455?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

