### PR TITLE
chore: sync init agent-workflow patterns (2026-07-19)

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -2,10 +2,16 @@
   "version": "0.0.1",
   "configurations": [
     {
+      "name": "desktop harness",
+      "runtimeExecutable": "pnpm",
+      "runtimeArgs": ["--filter", "@repo/desktop", "dev:harness"],
+      "port": 5173
+    },
+    {
       "name": "web",
       "runtimeExecutable": "pnpm",
       "runtimeArgs": ["dev:web"],
-      "port": 3000
+      "port": 5174
     }
   ]
 }

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,16 +1,25 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-settings.json",
-  "prompt": "inteligir is driven by coding agents — read AGENTS.md first. Fastest loop: `pnpm --filter @repo/desktop dev:harness` (browser, no backend, no auth). `pnpm dev:desktop` runs the real Electron host with CDP on :9222. Gate with `pnpm format:fix && pnpm verify` — format:fix runs BEFORE the gates, never after (a post-gate run corrupts the byte-pinned round-trip fixtures). Never run `db:push` or `db:push:remote`: both target the PRODUCTION D1. The local one is `db:push:local`.",
+  "prompt": "inteligir is driven by coding agents — read AGENTS.md first. Fastest loop: `pnpm --filter @repo/desktop dev:harness` (browser, no backend, no auth). `pnpm dev:desktop` runs the real Electron host with CDP on :9222. Gate with `pnpm format:fix && pnpm verify` — format:fix runs BEFORE the gates, never after (a post-gate run corrupts the byte-pinned round-trip fixtures). Never run `db:push`, `db:push:remote` or `db:studio`: all three target the PRODUCTION D1. The local one is `db:push:local`.",
   "permissions": {
     "allow": [
+      "Bash(pnpm install)",
       "Bash(pnpm verify:*)",
-      "Bash(pnpm format:fix)",
+      "Bash(pnpm typecheck:*)",
+      "Bash(pnpm lint:*)",
+      "Bash(pnpm format:*)",
+      "Bash(pnpm test:*)",
+      "Bash(pnpm build:*)",
       "Bash(pnpm knip:*)",
       "Bash(pnpm dev:desktop)",
       "Bash(pnpm dev:web)",
       "Bash(pnpm --filter @repo/desktop dev:harness)",
       "Bash(pnpm --filter @repo/cloud dev)",
+      "Bash(pnpm --filter @repo/cloud test)",
       "Bash(pnpm --filter @repo/cloud db:push:local)",
+      "Bash(pkill -f \"turbo watch dev\")",
+      "Bash(pkill -f \"electron-vite\")",
+      "Bash(pkill -f \"Electron.app/Contents/MacOS/Electron\")",
       "Bash(agent-browser:*)",
       "Bash(npx -y emulate:*)"
     ],
@@ -18,7 +27,9 @@
       "Bash(pnpm --filter @repo/cloud db:push)",
       "Bash(pnpm -F @repo/cloud db:push)",
       "Bash(pnpm --filter @repo/cloud db:push:remote)",
-      "Bash(pnpm -F @repo/cloud db:push:remote)"
+      "Bash(pnpm -F @repo/cloud db:push:remote)",
+      "Bash(pnpm --filter @repo/cloud db:studio)",
+      "Bash(pnpm -F @repo/cloud db:studio)"
     ]
   }
 }

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,24 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-settings.json",
+  "prompt": "inteligir is driven by coding agents — read AGENTS.md first. Fastest loop: `pnpm --filter @repo/desktop dev:harness` (browser, no backend, no auth). `pnpm dev:desktop` runs the real Electron host with CDP on :9222. Gate with `pnpm format:fix && pnpm verify` — format:fix runs BEFORE the gates, never after (a post-gate run corrupts the byte-pinned round-trip fixtures). Never run `db:push` or `db:push:remote`: both target the PRODUCTION D1. The local one is `db:push:local`.",
+  "permissions": {
+    "allow": [
+      "Bash(pnpm verify:*)",
+      "Bash(pnpm format:fix)",
+      "Bash(pnpm knip:*)",
+      "Bash(pnpm dev:desktop)",
+      "Bash(pnpm dev:web)",
+      "Bash(pnpm --filter @repo/desktop dev:harness)",
+      "Bash(pnpm --filter @repo/cloud dev)",
+      "Bash(pnpm --filter @repo/cloud db:push:local)",
+      "Bash(agent-browser:*)",
+      "Bash(npx -y emulate:*)"
+    ],
+    "deny": [
+      "Bash(pnpm --filter @repo/cloud db:push)",
+      "Bash(pnpm -F @repo/cloud db:push)",
+      "Bash(pnpm --filter @repo/cloud db:push:remote)",
+      "Bash(pnpm -F @repo/cloud db:push:remote)"
+    ]
+  }
+}

--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -1,3 +1,0 @@
-[mcp_servers.next-devtools]
-args = ["-y", "next-devtools-mcp@latest"]
-command = "npx"

--- a/.env.example
+++ b/.env.example
@@ -14,7 +14,8 @@
 #
 # DANGER: `pnpm -F @repo/cloud db:push` and `db:push:remote` BOTH push the
 # schema to the REMOTE production D1 — `db:push` differs only in reading this
-# file instead of .env.production.local. The LOCAL push is `db:push:local`.
+# file instead of .env.production.local. `db:studio` opens a read/WRITE UI over
+# that same production database. The LOCAL push is `db:push:local`.
 #
 # CLOUDFLARE_D1_TOKEN = a Cloudflare API token with D1:Edit.
 # CLOUDFLARE_DATABASE_ID = the id in apps/cloud/wrangler.jsonc -> d1_databases[0].

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,23 @@
+# Copy to .env (gitignored — NEVER commit real values).
+#
+# Nothing in this file is needed for local development. The desktop app, the
+# browser harness, the marketing site and the Worker's local/test loops all run
+# without it. It exists only for the OWNER-ONLY remote-D1 scripts in apps/cloud.
+#
+# Per-workspace env lives elsewhere:
+# - apps/desktop/.env       — see apps/desktop/.env.example (dev flags, bundled
+#                             Google OAuth client, voice keys, notarization)
+# - apps/cloud/.dev.vars    — see apps/cloud/.dev.vars.example (local wrangler dev)
+
+# --- Cloudflare D1 credentials (owner only) ----------------------------------
+# Consumed by apps/cloud/drizzle.config.ts (driver: d1-http).
+#
+# DANGER: `pnpm -F @repo/cloud db:push` and `db:push:remote` BOTH push the
+# schema to the REMOTE production D1 — `db:push` differs only in reading this
+# file instead of .env.production.local. The LOCAL push is `db:push:local`.
+#
+# CLOUDFLARE_D1_TOKEN = a Cloudflare API token with D1:Edit.
+# CLOUDFLARE_DATABASE_ID = the id in apps/cloud/wrangler.jsonc -> d1_databases[0].
+CLOUDFLARE_ACCOUNT_ID=
+CLOUDFLARE_DATABASE_ID=
+CLOUDFLARE_D1_TOKEN=

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,8 +1,0 @@
-{
-  "mcpServers": {
-    "next-devtools": {
-      "command": "npx",
-      "args": ["-y", "next-devtools-mcp@latest"]
-    }
-  }
-}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,7 +19,9 @@ pnpm install
 pnpm --filter @repo/desktop dev:harness    # → http://localhost:5173
 ```
 
-That's the whole setup. The harness is a plain browser page running the **real
+That's the whole setup for writing code. (Driving the app at runtime also wants
+the `agent-browser` binary — one `npm i -g`, see below.) The harness is a plain
+browser page running the **real
 renderer UI** over an in-memory fixture Bridge (`apps/desktop/dev/`) with a
 sample vault and the real knowledge engine. No Electron, no backend, no auth,
 no vault on disk. Use it for all UI and editor work — it is the fastest loop by
@@ -33,8 +35,9 @@ pnpm dev:desktop     # Electron + the @repo/server host, HMR, CDP :9222, executo
 
 ## Fresh clone / remote session
 
-`pnpm install` is the only provisioning step — there is no bootstrap script and
-nothing else to stand up. (`.codex/environments/environment.toml` runs `pnpm i`
+`pnpm install` is the only provisioning step for the repo itself — there is no
+bootstrap script and nothing else to stand up. (Runtime verification also needs
+the global `agent-browser` binary — see § Verify a change end-to-end.) (`.codex/environments/environment.toml` runs `pnpm i`
 for cloud runners.) Requirements: **Node ≥ 24**, **pnpm 10** (`corepack
 enable`), and **macOS** for the Electron app + voice; the browser harness runs
 anywhere.
@@ -82,9 +85,11 @@ Auth is rate-limited to 10 requests/60s per IP; a script that creates several
 users should set `RATE_LIMIT_DISABLED=true` in `.dev.vars` rather than weaken
 the limiter.
 
-> **Never run `db:push` or `db:push:remote`.** Both push to the PRODUCTION D1 —
-> `db:push` differs only in which env file it reads. The local one is
-> `db:push:local`.
+> **Never run `db:push`, `db:push:remote` or `db:studio`.** All three load
+> `drizzle.config.ts` (`driver: "d1-http"`) and hit the PRODUCTION D1 —
+> `db:push` differs from `db:push:remote` only in which env file it reads, and
+> `db:studio` is a read/write UI over that same database, not a local
+> inspector. The only local command is `db:push:local`.
 
 ## Verify a change end-to-end
 
@@ -103,6 +108,7 @@ Runtime — type-checks passing is not feature-correct. Drive the running app
 with [agent-browser](https://github.com/vercel-labs/agent-browser):
 
 ```sh
+npm i -g agent-browser && agent-browser install   # once, if missing
 pnpm --filter @repo/desktop dev:harness
 agent-browser open http://localhost:5173
 agent-browser snapshot                      # accessibility tree with @eN refs
@@ -150,8 +156,11 @@ assuming a URL.
 - **The renderer never imports electron/node/`@repo/server`** — that's a package
   fact (no dep edge), not a lint opinion. `@repo/notes` stays platform-neutral.
 - **`pnpm knip` is a CI gate.** A new file must be reachable from a knip `entry`
-  glob in `knip.json`, and a dependency used only outside a workspace's
-  `project` glob must be listed in `ignoreDependencies`, or CI goes red.
+  glob in `knip.json` or it reads as unused and CI goes red. Tooling deps are
+  usually fine as-is — knip's config-file plugins resolve them (it finds
+  `@libsql/client` from `drizzle.config.local.ts`); `ignoreDependencies` is the
+  escape hatch for the ones it genuinely can't see, not a blanket rule. Run it
+  rather than guess.
 - Plan files and ADR docs are deleted on purpose — `CLAUDE.md` § Decisions plus
   the PR history is the record. Don't add `plans/` or `*_GAPS.md`.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -156,11 +156,13 @@ assuming a URL.
 - **The renderer never imports electron/node/`@repo/server`** — that's a package
   fact (no dep edge), not a lint opinion. `@repo/notes` stays platform-neutral.
 - **`pnpm knip` is a CI gate.** A new file must be reachable from a knip `entry`
-  glob in `knip.json` or it reads as unused and CI goes red. Tooling deps are
-  usually fine as-is — knip's config-file plugins resolve them (it finds
-  `@libsql/client` from `drizzle.config.local.ts`); `ignoreDependencies` is the
-  escape hatch for the ones it genuinely can't see, not a blanket rule. Run it
-  rather than guess.
+  glob in `knip.json` or it reads as unused and CI goes red. A tooling dep may
+  pass for a non-obvious reason — `@libsql/client` survives because it is an
+  optional peer of the used `drizzle-orm`, not because a config plugin found it
+  (knip's drizzle plugin only matches `drizzle.config.{ts,js,json}`, never
+  `drizzle.config.local.ts`, and resolves only the `schema` field).
+  `ignoreDependencies` is the escape hatch for the ones it genuinely can't see,
+  not a blanket rule. Run it rather than guess.
 - Plan files and ADR docs are deleted on purpose — `CLAUDE.md` § Decisions plus
   the PR history is the record. Don't add `plans/` or `*_GAPS.md`.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,1 +1,177 @@
-CLAUDE.md
+# AGENTS.md
+
+**inteligir** is an AI-native notes app — Obsidian with an agent. The product is
+an **Electron desktop app** over a local Node host; a Cloudflare Worker serves
+opt-in vault sync, an Expo app is a read/light-edit companion, and a TanStack
+Start site is marketing. This is the tool-agnostic guide for coding agents —
+it's meant to be **run**, not just read. `CLAUDE.md` holds the architecture and
+the durable decisions; `docs/development.md` the full dev loop. Both point back
+here.
+
+Unusually for a desktop product, **every surface except mobile is headlessly
+agent-verifiable** — the dev script already exposes Electron's remote-debugging
+port. There is no excuse for leaving a UI change "unverified".
+
+## Quickstart (headless)
+
+```sh
+pnpm install
+pnpm --filter @repo/desktop dev:harness    # → http://localhost:5173
+```
+
+That's the whole setup. The harness is a plain browser page running the **real
+renderer UI** over an in-memory fixture Bridge (`apps/desktop/dev/`) with a
+sample vault and the real knowledge engine. No Electron, no backend, no auth,
+no vault on disk. Use it for all UI and editor work — it is the fastest loop by
+a wide margin.
+
+The real product:
+
+```sh
+pnpm dev:desktop     # Electron + the @repo/server host, HMR, CDP :9222, executor :47888
+```
+
+## Fresh clone / remote session
+
+`pnpm install` is the only provisioning step — there is no bootstrap script and
+nothing else to stand up. (`.codex/environments/environment.toml` runs `pnpm i`
+for cloud runners.) Requirements: **Node ≥ 24**, **pnpm 10** (`corepack
+enable`), and **macOS** for the Electron app + voice; the browser harness runs
+anywhere.
+
+Two footguns that only bite fresh checkouts:
+
+```sh
+# `pnpm dev:desktop` dies with `Error: Electron uninstall` after a fresh
+# checkout or `git worktree` — Electron is unpacked but not downloaded:
+node apps/desktop/node_modules/electron/install.js
+
+# Stale processes hold 9222 / 47888 and the next launch can't bind them:
+pkill -f "turbo watch dev"; pkill -f "electron-vite"; pkill -f "Electron.app/Contents/MacOS/Electron"
+```
+
+**No login is needed for the product.** The desktop app is guest by default and
+vault sync is OFF by default, so chat, the editor, delegation, knowledge and
+the vault all work with zero provisioning.
+
+## There is no seeded login — provision one only for the account surface
+
+This repo ships **no seed script and no test account**. Notes live in the
+user's local vault, never in a server database, so there is nothing to seed
+beyond a user row. If you actually need an account (Settings → Account, vault
+sync, mobile sign-in), stand up the local Worker — verified end to end:
+
+```sh
+cp apps/cloud/.dev.vars.example apps/cloud/.dev.vars   # set BETTER_AUTH_SECRET to anything
+pnpm --filter @repo/cloud dev                          # wrangler dev → http://localhost:8787
+
+curl -s -o /dev/null localhost:8787/api/auth/get-session   # materializes the local D1 file
+pnpm --filter @repo/cloud db:push:local                    # apply the schema to it
+
+curl -s -X POST localhost:8787/api/auth/sign-up/email \
+  -H 'content-type: application/json' \
+  -d '{"email":"dev@inteligir.local","password":"password","name":"Dev"}'
+```
+
+The sign-up returns 200 with a `set-auth-token` header — that bearer is exactly
+what the sync clients use, so you can drive `/v1/vault/*` with curl alone. To
+drive it through a UI instead, put `http://localhost:8787` in the desktop's
+Settings → Account coordinator URL (mobile defaults to the Metro host on 8787).
+
+Auth is rate-limited to 10 requests/60s per IP; a script that creates several
+users should set `RATE_LIMIT_DISABLED=true` in `.dev.vars` rather than weaken
+the limiter.
+
+> **Never run `db:push` or `db:push:remote`.** Both push to the PRODUCTION D1 —
+> `db:push` differs only in which env file it reads. The local one is
+> `db:push:local`.
+
+## Verify a change end-to-end
+
+Static gate — mirrors CI exactly (typecheck · lint · knip · format · test ·
+build):
+
+```sh
+pnpm format:fix && pnpm verify
+```
+
+`format:fix` runs **FIRST and never after the gates**: a post-gate format run
+once rewrote the byte-pinned round-trip fixtures and shipped red (#362).
+`verify` is check-only for exactly that reason.
+
+Runtime — type-checks passing is not feature-correct. Drive the running app
+with [agent-browser](https://github.com/vercel-labs/agent-browser):
+
+```sh
+pnpm --filter @repo/desktop dev:harness
+agent-browser open http://localhost:5173
+agent-browser snapshot                      # accessibility tree with @eN refs
+agent-browser click @e1
+agent-browser get text                      # assert what changed
+agent-browser screenshot /tmp/after.png
+```
+
+For the real product, `pnpm dev:desktop` then `agent-browser connect 9222`
+attaches to the Electron renderer over CDP.
+
+Two things worth knowing before you reach for the UI:
+
+- **Drive the Bridge directly.** The renderer holds `{ url, token }` at
+  `window.bridgeBootstrap`; from `agent-browser eval` you can open that
+  WebSocket and call ANY Bridge method (`readVaultDoc`, `writeVaultDoc`,
+  `createDelegation`, …). Exact snippet in `docs/e2e-driving.md`.
+- **Agent, delegation and connector flows are login-free.** Two fail-closed
+  dev flags (`INTELIGIR_FAUX_AGENT=1`, `INTELIGIR_EMULATE_CONNECTORS=1` in
+  `apps/desktop/.env`) script the pi provider and point Google OAuth at a local
+  `emulate` stub. See `.claude/skills/e2e-drive` and `docs/e2e-driving.md` —
+  including the mandatory teardown.
+
+## Platform matrix
+
+| Surface           | Dev command                               | Where     | Agent-verifiable at runtime?                                                  |
+| ----------------- | ----------------------------------------- | --------- | ----------------------------------------------------------------------------- |
+| Desktop harness   | `pnpm --filter @repo/desktop dev:harness` | :5173     | **Yes** — `agent-browser open`                                                |
+| Desktop (product) | `pnpm dev:desktop`                        | CDP :9222 | **Yes** — `agent-browser connect 9222`                                        |
+| Web (marketing)   | `pnpm dev:web`                            | :5174     | **Yes** — `agent-browser open`                                                |
+| Cloud Worker      | `pnpm --filter @repo/cloud dev`           | :8787     | **Yes** — curl; no UI. Also `-F @repo/cloud test` (real in-process miniflare) |
+| Mobile (Expo)     | `pnpm --filter @repo/mobile dev`          | simulator | **No** — verify with `typecheck` + `test`                                     |
+
+Ports auto-increment if taken, so read the dev server's own output before
+assuming a URL.
+
+## Rules that matter
+
+- **`pnpm format:fix` before the gates, commit after.** Never the other way.
+- **Never hand-edit or format `apps/desktop/src/renderer/__tests__/fixtures/`** —
+  those bytes _are_ the test contract (trailing spaces, indentation, line
+  endings). Generate them through the `roundTrip` pipeline itself.
+- **No `any`, no non-null `!`, no `as` casts** (lint-enforced). Kebab-case
+  filenames. Make illegal states unrepresentable.
+- **The renderer never imports electron/node/`@repo/server`** — that's a package
+  fact (no dep edge), not a lint opinion. `@repo/notes` stays platform-neutral.
+- **`pnpm knip` is a CI gate.** A new file must be reachable from a knip `entry`
+  glob in `knip.json`, and a dependency used only outside a workspace's
+  `project` glob must be listed in `ignoreDependencies`, or CI goes red.
+- Plan files and ADR docs are deleted on purpose — `CLAUDE.md` § Decisions plus
+  the PR history is the record. Don't add `plans/` or `*_GAPS.md`.
+
+## Map
+
+```
+apps/desktop    Electron shell + the product UI (renderer)      @repo/desktop
+apps/mobile     Expo companion — sync/read/light-edit           @repo/mobile
+apps/web        TanStack Start marketing site on Workers        @repo/web
+apps/cloud      CF Worker — Better Auth (D1) + vault sync (DO+R2)  @repo/cloud
+packages/notes  Pure domain — sync engine, knowledge, markdown  @repo/notes
+packages/bridge Iso wire contract — IPC registry, ws, schemas   @repo/bridge
+packages/server Node host — the composition root                @repo/server
+packages/{agent,vault,storage,voice,connectors,sync,installer,ui}
+```
+
+- `CLAUDE.md` — architecture, the dep DAG, and § Decisions.
+- `docs/development.md` — the two run modes, ports + `~/.inteligir` shared
+  state, change checklists, per-package test commands.
+- `docs/e2e-driving.md` — login-free chat / delegation / connector recipes.
+- `docs/privacy.md` — the `private: true` guarantee and its holes.
+- `apps/cloud/README.md` — the Worker's protocol, local loop, and owner-only
+  deploy.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -116,12 +116,36 @@ pnpm build            # Build all
 pnpm typecheck        # Type check all
 pnpm lint             # Lint all   (oxlint)
 pnpm format:fix       # Format     (oxfmt) — run BEFORE gates, never after
+pnpm verify           # The whole gate, mirroring CI (see Quality Gates)
 ```
 
 **`docs/development.md` is the full dev guide**: the two run modes (fixture
 harness / Electron), ports + `~/.inteligir` shared state +
 `host.lock`, the fixture byte-pinning rule, verification patterns, and the
 add-a-Bridge-channel / add-a-node-type checklists.
+
+## Agent-driven development
+
+`AGENTS.md` is the tool-agnostic guide meant to be **run** — read it before
+touching anything. The essentials:
+
+- **Provision**: `pnpm install`. That's all — there is no bootstrap script and
+  the desktop app is guest by default (sync is off), so most flows need no
+  account at all.
+- **Fastest loop**: `pnpm --filter @repo/desktop dev:harness` — the real
+  renderer UI in a plain browser over the fixture Bridge, no Electron, no
+  backend.
+- **Verify**: `pnpm format:fix && pnpm verify` for the static gate, then drive
+  the running app. Every surface except mobile is headlessly verifiable —
+  harness and web via `agent-browser open`, the real Electron app via
+  `agent-browser connect 9222`, the Worker via curl.
+- **No seeded login.** If you need an account, stand up the local Worker —
+  `AGENTS.md` § "There is no seeded login" has the verified four-command
+  recipe. Never run `db:push` / `db:push:remote`: both hit production D1.
+- **Login-free agent flows**: `INTELIGIR_FAUX_AGENT=1` /
+  `INTELIGIR_EMULATE_CONNECTORS=1` (both fail closed) drive chat, delegation
+  and a connector connect with zero OAuth — `.claude/skills/e2e-drive` and
+  `docs/e2e-driving.md`.
 
 ## Verifying Changes
 
@@ -140,9 +164,14 @@ driving it; type/test passing isn't feature-correct.
 Before committing:
 
 ```bash
-pnpm format:fix   # FIRST — never after gates
-pnpm typecheck && pnpm lint && pnpm knip && pnpm format && pnpm test && pnpm build
+pnpm format:fix && pnpm verify
 ```
+
+`verify` is `typecheck && lint && knip && format && test && build` — the same
+six steps CI runs, in one command so the three places that used to spell it out
+can't drift. It is deliberately check-only: `format:fix` runs FIRST and never
+after the gates (a post-gate run once corrupted the byte-pinned fixtures and
+shipped red, #362).
 
 ## Desktop architecture (@repo/desktop)
 

--- a/README.md
+++ b/README.md
@@ -18,6 +18,11 @@ packages/          Libraries
   bridge/          Iso wire contract — Bridge/IPC registry, ws client, schemas (@repo/bridge)
   installer/       Generic CLI provisioning (@repo/installer)
   agent/           The pi capability (@repo/agent)
+  storage/         Node fs/json substrate over ~/.inteligir (@repo/storage)
+  vault/           VaultManager — the user's markdown folder (@repo/vault)
+  voice/           Voice capability — STT + TTS proxy (@repo/voice)
+  connectors/      MCP/connectors capability + executor daemon (@repo/connectors)
+  sync/            Desktop vault-sync adapters (@repo/sync)
   server/          Node backend — vault, delegation, connectors, voice, boot (@repo/server)
   ui/              Shared UI components (@repo/ui)
 ```
@@ -32,10 +37,12 @@ Workspace `README.md`s:
 | `packages/server/src` | [node backend — createHost, HostPlatform](./packages/server/src/README.md) |
 | `packages/ui`         | [shared design system](./packages/ui/README.md)                            |
 
+**[`AGENTS.md`](./AGENTS.md) is the guide for coding agents** — quickstart, the
+platform matrix of what is headlessly verifiable, and the runtime recipes.
 **[`docs/development.md`](./docs/development.md) is the dev guide** — the
 ways to run the app, ports/shared state, gates, verification, and
-change checklists. `CLAUDE.md` (root) is read by Claude Code / agents working
-in the repo — architecture summary + conventions.
+change checklists. `CLAUDE.md` (root) holds the architecture summary,
+conventions, and the durable decisions.
 
 ## Common commands
 
@@ -46,9 +53,10 @@ pnpm dev:desktop      # Desktop only
 pnpm build
 pnpm typecheck
 pnpm lint             # oxlint
-pnpm format           # oxfmt
+pnpm format           # oxfmt --check
 pnpm test
 pnpm knip             # Dead exports / unused deps
+pnpm verify           # All of the above, in CI's order
 ```
 
 ## Quality gates
@@ -56,5 +64,7 @@ pnpm knip             # Dead exports / unused deps
 Before committing:
 
 ```bash
-pnpm typecheck && pnpm lint && pnpm test && pnpm knip && pnpm build
+pnpm format:fix && pnpm verify
 ```
+
+`format:fix` runs FIRST and never after the gates — see `docs/development.md`.

--- a/apps/cloud/.dev.vars.example
+++ b/apps/cloud/.dev.vars.example
@@ -1,0 +1,19 @@
+# Copy to apps/cloud/.dev.vars (gitignored — NEVER commit real values).
+#
+# `wrangler dev` loads this as the Worker's secrets. Production sets the same
+# keys with `wrangler secret put` (see README.md -> Deploy).
+
+# Better Auth's signing key. Required — without it every /api/auth/* request
+# fails. Any value works locally: `openssl rand -base64 32`.
+BETTER_AUTH_SECRET=
+
+# Optional social OAuth. A provider is live only when BOTH halves are set —
+# otherwise it is absent from /v1/capabilities and no client renders its button.
+# GITHUB_CLIENT_ID=
+# GITHUB_CLIENT_SECRET=
+# GOOGLE_CLIENT_ID=
+# GOOGLE_CLIENT_SECRET=
+
+# Set to "true" ONLY when a local script signs up several users from one IP —
+# auth is rate-limited to 10 requests/60s per IP (see src/auth/auth.ts).
+# RATE_LIMIT_DISABLED=true

--- a/apps/cloud/README.md
+++ b/apps/cloud/README.md
@@ -71,11 +71,23 @@ CORS headers, `OPTIONS` is answered as a preflight, and `x-vault-version` /
 
 ```bash
 pnpm --filter @repo/cloud dev          # wrangler dev (local R2 + DO + D1 simulation)
-pnpm --filter @repo/cloud db:push:local # push the schema to the local miniflare D1 (run `dev` once first)
+pnpm --filter @repo/cloud db:push:local # push the schema to the local miniflare D1 (see below)
 pnpm --filter @repo/cloud test         # vitest vs in-process miniflare (schema exported from schema.ts)
 pnpm --filter @repo/cloud typecheck    # tsc --noEmit
 pnpm --filter @repo/cloud cf-typegen   # regenerate worker-configuration.d.ts after config changes
 ```
+
+`db:push:local` needs the miniflare D1 file to exist, and `dev` alone does not
+create it — miniflare materializes it lazily on the first request that touches
+the binding. So: start `dev`, hit a D1 route
+(`curl -s -o /dev/null localhost:8787/api/auth/get-session`), _then_ push. The
+full recipe, including creating an account, is in AGENTS.md § "There is no
+seeded login".
+
+> **Never run `db:push`, `db:push:remote` or `db:studio`.** All three go through
+> `drizzle.config.ts` (`driver: "d1-http"`) at the PRODUCTION D1 — `db:push`
+> differs from `db:push:remote` only in which env file it reads, and `db:studio`
+> is a read/write UI over the same database. The local one is `db:push:local`.
 
 ## Deploy (run by the account owner)
 

--- a/apps/cloud/drizzle.config.local.ts
+++ b/apps/cloud/drizzle.config.local.ts
@@ -8,12 +8,19 @@ import type { Config } from "drizzle-kit";
 // prod (d1-http); this one points the sqlite driver at the local SQLite file.
 // Miniflare names that file with a content hash, so resolve it from .wrangler
 // state rather than hard-coding it. Run `pnpm db:push:local` to apply the schema.
+//
+// The directory ALSO holds miniflare's own `metadata.sqlite`. Matching any
+// `*.sqlite` picked that one first (readdir order), so the push "succeeded"
+// into miniflare's bookkeeping DB and the real D1 stayed empty — every auth
+// request then 500'd on a missing table. Match the 64-hex content-hash name.
+const D1_FILE = /^[0-9a-f]{64}\.sqlite$/;
 const here = dirname(fileURLToPath(import.meta.url));
 const d1Dir = join(here, ".wrangler/state/v3/d1/miniflare-D1DatabaseObject");
-const file = existsSync(d1Dir) ? readdirSync(d1Dir).find((f) => f.endsWith(".sqlite")) : undefined;
+const file = existsSync(d1Dir) ? readdirSync(d1Dir).find((f) => D1_FILE.test(f)) : undefined;
 if (file === undefined) {
   throw new Error(
-    "Local D1 not found — run `pnpm --filter @repo/cloud dev` once to initialize it.",
+    "Local D1 not found — start `pnpm --filter @repo/cloud dev`, then hit a route " +
+      "that touches D1 (`curl -s localhost:8787/api/auth/get-session`) to materialize it.",
   );
 }
 

--- a/apps/cloud/package.json
+++ b/apps/cloud/package.json
@@ -24,6 +24,7 @@
   },
   "devDependencies": {
     "@cloudflare/vitest-pool-workers": "catalog:",
+    "@libsql/client": "^0.17.4",
     "drizzle-kit": "catalog:",
     "typescript": "catalog:",
     "vitest": "catalog:",

--- a/apps/desktop/.env.example
+++ b/apps/desktop/.env.example
@@ -27,9 +27,10 @@ INTELIGIR_GOOGLE_OAUTH_CLIENT_SECRET=
 # INTELIGIR_EMULATE_CONNECTORS=1  # route Google OAuth at a local `emulate` stub
 
 # --- Voice (dev, optional) ---------------------------------------------------
-# ELEVENLABS_VOICE_ID overrides packages/voice's built-in default voice.
+# ELEVENLABS_VOICE_ID overrides packages/voice's built-in default voice — leave
+# it COMMENTED OUT to keep that default.
 ELEVENLABS_API_KEY=
-ELEVENLABS_VOICE_ID=
+# ELEVENLABS_VOICE_ID=
 DEEPGRAM_API_KEY=
 LIVEKIT_URL=
 LIVEKIT_API_KEY=

--- a/apps/desktop/.env.example
+++ b/apps/desktop/.env.example
@@ -19,8 +19,17 @@
 INTELIGIR_GOOGLE_OAUTH_CLIENT_ID=
 INTELIGIR_GOOGLE_OAUTH_CLIENT_SECRET=
 
+# --- Dev-only agent/connector stubs (optional) -------------------------------
+# Login-free E2E driving — see docs/e2e-driving.md and the `e2e-drive` skill.
+# Both fail closed: they are ignored in a packaged build, so unset (or shipped)
+# the app is byte-identical to production. Remove them when done.
+# INTELIGIR_FAUX_AGENT=1          # scripted pi `faux` provider (chat + delegation)
+# INTELIGIR_EMULATE_CONNECTORS=1  # route Google OAuth at a local `emulate` stub
+
 # --- Voice (dev, optional) ---------------------------------------------------
+# ELEVENLABS_VOICE_ID overrides packages/voice's built-in default voice.
 ELEVENLABS_API_KEY=
+ELEVENLABS_VOICE_ID=
 DEEPGRAM_API_KEY=
 LIVEKIT_URL=
 LIVEKIT_API_KEY=

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -1,10 +1,21 @@
+import { fileURLToPath } from "node:url";
 import { cloudflare } from "@cloudflare/vite-plugin";
 import tailwindcss from "@tailwindcss/vite";
 import { tanstackStart } from "@tanstack/react-start/plugin/vite";
 import viteReact from "@vitejs/plugin-react";
 import { defineConfig } from "vite";
 
+const src = fileURLToPath(new URL("./src", import.meta.url));
+
 export default defineConfig({
+  // Pin the dev port. Vite's default is 5173 — which is also the desktop
+  // harness (`pnpm -F @repo/desktop dev:harness`), so `pnpm dev` silently
+  // bumped one of the two and nothing could name the web app's URL.
+  server: { port: 5174 },
+  // `@/*` is declared in tsconfig paths only. `vite build` resolves it (the
+  // start plugin reads tsconfig), but the dev SSR runner does not — `vite dev`
+  // 500'd with "Cannot find module '@/lib/site-config'". Declare it for both.
+  resolve: { alias: { "@": src } },
   plugins: [
     cloudflare({ viteEnvironment: { name: "ssr" } }),
     tanstackStart(),

--- a/docs/development.md
+++ b/docs/development.md
@@ -66,6 +66,8 @@ one walk+stat snapshot inside VaultManager (~1s TTL).
 | What                                                                      | Where                                                                     |
 | ------------------------------------------------------------------------- | ------------------------------------------------------------------------- |
 | App dev harness (vite)                                                    | 5173 (auto-increments)                                                    |
+| Marketing site (`pnpm dev:web`)                                           | 5174 (auto-increments)                                                    |
+| Coordinator Worker (`wrangler dev`)                                       | 8787                                                                      |
 | Electron CDP debugging                                                    | 9222                                                                      |
 | Executor daemon                                                           | 47888                                                                     |
 | App state (auth, sessions, ui-state, delegations, snapshots, `host.lock`) | `~/.inteligir`                                                            |
@@ -80,9 +82,12 @@ the next `pnpm dev:desktop`.
 ## Quality gates
 
 ```bash
-pnpm format:fix   # FIRST — never after gates (see fixture rule below)
-pnpm typecheck && pnpm lint && pnpm knip && pnpm format && pnpm test && pnpm build
+pnpm format:fix && pnpm verify
 ```
+
+`pnpm verify` = `typecheck && lint && knip && format && test && build`, the same
+six steps CI runs. It is check-only on purpose — `format:fix` is a separate
+first step, never folded in.
 
 Rules that have bitten before:
 

--- a/package.json
+++ b/package.json
@@ -8,13 +8,14 @@
     "dev": "turbo watch dev --continue",
     "dev:web": "turbo watch dev -F @repo/web...",
     "dev:desktop": "turbo watch dev -F @repo/desktop...",
-    "lint": "oxlint --report-unused-disable-directives",
+    "lint": "oxlint --report-unused-disable-directives --deny-warnings",
     "lint:fix": "oxlint --fix",
     "format": "oxfmt --check",
     "format:fix": "oxfmt --write",
     "knip": "knip",
     "test": "turbo run test",
-    "typecheck": "turbo run typecheck"
+    "typecheck": "turbo run typecheck",
+    "verify": "pnpm typecheck && pnpm lint && pnpm knip && pnpm format && pnpm test && pnpm build"
   },
   "devDependencies": {
     "dotenv-cli": "^11.0.0",

--- a/packages/server/src/__tests__/delegation-manager.test.ts
+++ b/packages/server/src/__tests__/delegation-manager.test.ts
@@ -258,9 +258,12 @@ describe("DelegationManager run lifecycle", () => {
     live = "## Today\n\nSome new note above.\n\n- [ ] task one\n- [ ] task two\n";
     const fake = fakeAgent();
     mgr.setRunner(() => fake.agent);
-    await flush();
-
-    expect(mgr.getDelegations()[0]?.status).toBe("running");
+    // Poll the terminal state rather than a single tick: dispatch runs through
+    // several async hops (processNext → run → resolve), and one setTimeout(0) is
+    // not guaranteed to cover them on a contended CI runner.
+    await vi.waitFor(() => {
+      expect(mgr.getDelegations()[0]?.status).toBe("running");
+    });
     expect(fake.prompts[0]).toContain("task one");
   });
 
@@ -280,10 +283,10 @@ describe("DelegationManager run lifecycle", () => {
     live = "## Today\n\n- [ ] inserted\n- [ ] task one\n- [ ] task two\n";
     const fake = fakeAgent();
     mgr.setRunner(() => fake.agent);
-    await flush();
-
+    await vi.waitFor(() => {
+      expect(mgr.getDelegations()[0]?.status).toBe("failed");
+    });
     const d = mgr.getDelegations()[0];
-    expect(d?.status).toBe("failed");
     expect(d?.error).toContain("changed");
     expect(fake.prompts.length).toBe(0);
   });
@@ -301,10 +304,10 @@ describe("DelegationManager run lifecycle", () => {
     live = "## Today\n\n(all tasks removed)\n";
     const fake = fakeAgent();
     mgr.setRunner(() => fake.agent);
-    await flush();
-
+    await vi.waitFor(() => {
+      expect(mgr.getDelegations()[0]?.status).toBe("failed");
+    });
     const d = mgr.getDelegations()[0];
-    expect(d?.status).toBe("failed");
     expect(d?.error).toContain("no longer");
     expect(fake.prompts.length).toBe(0);
   });

--- a/packages/voice/src/tts-proxy.ts
+++ b/packages/voice/src/tts-proxy.ts
@@ -69,7 +69,10 @@ function ensureConnection(): WebSocket | null {
   if (ws && ws.readyState <= WebSocket.OPEN) return ws;
   const apiKey = resolveApiKey();
   if (!apiKey) return null;
-  const voiceId = process.env["ELEVENLABS_VOICE_ID"] ?? DEFAULT_VOICE_ID;
+  // Blank-safe: a `.env` line of `ELEVENLABS_VOICE_ID=` loads as "" (a value,
+  // not "unset"), which `??` would happily pass through into the endpoint URL.
+  const voiceOverride = process.env["ELEVENLABS_VOICE_ID"]?.trim();
+  const voiceId = voiceOverride ? voiceOverride : DEFAULT_VOICE_ID;
   const socket = new WebSocket(endpoint(voiceId));
   ws = socket;
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -186,14 +186,17 @@ importers:
         version: link:../../packages/notes
       better-auth:
         specifier: 'catalog:'
-        version: 1.6.23(@opentelemetry/api@1.9.1)(@tanstack/react-start@1.168.27(esbuild@0.28.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(vite@8.1.4(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.0)(yaml@2.9.0)))(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@opentelemetry/api@1.9.1)(@types/sql.js@1.4.11)(kysely@0.29.3)(sql.js@1.14.1))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(vitest@4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.1.1)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.14.6(@types/node@26.1.1)(typescript@7.0.2))(vite@8.1.4(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.0)(yaml@2.9.0)))
+        version: 1.6.23(@opentelemetry/api@1.9.1)(@tanstack/react-start@1.168.27(esbuild@0.28.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(vite@8.1.4(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.0)(yaml@2.9.0)))(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@libsql/client@0.17.4)(@opentelemetry/api@1.9.1)(@types/sql.js@1.4.11)(kysely@0.29.3)(sql.js@1.14.1))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(vitest@4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.1.1)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.14.6(@types/node@26.1.1)(typescript@7.0.2))(vite@8.1.4(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.0)(yaml@2.9.0)))
       drizzle-orm:
         specifier: 'catalog:'
-        version: 0.45.2(@opentelemetry/api@1.9.1)(@types/sql.js@1.4.11)(kysely@0.29.3)(sql.js@1.14.1)
+        version: 0.45.2(@libsql/client@0.17.4)(@opentelemetry/api@1.9.1)(@types/sql.js@1.4.11)(kysely@0.29.3)(sql.js@1.14.1)
     devDependencies:
       '@cloudflare/vitest-pool-workers':
         specifier: 'catalog:'
         version: 0.18.4(@vitest/runner@4.1.10)(@vitest/snapshot@4.1.10)(vitest@4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.1.1)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.14.6(@types/node@26.1.1)(typescript@7.0.2))(vite@8.1.4(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.0)(yaml@2.9.0)))
+      '@libsql/client':
+        specifier: ^0.17.4
+        version: 0.17.4
       drizzle-kit:
         specifier: 'catalog:'
         version: 0.31.10
@@ -441,7 +444,7 @@ importers:
     dependencies:
       '@better-auth/expo':
         specifier: 'catalog:'
-        version: 1.6.23(87bd07de6d60f11ac8a5e5fd7ba7f5ee)
+        version: 1.6.23(e72c614e023ab501af336d46f1e5afc1)
       '@expo/metro-runtime':
         specifier: 'catalog:'
         version: 57.0.3(@expo/log-box@57.0.0)(expo@57.0.4)(react-dom@19.2.7(react@19.2.7))(react-native@0.86.0(@babel/core@7.29.7)(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.2.17)(react@19.2.7))(react@19.2.7)
@@ -453,7 +456,7 @@ importers:
         version: link:../../packages/notes
       better-auth:
         specifier: 'catalog:'
-        version: 1.6.23(@opentelemetry/api@1.9.1)(@tanstack/react-start@1.168.27(esbuild@0.28.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(vite@8.1.4(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.0)(yaml@2.9.0)))(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@opentelemetry/api@1.9.1)(@types/sql.js@1.4.11)(kysely@0.29.3)(sql.js@1.14.1))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(vitest@4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.1.1)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.14.6(@types/node@26.1.1)(typescript@7.0.2))(vite@8.1.4(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.0)(yaml@2.9.0)))
+        version: 1.6.23(@opentelemetry/api@1.9.1)(@tanstack/react-start@1.168.27(esbuild@0.28.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(vite@8.1.4(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.0)(yaml@2.9.0)))(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@libsql/client@0.17.4)(@opentelemetry/api@1.9.1)(@types/sql.js@1.4.11)(kysely@0.29.3)(sql.js@1.14.1))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(vitest@4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.1.1)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.14.6(@types/node@26.1.1)(typescript@7.0.2))(vite@8.1.4(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.0)(yaml@2.9.0)))
       expo:
         specifier: 'catalog:'
         version: 57.0.4(@babel/core@7.29.7)(@expo/dom-webview@56.0.5)(@expo/metro-runtime@57.0.3)(expo-router@57.0.4)(react-dom@19.2.7(react@19.2.7))(react-native-worklets@0.10.2(@babel/core@7.29.7)(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(react-native@0.86.0(@babel/core@7.29.7)(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.2.17)(react@19.2.7))(react@19.2.7))(react-native@0.86.0(@babel/core@7.29.7)(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.2.17)(react@19.2.7))(react@19.2.7)(typescript@7.0.2)
@@ -839,7 +842,7 @@ importers:
         version: 0.34.50
       better-auth:
         specifier: 'catalog:'
-        version: 1.6.23(@opentelemetry/api@1.9.1)(@tanstack/react-start@1.168.27(esbuild@0.28.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(vite@8.1.4(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.0)(yaml@2.9.0)))(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@opentelemetry/api@1.9.1)(@types/sql.js@1.4.11)(kysely@0.29.3)(sql.js@1.14.1))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(vitest@4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.1.1)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.14.6(@types/node@26.1.1)(typescript@7.0.2))(vite@8.1.4(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.0)(yaml@2.9.0)))
+        version: 1.6.23(@opentelemetry/api@1.9.1)(@tanstack/react-start@1.168.27(esbuild@0.28.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(vite@8.1.4(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.0)(yaml@2.9.0)))(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@libsql/client@0.17.4)(@opentelemetry/api@1.9.1)(@types/sql.js@1.4.11)(kysely@0.29.3)(sql.js@1.14.1))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(vitest@4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.1.1)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.14.6(@types/node@26.1.1)(typescript@7.0.2))(vite@8.1.4(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.0)(yaml@2.9.0)))
       open:
         specifier: ^11.0.0
         version: 11.0.0
@@ -2821,6 +2824,63 @@ packages:
   '@juggle/resize-observer@3.4.0':
     resolution: {integrity: sha512-dfLbk+PwWvFzSxwk3n5ySL0hfBog779o8h68wK/7/APo/7cgyWp5jcXockbxdk5kFRkbeXWm4Fbi9FrdN381sA==}
 
+  '@libsql/client@0.17.4':
+    resolution: {integrity: sha512-lYayFWasDV78A+TjlEhr6ubb3odBV6OHjb+wdp8VQcyWWAEIjuwbCHaraEUS4m4yWoo0BvZo96It4VdzZRmRWw==}
+
+  '@libsql/core@0.17.4':
+    resolution: {integrity: sha512-LqF9gIvnJ38nmAH1y/ChizHqDO/MO1wLgA96XrraulEEbqXxLjleSH92YWTolbuJKgPUmGu4aJk9W3UnAcxLOQ==}
+
+  '@libsql/darwin-arm64@0.5.29':
+    resolution: {integrity: sha512-K+2RIB1OGFPYQbfay48GakLhqf3ArcbHqPFu7EZiaUcRgFcdw8RoltsMyvbj5ix2fY0HV3Q3Ioa/ByvQdaSM0A==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@libsql/darwin-x64@0.5.29':
+    resolution: {integrity: sha512-OtT+KFHsKFy1R5FVadr8FJ2Bb1mghtXTyJkxv0trocq7NuHntSki1eUbxpO5ezJesDvBlqFjnWaYYY516QNLhQ==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@libsql/hrana-client@0.10.0':
+    resolution: {integrity: sha512-OoA4EMqRAC7kn7V2P6EQqRcpZf2W+AjsNIyCizBg339Tq/aMC7sRnzs3SklderhmQWAqEzvv8A2vhxVmWpkVvw==}
+
+  '@libsql/isomorphic-ws@0.1.5':
+    resolution: {integrity: sha512-DtLWIH29onUYR00i0GlQ3UdcTRC6EP4u9w/h9LxpUZJWRMARk6dQwZ6Jkd+QdwVpuAOrdxt18v0K2uIYR3fwFg==}
+
+  '@libsql/linux-arm-gnueabihf@0.5.29':
+    resolution: {integrity: sha512-CD4n4zj7SJTHso4nf5cuMoWoMSS7asn5hHygsDuhRl8jjjCTT3yE+xdUvI4J7zsyb53VO5ISh4cwwOtf6k2UhQ==}
+    cpu: [arm]
+    os: [linux]
+
+  '@libsql/linux-arm-musleabihf@0.5.29':
+    resolution: {integrity: sha512-2Z9qBVpEJV7OeflzIR3+l5yAd4uTOLxklScYTwpZnkm2vDSGlC1PRlueLaufc4EFITkLKXK2MWBpexuNJfMVcg==}
+    cpu: [arm]
+    os: [linux]
+
+  '@libsql/linux-arm64-gnu@0.5.29':
+    resolution: {integrity: sha512-gURBqaiXIGGwFNEaUj8Ldk7Hps4STtG+31aEidCk5evMMdtsdfL3HPCpvys+ZF/tkOs2MWlRWoSq7SOuCE9k3w==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@libsql/linux-arm64-musl@0.5.29':
+    resolution: {integrity: sha512-fwgYZ0H8mUkyVqXZHF3mT/92iIh1N94Owi/f66cPVNsk9BdGKq5gVpoKO+7UxaNzuEH1roJp2QEwsCZMvBLpqg==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@libsql/linux-x64-gnu@0.5.29':
+    resolution: {integrity: sha512-y14V0vY0nmMC6G0pHeJcEarcnGU2H6cm21ZceRkacWHvQAEhAG0latQkCtoS2njFOXiYIg+JYPfAoWKbi82rkg==}
+    cpu: [x64]
+    os: [linux]
+
+  '@libsql/linux-x64-musl@0.5.29':
+    resolution: {integrity: sha512-gquqwA/39tH4pFl+J9n3SOMSymjX+6kZ3kWgY3b94nXFTwac9bnFNMffIomgvlFaC4ArVqMnOZD3nuJ3H3VO1w==}
+    cpu: [x64]
+    os: [linux]
+
+  '@libsql/win32-x64-msvc@0.5.29':
+    resolution: {integrity: sha512-4/0CvEdhi6+KjMxMaVbFM2n2Z44escBRoEYpR+gZg64DdetzGnYm8mcNLcoySaDJZNaBd6wz5DNdgRmcI4hXcg==}
+    cpu: [x64]
+    os: [win32]
+
   '@malept/cross-spawn-promise@2.0.0':
     resolution: {integrity: sha512-1DpKU0Z5ThltBwjNySMC14g0CkbyhCaz9FkhxqNsZI6uAPJXFS8cMXlBKo26FJ8ZuW6S9GCMcR9IO5k2X5/9Fg==}
     engines: {node: '>= 12.13.0'}
@@ -2927,6 +2987,9 @@ packages:
     peerDependencies:
       '@emnapi/core': ^1.7.1
       '@emnapi/runtime': ^1.7.1
+
+  '@neon-rs/load@0.0.4':
+    resolution: {integrity: sha512-kTPhdZyTQxB+2wpiRcFWrDcejc4JI6tkPuS7UZCG4l6Zvc5kU/gGQ/ozvHTh1XR5tS+UlfAfGuPajjzQjCiHCw==}
 
   '@noble/ciphers@2.2.0':
     resolution: {integrity: sha512-Z6pjIZ/8IJcCGzb2S/0Px5J81yij85xASuk1teLNeg75bfT07MV3a/O2Mtn1I2se43k3lkVEcFaR10N4cgQcZA==}
@@ -5960,6 +6023,10 @@ packages:
     resolution: {integrity: sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==}
     engines: {node: '>= 0.8', npm: 1.2.8000 || >= 1.4.16}
 
+  detect-libc@2.0.2:
+    resolution: {integrity: sha512-UX6sGumvvqSaXgdKGUsgZWqcUyIXZ/vZTrlRT/iobiKhGL0zL4d3osHj3uqllWJK+i+sixDS/3COVEOFbupFyw==}
+    engines: {node: '>=8'}
+
   detect-libc@2.1.2:
     resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
     engines: {node: '>=8'}
@@ -7316,6 +7383,9 @@ packages:
       react:
         optional: true
 
+  js-base64@3.9.1:
+    resolution: {integrity: sha512-U73qptcvf/HIOauFOmqT3a0mDUp0MYlfd15oqoe9kqZt5XhiXVb+HG09sLvI9PQ9tZIBFS4nlErai8zbWazP0g==}
+
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
@@ -7432,6 +7502,11 @@ packages:
   leven@3.1.0:
     resolution: {integrity: sha512-qsda+H8jTaUaN/x5vzW2rzc+8Rw4TAQ/4KjB46IwK5VH+IlVeeeje/EoZRpiXvIqjFgK84QffqPztGI3VBLG1A==}
     engines: {node: '>=6'}
+
+  libsql@0.5.29:
+    resolution: {integrity: sha512-8lMP8iMgiBzzoNbAPQ59qdVcj6UaE/Vnm+fiwX4doX4Narook0a4GPKWBEv+CR8a1OwbfkgL18uBfBjWdF0Fzg==}
+    cpu: [x64, arm64, wasm32, arm]
+    os: [darwin, linux, win32]
 
   lighthouse-logger@1.4.2:
     resolution: {integrity: sha512-gPWxznF6TKmUHrOQjlVo2UbaL2EJ71mb2CCeRs/2qBpi4L/g4LUVc9+3lKQ6DTUZwJswfM7ainGrLO1+fOqa2g==}
@@ -8482,6 +8557,9 @@ packages:
   progress@2.0.3:
     resolution: {integrity: sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==}
     engines: {node: '>=0.4.0'}
+
+  promise-limit@2.7.0:
+    resolution: {integrity: sha512-7nJ6v5lnJsXwGprnGXga4wx6d1POjvi5Qmf1ivTRxTjH4Z/9Czja/UCMLVmB9N93GeWOU93XaFaEt6jbuoagNw==}
 
   promise-retry@2.0.1:
     resolution: {integrity: sha512-y+WKFlBR8BGXnsNlIHFGPZmyDf3DFMoLhaflAnyZgV6rG6xu+JwesTo2Q9R6XwYmtmwAFCkAk3e35jEdoeh/3g==}
@@ -10993,18 +11071,18 @@ snapshots:
     optionalDependencies:
       '@opentelemetry/api': 1.9.1
 
-  '@better-auth/drizzle-adapter@1.6.23(@better-auth/core@1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.29.3)(nanostores@1.4.0))(@better-auth/utils@0.4.2)(drizzle-orm@0.45.2(@opentelemetry/api@1.9.1)(@types/sql.js@1.4.11)(kysely@0.29.3)(sql.js@1.14.1))':
+  '@better-auth/drizzle-adapter@1.6.23(@better-auth/core@1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.29.3)(nanostores@1.4.0))(@better-auth/utils@0.4.2)(drizzle-orm@0.45.2(@libsql/client@0.17.4)(@opentelemetry/api@1.9.1)(@types/sql.js@1.4.11)(kysely@0.29.3)(sql.js@1.14.1))':
     dependencies:
       '@better-auth/core': 1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.29.3)(nanostores@1.4.0)
       '@better-auth/utils': 0.4.2
     optionalDependencies:
-      drizzle-orm: 0.45.2(@opentelemetry/api@1.9.1)(@types/sql.js@1.4.11)(kysely@0.29.3)(sql.js@1.14.1)
+      drizzle-orm: 0.45.2(@libsql/client@0.17.4)(@opentelemetry/api@1.9.1)(@types/sql.js@1.4.11)(kysely@0.29.3)(sql.js@1.14.1)
 
-  '@better-auth/expo@1.6.23(87bd07de6d60f11ac8a5e5fd7ba7f5ee)':
+  '@better-auth/expo@1.6.23(e72c614e023ab501af336d46f1e5afc1)':
     dependencies:
       '@better-auth/core': 1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.29.3)(nanostores@1.4.0)
       '@better-fetch/fetch': 1.3.1
-      better-auth: 1.6.23(@opentelemetry/api@1.9.1)(@tanstack/react-start@1.168.27(esbuild@0.28.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(vite@8.1.4(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.0)(yaml@2.9.0)))(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@opentelemetry/api@1.9.1)(@types/sql.js@1.4.11)(kysely@0.29.3)(sql.js@1.14.1))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(vitest@4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.1.1)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.14.6(@types/node@26.1.1)(typescript@7.0.2))(vite@8.1.4(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.0)(yaml@2.9.0)))
+      better-auth: 1.6.23(@opentelemetry/api@1.9.1)(@tanstack/react-start@1.168.27(esbuild@0.28.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(vite@8.1.4(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.0)(yaml@2.9.0)))(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@libsql/client@0.17.4)(@opentelemetry/api@1.9.1)(@types/sql.js@1.4.11)(kysely@0.29.3)(sql.js@1.14.1))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(vitest@4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.1.1)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.14.6(@types/node@26.1.1)(typescript@7.0.2))(vite@8.1.4(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.0)(yaml@2.9.0)))
       better-call: 1.3.7(zod@4.4.3)
       zod: 4.4.3
     optionalDependencies:
@@ -12240,6 +12318,64 @@ snapshots:
 
   '@juggle/resize-observer@3.4.0': {}
 
+  '@libsql/client@0.17.4':
+    dependencies:
+      '@libsql/core': 0.17.4
+      '@libsql/hrana-client': 0.10.0
+      js-base64: 3.9.1
+      libsql: 0.5.29
+      promise-limit: 2.7.0
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+
+  '@libsql/core@0.17.4':
+    dependencies:
+      js-base64: 3.9.1
+
+  '@libsql/darwin-arm64@0.5.29':
+    optional: true
+
+  '@libsql/darwin-x64@0.5.29':
+    optional: true
+
+  '@libsql/hrana-client@0.10.0':
+    dependencies:
+      '@libsql/isomorphic-ws': 0.1.5
+      js-base64: 3.9.1
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+
+  '@libsql/isomorphic-ws@0.1.5':
+    dependencies:
+      '@types/ws': 8.18.1
+      ws: 8.21.0
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+
+  '@libsql/linux-arm-gnueabihf@0.5.29':
+    optional: true
+
+  '@libsql/linux-arm-musleabihf@0.5.29':
+    optional: true
+
+  '@libsql/linux-arm64-gnu@0.5.29':
+    optional: true
+
+  '@libsql/linux-arm64-musl@0.5.29':
+    optional: true
+
+  '@libsql/linux-x64-gnu@0.5.29':
+    optional: true
+
+  '@libsql/linux-x64-musl@0.5.29':
+    optional: true
+
+  '@libsql/win32-x64-msvc@0.5.29':
+    optional: true
+
   '@malept/cross-spawn-promise@2.0.0':
     dependencies:
       cross-spawn: 7.0.6
@@ -12381,6 +12517,8 @@ snapshots:
       '@emnapi/runtime': 1.11.1
       '@tybys/wasm-util': 0.10.3
     optional: true
+
+  '@neon-rs/load@0.0.4': {}
 
   '@noble/ciphers@2.2.0': {}
 
@@ -14587,10 +14725,10 @@ snapshots:
 
   baseline-browser-mapping@2.10.42: {}
 
-  better-auth@1.6.23(@opentelemetry/api@1.9.1)(@tanstack/react-start@1.168.27(esbuild@0.28.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(vite@8.1.4(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.0)(yaml@2.9.0)))(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@opentelemetry/api@1.9.1)(@types/sql.js@1.4.11)(kysely@0.29.3)(sql.js@1.14.1))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(vitest@4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.1.1)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.14.6(@types/node@26.1.1)(typescript@7.0.2))(vite@8.1.4(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.0)(yaml@2.9.0))):
+  better-auth@1.6.23(@opentelemetry/api@1.9.1)(@tanstack/react-start@1.168.27(esbuild@0.28.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(vite@8.1.4(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.0)(yaml@2.9.0)))(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@libsql/client@0.17.4)(@opentelemetry/api@1.9.1)(@types/sql.js@1.4.11)(kysely@0.29.3)(sql.js@1.14.1))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(vitest@4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.1.1)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.14.6(@types/node@26.1.1)(typescript@7.0.2))(vite@8.1.4(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.0)(yaml@2.9.0))):
     dependencies:
       '@better-auth/core': 1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.29.3)(nanostores@1.4.0)
-      '@better-auth/drizzle-adapter': 1.6.23(@better-auth/core@1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.29.3)(nanostores@1.4.0))(@better-auth/utils@0.4.2)(drizzle-orm@0.45.2(@opentelemetry/api@1.9.1)(@types/sql.js@1.4.11)(kysely@0.29.3)(sql.js@1.14.1))
+      '@better-auth/drizzle-adapter': 1.6.23(@better-auth/core@1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.29.3)(nanostores@1.4.0))(@better-auth/utils@0.4.2)(drizzle-orm@0.45.2(@libsql/client@0.17.4)(@opentelemetry/api@1.9.1)(@types/sql.js@1.4.11)(kysely@0.29.3)(sql.js@1.14.1))
       '@better-auth/kysely-adapter': 1.6.23(@better-auth/core@1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.29.3)(nanostores@1.4.0))(@better-auth/utils@0.4.2)(kysely@0.29.3)
       '@better-auth/memory-adapter': 1.6.23(@better-auth/core@1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.29.3)(nanostores@1.4.0))(@better-auth/utils@0.4.2)
       '@better-auth/mongo-adapter': 1.6.23(@better-auth/core@1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.29.3)(nanostores@1.4.0))(@better-auth/utils@0.4.2)
@@ -14609,7 +14747,7 @@ snapshots:
     optionalDependencies:
       '@tanstack/react-start': 1.168.27(esbuild@0.28.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(vite@8.1.4(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.0)(yaml@2.9.0))
       drizzle-kit: 0.31.10
-      drizzle-orm: 0.45.2(@opentelemetry/api@1.9.1)(@types/sql.js@1.4.11)(kysely@0.29.3)(sql.js@1.14.1)
+      drizzle-orm: 0.45.2(@libsql/client@0.17.4)(@opentelemetry/api@1.9.1)(@types/sql.js@1.4.11)(kysely@0.29.3)(sql.js@1.14.1)
       react: 19.2.7
       react-dom: 19.2.7(react@19.2.7)
       vitest: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.1.1)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.14.6(@types/node@26.1.1)(typescript@7.0.2))(vite@8.1.4(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.0)(yaml@2.9.0))
@@ -15335,6 +15473,8 @@ snapshots:
 
   destroy@1.2.0: {}
 
+  detect-libc@2.0.2: {}
+
   detect-libc@2.1.2: {}
 
   detect-node-es@1.1.0: {}
@@ -15407,8 +15547,9 @@ snapshots:
       esbuild: 0.25.12
       tsx: 4.23.0
 
-  drizzle-orm@0.45.2(@opentelemetry/api@1.9.1)(@types/sql.js@1.4.11)(kysely@0.29.3)(sql.js@1.14.1):
+  drizzle-orm@0.45.2(@libsql/client@0.17.4)(@opentelemetry/api@1.9.1)(@types/sql.js@1.4.11)(kysely@0.29.3)(sql.js@1.14.1):
     optionalDependencies:
+      '@libsql/client': 0.17.4
       '@opentelemetry/api': 1.9.1
       '@types/sql.js': 1.4.11
       kysely: 0.29.3
@@ -16820,6 +16961,8 @@ snapshots:
       '@types/react': 19.2.17
       react: 19.2.7
 
+  js-base64@3.9.1: {}
+
   js-tokens@4.0.0: {}
 
   js-yaml@4.3.0:
@@ -16948,6 +17091,21 @@ snapshots:
   lazy-val@1.0.5: {}
 
   leven@3.1.0: {}
+
+  libsql@0.5.29:
+    dependencies:
+      '@neon-rs/load': 0.0.4
+      detect-libc: 2.0.2
+    optionalDependencies:
+      '@libsql/darwin-arm64': 0.5.29
+      '@libsql/darwin-x64': 0.5.29
+      '@libsql/linux-arm-gnueabihf': 0.5.29
+      '@libsql/linux-arm-musleabihf': 0.5.29
+      '@libsql/linux-arm64-gnu': 0.5.29
+      '@libsql/linux-arm64-musl': 0.5.29
+      '@libsql/linux-x64-gnu': 0.5.29
+      '@libsql/linux-x64-musl': 0.5.29
+      '@libsql/win32-x64-msvc': 0.5.29
 
   lighthouse-logger@1.4.2:
     dependencies:
@@ -18433,6 +18591,8 @@ snapshots:
   process-nextick-args@2.0.1: {}
 
   progress@2.0.3: {}
+
+  promise-limit@2.7.0: {}
 
   promise-retry@2.0.1:
     dependencies:

--- a/turbo.json
+++ b/turbo.json
@@ -7,11 +7,14 @@
     },
     "build": {
       "dependsOn": ["^build"],
-      "outputs": [".cache/tsbuildinfo.json", "dist/**", ".output/**"]
+      // What the builds actually emit: vite/wrangler -> dist/, electron-vite ->
+      // .output/. tsbuildinfo belongs to `typecheck` (tsc --noEmit, incremental),
+      // not here — declaring it as a build output cached the wrong artifact.
+      "outputs": ["dist/**", ".output/**"]
     },
     "@repo/desktop#build": {
       "dependsOn": ["^build"],
-      "outputs": [".cache/tsbuildinfo.json", ".output/**"],
+      "outputs": [".output/**"],
       "env": ["INTELIGIR_GOOGLE_OAUTH_CLIENT_ID", "INTELIGIR_GOOGLE_OAUTH_CLIENT_SECRET"]
     },
     "dev": {
@@ -20,7 +23,10 @@
     },
     "typecheck": {
       "dependsOn": ["^topo"],
-      "outputs": []
+      // tsc runs incremental (tsconfig.base.json `tsBuildInfoFile`), so the
+      // incremental state IS this task's output — cache it or every restore
+      // re-checks from cold.
+      "outputs": [".cache/tsbuildinfo.json"]
     },
     "test": {
       "dependsOn": ["^topo"],


### PR DESCRIPTION
Ports the agent-workflow patterns that landed in `kyh/init` on 2026-07-19 — the second sync after the 2026-07-18 sweep.

## Landed

- **AGENTS.md is a real file** (was a tracked symlink to CLAUDE.md). Written for this repo: harness-vs-Electron run modes, the fresh-checkout footguns (`electron/install.js`, the pkill line), a verified 4-command local-Worker account recipe (there is no seed script and no test account), agent-browser recipes for the harness and for Electron over CDP :9222, a platform matrix, and the rules that actually bite. `CLAUDE.md` gained an `## Agent-driven development` pointer.
- **`.claude/settings.json`** (new, tracked): repo `prompt` (harness is the fast loop; `format:fix` before the gates; never touch the production D1) + `permissions.allow` for this repo's dev/gate commands + a `deny` on the production-D1 scripts. `settings.local.json` untouched.
- **`pnpm verify`** = `typecheck && lint && knip && format && test && build`, mirroring ci.yml's six steps. `lint` gained `--deny-warnings` (0 warnings today). Check-only on purpose — `format:fix` stays a separate FIRST step (incident #362). Three drifted hand-written gate blocks (CLAUDE.md, docs/development.md, README.md) collapsed to reference it.
- **turbo.json**: dropped the dead `.cache/tsbuildinfo.json` from `build.outputs` (root + `@repo/desktop#build`) and declared it under `typecheck.outputs`, which is what `tsc --noEmit` actually emits here. Verified with `--dry=json` and two consecutive FULL TURBO runs.
- **`db:push:local` was silently broken** — `drizzle.config.local.ts` globbed any `*.sqlite` in the miniflare dir and matched miniflare's own `metadata.sqlite`, so the schema went into miniflare's bookkeeping DB and every local auth request 500'd on a missing `rate_limit` table. Now matches the 64-hex content-hash name and fails loudly. Added `@libsql/client` devDep (drizzle-kit had no sqlite driver at all).
- **`pnpm dev:web` was broken on main** — `@/*` exists only in tsconfig paths, which `vite build` honours but the dev SSR runner does not, so every request 500'd. Added `resolve.alias` and pinned `server.port: 5174` (5173 is the harness). `.claude/launch.json` and the docs ports table corrected.
- **Env docs**: new root `.env.example` (owner-only `CLOUDFLARE_*`, with the production-D1 DANGER block) and `apps/cloud/.dev.vars.example`; `apps/desktop/.env.example` gained the two dev-only e2e flags and the undocumented `ELEVENLABS_VOICE_ID`.
- **Cleanup**: deleted the dead `next-devtools` MCP registration (`.mcp.json`, `.codex/config.toml`) — no Next.js here. README's packages table gained the five missing workspaces.

## Review-pass fixes (second commit)

- `ELEVENLABS_VOICE_ID` is now commented out in `.env.example`: `process.loadEnvFile` turns `KEY=` into `""`, and `?? DEFAULT_VOICE_ID` passed that straight into the TTS endpoint URL. `tts-proxy.ts` made blank-safe too.
- `db:studio` named alongside `db:push`/`db:push:remote` in every guard (AGENTS.md, `.env.example`, settings.json `deny`, apps/cloud/README.md) — it's a read/write UI over the same production D1.
- apps/cloud/README.md's local-D1 recipe was a fourth, stale copy: `dev` alone does not materialize the miniflare D1, you must hit a D1 route first.
- AGENTS.md: added the `agent-browser` install one-liner (nothing vendors it) and corrected the knip rule — knip's config plugins already resolve tooling deps, `ignoreDependencies` is the exception, not the rule.
- settings.json `allow` now covers what AGENTS.md tells agents to run: `pnpm install`, the individual gates, `-F @repo/cloud test`, the three specific pkills.

## Not ported

- **`.agents/` + skill stubs + bootstrap script** — out of scope by instruction. AGENTS.md documents the real provisioning (`pnpm install`) and never names a bootstrap command.
- **`db:seed`** — N/A by design. Notes live in the user's local vault, never in a server DB, so a seed would only ever write one user row. AGENTS.md carries the verified 4-command recipe instead; fixing `db:push:local` was the actual blocker.
- **`--force` on the remote pushes** — deliberately not added. `db:push:local` already has it; both other scripts target production.
- **Offline GitHub OAuth via `emulate` + genericOAuth** — deferred. No web login page here; the flow is Electron → system browser → `inteligir://session` → host-side exchange, and `/v1/capabilities` gates the button. Not worth touching production auth code when email/password against a local Worker already works headlessly.
- **Next.js-shaped themes** (Suspense/`useSearchParams`, `CI=1` build semantics) — no Next.js in this repo.
- **Kill the global MutationCache** — verified N/A: zero `@tanstack/react-query` hits anywhere. Renderer state is zustand + context.
- **`hasPermission()` on ac/roles**, **drop redundant `slug` from procedure inputs**, **tRPC `onError` code skipping** — N/A: no better-auth organization plugin, no tRPC.
- **Parsed env module** — partial by choice. The Worker half already exists (`apps/cloud/src/env.d.ts`, optional-everything, consumers degrade); the Node host goes through two audited funnels (`dev-flags.ts`, `optionOrEnv`). The only real gap was the undocumented `ELEVENLABS_VOICE_ID`, now documented.
- **Shared `formatDate`** — skipped on the merits. No SSR'd dates to mismatch; all seven `toLocale*` sites deliberately want the user's locale, and the agent's date context deliberately wants local today.
- **`shadcn` → devDependencies** — already correct.
- **Remove in-app AI / mobile social-parity** — N/A (this product is AI-native) and deliberate divergence documented at `apps/cloud/src/auth/auth.ts` (pulling `@better-auth/expo` into the Worker drags the Expo SDK in).

## Verification

- Baseline on clean `main` (e95465a5), each gate run separately: typecheck, lint (0 warnings), knip, format, test, build — all exit 0. No pre-existing failures.
- After the review fixes: `pnpm format:fix` FIRST, then `CI=1 pnpm verify` → **exit 0** (typecheck 15/15, lint, knip, format --check, test 13/13, build 3/3). Run under `CI=1` even though there is no Next.js app here, so it changes nothing behaviourally.
- Turbo config checked structurally (`turbo run build|typecheck --dry=json`) and behaviourally (second run reports FULL TURBO).
- Runtime, all actually executed: `dev:harness` serves the harness; `pnpm dev:web` → 200 with `<title>Inteligir</title>` on :5174; `-F @repo/cloud dev` → `/v1/capabilities` 200 → get-session materializes the D1 → `db:push:local` applies the schema → sign-up and sign-in both 200 with `set-auth-token`.
- **No remote/production DB command was ever run.** Local artifacts (`apps/cloud/.dev.vars`, `.wrangler/state`) deleted; no stray dev servers.

## Owner decisions

- `@libsql/client` is the largest-footprint change (+173 lockfile lines, prebuilt native binaries). CLI-only — nothing in `src` imports it, Worker bundle unaffected. Alternatives: `better-sqlite3` (native compile) or leaving `db:push:local` broken.
- `lint --deny-warnings` is a no-op today but changes what CI accepts going forward.
- The untracked `.claude/settings.local.json` still lists `"enabledMcpjsonServers": ["next-devtools"]`. Dangling and harmless now that `.mcp.json` is gone — prune by hand if you care. It has no `prompt` key, so no conflict with the new tracked settings.
- The `deny` block matches six exact spellings; it can't be made airtight without also denying `db:push:local`. The real guard is the prose warning.
- The catalog pins `typescript: ^7.0.2` here, contradicting the global "stay on ^6.x" rule. Untouched, all gates green (no Next.js/pkgroll in this repo), but flagging it.
- apps/web's `server.port: 5174` has no `strictPort` — vite will still auto-increment if it's taken.
- AGENTS.md's agent-browser subcommand spellings are inherited from init's canonical file, not re-executed in this session. Everything else in it was run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Syncs the agent-workflow layer from init: adds a runnable AGENTS.md, a single `pnpm verify` gate mirroring CI, safer local defaults, and stabilizes flaky delegation tests. Fixes local D1 push and web dev SSR; improves turbo caching, env docs, voice config, and clarifies knip guidance.

- New Features
  - AGENTS.md is now repo-specific (quickstart, verified local Worker recipe, platform matrix, rules); `CLAUDE.md` links to it and adds an agent-driven dev section.
  - `.claude/settings.json` adds a repo prompt, allowlist, and denies `db:push`, `db:push:remote`, and `db:studio`.
  - `pnpm verify` runs CI’s six gates; lint uses `--deny-warnings`. Docs reference `format:fix && verify`.
  - New env examples: root `.env.example` (owner-only Cloudflare D1), `apps/cloud/.dev.vars.example`; `apps/desktop/.env.example` documents dev-only flags and comments out `ELEVENLABS_VOICE_ID`. Removed dead Next.js MCP config; updated `.claude/launch.json`.

- Bug Fixes
  - Local D1 push: `drizzle.config.local.ts` targets the hashed D1 file (not `metadata.sqlite`) and fails loudly; added `@libsql/client` devDep.
  - Web dev SSR: added `resolve.alias` for `@/*`; pinned `apps/web` dev port to 5174.
  - Voice: `ELEVENLABS_VOICE_ID` handled blank-safe in the TTS proxy; example commented out.
  - Turbo caching: moved `.cache/tsbuildinfo.json` to `typecheck.outputs`; build outputs limited to real artifacts.
  - Tests: deflake `DelegationManager` anchor re-resolution tests by polling terminal state with `vi.waitFor` instead of a single tick flush.

<sup>Written for commit ce5ea9ed033d2077cd2ce855d9aac897fea9cd95. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kyh/inteligir/pull/468?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

