### PR TITLE
perf(knowledge,vault): bound the graph payload, stop the crawl blocking

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -66,44 +66,76 @@
     "unicorn/prefer-node-protocol": "error",
 
     // Type-aware rules, staged. `options.typeAware` switches on EVERY
-    // type-aware rule the enabled categories carry, so the ones not wanted yet
-    // are written off by name rather than left implicit: this list is the
-    // ladder, and a rule graduates by flipping to "error" once its findings
-    // are cleared. The promise set is what runs today — a dropped promise, or
-    // one handed to a slot that expects a void return, is a real bug class no
+    // type-aware rule the enabled categories carry, so every one is named
+    // here rather than left implicit: this list is the ladder, and a rule
+    // graduates by flipping to "error" once its findings are cleared. A rule
+    // still "off" carries the reason it is blocked — a bare "off" makes the
+    // ladder invisible, which is how it stalls.
+    //
+    // The promise set is the load-bearing one: a dropped promise, or one
+    // handed to a slot that expects a void return, is a real bug class no
     // type-blind rule can see. `no-misused-promises` is not category-enabled,
-    // so it is opted in by name.
+    // so it is opted in by name. None of the three may be relaxed in the
+    // `__tests__` override — that would fail open on exactly the flake class
+    // they exist for.
     "typescript/await-thenable": "error",
     "typescript/no-floating-promises": "error",
     "typescript/no-misused-promises": "error",
-    "typescript/consistent-return": "off",
-    "typescript/no-array-delete": "off",
-    "typescript/no-base-to-string": "off",
-    "typescript/no-duplicate-type-constituents": "off",
-    "typescript/no-for-in-array": "off",
-    "typescript/no-implied-eval": "off",
-    "typescript/no-meaningless-void-operator": "off",
-    "typescript/no-misused-spread": "off",
-    "typescript/no-redundant-type-constituents": "off",
-    "typescript/no-unnecessary-boolean-literal-compare": "off",
-    "typescript/no-unnecessary-template-expression": "off",
-    "typescript/no-unnecessary-type-arguments": "off",
-    "typescript/no-unnecessary-type-assertion": "off",
-    "typescript/no-unnecessary-type-conversion": "off",
-    "typescript/no-unnecessary-type-parameters": "off",
-    "typescript/no-unsafe-enum-comparison": "off",
-    "typescript/no-unsafe-type-assertion": "off",
-    "typescript/no-unsafe-unary-minus": "off",
-    "typescript/no-useless-default-assignment": "off",
-    "typescript/require-array-sort-compare": "off",
-    "typescript/restrict-template-expressions": "off",
-    "typescript/unbound-method": "off"
+
+    // `no-unsafe-type-assertion` is the type-aware complement to the
+    // `consistent-type-assertions: never` above: it sees through the generic
+    // `as unknown as T` escapes the syntactic rule cannot. The handful of
+    // sanctioned escapes carry a narrow per-site disable naming both rules.
+    "typescript/no-array-delete": "error",
+    "typescript/no-base-to-string": "error",
+    "typescript/no-duplicate-type-constituents": "error",
+    "typescript/no-for-in-array": "error",
+    "typescript/no-implied-eval": "error",
+    "typescript/no-meaningless-void-operator": "error",
+    "typescript/no-misused-spread": "error",
+    "typescript/no-redundant-type-constituents": "error",
+    "typescript/no-unnecessary-boolean-literal-compare": "error",
+    "typescript/no-unnecessary-template-expression": "error",
+    "typescript/no-unnecessary-type-arguments": "error",
+    "typescript/no-unnecessary-type-assertion": "error",
+    "typescript/no-unnecessary-type-conversion": "error",
+    "typescript/no-unnecessary-type-parameters": "error",
+    "typescript/no-unsafe-enum-comparison": "error",
+    "typescript/no-unsafe-type-assertion": "error",
+    "typescript/no-unsafe-unary-minus": "error",
+    "typescript/no-useless-default-assignment": "error",
+    "typescript/require-array-sort-compare": "error",
+    "typescript/restrict-template-expressions": "error",
+    "typescript/unbound-method": "error",
+
+    // BLOCKED: 51 findings, and the two shapes behind them are both idioms
+    // this repo relies on.
+    //   1. An exhaustive `switch` over a discriminated union with no `default`
+    //      — the fall-off-the-end the rule objects to is what makes TS reject
+    //      the function when a new union member appears. Satisfying the rule
+    //      means a `default` or a widened return type, either of which DELETES
+    //      that exhaustiveness check. ~25 of the 51.
+    //   2. `useEffect(() => { if (x) return; …; return cleanup; })` — React's
+    //      own contract for a conditional cleanup. ~20 of the 51.
+    // Neither is a "sometimes returns a value" bug; graduating this rule buys
+    // nothing and costs a real invariant.
+    "typescript/consistent-return": "off"
   },
   "overrides": [
     {
       "files": ["**/__tests__/**", "**/*.test.ts", "**/*.test.tsx"],
       "rules": {
-        "typescript/consistent-type-assertions": "off"
+        // A test builds the shapes production code receives from the wire, so
+        // it asserts where production parses. `no-unsafe-type-assertion` is
+        // the type-aware half of the same exemption — leaving it on here would
+        // contradict the line above it.
+        "typescript/consistent-type-assertions": "off",
+        "typescript/no-unsafe-type-assertion": "off",
+        // `expect(ops.someMethod).toHaveBeenCalledWith(…)` reads a fake port's
+        // member detached, which is the whole assertion. An unbound reference
+        // inside a mock cannot lose a `this` no production call ever makes.
+        // Scoped to tests only — production keeps the rule.
+        "typescript/unbound-method": "off"
       }
     },
     {

--- a/apps/desktop/dev/fixture-bridge.ts
+++ b/apps/desktop/dev/fixture-bridge.ts
@@ -34,7 +34,7 @@ import { toggleCheckboxLine, toggleTaskAtOrdinal } from "@repo/notes/knowledge/g
 import { SEARCH_DEFAULT_LIMIT } from "@repo/notes/knowledge/knowledge-index";
 import type { KnowledgeStore } from "@repo/notes/knowledge/knowledge-store";
 import { scanTaskItems, titleFromPath } from "@repo/notes/knowledge/link-extract";
-import { LinkGraphIndex } from "@repo/notes/knowledge/link-graph-index";
+import { boundGraph, LinkGraphIndex } from "@repo/notes/knowledge/link-graph-index";
 import { checkNoteName, noteNameErrorMessage } from "@repo/notes/knowledge/note-name";
 import { projectDoc } from "@repo/notes/knowledge/projection";
 import { computeRenameEdits } from "@repo/notes/knowledge/rename-links";
@@ -1183,7 +1183,10 @@ export function createFixtureBridge(openKnowledgeStore: (root: string) => Knowle
     // store's FTS5 bm25 as the lexical port.
     getRelatedNotes: async ({ path }) =>
       relatedNotes(linkGraph, (query, limit) => knowledgeStore.search(query, limit), path),
-    getLinkGraph: async () => linkGraph.graph(),
+    // Bounded through the SAME pure pass the host handler uses, so the
+    // "showing N of M" affordance is exercisable in the harness (drop the
+    // caps low against the sample vault and it fires).
+    getLinkGraph: async (bounds) => boundGraph(linkGraph.graph(), bounds),
     searchVault: async ({ query, limit }) =>
       knowledgeStore.search(query, limit ?? SEARCH_DEFAULT_LIMIT),
     listWikiTargets: async () => linkGraph.wikiTargets(),

--- a/apps/desktop/scripts/verify-runtime-model-registry.mjs
+++ b/apps/desktop/scripts/verify-runtime-model-registry.mjs
@@ -75,6 +75,9 @@ for (const { provider, modelId } of pairs) {
     console.error(`[verify] Model "${provider}/${modelId}" not found in pi-ai model registry.`);
     continue;
   }
+  // pi-ai types `Api` as `KnownApi | (string & {})`; the type-aware pass does
+  // not read that intersection as string-like, so the interpolation is fine.
+  // oxlint-disable-next-line typescript/restrict-template-expressions
   console.log(`[verify] OK: ${provider}/${modelId} -> ${model.name} (api=${model.api})`);
 }
 

--- a/apps/desktop/src/renderer/__tests__/fixture-knowledge.test.ts
+++ b/apps/desktop/src/renderer/__tests__/fixture-knowledge.test.ts
@@ -37,7 +37,7 @@ describe("fixture bridge knowledge channels", () => {
     const targets = await bridge.listWikiTargets();
     expect(targets.map((t) => t.path)).toContain("review/probe.md");
 
-    const graph = await bridge.getLinkGraph();
+    const graph = await bridge.getLinkGraph({});
     expect(graph.nodes.map((n) => n.id)).toContain("review/probe.md");
   });
 

--- a/apps/desktop/src/renderer/__tests__/inline-combobox.test.ts
+++ b/apps/desktop/src/renderer/__tests__/inline-combobox.test.ts
@@ -178,7 +178,7 @@ describe("reconcileInsertionCaret (the #367 first-commit caret quirk)", () => {
     for (const word of ["deep", "tada"]) {
       let value = "";
       let caret = 0;
-      for (const [i, char] of [...word].entries()) {
+      for (const [i, char] of Array.from(word).entries()) {
         const next = value.slice(0, caret) + char + value.slice(caret);
         // The browser strands the caret on the first commit, then behaves.
         const reported = i === 0 ? caret : caret + 1;

--- a/apps/desktop/src/renderer/composer/chat-message.tsx
+++ b/apps/desktop/src/renderer/composer/chat-message.tsx
@@ -156,6 +156,11 @@ const MAX_ARGS_LEN = 120;
 function formatToolArgs(input: unknown): string | null {
   if (input === null || input === undefined) return null;
   if (typeof input === "string") return truncate(input, MAX_ARGS_LEN);
+  // isRecord absorbs every non-null object bar arrays, so what reaches here is
+  // a primitive, an array or a function — none of which stringify to
+  // `[object Object]`. `input` stays `unknown` because a type predicate can't
+  // narrow the negative branch.
+  // oxlint-disable-next-line typescript/no-base-to-string
   if (!isRecord(input)) return truncate(String(input), MAX_ARGS_LEN);
 
   // Prioritised keys that read well as a one-line subtitle.

--- a/apps/desktop/src/renderer/editor/markdown/markdown-doc.ts
+++ b/apps/desktop/src/renderer/editor/markdown/markdown-doc.ts
@@ -214,7 +214,7 @@ export function parseMarkdown(
   if (!converted.ok) return { ok: false, reason: converted.reason };
   // mdast root children are flow nodes, so the converted value is TElement[]
   // in practice; Plate's own deserializeMd performs this exact widening.
-  // oxlint-disable-next-line typescript/consistent-type-assertions
+  // oxlint-disable-next-line typescript/consistent-type-assertions, typescript/no-unsafe-type-assertion -- mdast root children are flow nodes, see doc above
   return { ok: true, value: converted.value as Value };
 }
 

--- a/apps/desktop/src/renderer/editor/markdown/md-rules.ts
+++ b/apps/desktop/src/renderer/editor/markdown/md-rules.ts
@@ -67,8 +67,10 @@ const ALERT_RE = /^\s*\[!(NOTE|TIP|IMPORTANT|WARNING|CAUTION)\]/;
 // defaultRule returns `html` for bare autolinks) — MdRules just over-narrows
 // each rule's return type. The ONE sanctioned escape hatch bridging that
 // over-narrow third-party type; `T` is the rule signature's demanded return.
+// `T` living only in the return position IS the escape, not an oversight.
+// oxlint-disable-next-line typescript/no-unnecessary-type-parameters
 function verbatimHtml<T>(value: string): T {
-  // oxlint-disable-next-line typescript/consistent-type-assertions
+  // oxlint-disable-next-line typescript/consistent-type-assertions, typescript/no-unsafe-type-assertion -- the sanctioned escape, see doc above
   return { type: "html", value } as unknown as T;
 }
 

--- a/apps/desktop/src/renderer/editor/properties/property-fields.tsx
+++ b/apps/desktop/src/renderer/editor/properties/property-fields.tsx
@@ -82,7 +82,7 @@ export function CheckboxField({
     <div className="flex h-7 items-center px-1.5">
       <Checkbox
         checked={prop.value}
-        onCheckedChange={(value) => onChange({ ...prop, value: value === true })}
+        onCheckedChange={(value) => onChange({ ...prop, value })}
         aria-label={prop.key}
       />
     </div>

--- a/apps/desktop/src/renderer/settings/sections/sync-section.tsx
+++ b/apps/desktop/src/renderer/settings/sections/sync-section.tsx
@@ -142,7 +142,7 @@ export function SyncSection({ onRequestClose }: { onRequestClose?: (() => void) 
               variant="ghost"
               size="sm"
               onClick={() => void handleSyncNow()}
-              disabled={busy || loading || !signedIn || state?.enabled !== true}
+              disabled={busy || loading || !signedIn || !state.enabled}
               className="h-auto px-2 py-0.5 text-[10px] text-muted-foreground"
             >
               Sync now

--- a/apps/desktop/src/renderer/workspace/graph-view.tsx
+++ b/apps/desktop/src/renderer/workspace/graph-view.tsx
@@ -9,6 +9,12 @@
 // are sized by degree; phantoms draw dashed; the open note gets a
 // highlight ring. Data refreshes on onKnowledgeUpdated, preserving layout
 // positions by node id.
+//
+// The request is BOUNDED (see MAX_NODES/MAX_EDGES): the whole graph of a 50k
+// vault is ~42MB of JSON and 400k links into d3-force. A vault that fits under
+// the caps still gets every node and edge — the bound is the cap itself, not a
+// separate mode — and whenever it does engage the view says so, because a
+// silently truncated graph reads as "these notes are unconnected".
 
 import { useCallback, useEffect, useLayoutEffect, useRef, useState } from "react";
 import {
@@ -30,7 +36,7 @@ import { useViewStore } from "@renderer/stores/view-store";
 import { openDocPath } from "@renderer/workspace/open-doc";
 import { useOpenNote } from "@renderer/workspace/open-note-store";
 import { useVaultActions } from "@renderer/workspace/vault-context";
-import type { LinkGraph } from "@repo/notes/knowledge/link-graph-index";
+import type { BoundedLinkGraph } from "@repo/notes/knowledge/link-graph-index";
 
 type SimNode = SimulationNodeDatum & {
   id: string;
@@ -61,7 +67,36 @@ function nodeRadius(node: SimNode): number {
   return 4 + Math.min(10, Math.sqrt(node.degree) * 2);
 }
 
-function toGraphData(graph: LinkGraph, previous: GraphData | null): GraphData {
+/** What the view will draw, and what a d3-force tick can move, before either
+ * turns into a slideshow: ~1MB on the wire against a 50k-note vault (measured
+ * — 42MB unbounded) and ~10k canvas ops per frame. Both are caps, not targets:
+ * a vault under them transfers whole. */
+const MAX_NODES = 2000;
+const MAX_EDGES = 8000;
+
+/** The affordance's numbers, non-null exactly when something was dropped. */
+type Shortfall = {
+  nodes: number;
+  totalNodes: number;
+  edges: number;
+  totalEdges: number;
+  /** Whether the request named the open note, which decides what "dropped"
+   * means: the outermost notes, or the least-connected ones. */
+  focused: boolean;
+};
+
+function shortfallOf(graph: BoundedLinkGraph, focused: boolean): Shortfall | null {
+  if (graph.nodes.length >= graph.totalNodes && graph.edges.length >= graph.totalEdges) return null;
+  return {
+    nodes: graph.nodes.length,
+    totalNodes: graph.totalNodes,
+    edges: graph.edges.length,
+    totalEdges: graph.totalEdges,
+    focused,
+  };
+}
+
+function toGraphData(graph: BoundedLinkGraph, previous: GraphData | null): GraphData {
   const byId = new Map<string, SimNode>();
   const nodes = graph.nodes.map((node): SimNode => {
     const prior = previous?.byId.get(node.id);
@@ -113,6 +148,7 @@ export default function GraphView() {
   const setSurface = useViewStore((s) => s.setSurface);
   const { resolved: resolvedTheme } = useTheme();
   const [empty, setEmpty] = useState(false);
+  const [shortfall, setShortfall] = useState<Shortfall | null>(null);
 
   const canvasRef = useRef<HTMLCanvasElement>(null);
   const dataRef = useRef<GraphData | null>(null);
@@ -219,11 +255,12 @@ export default function GraphView() {
     const bridge = getBridge();
     let disposed = false;
 
-    const apply = (graph: LinkGraph) => {
+    const apply = (graph: BoundedLinkGraph, focused: boolean) => {
       if (disposed) return;
       const data = toGraphData(graph, dataRef.current);
       dataRef.current = data;
       setEmpty(data.nodes.length === 0);
+      setShortfall(shortfallOf(graph, focused));
       const links: SimulationLinkDatum<SimNode>[] = data.edges.map((edge) => ({
         source: edge.source,
         target: edge.target,
@@ -258,9 +295,16 @@ export default function GraphView() {
     };
 
     const refresh = () => {
+      // Read the open note at request time rather than closing over it: the
+      // effect runs once, and navigation leaves this surface anyway.
+      const focus = activePathRef.current;
       bridge
-        .getLinkGraph()
-        .then(apply)
+        .getLinkGraph({
+          maxNodes: MAX_NODES,
+          maxEdges: MAX_EDGES,
+          ...(focus !== null && { focus }),
+        })
+        .then((graph) => apply(graph, focus !== null))
         .catch(() => {});
     };
     refresh();
@@ -435,6 +479,23 @@ export default function GraphView() {
       {empty && (
         <div className="pointer-events-none absolute inset-0 flex items-center justify-center text-sm text-muted-foreground">
           Nothing to graph yet — link notes with [[wiki links]].
+        </div>
+      )}
+      {shortfall !== null && (
+        <div
+          role="status"
+          className="pointer-events-none absolute top-3 left-3 rounded-md border border-border bg-background/85 px-2 py-1 text-xs text-muted-foreground"
+        >
+          <div>
+            {`Showing ${shortfall.nodes.toLocaleString()} of ${shortfall.totalNodes.toLocaleString()} notes`}
+            {" · "}
+            {`${shortfall.edges.toLocaleString()} of ${shortfall.totalEdges.toLocaleString()} links`}
+          </div>
+          <div className="text-muted-foreground/70">
+            {shortfall.focused
+              ? "Nearest the open note first — this vault is too large to draw whole."
+              : "Most-connected notes first — this vault is too large to draw whole."}
+          </div>
         </div>
       )}
       <div className="pointer-events-none absolute bottom-3 left-1/2 -translate-x-1/2 text-xs text-muted-foreground/70">

--- a/apps/desktop/src/renderer/workspace/html-app-runtime.test.tsx
+++ b/apps/desktop/src/renderer/workspace/html-app-runtime.test.tsx
@@ -49,6 +49,9 @@ beforeAll(() => {
     posted.push(msg as Posted);
   });
   // Evaluate the IIFE against the jsdom globals (window/document/setTimeout).
+  // Evaluating the SHIPPED source is the point of this suite — a hand-imported
+  // module copy would test something the browser never runs.
+  // oxlint-disable-next-line typescript/no-implied-eval
   new Function(runtimeSource)();
 });
 

--- a/apps/mobile/src/lib/host/connection-core.ts
+++ b/apps/mobile/src/lib/host/connection-core.ts
@@ -47,8 +47,11 @@ export type HostConnection = {
   /** The live bridge, or null when stopped / unauthorized. Requests made
    * while merely disconnected queue inside the bridge until reconnect. */
   getBridge(): Bridge | null;
-  getSnapshot(): HostSnapshot;
-  subscribe(onChange: () => void): () => void;
+  // Declared as function PROPERTIES, not methods: React reads these detached
+  // (`useSyncExternalStore(connection.subscribe, connection.getSnapshot)`), so
+  // the type has to promise they carry no `this`.
+  getSnapshot: () => HostSnapshot;
+  subscribe: (onChange: () => void) => () => void;
   /** Tear down everything including the lifecycle subscription (tests). */
   dispose(): void;
 };

--- a/packages/agent/src/browser/extension.ts
+++ b/packages/agent/src/browser/extension.ts
@@ -201,7 +201,7 @@ function installBrowserRuntime(
 
     const child = execFile(binPath, ["install"], { timeout: 300_000 }, (err, stdout, stderr) => {
       if (err) {
-        reject(new Error(`browser runtime install failed: ${String(stdout)}${String(stderr)}`));
+        reject(new Error(`browser runtime install failed: ${stdout}${stderr}`));
         return;
       }
       resolve();

--- a/packages/bridge/src/ipc-registry.ts
+++ b/packages/bridge/src/ipc-registry.ts
@@ -51,8 +51,8 @@ import {
 import type { SearchResult } from "@repo/notes/knowledge/knowledge-index";
 import type {
   BacklinkEntry,
+  BoundedLinkGraph,
   ForwardLinkEntry,
-  LinkGraph,
   VaultTaskEntry,
   WikiTarget,
 } from "@repo/notes/knowledge/link-graph-index";
@@ -311,6 +311,19 @@ const KnowledgeSearchSchema = Type.Object(
 
 const KnowledgeTagSchema = Type.Object({ tag: Type.String() }, { additionalProperties: false });
 
+// How much of the link graph to return — the wire face of @repo/notes'
+// GraphBounds. Every field optional: `{}` asks for the whole vault, which is
+// what a small one still answers.
+const LinkGraphBoundsSchema = Type.Object(
+  {
+    /** Vault path whose neighbourhood is expanded first (typically the open note). */
+    focus: Type.Optional(Type.String()),
+    maxNodes: Type.Optional(Type.Number({ minimum: 1 })),
+    maxEdges: Type.Optional(Type.Number({ minimum: 0 })),
+  },
+  { additionalProperties: false },
+);
+
 // Guarded task toggle — keyed by ORDINAL (delegation's anchor key; survives
 // line shifts and duplicate identical lines) plus the exact recorded line.
 const ToggleTaskSchema = Type.Object(
@@ -530,9 +543,13 @@ export const IPC = {
    * `reasons`. Direct link neighbors are excluded by design (the Links and
    * Backlinks panels already surface them). */
   getRelatedNotes: invoke<typeof VaultPathSchema, RelatedNoteEntry[]>(VaultPathSchema),
-  /** Whole-vault link graph, shaped for a force-graph renderer (unresolved
-   * targets appear as flagged phantom nodes). */
-  getLinkGraph: invokeVoid<LinkGraph>(),
+  /** Vault link graph, shaped for a force-graph renderer (unresolved targets
+   * appear as flagged phantom nodes). The caller's bounds are applied HOST-side,
+   * before serialization — the whole graph is ~42MB of JSON at 50k notes, so a
+   * renderer-side filter would save nothing that matters. The reply always
+   * carries the whole graph's counts, so a bounded view can say how much of the
+   * vault it is showing. */
+  getLinkGraph: invoke<typeof LinkGraphBoundsSchema, BoundedLinkGraph>(LinkGraphBoundsSchema),
   /** Ranked lexical full-text search (title > heading > body tiers). */
   searchVault: invoke<typeof KnowledgeSearchSchema, SearchResult[]>(KnowledgeSearchSchema),
   /** Every linkable target for the `[[`-autocomplete picker: notes first,

--- a/packages/bridge/src/ws-bridge.ts
+++ b/packages/bridge/src/ws-bridge.ts
@@ -308,7 +308,7 @@ export function createWsBridge(options: WsBridgeOptions): { bridge: Bridge; disp
     }
   });
 
-  // oxlint-disable-next-line typescript/consistent-type-assertions -- runtime fold over the registry; shape proven by derivation above
+  // oxlint-disable-next-line typescript/consistent-type-assertions, typescript/no-unsafe-type-assertion -- runtime fold over the registry; shape proven by derivation above
   const bridge = Object.fromEntries(entries) as unknown as Bridge;
 
   function dispose(): void {

--- a/packages/installer/src/run-cli.ts
+++ b/packages/installer/src/run-cli.ts
@@ -69,7 +69,7 @@ export function runCli(
           return;
         }
         const code = typeof rawCode === "number" ? rawCode : err ? 1 : 0;
-        resolve({ stdout: String(stdout), stderr: String(stderr), code });
+        resolve({ stdout, stderr, code });
       },
     );
     if (opts.stdin !== undefined) {

--- a/packages/notes/src/knowledge/__tests__/graph-bounds.test.ts
+++ b/packages/notes/src/knowledge/__tests__/graph-bounds.test.ts
@@ -1,0 +1,227 @@
+// ---------------------------------------------------------------------------
+// boundGraph — the graph view's TRANSFER bound. Two properties carry the
+// feature and are pinned here: a bounded answer is a strict SUBSET of the
+// unbounded one (so nothing is invented and node identity survives a refresh),
+// and it always reports the whole graph's counts (so the view can say what it
+// is not showing — a silent truncation reads as "these notes are unconnected").
+//
+// The last block is an OPT-IN payload measurement, not a wall-clock assertion:
+// set KNOWLEDGE_BENCH_DOCS (the same knob @repo/server's knowledge-query-perf
+// bench uses) to print the bytes at 50k notes.
+// ---------------------------------------------------------------------------
+
+import { describe, expect, it } from "vitest";
+
+import {
+  boundGraph,
+  LinkGraphIndex,
+  type BoundedLinkGraph,
+  type GraphEdge,
+  type GraphNode,
+  type LinkGraph,
+} from "../link-graph-index";
+import { projectDoc } from "../projection";
+
+/** A graph from bare id pairs, applying graph()'s own degree rule (degree
+ * counts EDGES; a self-edge counts once). `loners` are nodes with no edges. */
+function graphOf(
+  pairs: ReadonlyArray<readonly [string, string]>,
+  loners: readonly string[] = [],
+): LinkGraph {
+  const nodes = new Map<string, GraphNode>();
+  const node = (id: string): GraphNode => {
+    const found = nodes.get(id);
+    if (found !== undefined) return found;
+    const created: GraphNode = { id, title: id, path: id, phantom: false, degree: 0 };
+    nodes.set(id, created);
+    return created;
+  };
+  for (const id of loners) node(id);
+  const edges = pairs.map(([source, target]): GraphEdge => {
+    node(source).degree += 1;
+    if (target !== source) node(target).degree += 1;
+    return { source, target, kind: "wiki", count: 1 };
+  });
+  return { nodes: [...nodes.values()], edges };
+}
+
+const idsOf = (graph: LinkGraph): string[] => graph.nodes.map((node) => node.id);
+const edgeKeysOf = (graph: LinkGraph): string[] =>
+  graph.edges.map((edge) => `${edge.source}->${edge.target}`);
+
+/** The invariants every bounded answer owes its caller, whatever the bounds. */
+function expectSubsetOf(bounded: BoundedLinkGraph, full: LinkGraph): void {
+  expect(bounded.totalNodes).toBe(full.nodes.length);
+  expect(bounded.totalEdges).toBe(full.edges.length);
+  const kept = new Set(idsOf(bounded));
+  for (const node of bounded.nodes) expect(full.nodes).toContainEqual(node);
+  for (const edge of bounded.edges) {
+    expect(full.edges).toContainEqual(edge);
+    // No half-drawn edge: an endpoint the renderer can't place is a line to
+    // nowhere.
+    expect(kept.has(edge.source) && kept.has(edge.target)).toBe(true);
+  }
+}
+
+const CHAIN: ReadonlyArray<readonly [string, string]> = [
+  ["a.md", "b.md"],
+  ["b.md", "c.md"],
+  ["c.md", "d.md"],
+  ["d.md", "e.md"],
+];
+
+/** One hub every leaf links to — the shape that makes an unbounded frontier
+ * cost the whole vault. */
+function starGraph(leaves: number): LinkGraph {
+  const pairs = Array.from(
+    { length: leaves },
+    (_, i) => [`leaf-${String(i).padStart(5, "0")}.md`, "hub.md"] as const,
+  );
+  return graphOf(pairs);
+}
+
+describe("boundGraph", () => {
+  it("returns the whole graph, and its counts, when nothing is capped", () => {
+    const full = graphOf(CHAIN);
+    for (const bounds of [{}, { maxNodes: 5, maxEdges: 4 }, { maxNodes: 500 }]) {
+      const bounded = boundGraph(full, bounds);
+      expect(idsOf(bounded)).toEqual(idsOf(full));
+      expect(bounded.edges).toEqual(full.edges);
+      expect(bounded.totalNodes).toBe(5);
+      expect(bounded.totalEdges).toBe(4);
+    }
+  });
+
+  it("expands outward from the focus, nearest first", () => {
+    const full = graphOf(CHAIN);
+    const bounded = boundGraph(full, { focus: "a.md", maxNodes: 3 });
+    expect(idsOf(bounded).toSorted()).toEqual(["a.md", "b.md", "c.md"]);
+    expect(edgeKeysOf(bounded)).toEqual(["a.md->b.md", "b.md->c.md"]);
+    expectSubsetOf(bounded, full);
+  });
+
+  it("reaches the focus through INBOUND links too", () => {
+    // e.md only ever appears as a target; walking forward-only would strand it.
+    const full = graphOf(CHAIN);
+    const bounded = boundGraph(full, { focus: "e.md", maxNodes: 2 });
+    expect(idsOf(bounded).toSorted()).toEqual(["d.md", "e.md"]);
+  });
+
+  it("fills the remaining budget with the most-connected notes", () => {
+    const full = graphOf(CHAIN, ["island.md"]);
+    // The focus's whole component is 5 nodes; a 6th slot picks up the island.
+    expect(boundGraph(full, { focus: "a.md", maxNodes: 6 }).nodes).toHaveLength(6);
+    // Isolated focus: itself, then the hubs.
+    const bounded = boundGraph(full, { focus: "island.md", maxNodes: 3 });
+    expect(idsOf(bounded)).toContain("island.md");
+    expect(bounded.nodes).toHaveLength(3);
+    expectSubsetOf(bounded, full);
+  });
+
+  it("seeds by degree when no focus is given, or the focus names no node", () => {
+    const full = starGraph(6);
+    for (const bounds of [{ maxNodes: 3 }, { focus: "nowhere.md", maxNodes: 3 }]) {
+      const bounded = boundGraph(full, bounds);
+      expect(idsOf(bounded)).toContain("hub.md");
+      expect(bounded.nodes).toHaveLength(3);
+      expect(idsOf(bounded)).not.toContain("nowhere.md");
+      expectSubsetOf(bounded, full);
+    }
+  });
+
+  it("bounds the answer against a hub that touches the whole vault", () => {
+    const full = starGraph(5_000);
+    const bounded = boundGraph(full, { focus: "leaf-04999.md", maxNodes: 10 });
+    expect(bounded.nodes).toHaveLength(10);
+    expect(idsOf(bounded)).toContain("leaf-04999.md");
+    expect(idsOf(bounded)).toContain("hub.md");
+    expect(bounded.totalNodes).toBe(5_001);
+    expectSubsetOf(bounded, full);
+  });
+
+  it("cuts the outermost edges when the induced set still exceeds maxEdges", () => {
+    const full = graphOf(CHAIN);
+    const bounded = boundGraph(full, { focus: "a.md", maxNodes: 5, maxEdges: 2 });
+    // Every node survives; only the far end of the chain loses its links.
+    expect(idsOf(bounded)).toEqual(idsOf(full));
+    expect(edgeKeysOf(bounded)).toEqual(["a.md->b.md", "b.md->c.md"]);
+    expectSubsetOf(bounded, full);
+  });
+
+  it("answers an empty graph, and a zero budget, without inventing anything", () => {
+    const empty = boundGraph({ nodes: [], edges: [] }, { maxNodes: 10, maxEdges: 10 });
+    expect(empty).toEqual({ nodes: [], edges: [], totalNodes: 0, totalEdges: 0 });
+    const none = boundGraph(graphOf(CHAIN), { maxNodes: 0 });
+    expect(none).toEqual({ nodes: [], edges: [], totalNodes: 5, totalEdges: 4 });
+  });
+
+  it("bounds the REAL index's graph, phantoms and all", () => {
+    const index = new LinkGraphIndex();
+    const corpus: Record<string, string> = {
+      "notes/hub.md": "# Hub\n\n[[notes/one]] [[notes/two]] [[not written yet]]\n",
+      "notes/one.md": "# One\n\n[[notes/two]]\n",
+      "notes/two.md": "# Two\n",
+      "notes/far.md": "# Far\n",
+    };
+    for (const [path, content] of Object.entries(corpus)) {
+      index.applyDoc(path, projectDoc(path, content));
+    }
+    const full = index.graph();
+    expect(full.nodes).toHaveLength(5); // 4 docs + the phantom
+
+    const bounded = boundGraph(full, { focus: "notes/one.md", maxNodes: 3 });
+    expect(idsOf(bounded).toSorted()).toEqual(["notes/hub.md", "notes/one.md", "notes/two.md"]);
+    expect(bounded.totalNodes).toBe(5);
+    expect(bounded.totalEdges).toBe(full.edges.length);
+    expectSubsetOf(bounded, full);
+
+    // Degree is the WHOLE graph's, so a note is drawn the same size bounded or not.
+    const hub = bounded.nodes.find((node) => node.id === "notes/hub.md");
+    expect(hub?.degree).toBe(full.nodes.find((node) => node.id === "notes/hub.md")?.degree);
+  });
+});
+
+// ---- Payload size --------------------------------------------------------------
+//
+// BYTES, not milliseconds: the wire payload is deterministic for a fixed
+// corpus, so this belongs in the always-on gate (the repo's no-wall-clock rule
+// costs nothing here). Measured against @repo/server's 50k-doc query-perf
+// corpus — 55,000 nodes / 400,000 edges: 42,020,060 bytes unbounded,
+// 937,138 bytes under the renderer's 2,000 / 8,000 caps.
+
+const benchPath = (i: number): string => `notes/note-${String(i).padStart(6, "0")}.md`;
+
+/** That corpus's SHAPE, built as a graph directly: `docs` notes, 7 resolving
+ * links each, plus one dangling link per 10 notes collapsing into shared
+ * phantoms. Ids are fixed-width, so per-node/per-edge bytes don't drift with
+ * `docs` — only their COUNT does, which is the point below. */
+function benchGraph(docs: number): LinkGraph {
+  const pairs: Array<readonly [string, string]> = [];
+  for (let i = 0; i < docs; i++) {
+    for (let k = 1; k <= 7; k++) pairs.push([benchPath(i), benchPath((i + k * 37) % docs)]);
+    pairs.push([benchPath(i), `phantom:missing-${String(i % (docs / 10)).padStart(6, "0")}`]);
+  }
+  return graphOf(pairs);
+}
+
+describe("graph payload", () => {
+  it("is sized by the caps, not by the vault", () => {
+    const bounds = { focus: benchPath(42), maxNodes: 2_000, maxEdges: 8_000 };
+    const smallVault = boundGraph(benchGraph(2_500), bounds);
+    const largeVault = boundGraph(benchGraph(10_000), bounds);
+
+    // Four times the vault, the same answer size — an unbounded graph would be
+    // four times the transfer.
+    for (const bounded of [smallVault, largeVault]) {
+      expect(bounded.nodes).toHaveLength(2_000);
+      expect(bounded.edges).toHaveLength(8_000);
+      expect(JSON.stringify(bounded).length).toBeLessThan(1_100_000);
+    }
+    expect(largeVault.totalNodes).toBe(4 * smallVault.totalNodes);
+
+    // …against the whole-vault payload, which outgrows the view well before
+    // 50k notes.
+    const unbounded = JSON.stringify(boundGraph(benchGraph(10_000), {})).length;
+    expect(unbounded).toBeGreaterThan(6_000_000);
+  }, 30_000);
+});

--- a/packages/notes/src/knowledge/link-graph-index.ts
+++ b/packages/notes/src/knowledge/link-graph-index.ts
@@ -67,7 +67,8 @@ export type GraphNode = {
   /** Vault path for real files; absent on phantom (unresolved-target) nodes. */
   path?: string;
   phantom: boolean;
-  /** Total edges touching the node (node sizing). */
+  /** Total edges touching the node, counted over the WHOLE graph — so node
+   * sizing means the same thing in a bounded view as in an unbounded one. */
   degree: number;
 };
 
@@ -80,6 +81,30 @@ export type GraphEdge = {
 };
 
 export type LinkGraph = { nodes: GraphNode[]; edges: GraphEdge[] };
+
+/** How much of the graph a caller wants. Every field is optional and an
+ * omitted field means "no bound", so `{}` asks for the whole vault.
+ *
+ * This is a TRANSFER bound, applied where the graph is assembled: the payload
+ * at 50k notes is ~42MB of JSON (55k nodes, 400k edges) and a renderer-side
+ * filter would still pay all of it, plus hand d3-force 400k links. */
+export type GraphBounds = {
+  /** Vault path expanded FIRST, so the note the user is looking at and its
+   * neighbourhood always survive the node cap. Ignored when it names no node
+   * (nothing open, or a path outside the graph). */
+  focus?: string | undefined;
+  /** Cap on returned nodes. */
+  maxNodes?: number | undefined;
+  /** Cap on returned edges. */
+  maxEdges?: number | undefined;
+};
+
+/** A possibly-bounded graph plus what the whole vault holds. There is no
+ * `truncated` flag on purpose — `nodes.length === totalNodes &&
+ * edges.length === totalEdges` IS the "nothing was dropped" test, so no second
+ * field can disagree with the arrays. Callers MUST surface a shortfall: a
+ * silently truncated graph reads as "these notes are unconnected". */
+export type BoundedLinkGraph = LinkGraph & { totalNodes: number; totalEdges: number };
 
 /** A `[[` picker entry: notes AND attachments suggest (Obsidian-style); the
  * `type` flag lets the picker group them and insert `![[..]]` for assets.
@@ -476,6 +501,109 @@ export class LinkGraphIndex {
     this.pendingDocs.clear();
     return true;
   }
+}
+
+// ---- Bounding ----------------------------------------------------------------
+//
+// A pure post-pass over an assembled graph rather than a second assembly path:
+// the resolution/collapse/phantom rules stay written exactly once, and a
+// bounded answer is provably a SUBSET of the unbounded one.
+
+/** Narrow `graph` to `bounds`, reporting what the whole graph held.
+ *
+ * Node selection is one rule with two seeds: breadth-first from `focus`
+ * (nearest first — the view the user is standing in), then the highest-degree
+ * nodes to fill any remaining budget (the vault's hubs — the view that makes
+ * sense with nothing open). A focus is therefore a PRIORITY, not a filter: the
+ * graph stays global, it just can't lose the open note to the cap.
+ *
+ * Edges are the ones induced by the kept nodes; if that still exceeds
+ * `maxEdges`, the outermost go first (see {@link edgeDistance}). */
+export function boundGraph(graph: LinkGraph, bounds: GraphBounds): BoundedLinkGraph {
+  const totalNodes = graph.nodes.length;
+  const totalEdges = graph.edges.length;
+  const maxNodes = bounds.maxNodes ?? totalNodes;
+  const maxEdges = bounds.maxEdges ?? totalEdges;
+  if (totalNodes <= maxNodes && totalEdges <= maxEdges) {
+    return { nodes: graph.nodes, edges: graph.edges, totalNodes, totalEdges };
+  }
+
+  // Insertion order IS selection order, and selection order is distance from
+  // the focus — which is what an edge cut wants to order by.
+  const rank = new Map<string, number>();
+  for (const id of selectNodes(graph, bounds.focus, maxNodes)) rank.set(id, rank.size);
+
+  const induced = graph.edges.filter((edge) => rank.has(edge.source) && rank.has(edge.target));
+  const edges =
+    induced.length <= maxEdges
+      ? induced
+      : induced
+          .map((edge) => ({ edge, at: edgeDistance(edge, rank) }))
+          .toSorted((a, b) => a.at - b.at)
+          .slice(0, maxEdges)
+          .map((entry) => entry.edge);
+
+  // Kept nodes stay even when the edge cut leaves them isolated: dropping them
+  // would make the reported node count a lie.
+  return { nodes: graph.nodes.filter((node) => rank.has(node.id)), edges, totalNodes, totalEdges };
+}
+
+/** An edge becomes drawable only once its LATER endpoint is selected, so the
+ * later rank is exactly its distance from the focus. */
+function edgeDistance(edge: GraphEdge, rank: ReadonlyMap<string, number>): number {
+  return Math.max(rank.get(edge.source) ?? 0, rank.get(edge.target) ?? 0);
+}
+
+/** Up to `maxNodes` node ids, nearest the focus first and highest-degree
+ * after — in selection order. */
+function selectNodes(graph: LinkGraph, focus: string | undefined, maxNodes: number): Set<string> {
+  const kept = new Set<string>();
+  if (maxNodes <= 0) return kept;
+
+  // A focus that names no node contributes nothing, so the adjacency map (the
+  // one O(edges) allocation here) is built only when it will actually be
+  // walked.
+  if (focus !== undefined && graph.nodes.some((node) => node.id === focus)) {
+    const adjacency = buildAdjacency(graph.edges);
+    const queue = [focus];
+    let head = 0;
+    while (head < queue.length && kept.size < maxNodes) {
+      const id = queue[head++];
+      if (id === undefined || kept.has(id)) continue;
+      kept.add(id);
+      for (const neighbour of adjacency.get(id) ?? []) {
+        // Never queue more candidates than the remaining budget can consume —
+        // one hub with a 20k in-degree would otherwise make a bounded answer
+        // cost a whole-vault frontier.
+        if (queue.length - head >= maxNodes) break;
+        if (!kept.has(neighbour)) queue.push(neighbour);
+      }
+    }
+  }
+
+  if (kept.size < maxNodes) {
+    for (const node of graph.nodes.toSorted((a, b) => b.degree - a.degree)) {
+      if (kept.size >= maxNodes) break;
+      kept.add(node.id);
+    }
+  }
+  return kept;
+}
+
+/** Undirected neighbour lists. The graph is drawn undirected, so traversal is
+ * too — a note reached only by an inbound link is still a neighbour. */
+function buildAdjacency(edges: readonly GraphEdge[]): Map<string, string[]> {
+  const adjacency = new Map<string, string[]>();
+  const link = (from: string, to: string): void => {
+    const list = adjacency.get(from);
+    if (list === undefined) adjacency.set(from, [to]);
+    else list.push(to);
+  };
+  for (const edge of edges) {
+    link(edge.source, edge.target);
+    if (edge.target !== edge.source) link(edge.target, edge.source);
+  }
+  return adjacency;
 }
 
 /** Insert `occurrence` keeping the target's list in corpus order. Equal seqs

--- a/packages/server/src/handlers/handler-registry.ts
+++ b/packages/server/src/handlers/handler-registry.ts
@@ -49,11 +49,12 @@ function parsePayload(method: IpcMethod, schema: TSchema, raw: unknown): unknown
   return raw;
 }
 
-// The `fn as ...` casts below are the classic correlated-union limitation
-// (microsoft/TypeScript#30581): narrowing `def.kind` cannot narrow the
-// generic `IpcHandler<K>`, so each branch widens `fn` to its runtime shape.
-// Soundness is carried by the registry: `def.kind` and `IpcHandler<K>` are
-// derived from the same entry, and payloads are schema-validated first.
+// The `invoke-void` branch below casts `fn` to its runtime shape: that is the
+// classic correlated-union limitation (microsoft/TypeScript#30581) — narrowing
+// `def.kind` cannot narrow the generic `IpcHandler<K>`, and the arity differs
+// from the payload-taking branches, which call `fn` directly. Soundness is
+// carried by the registry: `def.kind` and `IpcHandler<K>` are derived from the
+// same entry, and payloads are schema-validated first.
 
 /**
  * Run every handler group against a fresh registrar and return the complete,
@@ -71,12 +72,11 @@ export function collectHandlers(register: (handle: HandlerRegistrar) => void): H
       case "invoke":
         map.set(method, (raw) => {
           const payload = parsePayload(method, def.payload, raw);
-          // oxlint-disable-next-line typescript/consistent-type-assertions -- correlated union, see doc above
-          return (fn as (p: unknown) => unknown)(payload);
+          return fn(payload);
         });
         return;
       case "invoke-void":
-        // oxlint-disable-next-line typescript/consistent-type-assertions -- correlated union, see doc above
+        // oxlint-disable-next-line typescript/consistent-type-assertions, typescript/no-unsafe-type-assertion -- correlated union, see doc above
         map.set(method, () => (fn as () => unknown)());
         return;
       case "send":
@@ -85,8 +85,7 @@ export function collectHandlers(register: (handle: HandlerRegistrar) => void): H
           // transport's event loop, so swallow + log.
           try {
             const payload = parsePayload(method, def.payload, raw);
-            // oxlint-disable-next-line typescript/consistent-type-assertions -- correlated union, see doc above
-            (fn as (p: unknown) => void)(payload);
+            fn(payload);
           } catch (err) {
             console.error(`[ipc] send handler "${method}" failed:`, err);
           }
@@ -103,6 +102,6 @@ export function collectHandlers(register: (handle: HandlerRegistrar) => void): H
   }
   const handlers: Partial<Record<HostMethod, WireHandler>> = {};
   for (const [method, handler] of map) handlers[method] = handler;
-  // oxlint-disable-next-line typescript/consistent-type-assertions -- completeness proven by the missing-check above
+  // oxlint-disable-next-line typescript/consistent-type-assertions, typescript/no-unsafe-type-assertion -- completeness proven by the missing-check above
   return handlers as HostHandlers;
 }

--- a/packages/server/src/handlers/knowledge-handlers.ts
+++ b/packages/server/src/handlers/knowledge-handlers.ts
@@ -1,4 +1,5 @@
 import { toggleTaskAtOrdinal } from "@repo/notes/knowledge/guarded-line-edit";
+import { boundGraph } from "@repo/notes/knowledge/link-graph-index";
 import { toErrorMessage } from "@repo/bridge/wire-helpers";
 import type { ToggleTaskResult } from "@repo/bridge/ipc-registry";
 
@@ -23,7 +24,9 @@ export function registerKnowledgeHandlers(handle: HandlerRegistrar): void {
   handle("getBacklinks", ({ path }) => getKnowledgeManager().backlinks(path));
   handle("getForwardLinks", ({ path }) => getKnowledgeManager().forwardLinks(path));
   handle("getRelatedNotes", ({ path }) => getKnowledgeManager().relatedNotes(path));
-  handle("getLinkGraph", () => getKnowledgeManager().graph());
+  // Assembly is whole-vault (the index has no cheaper way to know the totals
+  // it reports); the BOUND is what keeps the reply off the wire.
+  handle("getLinkGraph", (bounds) => boundGraph(getKnowledgeManager().graph(), bounds));
   handle("searchVault", ({ query, limit }) => getKnowledgeManager().search(query, limit));
   handle("listWikiTargets", () => getKnowledgeManager().wikiTargets());
   handle("listTags", () => getKnowledgeManager().tags());

--- a/packages/server/src/knowledge/knowledge-manager.ts
+++ b/packages/server/src/knowledge/knowledge-manager.ts
@@ -17,7 +17,7 @@
 // off the DB, not off the mirror. Numbers live in
 // __tests__/knowledge-hydration.test.ts, which reproduces them.
 //
-// Reconcile diffs the vault's stat snapshot against recorded
+// Reconcile diffs the vault's stat listing against recorded
 // fingerprints; a changed file is re-read and content-hashed, and only a
 // changed HASH re-projects and re-writes — a provider-wide mtime rewrite
 // updates fingerprints without any projection/FTS churn. Passes are
@@ -367,10 +367,17 @@ export class KnowledgeManager {
       if (this.generation !== generation || this.store !== store) return;
     }
 
+    // The vault's crawl + stat sweep is itself budgeted and yields, so this
+    // never stalls the host on one call however large the vault; the world can
+    // move on across those yields, so re-check before spending a diff on a pass
+    // whose store is gone.
+    const listing = await vault.listWithStats();
+    if (this.generation !== generation || this.store !== store) return;
+
     const seen = new Set<string>();
     const work: Array<{ path: string; fingerprint: StoredFingerprint }> = [];
     const newOthers: string[] = [];
-    for (const entry of vault.listWithStats()) {
+    for (const entry of listing) {
       seen.add(entry.path);
       if (entry.kind !== "doc") {
         if (!this.otherPaths.has(entry.path)) {

--- a/packages/storage/src/json-store.ts
+++ b/packages/storage/src/json-store.ts
@@ -171,7 +171,7 @@ export class JsonStore<T> {
     // against `schema`, but `schema: TSchema` erases its Static type, so the
     // compiler can't connect it to T. Callers omitting `decode` assert
     // Static<schema> is T.
-    // oxlint-disable-next-line typescript/consistent-type-assertions -- schema↔generic seam, see doc above
+    // oxlint-disable-next-line typescript/consistent-type-assertions, typescript/no-unsafe-type-assertion -- schema↔generic seam, see doc above
     this.decode = options.decode ?? ((raw) => raw as T);
     this.encode = options.encode ?? ((value) => value);
     this.versioning = options.versioning;

--- a/packages/vault/src/__tests__/crawl-cost.test.ts
+++ b/packages/vault/src/__tests__/crawl-cost.test.ts
@@ -1,0 +1,278 @@
+// ---------------------------------------------------------------------------
+// The vault crawl — the property under test is COST SHAPE, not speed.
+//
+// The crawl is on-demand by design (vault liveness — CLAUDE.md § Decisions),
+// so its whole cost lands on the host's only thread at every refresh trigger.
+// Two things keep that bounded, and both are asserted here as syscall counts
+// and event-loop turns rather than milliseconds (this repo's perf convention —
+// see packages/server/src/__tests__/knowledge-hydration.test.ts):
+//
+//   1. The walk NEVER stats. list()/listAllPaths() answer off Dirents alone, so
+//      the syscall count of a listing is one readdir per directory — nothing
+//      per file. Stats are filled in lazily and memoized on the snapshot, so
+//      the consumers that need them (knowledge reconcile, the sync hash cache)
+//      pay one stat per file BETWEEN them, not one each.
+//   2. The stat sweep behind listWithStats() runs in slices with event-loop
+//      yields, so no single synchronous step grows with the vault.
+//
+// Wall-clock numbers, MacBook / Node 24, 50,000 files in 500 folders, warm OS
+// page cache, measured by the `bench` case below against its own oracle:
+//
+//                                total     longest main-thread block
+//   eager walk+stat (oracle)     369 ms            369 ms
+//   list()  (walk only)           58 ms             58 ms
+//   listWithStats() (15 slices)  284 ms             56 ms
+//
+// The oracle is the shape one walk-plus-stat pass has, and more than half of it
+// is per-entry path.join/path.relative math rather than the filesystem: the
+// readdir syscalls for all 50,000 files come to ~40 ms on their own.
+//
+// Set VAULT_BENCH_FILES=50000 to reproduce.
+// ---------------------------------------------------------------------------
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import { VaultManager } from "../vault";
+
+const BENCH_FILES = Number(process.env["VAULT_BENCH_FILES"] ?? 0);
+
+let tmp: string;
+let root: string;
+let settingsPath: string;
+
+beforeEach(() => {
+  tmp = fs.mkdtempSync(path.join(os.tmpdir(), "vault-crawl-"));
+  root = path.join(tmp, "vault");
+  settingsPath = path.join(tmp, "settings.json");
+});
+
+afterEach(() => {
+  fs.rmSync(tmp, { recursive: true, force: true });
+});
+
+function newManager(): VaultManager {
+  return new VaultManager({ settingsPath, defaultRoot: root, manageAgentLink: false });
+}
+
+/** Fill the vault with `files` docs spread over `folders` subdirectories. */
+function seed(files: number, folders: number): void {
+  fs.mkdirSync(root, { recursive: true });
+  const perFolder = Math.ceil(files / folders);
+  for (let d = 0; d < folders; d++) {
+    const dir = path.join(root, `folder-${String(d).padStart(4, "0")}`);
+    fs.mkdirSync(dir, { recursive: true });
+    for (let f = 0; f < perFolder && d * perFolder + f < files; f++) {
+      fs.writeFileSync(path.join(dir, `note-${String(f).padStart(4, "0")}.md`), "# Note\n");
+    }
+  }
+}
+
+/** Count `fs.statSync` calls made while `run` executes. */
+function countStats<T>(run: () => T): { result: T; stats: number } {
+  const real = fs.statSync.bind(fs);
+  let stats = 0;
+  const spy = vi.spyOn(fs, "statSync").mockImplementation((target, options) => {
+    stats++;
+    return real(target, options);
+  });
+  try {
+    return { result: run(), stats };
+  } finally {
+    spy.mockRestore();
+  }
+}
+
+/** Watch the event loop: how many turns it got, and the longest stretch it was
+ * denied one (i.e. the longest synchronous block on this thread). */
+function watchEventLoop(): { stop: () => { turns: number; longestBlockMs: number } } {
+  let turns = 0;
+  let longestBlockMs = 0;
+  let last = Date.now();
+  let running = true;
+  const tick = (): void => {
+    if (!running) return;
+    const now = Date.now();
+    longestBlockMs = Math.max(longestBlockMs, now - last);
+    last = now;
+    turns++;
+    setImmediate(tick);
+  };
+  setImmediate(tick);
+  return {
+    stop: () => {
+      running = false;
+      return { turns, longestBlockMs };
+    },
+  };
+}
+
+describe("vault crawl cost", () => {
+  it("lists without stat-ing: one readdir per directory, nothing per file", () => {
+    const mgr = newManager();
+    seed(40, 4);
+
+    // A cold crawl, then the cached one, then the sync-facing listing: none of
+    // them may cost a stat per file.
+    const cold = countStats(() => mgr.list());
+    expect(cold.result).toHaveLength(40);
+    expect(cold.stats).toBe(0);
+    expect(countStats(() => mgr.list()).stats).toBe(0);
+    expect(countStats(() => mgr.listAllPaths()).stats).toBe(0);
+  });
+
+  it("stats each file at most once per snapshot, shared across consumers", async () => {
+    const mgr = newManager();
+    seed(40, 4);
+    const paths = mgr.listAllPaths();
+
+    // The knowledge reconcile's sweep: one stat per file, no more.
+    const real = fs.statSync.bind(fs);
+    let stats = 0;
+    const spy = vi.spyOn(fs, "statSync").mockImplementation((target, options) => {
+      stats++;
+      return real(target, options);
+    });
+    try {
+      const listing = await mgr.listWithStats();
+      expect(listing).toHaveLength(40);
+      expect(stats).toBe(40);
+
+      // The sync hash cache asking for the same files inside the same snapshot
+      // window reuses the memo instead of sweeping again.
+      stats = 0;
+      for (const p of paths) expect(mgr.statFingerprint(p)).not.toBeNull();
+      expect(stats).toBe(0);
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
+  it("yields the event loop while sweeping stats, instead of blocking on the whole vault", async () => {
+    const mgr = newManager();
+    seed(60, 3);
+    mgr.list(); // warm the walk so only the sweep is measured
+
+    // Make each stat cost ~1ms of wall clock, so 60 files is ~60ms of sweep —
+    // several times the slice budget on ANY machine (contention only makes it
+    // more slices, never fewer).
+    const real = fs.statSync.bind(fs);
+    const spy = vi.spyOn(fs, "statSync").mockImplementation((target, options) => {
+      const until = Date.now() + 1;
+      while (Date.now() < until) {
+        /* burn a millisecond the way a cold-cache stat would */
+      }
+      return real(target, options);
+    });
+    const loop = watchEventLoop();
+    try {
+      expect(await mgr.listWithStats()).toHaveLength(60);
+    } finally {
+      spy.mockRestore();
+    }
+    // The sweep handed the loop back repeatedly rather than running to
+    // completion in one uninterruptible call.
+    expect(loop.stop().turns).toBeGreaterThan(1);
+  });
+
+  it("keeps the walk's relative paths identical to path.relative's", () => {
+    // The walk builds each entry's path by carrying a prefix down instead of
+    // calling path.relative per entry (the expensive way). Nested, spaced and
+    // non-ASCII names all have to come out the same.
+    const mgr = newManager();
+    const expected = [
+      "a.md",
+      "café/über/note.md",
+      "deep/deeper/deepest/leaf.md",
+      "with space/and.another/x.md",
+    ];
+    for (const rel of expected) mgr.writeText(rel, "x");
+    expect(mgr.listAllPaths()).toEqual(expected);
+    // ...and every one of them still resolves back to a real file.
+    for (const rel of mgr.listAllPaths()) expect(mgr.readText(rel)).toBe("x");
+  });
+});
+
+// OPT-IN, and it asserts nothing about wall clock. A millisecond ceiling here
+// would compare timings taken on a box running a dozen other workspaces' suites
+// in parallel, so a GC pause flips it red for a machine hiccup rather than a
+// regression. The properties that must not regress — zero stats per listing,
+// one stat per file per snapshot, a sweep that yields — are counts, and are
+// asserted deterministically above. This block exists to print the numbers:
+//   VAULT_BENCH_FILES=50000 pnpm --filter @repo/vault test
+/** The cost shape a single walk-plus-stat pass has: every entry's relative path
+ * derived with path.relative, and a stat for every file before anything is
+ * returned. Not a copy of the crawl — an ORACLE for the shape the crawl avoids,
+ * so the benchmark carries its own baseline instead of quoting a number nobody
+ * can re-measure. */
+function eagerWalkAndStatOracle(dir: string): number {
+  let stats = 0;
+  const visit = (current: string): void => {
+    let dirents: fs.Dirent[];
+    try {
+      dirents = fs.readdirSync(current, { withFileTypes: true });
+    } catch {
+      return;
+    }
+    for (const dirent of dirents) {
+      const full = path.join(current, dirent.name);
+      const rel = path.relative(root, full).split(path.sep).join("/");
+      if (dirent.isDirectory()) {
+        visit(full);
+      } else if (dirent.isFile()) {
+        try {
+          fs.statSync(path.join(root, rel));
+          stats++;
+        } catch {
+          /* the eager sweep drops it */
+        }
+      }
+    }
+  };
+  visit(dir);
+  return stats;
+}
+
+describe.skipIf(BENCH_FILES <= 0)("crawl benchmark", () => {
+  it(`reports crawl cost at ${BENCH_FILES} files`, async () => {
+    const mgr = newManager();
+    const buildStart = performance.now();
+    seed(BENCH_FILES, Math.max(1, Math.round(BENCH_FILES / 100)));
+    const buildMs = performance.now() - buildStart;
+
+    const oracleLoop = watchEventLoop();
+    const oracleStart = performance.now();
+    expect(eagerWalkAndStatOracle(root)).toBe(BENCH_FILES);
+    const oracleMs = performance.now() - oracleStart;
+    oracleLoop.stop();
+
+    const report: string[] = [
+      `build=${buildMs.toFixed(0)}ms`,
+      `eager walk+stat oracle=${oracleMs.toFixed(0)}ms (one block)`,
+    ];
+    for (const round of ["cold", "uncached"]) {
+      const listStart = performance.now();
+      const entries = mgr.list();
+      const listMs = performance.now() - listStart;
+      expect(entries).toHaveLength(BENCH_FILES);
+
+      mgr.refresh(); // drop the snapshot: the sweep pays for its own fresh walk
+      const loop = watchEventLoop();
+      const sweepStart = performance.now();
+      const withStats = await mgr.listWithStats();
+      const sweepMs = performance.now() - sweepStart;
+      const { turns, longestBlockMs } = loop.stop();
+      expect(withStats).toHaveLength(BENCH_FILES);
+
+      report.push(
+        `${round}: list=${listMs.toFixed(0)}ms | ` +
+          `listWithStats total=${sweepMs.toFixed(0)}ms slices=${turns} ` +
+          `longest-block=${longestBlockMs}ms`,
+      );
+      mgr.refresh();
+    }
+    console.log(`[vault crawl @ ${BENCH_FILES} files] ${report.join(" | ")}`);
+  }, 600_000);
+});

--- a/packages/vault/src/__tests__/vault.test.ts
+++ b/packages/vault/src/__tests__/vault.test.ts
@@ -178,7 +178,7 @@ describe("VaultManager", () => {
   // local delete and fans it out to every device. The shared crawl records
   // completeness; the sync-facing listAllPaths() refuses an incomplete one,
   // while the UI-facing list()/listWithStats() stay lenient on the partial.
-  it("listAllPaths() throws when the vault root is missing; list()/listWithStats() stay lenient", () => {
+  it("listAllPaths() throws when the vault root is missing; list()/listWithStats() stay lenient", async () => {
     const mgr = newManager(); // ensureReady() never called — the root does not exist
     expect(fs.existsSync(root)).toBe(false);
 
@@ -186,7 +186,7 @@ describe("VaultManager", () => {
     expect(() => mgr.listAllPaths()).toThrow(/refusing to treat unread files as deleted/);
     // The UI tolerates a momentarily-missing root — empty listing, no throw.
     expect(mgr.list()).toEqual([]);
-    expect(mgr.listWithStats()).toEqual([]);
+    await expect(mgr.listWithStats()).resolves.toEqual([]);
 
     // The root appearing is picked up IMMEDIATELY — an incomplete crawl is
     // never cached, so no TTL window can serve the stale failure.
@@ -198,7 +198,7 @@ describe("VaultManager", () => {
   // chmod-based EACCES needs a non-root uid (root bypasses permission checks).
   it.skipIf(typeof process.getuid === "function" && process.getuid() === 0)(
     "listAllPaths() throws when a subtree readdir fails; list() serves the partial (lenient)",
-    () => {
+    async () => {
       const mgr = newManager();
       mgr.writeText("keep.md", "x");
       mgr.writeText("locked/hidden.md", "x");
@@ -211,7 +211,8 @@ describe("VaultManager", () => {
         const paths = mgr.list().map((e) => e.path);
         expect(paths).toContain("keep.md");
         expect(paths).not.toContain("locked/hidden.md");
-        expect(mgr.listWithStats().map((e) => e.path)).toEqual(paths);
+        const withStats = await mgr.listWithStats();
+        expect(withStats.map((e) => e.path)).toEqual(paths);
       } finally {
         fs.chmodSync(lockedDir, 0o700);
       }
@@ -222,11 +223,13 @@ describe("VaultManager", () => {
   );
 
   // A per-FILE statSync hiccup (a flaky network mount) on a still-present file
-  // is the same "transient read → drop → sync reads it as a delete" class as a
-  // failed readdir: the file was LISTED but couldn't be stat'd, so it silently
-  // fell out of the crawl. It must mark the crawl incomplete too, not just the
-  // readdir-failure path.
-  it("listAllPaths() throws when a listed file's statSync fails; list() serves the partial", () => {
+  // must never reach sync as a deletion. The crawl doesn't stat, so the file
+  // stays LISTED whatever stat does — it cannot fall out of the manifest at all.
+  // Its fingerprint goes null instead, which makes the engine re-read the bytes
+  // rather than trust a cached hash (and fail the pass loudly if the read is
+  // broken too). Only listWithStats() — derived knowledge, lenient and
+  // self-healing — omits it until the next pass.
+  it("keeps an unstattable file in list()/listAllPaths(); listWithStats() omits it", async () => {
     const mgr = newManager();
     mgr.writeText("keep.md", "x");
     mgr.writeText("flaky.md", "x");
@@ -234,24 +237,23 @@ describe("VaultManager", () => {
     const realStatSync = fs.statSync.bind(fs);
     const flaky = path.join(root, "flaky.md");
     const statSpy = vi.spyOn(fs, "statSync").mockImplementation((target, options) => {
-      // readdir still lists flaky.md, but its stat throws (transient) — the file
-      // is present, yet dropped from this crawl.
+      // readdir still lists flaky.md, but its stat throws (transient).
       if (target === flaky) throw new Error("EIO: simulated transient stat failure");
       return realStatSync(target, options);
     });
     try {
-      // Sync-facing: the drop is refused, never presented as a deletion.
-      expect(() => mgr.listAllPaths()).toThrow(VaultListingIncompleteError);
-      // UI-facing: lenient — the stattable files still list, flaky.md dropped.
-      const paths = mgr.list().map((e) => e.path);
-      expect(paths).toContain("keep.md");
-      expect(paths).not.toContain("flaky.md");
-      expect(mgr.listWithStats().map((e) => e.path)).toEqual(paths);
+      // Sync-facing: the file is present, so nothing can read as a deletion.
+      expect(mgr.listAllPaths()).toEqual(["flaky.md", "keep.md"]);
+      expect(mgr.list().map((e) => e.path)).toEqual(["flaky.md", "keep.md"]);
+      // ...and it has no fingerprint, so no cached hash can be reused for it.
+      expect(mgr.statFingerprint("flaky.md")).toBeNull();
+      expect(mgr.statFingerprint("keep.md")).not.toBeNull();
+      // Knowledge-facing: lenient — the unstattable file is simply absent.
+      const withStats = await mgr.listWithStats();
+      expect(withStats.map((e) => e.path)).toEqual(["keep.md"]);
     } finally {
       statSpy.mockRestore();
     }
-    // Recovery is immediate (incomplete crawls are never cached): with stat
-    // succeeding again, sync sees the full listing.
     expect(mgr.listAllPaths()).toEqual(["flaky.md", "keep.md"]);
   });
 

--- a/packages/vault/src/vault.ts
+++ b/packages/vault/src/vault.ts
@@ -83,27 +83,41 @@ const IGNORE_FILES = [".gitignore", ".ignore"];
  * § Decisions). */
 export type VaultChangeKind = "refresh" | "save";
 
-/** A listed vault file with its stat identity — what one crawl+stat pass
- * yields, shared by the sidebar listing, knowledge reconcile, and sync. */
-export type VaultStatEntry = {
-  path: string;
-  name: string;
-  kind: VaultEntry["kind"];
-  mtimeMs: number;
-  size: number;
-  ino: number;
-};
+/** A listed vault file as the WALK sees it: identity and kind straight off the
+ * Dirent, no stat. This is everything the sidebar listing and the sync manifest
+ * need, which is why the crawl never pays a stat to produce them. */
+type VaultWalkEntry = { path: string; name: string; kind: VaultEntry["kind"] };
 
-/** How long a walk+stat snapshot may be reused. Bounds staleness for sync's
+/** The stat triple change-detection diffs on. Content can't change without
+ * moving at least one of these. */
+type StatIdentity = { mtimeMs: number; size: number; ino: number };
+
+/** A listed vault file with its stat identity — the knowledge reconcile's diff
+ * basis. */
+export type VaultStatEntry = VaultWalkEntry & StatIdentity;
+
+/** How long a walk snapshot may be reused. Bounds staleness for sync's
  * snapshot-served fingerprints; a refresh burst (window focus fans into
  * renderer listing + knowledge + sync) shares ONE crawl inside the window. */
 const SNAPSHOT_TTL_MS = 1000;
 
+/** How long the stat sweep behind `listWithStats()` may run before yielding to
+ * the event loop. Matches the knowledge pass's batch budget — short enough that
+ * no single synchronous step grows with the vault. */
+const STAT_SLICE_BUDGET_MS = 15;
+
 type VaultSnapshot = {
   at: number;
   root: string;
-  entries: VaultStatEntry[];
-  byPath: Map<string, VaultStatEntry>;
+  entries: VaultWalkEntry[];
+  /** Membership set over `entries`: tells `statFingerprint` whether a path came
+   * out of the crawl (already confined under the root) or has to go through the
+   * `resolve()` funnel. */
+  crawled: Set<string>;
+  /** Stat identities, filled LAZILY by `statOf` and memoized here — so a
+   * refresh burst pays each file's stat at most once no matter how many
+   * consumers ask, and files nobody asks about cost nothing. */
+  stats: Map<string, StatIdentity>;
   /** Did the crawl observe the WHOLE vault? `false` when the root was missing
    * or any directory read failed — `entries` is then a best-effort partial.
    * The UI listing serves it anyway (lenient); `listAllPaths()` (the sync
@@ -167,11 +181,11 @@ export class VaultManager {
   // baseline for deciding reload vs. no-op.
   private watchedFingerprint: string | null = null;
   private readonly selfSaves = new SelfSaveRegistry();
-  // TTL-cached walk+stat snapshot backing list()/listAllPaths()/listWithStats()
-  // and (when fresh) statFingerprint. Invalidated by every mutating method and
-  // by refresh(); external edits surface on the next refresh trigger — the
-  // ephemeral-liveness contract (CLAUDE.md § Decisions) unchanged, just
-  // deduplicated.
+  // TTL-cached walk snapshot backing list()/listAllPaths()/listWithStats() and
+  // (when fresh) statFingerprint, plus the lazily-filled stat memo those last
+  // two share. Invalidated by every mutating method and by refresh(); external
+  // edits surface on the next refresh trigger — the ephemeral-liveness contract
+  // (CLAUDE.md § Decisions) unchanged, just deduplicated.
   private snapshot: VaultSnapshot | null = null;
 
   constructor(opts: VaultManagerOptions = {}) {
@@ -254,35 +268,74 @@ export class VaultManager {
    * unreadable subtree) instead of returning the partial; the engine
    * surfaces the throw as a failed pass and retries later. Ignore rules
    * filter what sync tracks by design; SKIP_DIRS + ignore files are the only
-   * exclusions, and they match list(). */
+   * exclusions, and they match list(). Nothing here stats, so a per-file stat
+   * hiccup cannot silently thin this listing — only a failed readdir or a
+   * missing root can, and both are refused above. */
   listAllPaths(): string[] {
     const snapshot = this.getSnapshot();
     if (!snapshot.complete) throw new VaultListingIncompleteError(snapshot.root);
     return snapshot.entries.map((e) => e.path);
   }
 
-  /** The listing WITH stat identities — the knowledge reconcile's one-crawl
-   * diff basis. Freshness follows the snapshot TTL: external edits surface on
-   * the next refresh trigger, exactly the ephemeral-liveness contract.
-   * Lenient like list(): derived knowledge tolerates a partial crawl (it
-   * self-heals on the next refresh); only sync (listAllPaths) must refuse. */
-  listWithStats(): VaultStatEntry[] {
-    return [...this.getSnapshot().entries];
+  /** The listing WITH stat identities — the knowledge reconcile's diff basis.
+   * Freshness follows the snapshot TTL: external edits surface on the next
+   * refresh trigger, exactly the ephemeral-liveness contract.
+   *
+   * ASYNC because one stat per file is the crawl's dominant syscall cost, and
+   * a whole-vault sweep in one uninterruptible call is a multi-hundred-
+   * millisecond stall on the host's only thread at 50k notes. The sweep runs in
+   * `STAT_SLICE_BUDGET_MS` slices with event-loop yields between them
+   * (SqlKnowledgeStore.hydrate's idiom), so no single synchronous step grows
+   * with the vault. The result describes the vault as of the crawl this call
+   * started on — a snapshot dropped mid-sweep still yields a coherent listing,
+   * and the next refresh picks up whatever moved.
+   *
+   * Lenient like list(): a file that can't be stat'd is simply absent, because
+   * derived knowledge self-heals on the next refresh. Only sync
+   * (`listAllPaths`) must refuse a partial, and it never stats at all. */
+  async listWithStats(): Promise<VaultStatEntry[]> {
+    // The slice clock starts BEFORE the walk: a cold call pays for its own
+    // crawl, so charging that to the first slice makes the sweep yield right
+    // after it rather than stacking a full slice on top of it.
+    let sliceStart = Date.now();
+    const snapshot = this.getSnapshot();
+    const entries: VaultStatEntry[] = [];
+    for (const entry of snapshot.entries) {
+      const identity = this.statOf(snapshot, entry.path);
+      if (identity !== null) {
+        entries.push({ path: entry.path, name: entry.name, kind: entry.kind, ...identity });
+      }
+      if (Date.now() - sliceStart >= STAT_SLICE_BUDGET_MS) {
+        await yieldToEventLoop();
+        sliceStart = Date.now();
+      }
+    }
+    return entries;
   }
 
-  // The shared crawl behind list()/listAllPaths()/listWithStats(): one walk +
-  // one stat per file, cached for SNAPSHOT_TTL_MS and invalidated by every
-  // mutating method (and rebuilt, never reused, by an explicit refresh()) —
-  // so the window-focus fan-out (renderer listing, knowledge diff, sync
-  // manifest+fingerprints) shares a single crawl instead of three.
+  // The shared crawl behind list()/listAllPaths()/listWithStats(): ONE walk,
+  // cached for SNAPSHOT_TTL_MS and invalidated by every mutating method (and
+  // rebuilt, never reused, by an explicit refresh()) — so the window-focus
+  // fan-out (renderer listing, knowledge diff, sync manifest+fingerprints)
+  // shares a single crawl instead of three.
+  //
+  // The crawl NEVER stats. Identity and kind come off the Dirent, which is
+  // everything list()/listAllPaths() need, while a stat is a syscall per file —
+  // the single largest cost in a large vault. Stats are filled in lazily by
+  // statOf() for the two consumers that want them and memoized on the snapshot.
+  //
+  // A stat-free walk is what keeps the sync-facing listing honest, too: a file
+  // readdir saw but stat cannot read (a flaky network mount) stays LISTED, so
+  // it can never fall out of the manifest and be read as a deletion. Its
+  // fingerprint goes null instead, which makes the engine re-read the bytes and
+  // fail the pass loudly if those are unreadable too.
   private getSnapshot(): VaultSnapshot {
     const root = this.getRoot();
     const cached = this.snapshot;
     if (cached && cached.root === root && Date.now() - cached.at <= SNAPSHOT_TTL_MS) {
       return cached;
     }
-    const entries: VaultStatEntry[] = [];
-    const byPath = new Map<string, VaultStatEntry>();
+    let entries: VaultWalkEntry[] = [];
     // A missing root is an INCOMPLETE crawl, not an empty vault — it feeds the
     // completeness flag (listAllPaths throws; list serves the empty partial)
     // rather than silently reading as "every file was deleted".
@@ -290,34 +343,19 @@ export class VaultManager {
     if (fs.existsSync(root)) {
       const walked = this.walk(root);
       complete = walked.complete;
-      for (const file of walked.files) {
-        let stat: fs.Stats;
-        try {
-          stat = fs.statSync(path.join(root, file.path));
-        } catch {
-          // readdir SAW this file but stat failed — a transient hiccup (a flaky
-          // network mount) on a still-present file, indistinguishable from a
-          // real vanish mid-crawl. Either way the file is dropped from this
-          // listing, so mark the crawl incomplete (mirrors the readdir-failure
-          // path): list() stays lenient on the partial, but listAllPaths()
-          // must refuse rather than let sync read the drop as a delete.
-          complete = false;
-          continue;
-        }
-        const entry: VaultStatEntry = {
-          path: file.path,
-          name: file.name,
-          kind: classify(file.name),
-          mtimeMs: stat.mtimeMs,
-          size: stat.size,
-          ino: stat.ino,
-        };
-        entries.push(entry);
-        byPath.set(file.path, entry);
-      }
+      entries = walked.entries;
       entries.sort((a, b) => a.path.localeCompare(b.path));
     }
-    const snapshot: VaultSnapshot = { at: Date.now(), root, entries, byPath, complete };
+    const crawled = new Set<string>();
+    for (const entry of entries) crawled.add(entry.path);
+    const snapshot: VaultSnapshot = {
+      at: Date.now(),
+      root,
+      entries,
+      crawled,
+      stats: new Map(),
+      complete,
+    };
     // Only COMPLETE crawls are cached: leniency may serve an incomplete
     // partial once, but the next call re-crawls — so recovery is immediate
     // and a cached failure can never satisfy a listAllPaths() retry after
@@ -326,46 +364,75 @@ export class VaultManager {
     return snapshot;
   }
 
+  // The stat identity of a CRAWLED path, memoized onto its snapshot so every
+  // consumer inside one TTL window shares the syscall. `null` when the file
+  // can't be stat'd (vanished mid-crawl, a flaky mount) — the caller decides
+  // what that means.
+  //
+  // Confinement comes from the crawl itself rather than resolve(): the walk
+  // neither descends through nor emits a symlink (a Dirent reports a symlink as
+  // neither isFile nor isDirectory), so every path in `entries` names a real
+  // file under the real root.
+  private statOf(snapshot: VaultSnapshot, rel: string): StatIdentity | null {
+    const memo = snapshot.stats.get(rel);
+    if (memo !== undefined) return memo;
+    let stat: fs.Stats;
+    try {
+      stat = fs.statSync(path.join(snapshot.root, rel));
+    } catch {
+      return null;
+    }
+    const identity: StatIdentity = { mtimeMs: stat.mtimeMs, size: stat.size, ino: stat.ino };
+    snapshot.stats.set(rel, identity);
+    return identity;
+  }
+
   private invalidateSnapshot(): void {
     this.snapshot = null;
   }
 
-  // Shared recursive walk backing both list() and listAllPaths(): skips
-  // dot-entries, SKIP_DIRS, ignore-matched paths, and the sibling *.tmp files
-  // atomicWrite creates mid-save. Returns entries in directory-read order
-  // (unsorted — callers sort), plus whether every directory read succeeded:
-  // a failed readdir still skips the subtree (list() stays lenient on the
-  // partial) but is RECORDED as incompleteness instead of hidden, so
-  // listAllPaths() can refuse to present the truncation as deletions.
-  private walk(root: string): { files: { path: string; name: string }[]; complete: boolean } {
-    const out: { path: string; name: string }[] = [];
+  // The recursive walk behind the snapshot: skips dot-entries, SKIP_DIRS,
+  // ignore-matched paths, and the sibling *.tmp files atomicWrite creates
+  // mid-save. Returns entries in directory-read order (unsorted — the caller
+  // sorts), plus whether every directory read succeeded: a failed readdir still
+  // skips the subtree (list() stays lenient on the partial) but is RECORDED as
+  // incompleteness instead of hidden, so listAllPaths() can refuse to present
+  // the truncation as deletions.
+  //
+  // Each entry's vault-relative path is carried DOWN as a prefix and extended
+  // by concatenation. Deriving it per entry with path.join + path.relative
+  // instead costs several times every readdir syscall in the crawl combined
+  // once a vault is large — the path math dominates this loop, not the
+  // filesystem.
+  private walk(root: string): { entries: VaultWalkEntry[]; complete: boolean } {
+    const out: VaultWalkEntry[] = [];
     let complete = true;
     const ig = this.loadIgnore(root);
-    const visit = (dir: string): void => {
-      let entries: fs.Dirent[];
+    const visit = (dir: string, prefix: string): void => {
+      let dirents: fs.Dirent[];
       try {
-        entries = fs.readdirSync(dir, { withFileTypes: true });
+        dirents = fs.readdirSync(dir, { withFileTypes: true });
       } catch {
         complete = false; // unreadable subtree — skip it, but never hide that
         return;
       }
-      for (const entry of entries) {
-        if (entry.name.startsWith(".") || SKIP_DIRS.has(entry.name)) continue;
-        if (entry.isFile() && entry.name.endsWith(".tmp")) continue;
-        const full = path.join(dir, entry.name);
-        const rel = path.relative(root, full).split(path.sep).join("/");
+      for (const dirent of dirents) {
+        const name = dirent.name;
+        if (name.startsWith(".") || SKIP_DIRS.has(name)) continue;
+        const rel = prefix + name;
         // `ignore` wants a trailing slash to match directory patterns.
-        if (entry.isDirectory()) {
+        if (dirent.isDirectory()) {
           if (ig !== null && ig.ignores(`${rel}/`)) continue;
-          visit(full);
-        } else if (entry.isFile()) {
+          visit(childPath(dir, name), `${rel}/`);
+        } else if (dirent.isFile()) {
+          if (name.endsWith(".tmp")) continue;
           if (ig !== null && ig.ignores(rel)) continue;
-          out.push({ path: rel, name: entry.name });
+          out.push({ path: rel, name, kind: classify(name) });
         }
       }
     };
-    visit(root);
-    return { files: out, complete };
+    visit(root, "");
+    return { entries: out, complete };
   }
 
   // Parse the root ignore files (.gitignore / .ignore) into a matcher, or null
@@ -443,15 +510,21 @@ export class VaultManager {
    * cache — `mtimeMs:size:ino`, or `null` on any error (missing file, etc.).
    * A change to content necessarily changes at least one of these, so a matching
    * fingerprint safely licenses reusing a cached hash instead of re-reading.
-   * Served from the shared snapshot when fresh (so a sync pass adds no second
-   * stat sweep, ≤SNAPSHOT_TTL_MS stale — own writes always invalidate); a path
-   * ABSENT from the snapshot (ignored files opened directly, non-listing
-   * spellings) falls through to a live stat, never to a false null. */
+   * Memoized on the shared snapshot when fresh (so a sync pass and a knowledge
+   * pass in the same window stat each file once between them, ≤SNAPSHOT_TTL_MS
+   * stale — own writes always invalidate); a path ABSENT from the crawl
+   * (ignored files opened directly, non-listing spellings) falls through to a
+   * resolve()-confined live stat, never to a false null. */
   statFingerprint(rel: string): string | null {
     const cached = this.snapshot;
-    if (cached && cached.root === this.getRoot() && Date.now() - cached.at <= SNAPSHOT_TTL_MS) {
-      const entry = cached.byPath.get(rel);
-      if (entry) return `${entry.mtimeMs}:${entry.size}:${entry.ino}`;
+    if (
+      cached &&
+      cached.root === this.getRoot() &&
+      Date.now() - cached.at <= SNAPSHOT_TTL_MS &&
+      cached.crawled.has(rel)
+    ) {
+      const identity = this.statOf(cached, rel);
+      return identity === null ? null : fingerprintOf(identity);
     }
     return this.liveStatFingerprint(rel);
   }
@@ -462,7 +535,7 @@ export class VaultManager {
   private liveStatFingerprint(rel: string): string | null {
     try {
       const stat = fs.statSync(this.resolve(rel));
-      return `${stat.mtimeMs}:${stat.size}:${stat.ino}`;
+      return fingerprintOf(stat);
     } catch {
       return null;
     }
@@ -724,7 +797,7 @@ export class VaultManager {
       this.notify("refresh");
       return;
     }
-    const current = `${stat.mtimeMs}:${stat.size}:${stat.ino}`;
+    const current = fingerprintOf(stat);
     // Our own autosave landing — never reload the editor onto what it just
     // wrote. Compared on the FULL fingerprint: an external edit that collides
     // on mtime alone still differs in size/ino and must surface below.
@@ -752,6 +825,29 @@ export class VaultManager {
       console.warn("[vault] change notification failed:", err);
     }
   }
+}
+
+/** The change-detection fingerprint: `mtimeMs:size:ino`. One spelling, so the
+ * open-note classifier, the sync hash cache and the snapshot memo can never
+ * disagree about what "unchanged" means. */
+function fingerprintOf(identity: StatIdentity): string {
+  return `${identity.mtimeMs}:${identity.size}:${identity.ino}`;
+}
+
+/** `dir` extended by a single directory-entry name. A dirent name never
+ * contains a separator, so plain concatenation is exactly path.join's result —
+ * and path.join is a measurable per-entry cost across a whole vault. The
+ * trailing-separator branch covers the one parent that can carry one: the
+ * filesystem root. */
+function childPath(dir: string, name: string): string {
+  return dir.endsWith(path.sep) ? dir + name : dir + path.sep + name;
+}
+
+/** Hand the event loop a turn between slices of a long sweep. */
+function yieldToEventLoop(): Promise<void> {
+  return new Promise((resolve) => {
+    setImmediate(resolve);
+  });
 }
 
 /** Canonical path with symlinks resolved. For a path that doesn't exist yet,


### PR DESCRIPTION
Finishes the remaining actionable p3 work. Closes #477 and #478; #479's ladder is 21/22 graduated.

## #477 — the graph view asked for the whole vault

42MB of JSON across the ws bridge at 50k notes, ~90ms to stringify and ~125ms to parse, then 400k links handed to d3-force. Filtering renderer-side saves nothing — the bytes still cross — so `getLinkGraph` is parameterised with `{focus?, maxNodes?, maxEdges?}` applied **host-side** by a new pure `boundGraph` pass. No new channel (the issue's STOP condition).

Selection is BFS outward from the open note, then highest-degree nodes fill the remaining budget. **Focus is a priority, not a filter** — the graph stays global rather than silently becoming a local one, and node `degree` stays the whole graph's so sizing means the same bounded or not. The BFS frontier is capped at the remaining budget so one 20k-degree hub can't make a bounded answer cost a whole-vault walk.

**42,020,060 B → 937,138 B** (44.8×). A vault under the caps still transfers whole — the cap *is* the threshold, there is no second mode.

The badge is non-null exactly when `nodes.length < totalNodes || edges.length < totalEdges`, so there's no separate `truncated` flag that could disagree with the arrays. It says how it narrowed, not just that it did.

## #478 — the crawl was blocking, but not for the reason the issue said

Reproduced at 355ms in one uninterruptible block at 50k files. Then the measurement contradicted the premise: **all 50,000 readdirs together are ~40ms**. Over half the time was per-entry `path.join` / `path.relative` / `split().join()`.

- The walk carries the vault-relative prefix down and extends it by concatenation: **187ms → 39ms**, byte-identical output.
- The crawl no longer stats at all. `list()` / `listAllPaths()` answer off Dirents — they never needed mtime/size/ino — and stats are filled lazily by `statOf()`, memoized on the snapshot, so the knowledge reconcile and the sync hash cache share one stat per file instead of one sweep each.
- `listWithStats()` yields in 15ms slices (its one production caller, `KnowledgeManager.runPass`, was already async).

**Longest main-thread block 355ms → 56ms**, under the 100ms bar.

`listAllPaths()` stays synchronous because core's `SyncIo.list()` is synchronous by contract — which is exactly why it can no longer afford to stat. No watcher was added; the listing is still an on-demand crawl, per CLAUDE.md.

## #479 — 21 of 22 rules graduated

11 already had zero findings. 8 had 1–4 each, fixed or given a narrow documented disable. `unbound-method` (47) had **exactly one** production finding — the rest are test mocks, where an unbound method cannot cause the failure class the rule guards, so it's scoped off under the existing `__tests__` override. `no-unsafe-type-assertion` (23) had 6 non-test findings, every one an already-documented sanctioned escape whose existing disable now names the type-aware rule too.

`consistent-return` (51) is a deliberate stop and keeps its ladder entry with a written reason. Cost is unchanged — the extra rules ride the same type-check.

## Verification

Full `pnpm verify` green; byte-pinned fixtures untouched. The bounding semantics get 10 unit tests (subset invariant, no half-drawn edges, hub shape, edge-cut order, zero budget) plus a **deterministic payload-size test** — byte counts are deterministic for a fixed corpus, so that measurement lives in the always-on gate rather than behind an env flag.

The graph affordance was driven in the harness both ways: full 29-node graph with no badge, then caps forced to 6/4 to confirm the badge reads `Showing 6 of 29 notes · 4 of 21 links` with the open note ringed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014tQQ3Jt3xQ9XdmXcFtXkDt


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add host-side bounds to the link graph and make the vault crawl non-blocking. Large vaults now send ~1MB instead of ~42MB, and the crawl’s longest main-thread block drops to ~56ms. Closes #477 and #478.

- **New Features**
  - Host applies graph bounds via `boundGraph({ focus?, maxNodes?, maxEdges? })`; reply includes `totalNodes/totalEdges` so the UI can show shortfall.
  - Selection: BFS from the focused note, then highest-degree nodes; edges trimmed by frontier distance; node degree stays global for consistent sizing.
  - Graph view shows “Showing N of M notes · X of Y links” when bounded; renderer caps set to 2,000 nodes / 8,000 edges.

- **Performance**
  - `list()` and `listAllPaths()` use Dirents only (no per-file stats); stats are filled lazily via a memoized `statOf()` shared across consumers.
  - `listWithStats()` runs in ~15ms slices with event-loop yields; `listAllPaths()` stays synchronous by contract.
  - Walk builds relative paths by carrying a prefix (no per-entry `path.join`/`path.relative`); output is byte-identical.
  - Behavior on transient `stat` failure: files remain in `list()`/`listAllPaths()`; their fingerprint is null and they’re omitted from `listWithStats()` until the next pass.
  - Results: graph payload ~42,020,060 B → ~937,138 B; path math 187ms → 39ms; longest block 355ms → 56ms.

<sup>Written for commit 39a92ebb8d0c839da2f9b0c97266d6d590908a47. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kyh/inteligir/pull/481?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

