### PR TITLE
perf(knowledge): unquadratic the agent search, scope link re-resolution

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -4,15 +4,22 @@
   // that 404s silently leaves every key in this file unvalidated in the
   // editor, so a misspelled option reads as "configured" and does nothing.
   "$schema": "./node_modules/oxlint/configuration_schema.json",
-  // These two are the gate's real strictness, so they belong to the config
-  // every consumer reads. Kept as CLI flags in the root `lint` script instead,
-  // they bind only in CI — `lint:fix` and the oxlint LSP then run a weaker
-  // rule set than the gate. CLI flags still win where both are set.
-  // `typeAware` is deliberately NOT enabled: it needs oxlint-tsgolint and
-  // surfaces ~138 findings, so turning it on here makes the gate unpassable.
+  // These are the gate's real strictness, so they belong to the config every
+  // consumer reads. Kept as CLI flags in the root `lint` script instead, they
+  // bind only in CI — `lint:fix` and the oxlint LSP then run a weaker rule set
+  // than the gate. CLI flags still win where both are set.
+  // `typeAware` runs the rules that need type information, by spawning the
+  // `oxlint-tsgolint` peer (a root devDependency — nothing extra to install,
+  // and every @repo/* exports TS source, so there is no build step to stage
+  // first). It costs seconds and about a gigabyte of resident memory where the
+  // type-blind pass costs neither, which is still small beside typecheck +
+  // test + build — so it rides in the one `lint` gate rather than a separate
+  // script every caller has to remember. WHICH type-aware rules run is staged
+  // in `rules` below.
   "options": {
     "denyWarnings": true,
-    "reportUnusedDisableDirectives": "error"
+    "reportUnusedDisableDirectives": "error",
+    "typeAware": true
   },
   "ignorePatterns": [
     "dist",
@@ -56,7 +63,41 @@
         "allowAsProps": true
       }
     ],
-    "unicorn/prefer-node-protocol": "error"
+    "unicorn/prefer-node-protocol": "error",
+
+    // Type-aware rules, staged. `options.typeAware` switches on EVERY
+    // type-aware rule the enabled categories carry, so the ones not wanted yet
+    // are written off by name rather than left implicit: this list is the
+    // ladder, and a rule graduates by flipping to "error" once its findings
+    // are cleared. The promise set is what runs today — a dropped promise, or
+    // one handed to a slot that expects a void return, is a real bug class no
+    // type-blind rule can see. `no-misused-promises` is not category-enabled,
+    // so it is opted in by name.
+    "typescript/await-thenable": "error",
+    "typescript/no-floating-promises": "error",
+    "typescript/no-misused-promises": "error",
+    "typescript/consistent-return": "off",
+    "typescript/no-array-delete": "off",
+    "typescript/no-base-to-string": "off",
+    "typescript/no-duplicate-type-constituents": "off",
+    "typescript/no-for-in-array": "off",
+    "typescript/no-implied-eval": "off",
+    "typescript/no-meaningless-void-operator": "off",
+    "typescript/no-misused-spread": "off",
+    "typescript/no-redundant-type-constituents": "off",
+    "typescript/no-unnecessary-boolean-literal-compare": "off",
+    "typescript/no-unnecessary-template-expression": "off",
+    "typescript/no-unnecessary-type-arguments": "off",
+    "typescript/no-unnecessary-type-assertion": "off",
+    "typescript/no-unnecessary-type-conversion": "off",
+    "typescript/no-unnecessary-type-parameters": "off",
+    "typescript/no-unsafe-enum-comparison": "off",
+    "typescript/no-unsafe-type-assertion": "off",
+    "typescript/no-unsafe-unary-minus": "off",
+    "typescript/no-useless-default-assignment": "off",
+    "typescript/require-array-sort-compare": "off",
+    "typescript/restrict-template-expressions": "off",
+    "typescript/unbound-method": "off"
   },
   "overrides": [
     {

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -534,6 +534,33 @@ record for the decisions code comments cite.
   OFF by default, so exposure is one resident DO per online synced device, and
   a rewrite would cross `@repo/notes/sync/wire` — the pure seam BOTH platforms
   drive — for a rounding-error bill. Revisit if sync becomes default-on.
+- **The D1 auth schema ships via `drizzle-kit push`; there are no migration
+  files.** Push is a supported primary flow for serverless databases, and the
+  three things that make it dangerous are all absent here: one deployer (the
+  account owner), an additive schema, and nothing derived that can rot —
+  `apps/cloud/vitest.config.ts` builds the test DDL by running
+  `drizzle-kit export` over `src/db/schema.ts`, so the suite always runs the
+  schema the source declares. A second deployer or a destructive column change
+  is the trigger for adopting migrations. The Better Auth tables in that
+  schema are hand-written and diverge from `@better-auth/cli generate` in two
+  places on purpose: timestamps are `mode: "timestamp"` (epoch SECONDS) where the
+  generator emits `timestamp_ms`, and the generator's three secondary indexes
+  (`session.userId`, `account.userId`, `verification.identifier`) are absent —
+  cold paths over a handful of rows, while the hot path `session.token` is
+  unique and therefore already indexed. **Never flip the timestamp mode in
+  place.** Both modes read the same INTEGER column, so a redeploy without an
+  accompanying `UPDATE <table> SET <col> = <col> * 1000` reads every stored
+  date back as 1970 — which expires every live session and every pending
+  verification token.
+- **Better Auth's `baseURL` is derived per-request from the request origin**,
+  never configured or allowlisted. Two things hold it up. The Worker declares
+  no `routes` and no custom domain, so its workers.dev hostname is the only one
+  that reaches it and a spoofed `Host` never arrives — which is what makes
+  trusting the incoming origin safe. And the coordinator URL is per-install
+  configuration (Settings → Account; a self-hoster points at their own Worker),
+  so a fixed fallback would mint password-reset links back at the wrong
+  deployment. Adding a route or a custom domain is the trigger to revisit: once
+  more than one hostname reaches the Worker, the origin needs a gate.
 - **React Compiler is deliberately not adopted** (both Vite configs; ~148 memo
   call sites). react.dev recommends it for _new_ apps and says existing apps
   should "roll out at your own pace." If it is ever adopted, annotation mode
@@ -549,6 +576,26 @@ record for the decisions code comments cite.
   that fails when a SIXTH dispatch path appears is worth more than a coverage
   number. If coverage is ever added: `coverage.include` is MANDATORY in
   Vitest 4 (`coverage.all` was removed), and gate only `@repo/notes`.
+- **Renderer component tests drive the DOM with `fireEvent`, not
+  `@testing-library/user-event`** (which is not a dependency). user-event is a
+  fidelity upgrade — it replays the full pointer/keyboard sequence — not a
+  correctness fix, and these tests assert handler wiring rather than input
+  semantics. It also costs something real here: `markdown-editor.test.tsx`
+  runs on fake timers to drive the autosave debounce, and user-event hangs
+  under fake timers unless every call is wired to `advanceTimers`. Reach for
+  it only for a test that genuinely depends on the event sequence a real user
+  produces.
+- **Two generator defaults are deliberately inert.**
+  `packages/ui/components.json` declares `rsc: true` and there is no per-app
+  `components.json`: the shadcn CLI's monorepo add flow is not used — components
+  live in `packages/ui` behind the no-orphan-components test — and the
+  `"use client"` directives the flag produces are ignored by both consumers,
+  which are plain Vite/Rollup builds with no RSC bundler in the graph.
+  `apps/mobile/src/styles.css` opens with `@import "tailwindcss"` rather than
+  the per-layer sub-imports; that file IS the inlined concatenation of theme +
+  preflight + utilities, so there is no compiled-output delta, and the
+  sub-import form only buys anything on a web target — `react-native-web` is
+  not in the mobile dependency graph.
 - **The CSP grants bare `https:` to `frame-src` and `connect-src`**
   (`apps/desktop/src/renderer/index.html`). Three MDX vocabulary nodes render
   remote https iframes (`<file>`, `<video>`, `<media_embed>`) and the embed
@@ -558,3 +605,17 @@ record for the decisions code comments cite.
   `apps/desktop/dev/index.html` must carry the same resource directives: it is
   the only surface that can catch a CSP regression, since jsdom does not
   enforce CSP.
+- **The packaged renderer loads over `file://`, not a custom `app://` scheme.**
+  This is a real deviation from the Electron security checklist, held safe by
+  everything around it: `sandbox: true`, `contextIsolation: true`,
+  `nodeIntegration: false`, the CSP, the navigation guard pinning the window to
+  the loaded URL, and a window-open handler that denies every popup. Migrating
+  ripples wider than the one `loadFile` call: the CSP's `'self'` starts meaning
+  something different, `isSameOriginNavigation`'s file: branch (opaque origin,
+  so exact-URL match) collapses into a normal origin compare, Vite's asset base
+  changes, and `html-app-view.tsx`'s broker gains a meaningful `event.origin` —
+  today the window and its no-same-origin frame both report the opaque `null`,
+  so source identity plus the per-open token is the only discriminator
+  available. Do it when the renderer needs a capability `file://` cannot
+  grant — a service worker, an origin-scoped storage API, or a fetch that must
+  be same-origin.

--- a/apps/cloud/src/vault-coordinator.ts
+++ b/apps/cloud/src/vault-coordinator.ts
@@ -86,7 +86,7 @@ export class VaultCoordinator extends DurableObject<Env> {
 
   constructor(ctx: DurableObjectState, env: Env) {
     super(ctx, env);
-    ctx.blockConcurrencyWhile(async () => {
+    void ctx.blockConcurrencyWhile(async () => {
       this.ctx.storage.sql.exec(
         `CREATE TABLE IF NOT EXISTS files (
            path TEXT PRIMARY KEY,

--- a/apps/desktop/src/__tests__/wasm-search-parity.test.ts
+++ b/apps/desktop/src/__tests__/wasm-search-parity.test.ts
@@ -69,6 +69,14 @@ describe("wasm vs node:sqlite search parity (harness ranks like desktop)", () =>
       for (const query of QUERIES) {
         const wasmHits = wasmStore.search(query, 20);
         const nodeHits = nodeStore.search(query, 20);
+        // The agent-facing private filter is a stored FTS5 column, so the two
+        // bindings must agree on it, not just on ranking. A divergence here
+        // means the harness and the app disagree about which notes an agent
+        // tool can see.
+        expect(
+          wasmStore.search(query, 20, { excludePrivate: true }).map((hit) => hit.path),
+          `query: ${query} (excludePrivate)`,
+        ).toEqual(nodeStore.search(query, 20, { excludePrivate: true }).map((hit) => hit.path));
         // Order + identity + snippet must match exactly…
         expect(
           wasmHits.map(({ path, title, snippet }) => ({ path, title, snippet })),

--- a/apps/desktop/src/renderer/__tests__/agent-store-send.test.ts
+++ b/apps/desktop/src/renderer/__tests__/agent-store-send.test.ts
@@ -76,7 +76,7 @@ describe("agent-store send", () => {
   it("appends the user message and nothing else on success", async () => {
     helpers.bridgeMock.sendAgentCommand.mockResolvedValue(undefined);
 
-    useAgentStore.getState().send("hello");
+    void useAgentStore.getState().send("hello");
     await flushMicrotasks();
 
     const messages = useAgentStore.getState().messages;
@@ -94,7 +94,7 @@ describe("agent-store send", () => {
   it("surfaces a rejected submission as an error bubble in the chat", async () => {
     helpers.bridgeMock.sendAgentCommand.mockRejectedValue(new Error("Agent unavailable"));
 
-    useAgentStore.getState().send("hello");
+    void useAgentStore.getState().send("hello");
     await flushMicrotasks();
 
     const messages = useAgentStore.getState().messages;

--- a/apps/desktop/src/renderer/ai-elements/prompt-input.tsx
+++ b/apps/desktop/src/renderer/ai-elements/prompt-input.tsx
@@ -269,8 +269,8 @@ export const PromptInput = ({
     [items, add, remove, clear, openFileDialog, matchesAccept],
   );
 
-  const handleSubmit: FormEventHandler<HTMLFormElement> = useCallback(
-    async (event) => {
+  const submitForm = useCallback(
+    async (event: FormEvent<HTMLFormElement>) => {
       event.preventDefault();
       if (submittingRef.current) return;
       submittingRef.current = true;
@@ -312,6 +312,18 @@ export const PromptInput = ({
       }
     },
     [items, onSubmit],
+  );
+
+  // The DOM handler slot is void-returning, so the async body is voided rather
+  // than handed over directly: an async function there returns a promise React
+  // never awaits, and a rejection escaping it is an unhandled rejection.
+  // submitForm swallows its own failures (both catch blocks above), so the
+  // void is a statement of intent, not a dropped error path.
+  const handleSubmit: FormEventHandler<HTMLFormElement> = useCallback(
+    (event) => {
+      void submitForm(event);
+    },
+    [submitForm],
   );
 
   return (

--- a/apps/desktop/src/renderer/editor/markdown-editor.test.tsx
+++ b/apps/desktop/src/renderer/editor/markdown-editor.test.tsx
@@ -130,7 +130,7 @@ describe("MarkdownEditor lifecycle", () => {
     const view = render(<MarkdownEditor {...props({ onChange })} />);
 
     fireEvent.click(view.getByRole("button", { name: "change" }));
-    act(() => vi.advanceTimersByTime(DELAY_MS));
+    void act(() => vi.advanceTimersByTime(DELAY_MS));
 
     expect(onChange).not.toHaveBeenCalled();
   });
@@ -143,7 +143,7 @@ describe("MarkdownEditor lifecycle", () => {
     fireEvent.click(view.getByRole("button", { name: "change" }));
 
     view.rerender(<MarkdownEditor {...props({ onChange: second })} />);
-    act(() => vi.advanceTimersByTime(DELAY_MS));
+    void act(() => vi.advanceTimersByTime(DELAY_MS));
 
     expect(first).not.toHaveBeenCalled();
     expect(second).toHaveBeenCalledOnce();
@@ -161,7 +161,7 @@ describe("MarkdownEditor lifecycle", () => {
     expect(onChange).toHaveBeenCalledOnce();
     expect(onChange).toHaveBeenCalledWith("edited");
     expect(mocks.currentMarkdown).toBe("external");
-    act(() => vi.advanceTimersByTime(DELAY_MS));
+    void act(() => vi.advanceTimersByTime(DELAY_MS));
     expect(onChange).toHaveBeenCalledOnce();
   });
 
@@ -183,7 +183,7 @@ describe("MarkdownEditor lifecycle", () => {
 
     expect(onChange).toHaveBeenCalledOnce();
     expect(onChange).toHaveBeenCalledWith("edited");
-    act(() => vi.advanceTimersByTime(DELAY_MS));
+    void act(() => vi.advanceTimersByTime(DELAY_MS));
     expect(onChange).toHaveBeenCalledOnce();
   });
 

--- a/apps/desktop/src/renderer/onboarding/onboarding-page.tsx
+++ b/apps/desktop/src/renderer/onboarding/onboarding-page.tsx
@@ -71,8 +71,13 @@ export function OnboardingPage() {
     });
   }, []);
 
+  // Same shape as the SETUP dispatch above: a rejection means the transition
+  // never reached the host, the error text and this button stay put, and
+  // pressing again IS the retry.
   const handleRetry = useCallback(() => {
-    getBridge().transition({ type: "RETRY" });
+    void getBridge()
+      .transition({ type: "RETRY" })
+      .catch(() => {});
   }, []);
 
   // Prefer the granular model-download progress when the voice model step is

--- a/apps/desktop/src/renderer/stores/voice-store.ts
+++ b/apps/desktop/src/renderer/stores/voice-store.ts
@@ -64,7 +64,7 @@ function teardown(): void {
   unsubscribeModelState?.();
   unsubscribeModelState = null;
   if (pipeline) {
-    trackTeardown(pipeline.disconnect());
+    void trackTeardown(pipeline.disconnect());
     pipeline = null;
   }
   machine.dispatch({ type: "reset" });
@@ -115,7 +115,7 @@ async function runConnect(): Promise<void> {
   if (gen !== machine.generation) {
     // Connect succeeded but state moved on — drop the now-orphaned mic on
     // the captured session, never the (possibly replaced) module-level ref.
-    trackTeardown(session.disconnect());
+    void trackTeardown(session.disconnect());
     return;
   }
   machine.dispatch({ type: "connect_ok" });
@@ -180,7 +180,7 @@ export const useVoiceStore = create<VoiceStore>()((set, _get) => ({
     if (!pipeline) return;
     const state = machine.state;
     if (state.kind === "listening") {
-      trackTeardown(pipeline.disconnect());
+      void trackTeardown(pipeline.disconnect());
       machine.dispatch({ type: "pipeline_disconnected" });
       return;
     }
@@ -199,7 +199,7 @@ export const useVoiceStore = create<VoiceStore>()((set, _get) => ({
     // disconnect) its captured session when connect settles; error holds no
     // session at all.
     if (state.kind === "listening" && pipeline) {
-      trackTeardown(pipeline.disconnect());
+      void trackTeardown(pipeline.disconnect());
     }
     machine.dispatch({ type: "reset" });
   },

--- a/apps/desktop/src/renderer/workspace/workspace-page.tsx
+++ b/apps/desktop/src/renderer/workspace/workspace-page.tsx
@@ -124,8 +124,14 @@ export function WorkspacePage() {
   const workspaceError =
     appState.phase === "error" && appState.prev === "ready" ? appState.message : null;
 
+  // The dispatch rides the local WS and rejects if the socket is down. A
+  // rejection means the transition never reached the host, so the banner and
+  // this button stay put — pressing again IS the retry, and there is nothing
+  // further to report.
   const handleRetry = useCallback(() => {
-    getBridge().transition({ type: "RETRY" });
+    void getBridge()
+      .transition({ type: "RETRY" })
+      .catch(() => {});
   }, []);
 
   return (

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "knip": "^6.29.0",
     "oxfmt": "^0.60.0",
     "oxlint": "^1.75.0",
+    "oxlint-tsgolint": "^7.0.2001",
     "turbo": "^2.10.6",
     "typescript": "catalog:"
   },

--- a/packages/agent/src/__tests__/knowledge-extension.test.ts
+++ b/packages/agent/src/__tests__/knowledge-extension.test.ts
@@ -27,7 +27,7 @@ function capture(port: KnowledgePort): Map<string, RegisteredTool> {
     registerTool: (tool: RegisteredTool) => tools.set(tool.name, tool),
   } as unknown as ExtensionAPI;
   const ports = { knowledge: port } as unknown as AgentPorts;
-  knowledgeExtension.register({ binDir: "/fake/bin", ports })(pi);
+  void knowledgeExtension.register({ binDir: "/fake/bin", ports })(pi);
   return tools;
 }
 

--- a/packages/notes/src/knowledge/link-graph-index.ts
+++ b/packages/notes/src/knowledge/link-graph-index.ts
@@ -6,16 +6,26 @@
 // directly, so the subtle resolver semantics (link-resolve's basename buckets,
 // ambiguity, shadowing) exist exactly once and never fork into SQL.
 //
-// Update model: applyDoc / remove touch one doc's records. Link RESOLUTION is
-// global (adding `note.md` can resolve another doc's dangling `[[note]]`, or
-// make a basename ambiguous), so the resolved forward/back maps are rebuilt
-// lazily on the first query after any mutation — a cheap fold over stored
-// links, no re-parsing.
+// Update model: applyDoc / remove touch one doc's records, and the resolved
+// forward/back maps are rebuilt lazily on the first query afterwards — a fold
+// over stored links, no re-parsing.
+//
+// That rebuild is whole-corpus, so it is scoped by what actually invalidates
+// it. Resolution depends on exactly two things: the set of vault paths and the
+// docs' `aliases:` (link-resolve's five tiers read nothing else). Re-projecting
+// a KNOWN doc with an unchanged alias list therefore leaves every OTHER doc's
+// resolution — and the resolver itself — correct, so only that doc's own links
+// are re-resolved and re-filed. That is the steady state (a note being edited),
+// and it is the difference between a per-edit fold over the whole vault and a
+// fold over eight links. Anything that moves a path or an alias still forces
+// the full rebuild, because it can silently re-point links anywhere in the
+// vault (a new `note.md` resolves another doc's dangling `[[note]]`, or makes a
+// basename ambiguous).
 // ---------------------------------------------------------------------------
 
 import { isDocPath } from "./doc-file";
 import type { ExtractedTask, LinkKind } from "./link-extract";
-import { buildResolver } from "./link-resolve";
+import { buildResolver, type TargetResolver } from "./link-resolve";
 import type { DocProjection, StoredLink } from "./projection";
 import { TagIndex, type TagCount } from "./tag-index";
 import { basenamePath, extnamePath } from "./vault-path";
@@ -105,45 +115,81 @@ type DocRecord = {
   aliases: string[];
   private: boolean;
   tasks: ExtractedTask[];
+  /** Corpus position, assigned when the path first enters `docs` and kept
+   * across re-projections — `docs` is a Map, so re-setting a live key holds
+   * its slot. It IS the doc iteration order, which is what a from-scratch
+   * resolution files backlink occurrences in; carrying it on the occurrence
+   * lets an incremental re-file land in that same order. */
+  seq: number;
 };
 
 type ResolvedLink = { link: StoredLink; targetPath: string | null };
 
+/** One inbound link, ordered by its source's corpus position. */
+type Occurrence = { sourcePath: string; link: StoredLink; seq: number };
+
 type ResolvedState = {
+  /** Valid for exactly as long as the path/alias namespace is unchanged. */
+  resolver: TargetResolver;
   forward: Map<string, ResolvedLink[]>;
-  /** target path → [source path, link] occurrences. */
-  backlinks: Map<string, Array<{ sourcePath: string; link: StoredLink }>>;
+  /** target path → inbound occurrences, in corpus order. */
+  backlinks: Map<string, Occurrence[]>;
 };
+
+/** Above this many docs waiting to be re-resolved, rebuild from scratch
+ * instead. Re-filing one doc splices into each of its targets' occurrence
+ * lists, so the incremental cost is O(docs × out-degree × in-degree) — no bound
+ * in terms of the corpus, where the fold is a flat O(corpus). The cap sits at
+ * the crossover for the worst realistic shape, a hub every note links to: over
+ * 20k docs with a 20k-in-degree hub, re-filing 256 docs costs about what the
+ * fold does (227ms vs 202ms), and an ordinary corpus is two orders cheaper
+ * again. */
+const MAX_INCREMENTAL_DOCS = 256;
 
 export class LinkGraphIndex {
   private readonly docs = new Map<string, DocRecord>();
   private readonly others = new Set<string>();
   private readonly tagIndex = new TagIndex();
   private resolved: ResolvedState | null = null;
+  /** Docs re-projected under an unchanged namespace since `resolved` was
+   * built — only their own links need re-resolving. Meaningless (and cleared)
+   * whenever `resolved` is dropped. */
+  private readonly pendingDocs = new Set<string>();
+  /** Monotonic source of {@link DocRecord.seq}. */
+  private nextSeq = 0;
   /** Memoized privatePaths() result — the agent gate reads it per bash/execute
-   * tool call. Invalidated exactly where `resolved` is (any mutation). */
+   * tool call. Invalidated on any mutation. */
   private privatePathsCache: string[] | null = null;
 
   /** Index (or re-index) a markdown doc from its projection. */
   applyDoc(path: string, projection: DocProjection): void {
     this.others.delete(path);
+    const prior = this.docs.get(path);
     this.docs.set(path, {
       title: projection.title,
       links: projection.links,
       aliases: projection.aliases,
       private: projection.private,
       tasks: projection.tasks,
+      seq: prior?.seq ?? this.nextSeq++,
     });
     this.tagIndex.set(path, projection.tags);
-    this.resolved = null;
     this.privatePathsCache = null;
+    // A known doc keeping its aliases leaves the namespace — and so every
+    // other doc's resolution — intact; anything else can re-point links
+    // vault-wide (see the header).
+    if (prior !== undefined && sameStrings(prior.aliases, projection.aliases)) {
+      if (this.resolved !== null) this.pendingDocs.add(path);
+    } else {
+      this.dropResolution();
+    }
   }
 
   /** Register a non-doc vault file (image, pdf, …) for link resolution only. */
   setOther(path: string): void {
     if (this.docs.delete(path)) this.tagIndex.remove(path);
     this.others.add(path);
-    this.resolved = null;
+    this.dropResolution();
     this.privatePathsCache = null;
   }
 
@@ -153,7 +199,7 @@ export class LinkGraphIndex {
     if (wasDoc) this.tagIndex.remove(path);
     const wasOther = this.others.delete(path);
     if (wasDoc || wasOther) {
-      this.resolved = null;
+      this.dropResolution();
       this.privatePathsCache = null;
     }
   }
@@ -162,7 +208,7 @@ export class LinkGraphIndex {
     this.docs.clear();
     this.others.clear();
     this.tagIndex.clear();
-    this.resolved = null;
+    this.dropResolution();
     this.privatePathsCache = null;
   }
 
@@ -238,8 +284,16 @@ export class LinkGraphIndex {
     for (const [path, record] of this.docs) {
       nodes.set(path, { id: path, title: record.title, path, phantom: false, degree: 0 });
     }
-    const edgeMap = new Map<string, GraphEdge>();
+    const edges: GraphEdge[] = [];
+    // Parallel links collapse per SOURCE, and `forward` is already grouped by
+    // source, so the dedupe map is scoped to the current source and holds a
+    // handful of short keys. Keying one vault-wide map on a concatenated path
+    // PAIR is the same answer for ~50% more time at 400k links — the scoping is
+    // load-bearing, not tidiness.
+    const bySource = new Map<string, GraphEdge>();
     for (const [sourcePath, links] of forward) {
+      bySource.clear();
+      const sourceNode = nodes.get(sourcePath);
       for (const { link, targetPath } of links) {
         // The graph is a NOTES graph: asset references (md images, `![[x.png]]`
         // embeds, `[pdf](x.pdf)` links) are content inside a note, not
@@ -261,19 +315,25 @@ export class LinkGraphIndex {
             nodes.set(targetId, { id: targetId, title: link.target, phantom: true, degree: 0 });
           }
         }
-        const key = `${sourcePath}\u0000${targetId}\u0000${link.kind}`;
-        const edge = edgeMap.get(key);
-        if (edge) edge.count += 1;
-        else edgeMap.set(key, { source: sourcePath, target: targetId, kind: link.kind, count: 1 });
+        const key = `${link.kind}\u0000${targetId}`;
+        const seen = bySource.get(key);
+        if (seen !== undefined) {
+          seen.count += 1;
+          continue;
+        }
+        const edge: GraphEdge = { source: sourcePath, target: targetId, kind: link.kind, count: 1 };
+        bySource.set(key, edge);
+        edges.push(edge);
+        // Degree counts EDGES, not link occurrences — so it moves only here,
+        // where a new pair is created, and once for a self-edge.
+        if (sourceNode) sourceNode.degree += 1;
+        if (targetId !== sourcePath) {
+          const targetNode = nodes.get(targetId);
+          if (targetNode) targetNode.degree += 1;
+        }
       }
     }
-    for (const edge of edgeMap.values()) {
-      const source = nodes.get(edge.source);
-      const target = nodes.get(edge.target);
-      if (source) source.degree += 1;
-      if (target && edge.target !== edge.source) target.degree += 1;
-    }
-    return { nodes: [...nodes.values()], edges: [...edgeMap.values()] };
+    return { nodes: [...nodes.values()], edges };
   }
 
   /** Docs first (title-bearing), assets after — the picker renders them as
@@ -332,8 +392,14 @@ export class LinkGraphIndex {
 
   // ---- Internals --------------------------------------------------------------
 
+  private dropResolution(): void {
+    this.resolved = null;
+    this.pendingDocs.clear();
+  }
+
   private ensureResolved(): ResolvedState {
-    if (this.resolved) return this.resolved;
+    const current = this.resolved;
+    if (current !== null && this.applyPending(current)) return current;
     // Alias entries feed the resolver's below-path tiers, so `[[alias]]`
     // links resolve in backlinks/forward-links/graph exactly like the
     // renderer's local resolver (which pulls the same aliases via
@@ -346,25 +412,99 @@ export class LinkGraphIndex {
     const forward = new Map<string, ResolvedLink[]>();
     const backlinks: ResolvedState["backlinks"] = new Map();
     for (const [sourcePath, record] of this.docs) {
-      const resolvedLinks: ResolvedLink[] = record.links.map((link) => ({
-        link,
-        targetPath:
-          link.kind === "wiki"
-            ? resolver.resolveWiki(link.target)
-            : resolver.resolveMd(link.target, sourcePath),
-      }));
+      const resolvedLinks = this.resolveLinks(resolver, sourcePath, record);
       forward.set(sourcePath, resolvedLinks);
       for (const { link, targetPath } of resolvedLinks) {
         if (targetPath === null) continue;
         const list = backlinks.get(targetPath);
-        const occurrence = { sourcePath, link };
+        const occurrence: Occurrence = { sourcePath, link, seq: record.seq };
         if (list) list.push(occurrence);
         else backlinks.set(targetPath, [occurrence]);
       }
     }
-    this.resolved = { forward, backlinks };
+    this.resolved = { resolver, forward, backlinks };
+    this.pendingDocs.clear();
     return this.resolved;
   }
+
+  private resolveLinks(
+    resolver: TargetResolver,
+    sourcePath: string,
+    record: DocRecord,
+  ): ResolvedLink[] {
+    return record.links.map((link) => ({
+      link,
+      targetPath:
+        link.kind === "wiki"
+          ? resolver.resolveWiki(link.target)
+          : resolver.resolveMd(link.target, sourcePath),
+    }));
+  }
+
+  /** Fold the pending docs into an otherwise-valid `state`, producing exactly
+   * what a from-scratch resolution would. False means "give up and rebuild" —
+   * either too many docs are pending to be worth splicing, or a pending doc
+   * has no prior forward entry (it predates this state, so its position among
+   * the occurrences is not known). */
+  private applyPending(state: ResolvedState): boolean {
+    if (this.pendingDocs.size === 0) return true;
+    if (this.pendingDocs.size > MAX_INCREMENTAL_DOCS) return false;
+    for (const path of this.pendingDocs) {
+      const record = this.docs.get(path);
+      const stale = state.forward.get(path);
+      if (record === undefined || stale === undefined) return false;
+      // Retract every occurrence this doc contributed, target by target…
+      const touched = new Set<string>();
+      for (const { targetPath } of stale) {
+        if (targetPath !== null) touched.add(targetPath);
+      }
+      for (const target of touched) {
+        const kept = state.backlinks.get(target)?.filter((o) => o.sourcePath !== path);
+        if (kept === undefined) continue;
+        if (kept.length === 0) state.backlinks.delete(target);
+        else state.backlinks.set(target, kept);
+      }
+      // …then re-resolve and re-file at the doc's own corpus position. The
+      // Map keeps its slot, so `forward` iteration order is untouched.
+      const links = this.resolveLinks(state.resolver, path, record);
+      state.forward.set(path, links);
+      for (const { link, targetPath } of links) {
+        if (targetPath === null) continue;
+        fileOccurrence(state.backlinks, targetPath, { sourcePath: path, link, seq: record.seq });
+      }
+    }
+    this.pendingDocs.clear();
+    return true;
+  }
+}
+
+/** Insert `occurrence` keeping the target's list in corpus order. Equal seqs
+ * (the same doc's own links, re-filed in link order) append after each other,
+ * which is the order a from-scratch build emits them in. */
+function fileOccurrence(
+  backlinks: Map<string, Occurrence[]>,
+  target: string,
+  occurrence: Occurrence,
+): void {
+  const list = backlinks.get(target);
+  if (list === undefined) {
+    backlinks.set(target, [occurrence]);
+    return;
+  }
+  let low = 0;
+  let high = list.length;
+  while (low < high) {
+    const mid = (low + high) >> 1;
+    const at = list[mid];
+    if (at !== undefined && at.seq <= occurrence.seq) low = mid + 1;
+    else high = mid;
+  }
+  list.splice(low, 0, occurrence);
+}
+
+function sameStrings(a: readonly string[], b: readonly string[]): boolean {
+  if (a.length !== b.length) return false;
+  return a.every((value, i) => value === b[i]);
 }
 
 function byPath(a: WikiTarget, b: WikiTarget): number {

--- a/packages/notes/src/knowledge/sql-knowledge-store.ts
+++ b/packages/notes/src/knowledge/sql-knowledge-store.ts
@@ -36,7 +36,7 @@ import { PROJECTION_VERSION } from "./projection";
 import { tokenize } from "./search-index";
 
 /** Bump on any DDL change — an older/newer file is wiped and rebuilt. */
-export const KNOWLEDGE_SCHEMA_VERSION = 6;
+export const KNOWLEDGE_SCHEMA_VERSION = 7;
 
 /** What the store binds/reads. SQLite NULL/REAL/INTEGER/TEXT — no blobs. */
 export type SqlValue = null | number | string;
@@ -159,7 +159,7 @@ CREATE TABLE tasks (
   PRIMARY KEY (path, ordinal)
 );
 CREATE VIRTUAL TABLE search_fts USING fts5(
-  title, headings, body, path UNINDEXED,
+  title, headings, body, path UNINDEXED, is_private UNINDEXED,
   tokenize='unicode61 tokenchars ''_'''
 );
 `;
@@ -177,17 +177,24 @@ ORDER BY rank, path
 LIMIT ?
 `;
 
-// The agent-facing variant: `private: true` docs are excluded INSIDE the query
-// (search_fts shares rowids with files), so the limit applies to public hits
-// and a private path/snippet can never even transit the result set. Column
-// default is 1 (private-until-parsed) — an unparsed row is excluded too.
+// The agent-facing variant: `private: true` docs are excluded INSIDE the query,
+// so the limit applies to public hits and a private path/snippet can never even
+// transit the result set.
+//
+// The flag is carried as an UNINDEXED FTS5 column rather than joined from
+// `files`, which is correctness-neutral and a large cost difference: an
+// `IN (SELECT rowid FROM files WHERE is_private = 0)` term against a MATCH
+// query is QUADRATIC in corpus size (SQLite re-drives the row list per matched
+// row) — at 4k docs a term appearing in every note took 1.1s, at 50k it took
+// 198s, against ~77ms for the same query unfiltered. As a stored column the
+// filter is a residual test on rows the cursor already produced, so the
+// agent-facing search costs what the renderer's does.
 const SEARCH_PUBLIC_SQL = `
 SELECT path, title,
   snippet(search_fts, 2, '', '', '…', 12) AS snip,
   bm25(search_fts, 10.0, 4.0, 1.0) AS rank
 FROM search_fts
-WHERE search_fts MATCH ?
-  AND rowid IN (SELECT rowid FROM files WHERE is_private = 0)
+WHERE search_fts MATCH ? AND is_private = 0
 ORDER BY rank, path
 LIMIT ?
 `;
@@ -610,13 +617,17 @@ export function createSqlKnowledgeStore(driver: SqlDriver, vaultRoot: string): S
           // Aliases ride the headings column — a ranking boost only (the alias
           // bytes already match via the body, which includes the frontmatter),
           // mirroring the pure SearchIndex composition in knowledge-index.ts.
-          "INSERT INTO search_fts (rowid, title, headings, body, path) VALUES (?, ?, ?, ?, ?)",
+          // `is_private` is stored, not indexed: it is the agent-facing query's
+          // filter (see SEARCH_PUBLIC_SQL), never a search term.
+          `INSERT INTO search_fts (rowid, title, headings, body, path, is_private)
+           VALUES (?, ?, ?, ?, ?, ?)`,
           [
             rowid,
             projection.title,
             [...projection.headings, ...projection.aliases].join("\n"),
             body,
             row.path,
+            projection.private ? 1 : 0,
           ],
         );
       });

--- a/packages/server/src/__tests__/knowledge-privacy.test.ts
+++ b/packages/server/src/__tests__/knowledge-privacy.test.ts
@@ -95,7 +95,7 @@ function captureTools(port: KnowledgePort): Map<string, RegisteredTool> {
     registerTool: (tool: RegisteredTool) => tools.set(tool.name, tool),
   } as unknown as ExtensionAPI;
   const ports = { knowledge: port } as unknown as AgentPorts;
-  knowledgeExtension.register({ binDir: "/fake/bin", ports })(pi);
+  void knowledgeExtension.register({ binDir: "/fake/bin", ports })(pi);
   return tools;
 }
 

--- a/packages/server/src/__tests__/knowledge-query-perf.test.ts
+++ b/packages/server/src/__tests__/knowledge-query-perf.test.ts
@@ -1,0 +1,533 @@
+// ---------------------------------------------------------------------------
+// Query-path cost shape — the always-on tests here assert DETERMINISTIC
+// properties (equivalence to a from-scratch build, how many docs get
+// re-resolved, what the agent-facing search's query plan is allowed to touch),
+// never wall-clock. A millisecond ceiling inside a parallel gate goes red for a
+// GC pause; the numbers live in the opt-in benchmark at the bottom, which is
+// what produced the table below (this repo's perf convention — see
+// knowledge-hydration.test.ts and knowledge-perf-oracle.test.ts).
+//
+// These live in @repo/server rather than beside LinkGraphIndex because the
+// second half needs the node:sqlite store to exercise FTS5.
+//
+// MacBook / Node 24, synthetic 50k-doc vault, 8 links + 4 headings + 3 tags +
+// 1 alias per doc (400k links, 55k graph nodes). Absolute values move ±30% with
+// machine load; the ratios do not.
+//
+//                                              scoped   whole-corpus
+//   re-resolve, 1 doc edited                   0.1 ms         545 ms
+//   re-resolve, 256 docs edited                5.6 ms         545 ms
+//   re-resolve, 257 docs edited (over the cap)   —            806 ms
+//   graph() assembly, resolution warm            —      350 / 519 ms
+//   graph() cold, first call after boot          —      900 / 900 ms
+//
+//   search, term in one doc                    1.1 ms
+//   search, term in every doc                   79 ms
+//   ...term in one doc, { excludePrivate }     1.1 ms        1055 ms
+//   ...term in every doc, { excludePrivate }    79 ms      198535 ms
+//
+// The two costs that moved are the two that RECUR. Whole-corpus re-resolution
+// ran on the first backlinks/links/related/graph query after any edit, because
+// one changed doc dropped the whole vault's resolution. `excludePrivate` is
+// every agent query, and joining `files` for it is QUADRATIC in corpus size —
+// 1.1s at 4k docs, 198s at 50k.
+//
+// What did NOT move, deliberately: graph()'s first call is a whole-corpus
+// projection and stays one (the pair above is per-source vs vault-wide edge
+// dedupe — same answer, ~30% apart). It is also not the graph view's
+// bottleneck at this size: the payload is 42MB of JSON, ~90ms to stringify and
+// ~125ms to parse, before d3-force ever sees 400k edges. Bounding what the
+// graph view ASKS for is a renderer decision, not an index one.
+//
+// Set KNOWLEDGE_BENCH_DOCS=50000 to reproduce (default 10k).
+// ---------------------------------------------------------------------------
+
+import { describe, expect, it } from "vitest";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { DatabaseSync } from "node:sqlite";
+
+import { isDocPath } from "@repo/notes/knowledge/doc-file";
+import {
+  LinkGraphIndex,
+  type GraphEdge,
+  type GraphNode,
+  type LinkGraph,
+} from "@repo/notes/knowledge/link-graph-index";
+import type { DocProjection, StoredLink } from "@repo/notes/knowledge/projection";
+import { relatedNotes } from "@repo/notes/knowledge/related-notes";
+import {
+  createSqlKnowledgeStore,
+  type SqlDriver,
+  type SqlKnowledgeStore,
+} from "@repo/notes/knowledge/sql-knowledge-store";
+import { extnamePath } from "@repo/notes/knowledge/vault-path";
+
+import { createSqliteKnowledgeStore } from "../knowledge/sqlite-knowledge-store";
+
+const BENCH_DOCS = Number(process.env["KNOWLEDGE_BENCH_DOCS"] ?? 10_000);
+
+// ---- Synthetic corpus ----------------------------------------------------------
+
+function docPath(i: number): string {
+  return `notes/note-${String(i).padStart(6, "0")}.md`;
+}
+
+/** `total` docs' worth of links, 7 of 8 resolving inside the corpus and the
+ * 8th dangling — the shape that makes both resolution and the graph expensive.
+ * `revision` perturbs the snippets so a re-projection is a real change. */
+function projection(i: number, total: number, revision = 0): DocProjection {
+  const id = String(i).padStart(6, "0");
+  return {
+    title: `Note ${id}`,
+    headings: [`Note ${id}`, "Context", "Details", "Next steps"],
+    links: Array.from({ length: 8 }, (_, k): StoredLink => {
+      const target =
+        k === 7
+          ? `missing-${String((i * 7 + k) % 5000).padStart(6, "0")}`
+          : `note-${String((i + k * 37) % total).padStart(6, "0")}`;
+      return {
+        kind: "wiki",
+        embed: k === 7,
+        target,
+        line: 10 + k,
+        snippet: `rev${revision}: see [[${target}]] for the rest`,
+      };
+    }),
+    tags: ["project", "meta", `bucket-${i % 50}`],
+    aliases: [`alias-${id}`],
+    private: i % 17 === 0,
+    tasks: [],
+  };
+}
+
+/** "the" is in every doc (a term FTS5 must rank the whole corpus for);
+ * `body-<id>` is in exactly one. */
+function body(i: number): string {
+  const id = String(i).padStart(6, "0");
+  return `# Note ${id}\n\nbody-${id} the quick brown fox ${"filler word the ".repeat(20)}\n`;
+}
+
+function seedIndex(docs: number): LinkGraphIndex {
+  const index = new LinkGraphIndex();
+  for (let i = 0; i < docs; i++) index.applyDoc(docPath(i), projection(i, docs));
+  return index;
+}
+
+// ---- Incremental resolution ------------------------------------------------------
+
+/** Every query that reads the resolved state, over every path — the surface an
+ * incremental re-resolve has to reproduce byte for byte. */
+function resolvedSurface(index: LinkGraphIndex, paths: readonly string[]): unknown {
+  return {
+    backlinks: paths.map((p) => index.backlinks(p)),
+    backlinksPublic: paths.map((p) => index.backlinks(p, { excludePrivate: true })),
+    forward: paths.map((p) => index.forwardLinks(p)),
+    graph: index.graph(),
+    wikiTargets: index.wikiTargets(),
+  };
+}
+
+/** The oracle: the same corpus applied to a virgin index, which has no
+ * incremental state to be wrong about. */
+function rebuilt(
+  applied: ReadonlyArray<[string, DocProjection]>,
+  others: readonly string[],
+): LinkGraphIndex {
+  const index = new LinkGraphIndex();
+  for (const [p, proj] of applied) index.applyDoc(p, proj);
+  for (const p of others) index.setOther(p);
+  return index;
+}
+
+/** Wrap a links array so the test can see WHICH docs got re-resolved:
+ * resolution is the only thing that calls `.map` on it. */
+function countingLinks(links: StoredLink[], onResolve: () => void): StoredLink[] {
+  return new Proxy(links, {
+    get(target, prop): unknown {
+      if (prop === "map") onResolve();
+      return Reflect.get(target, prop);
+    },
+  });
+}
+
+function withCountedLinks(base: DocProjection, onResolve: () => void): DocProjection {
+  return { ...base, links: countingLinks(base.links, onResolve) };
+}
+
+describe("incremental link resolution", () => {
+  it("re-projecting a doc re-resolves that doc's links and nothing else", () => {
+    const resolves = new Map<string, number>();
+    const index = new LinkGraphIndex();
+    const bump = (p: string) => (): void => {
+      resolves.set(p, (resolves.get(p) ?? 0) + 1);
+    };
+    for (let i = 0; i < 20; i++) {
+      index.applyDoc(docPath(i), withCountedLinks(projection(i, 20), bump(docPath(i))));
+    }
+    index.backlinks(docPath(0)); // the one whole-corpus fold
+    expect([...resolves.values()]).toEqual(Array.from({ length: 20 }, () => 1));
+
+    // A body edit — same path, same aliases.
+    resolves.clear();
+    index.applyDoc(docPath(3), withCountedLinks(projection(3, 20, 1), bump(docPath(3))));
+    index.backlinks(docPath(0));
+    expect([...resolves.entries()]).toEqual([[docPath(3), 1]]);
+
+    // Repeat queries re-resolve nothing at all.
+    resolves.clear();
+    index.backlinks(docPath(0));
+    index.forwardLinks(docPath(3));
+    index.graph();
+    expect([...resolves.entries()]).toEqual([]);
+  });
+
+  it("a changed alias re-resolves the whole corpus — it can re-point any link", () => {
+    const resolves = new Map<string, number>();
+    const index = new LinkGraphIndex();
+    const bump = (p: string) => (): void => {
+      resolves.set(p, (resolves.get(p) ?? 0) + 1);
+    };
+    for (let i = 0; i < 20; i++) {
+      index.applyDoc(docPath(i), withCountedLinks(projection(i, 20), bump(docPath(i))));
+    }
+    index.backlinks(docPath(0));
+
+    resolves.clear();
+    const renamedAlias: DocProjection = { ...projection(3, 20, 1), aliases: ["something else"] };
+    index.applyDoc(docPath(3), withCountedLinks(renamedAlias, bump(docPath(3))));
+    index.backlinks(docPath(0));
+    expect(resolves.size).toBe(20);
+
+    // …as does a new path appearing, for the same reason.
+    resolves.clear();
+    index.setOther("assets/pic.png");
+    index.backlinks(docPath(0));
+    expect(resolves.size).toBe(20);
+  });
+
+  it("answers exactly like a from-scratch build across a mutation sequence", () => {
+    const total = 40;
+    const applied = new Map<string, DocProjection>();
+    const others: string[] = [];
+    const index = new LinkGraphIndex();
+    const apply = (i: number, revision: number, over?: Partial<DocProjection>): void => {
+      const proj = { ...projection(i, total, revision), ...over };
+      applied.set(docPath(i), proj);
+      index.applyDoc(docPath(i), proj);
+    };
+    for (let i = 0; i < total; i++) apply(i, 0);
+
+    const check = (label: string): void => {
+      const paths = [...applied.keys(), ...others, "notes/nowhere.md", "missing-000001"];
+      const oracle = rebuilt([...applied.entries()], others);
+      expect(resolvedSurface(index, paths), label).toEqual(resolvedSurface(oracle, paths));
+    };
+    check("initial");
+
+    // Body edits — the incremental path.
+    apply(5, 1);
+    apply(6, 1);
+    check("two body edits");
+    // …interleaved with queries, so the pending set drains one doc at a time.
+    apply(7, 1);
+    check("edit, query, edit");
+    apply(8, 1);
+    check("again");
+
+    // Alias churn, both directions.
+    apply(9, 2, { aliases: ["Ninth", "IX"] });
+    check("aliases added");
+    apply(9, 3, { aliases: [] });
+    check("aliases dropped");
+
+    // A doc whose links now all dangle, then all resolve again.
+    apply(10, 4, { links: [] });
+    check("links removed");
+    apply(10, 5);
+    check("links restored");
+
+    // Namespace churn around a doc that is being edited.
+    index.remove(docPath(11));
+    applied.delete(docPath(11));
+    check("doc removed");
+    apply(12, 6);
+    check("edit after a removal");
+    index.setOther("assets/diagram.png");
+    others.push("assets/diagram.png");
+    check("asset added");
+    apply(13, 7);
+    check("edit after an asset appeared");
+
+    // A doc turning into an asset and back.
+    index.setOther(docPath(14));
+    applied.delete(docPath(14));
+    others.push(docPath(14));
+    check("doc became an asset");
+    apply(14, 8);
+    others.splice(others.indexOf(docPath(14)), 1);
+    check("asset became a doc again");
+
+    // Private flags move under excludePrivate.
+    apply(15, 9, { private: true });
+    check("doc turned private");
+    apply(16, 9, { private: false });
+    check("doc turned public");
+  });
+
+  it("stays equivalent when more docs change at once than it will splice", () => {
+    // Past the incremental ceiling the fold takes over; the answer must not
+    // depend on which branch ran.
+    const total = 600;
+    const index = seedIndex(total);
+    index.backlinks(docPath(0));
+    const applied = new Map<string, DocProjection>();
+    for (let i = 0; i < total; i++) applied.set(docPath(i), projection(i, total));
+    for (let i = 0; i < total; i++) {
+      const proj = projection(i, total, 1);
+      applied.set(docPath(i), proj);
+      index.applyDoc(docPath(i), proj);
+    }
+    const paths = [...applied.keys()];
+    expect(resolvedSurface(index, paths)).toEqual(
+      resolvedSurface(rebuilt([...applied.entries()], []), paths),
+    );
+  });
+});
+
+// ---- graph() assembly, against a brute-force reference -----------------------------
+
+/** The graph rebuilt from the public per-doc queries, applying the documented
+ * rules (asset references excluded, phantom node per unresolved doc-shaped
+ * target, parallel links collapsed with a count, degree counting EDGES). The
+ * fast path collapses parallel links per SOURCE instead of vault-wide, which is
+ * only equivalent because `forward` is grouped by source — this pins it. */
+function oracleGraph(index: LinkGraphIndex, docs: readonly string[]): LinkGraph {
+  const titles = new Map(index.wikiTargets().map((t) => [t.path, t.title]));
+  const nodes = new Map<string, GraphNode>();
+  for (const path of docs) {
+    nodes.set(path, { id: path, title: titles.get(path) ?? "", path, phantom: false, degree: 0 });
+  }
+  const edgeMap = new Map<string, GraphEdge>();
+  for (const source of docs) {
+    for (const link of index.forwardLinks(source)) {
+      if (link.kind === "image") continue;
+      let targetId: string;
+      if (link.targetPath !== null) {
+        if (!nodes.has(link.targetPath)) continue;
+        targetId = link.targetPath;
+      } else {
+        if (extnamePath(link.target) !== "" && !isDocPath(link.target)) continue;
+        targetId = `phantom:${link.target.toLowerCase()}`;
+        if (!nodes.has(targetId)) {
+          nodes.set(targetId, { id: targetId, title: link.target, phantom: true, degree: 0 });
+        }
+      }
+      const key = `${source} ${targetId} ${link.kind}`;
+      const seen = edgeMap.get(key);
+      if (seen) seen.count += 1;
+      else edgeMap.set(key, { source, target: targetId, kind: link.kind, count: 1 });
+    }
+  }
+  for (const edge of edgeMap.values()) {
+    const source = nodes.get(edge.source);
+    const target = nodes.get(edge.target);
+    if (source) source.degree += 1;
+    if (target && edge.target !== edge.source) target.degree += 1;
+  }
+  return { nodes: [...nodes.values()], edges: [...edgeMap.values()] };
+}
+
+describe("graph assembly", () => {
+  it("matches the brute-force reference, including edge counts and degrees", () => {
+    const total = 60;
+    const index = seedIndex(total);
+    const docs = Array.from({ length: total }, (_, i) => docPath(i));
+    expect(index.graph()).toEqual(oracleGraph(index, docs));
+
+    // Parallel links (same pair, same kind) and a self-link: the count/degree
+    // rules the per-source collapse has to preserve.
+    const twin: DocProjection = {
+      ...projection(0, total, 1),
+      links: [
+        { kind: "wiki", embed: false, target: "note-000001", line: 1, snippet: "a" },
+        { kind: "wiki", embed: false, target: "note-000001", line: 2, snippet: "b" },
+        { kind: "wiki", embed: true, target: "note-000001", line: 3, snippet: "c" },
+        { kind: "md", embed: false, target: "note-000001.md", line: 4, snippet: "d" },
+        { kind: "wiki", embed: false, target: "note-000000", line: 5, snippet: "self" },
+        { kind: "image", embed: true, target: "pic.png", line: 6, snippet: "img" },
+        { kind: "wiki", embed: false, target: "nowhere at all", line: 7, snippet: "phantom" },
+        { kind: "wiki", embed: false, target: "nowhere at all", line: 8, snippet: "phantom" },
+      ],
+    };
+    index.applyDoc(docPath(0), twin);
+    expect(index.graph()).toEqual(oracleGraph(index, docs));
+  });
+});
+
+// ---- The agent-facing search's query plan -------------------------------------------
+
+/** A node:sqlite driver that remembers the SQL it was asked to run, so a test
+ * can EXPLAIN the store's own statements without the store exporting them. */
+function recordingDriver(): SqlDriver & { queries: string[]; explain: (sql: string) => string[] } {
+  const db = new DatabaseSync(":memory:");
+  const queries: string[] = [];
+  return {
+    queries,
+    exec: (sql) => {
+      db.exec(sql);
+    },
+    run: (sql, params) => {
+      db.prepare(sql).run(...params);
+    },
+    all: (sql, params) => {
+      queries.push(sql);
+      return db.prepare(sql).all(...params);
+    },
+    explain: (sql) =>
+      db
+        .prepare(`EXPLAIN QUERY PLAN ${sql}`)
+        .all("x", 10)
+        .map((row) => String(row["detail"])),
+    reset: () => {
+      db.exec("DROP TABLE IF EXISTS files");
+    },
+    close: () => {
+      db.close();
+    },
+  };
+}
+
+describe("agent-facing search", () => {
+  it("filters private docs without reading the files table", () => {
+    // The `files` join this replaced was quadratic in corpus size (see header):
+    // SQLite re-drove the row list per matched row. The invariant that keeps it
+    // linear is that the private filter is a column ON the FTS row, so the
+    // query plan must not touch `files` at all.
+    const driver = recordingDriver();
+    try {
+      const store = createSqlKnowledgeStore(driver, "/test/vault");
+      for (let i = 0; i < 20; i++) {
+        store.upsertDoc(
+          {
+            path: docPath(i),
+            fingerprint: { mtimeMs: i, size: 1, ino: i },
+            contentHash: `hash-${i}`,
+            projection: projection(i, 20),
+          },
+          body(i),
+        );
+      }
+      driver.queries.length = 0;
+      const hits = store.search("the", 10, { excludePrivate: true });
+      expect(hits.length).toBeGreaterThan(0);
+      expect(hits.map((h) => h.path)).not.toContain(docPath(0)); // i % 17 === 0
+      const sql = driver.queries[0];
+      if (sql === undefined) throw new Error("no search query recorded");
+      const plan = driver.explain(sql);
+      expect(plan.join(" | ")).not.toMatch(/\bfiles\b/);
+    } finally {
+      driver.close();
+    }
+  });
+});
+
+// ---- The documented benchmark ---------------------------------------------------------
+
+function seedStore(store: SqlKnowledgeStore, docs: number): void {
+  for (let start = 0; start < docs; start += 1000) {
+    store.transaction(() => {
+      for (let i = start; i < Math.min(start + 1000, docs); i++) {
+        store.upsertDoc(
+          {
+            path: docPath(i),
+            fingerprint: { mtimeMs: 1_700_000_000_000 + i, size: 100, ino: 5000 + i },
+            contentHash: `hash-${i}`,
+            projection: projection(i, docs),
+          },
+          body(i),
+        );
+      }
+    });
+  }
+}
+
+function since(start: number): string {
+  return `${(performance.now() - start).toFixed(1)}ms`;
+}
+
+// OPT-IN, asserting nothing about wall-clock — see the header.
+describe.skipIf(process.env["KNOWLEDGE_BENCH_DOCS"] === undefined)("query benchmark", () => {
+  it(`reports resolution + graph cost at ${BENCH_DOCS} docs`, () => {
+    const index = seedIndex(BENCH_DOCS);
+
+    const cold = performance.now();
+    const graph = index.graph();
+    const coldMs = since(cold);
+    const warm0 = performance.now();
+    index.graph();
+    const warmMs = since(warm0);
+
+    // The incremental path, at one doc and at the ceiling; then a batch past
+    // it, which falls back to the whole-corpus fold.
+    const reresolve = (docs: number, revision: number): string => {
+      for (let i = 0; i < docs; i++)
+        index.applyDoc(docPath(i), projection(i, BENCH_DOCS, revision));
+      const start = performance.now();
+      index.backlinks(docPath(1));
+      return since(start);
+    };
+    const oneMs = reresolve(1, 1);
+    const ceilingMs = reresolve(256, 2);
+    const overMs = reresolve(257, 3);
+
+    const wire0 = performance.now();
+    const wire = JSON.stringify(graph);
+    const stringifyMs = since(wire0);
+    const parse0 = performance.now();
+    JSON.parse(wire);
+    const parseMs = since(parse0);
+
+    console.log(
+      `[graph @ ${BENCH_DOCS}] nodes=${graph.nodes.length} edges=${graph.edges.length} | ` +
+        `cold=${coldMs} warm=${warmMs} | ` +
+        `wire=${(wire.length / 1e6).toFixed(1)}MB stringify=${stringifyMs} parse=${parseMs}`,
+    );
+    console.log(
+      `[re-resolve @ ${BENCH_DOCS}] 1 doc=${oneMs} 256 docs=${ceilingMs} 257 docs=${overMs}`,
+    );
+    expect(graph.nodes.length).toBeGreaterThan(0);
+  }, 600_000);
+
+  it(`reports search cost at ${BENCH_DOCS} docs`, () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "knowledge-query-perf-"));
+    const store = createSqliteKnowledgeStore(path.join(tmp, "bench.sqlite"), "/test/vault");
+    try {
+      seedStore(store, BENCH_DOCS);
+      for (const [label, query] of [
+        ["term in one doc", "body-000042"],
+        ["term in every doc", "the"],
+        ["two common terms", "quick brown"],
+        ["prefix only", "fil"],
+      ] satisfies Array<[string, string]>) {
+        store.search(query, 25); // warm the page cache
+        const plain = performance.now();
+        store.search(query, 25);
+        const plainMs = since(plain);
+        const priv = performance.now();
+        store.search(query, 25, { excludePrivate: true });
+        console.log(`[search @ ${BENCH_DOCS}] ${label}: ${plainMs} | private ${since(priv)}`);
+      }
+      const index = seedIndex(BENCH_DOCS);
+      index.backlinks(docPath(1)); // warm resolution
+      const related = performance.now();
+      relatedNotes(index, (q, l) => store.search(q, l), docPath(1));
+      console.log(`[related @ ${BENCH_DOCS}] ${since(related)}`);
+      expect(store.search("body-000042", 25)).toHaveLength(1);
+    } finally {
+      store.dispose();
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
+  }, 600_000);
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -189,7 +189,10 @@ importers:
         version: 0.60.0
       oxlint:
         specifier: ^1.75.0
-        version: 1.75.0
+        version: 1.75.0(oxlint-tsgolint@7.0.2001)
+      oxlint-tsgolint:
+        specifier: ^7.0.2001
+        version: 7.0.2001
       turbo:
         specifier: ^2.10.6
         version: 2.10.6
@@ -3413,6 +3416,36 @@ packages:
   '@oxfmt/binding-win32-x64-msvc@0.60.0':
     resolution: {integrity: sha512-tz78yhmGPKboTMHCHSaUqXK8JrmoSejgDcWeqAtg2s07ZGKQ3rH5Jn8NuXPGNG33CDbY2e9NoQWXIVEmKO21Rw==}
     engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [win32]
+
+  '@oxlint-tsgolint/darwin-arm64@7.0.2001':
+    resolution: {integrity: sha512-CUJEdbSZ54+Xy9OXqOhWLTKZKV0BBiV7C2i/ygyVmXtkUNXx5YCzN8DpSSshTAKktoL7S+tnQ/ftFG/i7X896w==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@oxlint-tsgolint/darwin-x64@7.0.2001':
+    resolution: {integrity: sha512-pXfBb5BqONCcgrXQNUZWXgiYmRSWJzd97S8i41VVOh6ut0tyo+cJ5FKFpczDHxiVNfj/3e7c9B4MtztNdpIVCw==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@oxlint-tsgolint/linux-arm64@7.0.2001':
+    resolution: {integrity: sha512-roP7zujb/QDPzDwEKsFFpzNHHy91/Y7oX9vQXk78ekyZtcQj1QXDIMH33gjDdHBfRl4K9pZ36xhRgrP4Zr+R8A==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@oxlint-tsgolint/linux-x64@7.0.2001':
+    resolution: {integrity: sha512-UDezNqdECVmngu2TPnjaS1YoAmcTaBoI5lV9vk3VahBxoi+I5r9k3iJTT7qZoYWOXTD/7T7bNcwRgrocR6BscQ==}
+    cpu: [x64]
+    os: [linux]
+
+  '@oxlint-tsgolint/win32-arm64@7.0.2001':
+    resolution: {integrity: sha512-uJZhqB6pdXLuN+AD1F5082byyQti/NPmJA77GtcFlmT2HzRelqbNls3SaIqxpjdFgvSBF9g0yOKGBkGFg7kX8Q==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@oxlint-tsgolint/win32-x64@7.0.2001':
+    resolution: {integrity: sha512-FkDRm8hx9OwzGQqyWG1tO5QrTLRApff9DzSgpz9QZau37BR8d1VYKOxMLGf6shPZntJFoTwIIJYT68VndYDCog==}
     cpu: [x64]
     os: [win32]
 
@@ -8463,6 +8496,10 @@ packages:
       vite-plus:
         optional: true
 
+  oxlint-tsgolint@7.0.2001:
+    resolution: {integrity: sha512-KjK/XLcXr1DSyonKhsuFqJRiuKqcyG9j3LJ8nkOsrLzGvodBPqzHOKauy10asLMDI0sUpvb+1sxlzff3udZvfg==}
+    hasBin: true
+
   oxlint@1.75.0:
     resolution: {integrity: sha512-m9WzjRcRYA/uqIZDa9tclrieoPJ/ln1QYTKdFx6NUOs8uY5DiHlIwRQoCrHT6OM6O3ww3l2skY5gO7G7ZphE7g==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -12869,6 +12906,24 @@ snapshots:
     optional: true
 
   '@oxfmt/binding-win32-x64-msvc@0.60.0':
+    optional: true
+
+  '@oxlint-tsgolint/darwin-arm64@7.0.2001':
+    optional: true
+
+  '@oxlint-tsgolint/darwin-x64@7.0.2001':
+    optional: true
+
+  '@oxlint-tsgolint/linux-arm64@7.0.2001':
+    optional: true
+
+  '@oxlint-tsgolint/linux-x64@7.0.2001':
+    optional: true
+
+  '@oxlint-tsgolint/win32-arm64@7.0.2001':
+    optional: true
+
+  '@oxlint-tsgolint/win32-x64@7.0.2001':
     optional: true
 
   '@oxlint/binding-android-arm-eabi@1.75.0':
@@ -18606,7 +18661,16 @@ snapshots:
       '@oxfmt/binding-win32-ia32-msvc': 0.60.0
       '@oxfmt/binding-win32-x64-msvc': 0.60.0
 
-  oxlint@1.75.0:
+  oxlint-tsgolint@7.0.2001:
+    optionalDependencies:
+      '@oxlint-tsgolint/darwin-arm64': 7.0.2001
+      '@oxlint-tsgolint/darwin-x64': 7.0.2001
+      '@oxlint-tsgolint/linux-arm64': 7.0.2001
+      '@oxlint-tsgolint/linux-x64': 7.0.2001
+      '@oxlint-tsgolint/win32-arm64': 7.0.2001
+      '@oxlint-tsgolint/win32-x64': 7.0.2001
+
+  oxlint@1.75.0(oxlint-tsgolint@7.0.2001):
     optionalDependencies:
       '@oxlint/binding-android-arm-eabi': 1.75.0
       '@oxlint/binding-android-arm64': 1.75.0
@@ -18627,6 +18691,7 @@ snapshots:
       '@oxlint/binding-win32-arm64-msvc': 1.75.0
       '@oxlint/binding-win32-ia32-msvc': 1.75.0
       '@oxlint/binding-win32-x64-msvc': 1.75.0
+      oxlint-tsgolint: 7.0.2001
 
   p-cancelable@2.1.1: {}
 


### PR DESCRIPTION
Finishing the remaining p3 work. Started as "decide whether #448's worker-thread move is still justified"; the measurement found two costs worse than the one the issue named.

## The agent search was quadratic in corpus size

Every agent knowledge tool goes through `search(..., { excludePrivate: true })`. It filtered private docs with `rowid IN (SELECT rowid FROM files WHERE is_private = 0)` — SQLite re-drives that row list **per matched row**.

| docs | plain | excludePrivate |
| --- | --- | --- |
| 500 | 1.8 ms | 21.7 ms |
| 1,000 | 1.8 ms | 79.4 ms |
| 2,000 | 3.5 ms | 291.5 ms |
| 4,000 | 6.2 ms | 1,150.7 ms |
| 50,000 | 77 ms | **198,536 ms** |

Doubling the corpus quadrupled the time. `is_private` is now an UNINDEXED FTS5 column, so the filter is a residual test on rows the cursor already produced: **198,536ms → 79ms**, selective query **1,055ms → 1.1ms**. Same results, same pre-limit privacy semantics — a private path or snippet still never transits the result set.

This is not a 50k-vault problem. A **2,000-note vault already paid 291ms per agent search**, and `related_notes` fires up to 8 probes.

`KNOWLEDGE_SCHEMA_VERSION` 6 → 7. The index is a wipe-and-rebuild cache, so there is no migration.

## One edited note dropped the whole vault's link resolution

`LinkGraphIndex` invalidated `resolved` on any mutation, so the first backlinks/links/related/graph query after **every autosave** re-ran `buildResolver` over every path plus 400k link resolutions — 545ms at 50k, on an always-visible surface.

Resolution depends only on the path set and the docs' `aliases:`, so re-projecting a known doc with an unchanged alias list now re-resolves that doc's own links and splices its occurrences back at its corpus position: **545ms → 0.1ms**, byte-identical output. Any path or alias change still forces the full fold, and a batch over 256 docs falls back to it — a cap measured at the crossover for the worst shape (a hub every note links to).

`graph()` assembly is 519ms → 350ms by collapsing parallel links per source rather than vault-wide.

## The worker thread stays undone, deliberately

After these fixes the DB costs 1–82ms per query. Everything still above 100ms is pure JS in the in-memory `LinkGraphIndex` — the first whole-corpus resolution after boot, and graph assembly — and #448's own design keeps that mirror on the main thread. The refactor would make `search()` async across four packages to move work that is no longer where the cost is. Closing with the numbers rather than leaving it open forever.

## Also in here

- **oxlint type-aware linting on**, staged. `oxlint-tsgolint@7.0.2001` + `options.typeAware: true`, with exactly three rules live (`await-thenable`, `no-floating-promises`, `no-misused-promises`) and the other 22 written off **by name** so the ladder is explicit rather than implied. Two genuine unhandled rejections fixed; the deliberate fire-and-forget sites take `void`, not a blanket test carve-out — that would fail open on exactly the flake class the rule exists for. Cost: ~6.2s wall / ~2.0GB peak RSS repo-wide vs 0.09s / 92MB type-blind.
- **Seven design divergences recorded** in `CLAUDE.md § Decisions` (drizzle push + Better Auth schema, per-request baseURL, `fireEvent`, generator defaults, `file://` renderer), so audits stop re-deriving them. Includes the warning that flipping the auth timestamp mode without an `UPDATE … SET col = col * 1000` reads every date back as 1970 and invalidates all sessions.
- The wasm/node SQLite parity test now pins the **private filter**, not just ranking — `is_private` moved into FTS5, and a divergence there means the harness and the app disagree about which notes an agent can see.

## Verification

Full `pnpm verify` green. New deterministic pins (no wall-clock in the gate; the benchmark is opt-in behind `KNOWLEDGE_BENCH_DOCS`), each confirmed non-vacuous by reverting the fix and watching it fail: a re-resolve counter, a 16-step oracle sweep against a virgin index, and an `EXPLAIN QUERY PLAN` assertion that the agent search never reads the `files` table.

Closes #448

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014tQQ3Jt3xQ9XdmXcFtXkDt


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make knowledge queries fast by removing the quadratic privacy filter in agent search and making link re-resolution incremental. Large vaults go from multi‑second pauses to milliseconds with no behavior or privacy changes.

- **Performance**
  - Agent search: moved `is_private` into an UNINDEXED `FTS5` column and filter inside FTS (`is_private = 0`). 50k docs went from ~198s to ~79ms; limit applies to public hits only.
  - Link re-resolution: only re-resolve an edited doc when its path and `aliases:` are unchanged; splice occurrences back in place. ~545ms to ~0.1ms on large vaults; full rebuild still runs on path/alias changes or large batches.
  - Graph assembly: collapse parallel links per source. ~519ms to ~350ms.

- **Migration**
  - Bump `KNOWLEDGE_SCHEMA_VERSION` 6 → 7 (adds `is_private` to `search_fts`). No manual steps; the index is wiped and auto‑rebuilt.

<sup>Written for commit cbd9ddff2df048ae225533b38055b00adddcb703. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kyh/inteligir/pull/476?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

