### PR TITLE
chore(cloud): align D1 db scripts with vibedgames convention

### DIFF
--- a/apps/cloud/package.json
+++ b/apps/cloud/package.json
@@ -7,13 +7,15 @@
     "build": "wrangler deploy --dry-run --outdir dist",
     "clean": "git clean -xdf .cache .turbo .wrangler dist node_modules",
     "cf-typegen": "wrangler types",
+    "db:push": "pnpm with-env drizzle-kit push",
+    "db:push:remote": "dotenv -e ../../.env.production.local -- drizzle-kit push",
     "db:push:local": "drizzle-kit push --config drizzle.config.local.ts --force",
-    "db:push:remote": "drizzle-kit push",
-    "db:studio": "drizzle-kit studio --config drizzle.config.local.ts",
+    "db:studio": "pnpm with-env drizzle-kit studio",
     "deploy": "wrangler deploy",
     "dev": "wrangler dev",
     "test": "vitest run",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "with-env": "dotenv -e ../../.env --"
   },
   "dependencies": {
     "@repo/core": "workspace:*",


### PR DESCRIPTION
inteligir and vibedgames are both D1 — standardize the DB tooling to one convention.

## Scope
- `apps/cloud/package.json` scripts:
  - `db:push:remote`: now `dotenv -e ../../.env.production.local -- drizzle-kit push` (was bare `drizzle-kit push` relying on loose shell env).
  - add `with-env` (`dotenv -e ../../.env --`), `db:push` (`pnpm with-env drizzle-kit push`), and switch `db:studio` to `pnpm with-env drizzle-kit studio`.
  - `db:push:local` unchanged (miniflare config).

## Acceptance
- `pnpm -F cloud db:push:remote` reads `.env.production.local` (gitignored) — same shape as `pnpm -F db push:remote` in the packages/db repos.
- Requires `.env` + `.env.production.local` at repo root with `CLOUDFLARE_ACCOUNT_ID` / `CLOUDFLARE_DATABASE_ID` / `CLOUDFLARE_D1_TOKEN` (gitignored; not committed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Standardized D1 DB scripts in `apps/cloud` to match vibedgames. Commands now load env from `.env` and `.env.production.local` via `dotenv` instead of relying on shell env.

- **Refactors**
  - Added `with-env` (`dotenv -e ../../.env --`) helper.
  - `db:push`, `db:push:remote`, and `db:studio` now run `drizzle-kit` via `dotenv` to read `.env` / `.env.production.local`.
  - `db:push:local` unchanged.

- **Migration**
  - Add `.env` and `.env.production.local` at repo root with `CLOUDFLARE_ACCOUNT_ID`, `CLOUDFLARE_DATABASE_ID`, `CLOUDFLARE_D1_TOKEN` (gitignored).

<sup>Written for commit 7f68ff1607add3b8e05f4f8e48a9a93d432ab311. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kyh/inteligir/pull/456?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

