### PR TITLE
refactor: quality sweep over the session's work

### DIFF
--- a/apps/desktop/src/renderer/command/tags.ts
+++ b/apps/desktop/src/renderer/command/tags.ts
@@ -10,11 +10,11 @@
 // refresh, shared) and ONE way to open a tag, instead of the sidebar and the
 // chips each growing their own list rendering.
 //
-// The counts are a projection of note bodies, so they are refreshed on the
-// same cadence the rest of the app discovers vault changes (see CLAUDE.md
-// § Decisions, "ephemeral listing"): the palette refreshes on open, the
-// sidebar group on a structural listing change and on a completed save. There
-// is deliberately no subscription/push channel for tags.
+// The counts are a projection of the knowledge index, so a refresh is driven
+// by that index's own push (`onKnowledgeUpdated`, which the sidebar group
+// subscribes to) plus a read when the palette opens. The index pushes often —
+// including progress ticks through a rebuild — so an unchanged list keeps its
+// array identity and re-renders nothing.
 // ---------------------------------------------------------------------------
 
 import { create } from "zustand";
@@ -42,10 +42,22 @@ type TagsState = {
 
 export const useTags = create<TagsState>()(() => ({ loaded: false, request: null, tags: [] }));
 
-// Sequence guard: two surfaces can refresh concurrently (palette open while
-// the sidebar reacts to a save), and a slow earlier response must not land
-// over a newer one.
+// Sequence guard: two surfaces can refresh concurrently (a palette open racing
+// the sidebar's index push), and a slow earlier response must not land over a
+// newer one.
 let refreshSeq = 0;
+
+/** Same tags, same counts, same order. Compares the whole payload, so a count
+ * moving on an otherwise-identical list still publishes. */
+function sameTags(a: TagCount[], b: TagCount[]): boolean {
+  return (
+    a.length === b.length &&
+    a.every((entry, i) => {
+      const other = b[i];
+      return other !== undefined && other.tag === entry.tag && other.count === entry.count;
+    })
+  );
+}
 
 /** Re-read the tag index. Fire-and-forget: a failed read leaves the last good
  * list in place — a stale count is better than an empty sidebar group. */
@@ -54,7 +66,13 @@ export function refreshTags(): void {
   getBridge()
     .listTags()
     .then((tags) => {
-      if (seq === refreshSeq) useTags.setState({ loaded: true, tags });
+      if (seq !== refreshSeq) return undefined;
+      const state = useTags.getState();
+      // Hold the array identity when nothing moved: the always-mounted palette
+      // and the sidebar group both select `tags`, and a fresh array with
+      // identical contents would re-render both for no visible change.
+      if (state.loaded && sameTags(state.tags, tags)) return undefined;
+      useTags.setState({ loaded: true, tags });
       return undefined;
     })
     .catch(() => {});

--- a/apps/desktop/src/renderer/editor/kits/tag-chip-kit.tsx
+++ b/apps/desktop/src/renderer/editor/kits/tag-chip-kit.tsx
@@ -23,7 +23,9 @@ import {
   type SlateEditor,
 } from "platejs";
 
-import { TagChipLeaf, inlineTagSpans } from "@renderer/editor/nodes/tag-chip-node";
+import { inlineTagSpans } from "@repo/notes/knowledge/link-extract";
+
+import { TagChipLeaf } from "@renderer/editor/nodes/tag-chip-node";
 
 /** Element types whose text the tag index never scans. */
 function isSuppressedAncestor(editor: SlateEditor, type: string): boolean {

--- a/apps/desktop/src/renderer/editor/nodes/tag-chip-node.tsx
+++ b/apps/desktop/src/renderer/editor/nodes/tag-chip-node.tsx
@@ -14,38 +14,7 @@
 
 import { PlateLeaf, type PlateLeafProps } from "platejs/react";
 
-import { INLINE_TAG_RE } from "@repo/notes/knowledge/link-extract";
-
 import { browseTag } from "@renderer/command/tags";
-
-/** A `#tag` occurrence inside one text run: `[start, end)` covers the `#` and
- * the tag name, and `tag` is the name alone. */
-export type InlineTagSpan = { start: number; end: number; tag: string };
-
-// The tag index's OWN scanner, imported rather than copied: the chip must
-// highlight exactly what the index counted (`#` at a word boundary, then a
-// LETTER-first name, nested `a/b/c` and dashes allowed). The index walks mdast
-// text nodes and this walks Slate text runs, so the walkers can't be shared —
-// but the token grammar is the thing that must not drift, and a second copy
-// would drift into chips over text that is not a tag.
-
-/** Every `#tag` in a text run, in document order. Pure — the kit's `decorate`
- * turns these offsets into Slate ranges. */
-export function inlineTagSpans(text: string): InlineTagSpan[] {
-  const spans: InlineTagSpan[] = [];
-  for (const match of text.matchAll(INLINE_TAG_RE)) {
-    const start = match.index;
-    const raw = match[1];
-    if (start === undefined || raw === undefined) continue;
-    // A trailing dash reads as punctuation, not part of the name (`#bar-` →
-    // `bar`) — link-extract trims the same way, so the chip must stop short of
-    // it or it would link a tag that doesn't exist.
-    const tag = raw.replace(/-+$/, "");
-    if (tag === "") continue;
-    spans.push({ end: start + 1 + tag.length, start, tag });
-  }
-  return spans;
-}
 
 /** True when the user is mid-selection: a drag that ends over a chip fires a
  * click, and popping the palette out from under a selection is never what they

--- a/apps/desktop/src/renderer/editor/nodes/tag-chip.test.tsx
+++ b/apps/desktop/src/renderer/editor/nodes/tag-chip.test.tsx
@@ -15,7 +15,7 @@ import { useTags } from "@renderer/command/tags";
 import { EDITOR_KIT } from "@renderer/editor/kits/editor-kit";
 import { TagChipKit } from "@renderer/editor/kits/tag-chip-kit";
 import { MD_STRINGIFY, parseMarkdown } from "@renderer/editor/markdown/markdown-doc";
-import { inlineTagSpans } from "@renderer/editor/nodes/tag-chip-node";
+import { inlineTagSpans } from "@repo/notes/knowledge/link-extract";
 
 afterEach(cleanup);
 beforeEach(() => useTags.setState({ request: null }));
@@ -43,7 +43,9 @@ function chips(container: HTMLElement): string[] {
   );
 }
 
-describe("inlineTagSpans (grammar parity with the tag index)", () => {
+// The chip decorates with the tag index's OWN scanner, so these assert the
+// grammar the chip must highlight — the same tokens the index counted.
+describe("inlineTagSpans (the scanner the chip decorates with)", () => {
   it("finds letter-first tags, including nested and dashed names", () => {
     expect(inlineTagSpans("see #alpha and #a/b/c plus #kebab-case.")).toEqual([
       { end: 10, start: 4, tag: "alpha" },

--- a/apps/desktop/src/renderer/lib/use-disk-state.ts
+++ b/apps/desktop/src/renderer/lib/use-disk-state.ts
@@ -29,3 +29,12 @@ export function useDiskState<T>(
 
   return [value, setValue, loaded];
 }
+
+/**
+ * The `parseStored` every string-valued call site needs: an unknown row is a
+ * value only if it is a string, and anything else falls back to the default.
+ * Lives here rather than in each caller because `useDiskState`'s own signature
+ * is what demands it.
+ */
+export const parseStoredString = (value: unknown): string | undefined =>
+  typeof value === "string" ? value : undefined;

--- a/apps/desktop/src/renderer/settings/sections/notes-section.tsx
+++ b/apps/desktop/src/renderer/settings/sections/notes-section.tsx
@@ -1,16 +1,8 @@
 import { Input } from "@repo/ui/components/input";
 import { Label } from "@repo/ui/components/label";
 
-import {
-  CADENCE_ORDER,
-  CADENCES,
-  type Cadence,
-  type CadenceConfig,
-} from "@repo/bridge/daily-notes";
-import { useDiskState } from "@renderer/lib/use-disk-state";
-
-const parseString = (value: unknown): string | undefined =>
-  typeof value === "string" ? value : undefined;
+import { CADENCE_ORDER, CADENCES, type CadenceConfig } from "@repo/bridge/daily-notes";
+import { parseStoredString, useDiskState } from "@renderer/lib/use-disk-state";
 
 // Periodic-note locations, one group per cadence. Every field persists through
 // the generic ui-state channel (~/.inteligir/ui-state.json) via useDiskState —
@@ -28,14 +20,12 @@ export function NotesSection() {
   );
 }
 
-/** How each cadence is reached, appended to its group's hint line. Kept beside
- * the copy it belongs to rather than in the isomorphic cadence table, which the
- * host reads and has no notion of the palette. */
-const REACHED_BY: Record<Cadence, string> = {
-  daily: "⌘D or “Open today's note”",
-  weekly: "“Open this week's note”",
-  monthly: "“Open this month's note”",
-};
+/** How this cadence is reached, for its group's hint line. The command LABEL
+ * belongs to the cadence table (the host reads it too); the only renderer-local
+ * fact is that daily also sits on a hotkey. */
+function reachedBy(config: CadenceConfig): string {
+  return `${config.cadence === "daily" ? "⌘D or " : ""}“${config.commandLabel}”`;
+}
 
 /** One cadence's folder + filename-format pair. A hook per FIELD, so this is a
  * component rather than a loop body — useDiskState can't be called in a map. */
@@ -43,14 +33,18 @@ function CadenceRows({ config }: { config: CadenceConfig }) {
   const [folder, setFolder, loaded] = useDiskState(
     config.folderKey,
     config.defaultFolder,
-    parseString,
+    parseStoredString,
   );
-  const [format, setFormat] = useDiskState(config.formatKey, config.defaultFormat, parseString);
+  const [format, setFormat] = useDiskState(
+    config.formatKey,
+    config.defaultFormat,
+    parseStoredString,
+  );
 
   return (
     <div className="flex flex-col gap-2 rounded-[12px] bg-muted px-3 py-2">
       <p className="text-[10px] text-muted-foreground">
-        {config.settingsLabel} location, opened with {REACHED_BY[config.cadence]}. Seeded from{" "}
+        {config.settingsLabel} location, opened with {reachedBy(config)}. Seeded from{" "}
         <code>{config.templatePath}</code> when it exists.
       </p>
       <div className="flex flex-col gap-1">

--- a/apps/desktop/src/renderer/sidebar/tags-section.tsx
+++ b/apps/desktop/src/renderer/sidebar/tags-section.tsx
@@ -21,8 +21,7 @@ import {
 import { cn } from "@repo/ui/lib/utils";
 
 import { browseTag, openTagList, refreshTags, useTags } from "@renderer/command/tags";
-import { useOpenNote } from "@renderer/workspace/open-note-store";
-import { useVaultListing } from "@renderer/workspace/vault-context";
+import { getBridge } from "@renderer/lib/bridge";
 
 // A long tail of one-note tags would push the file tree off screen, and the
 // group is a browse shortcut, not a tag manager. Past this many rows the
@@ -32,30 +31,21 @@ const VISIBLE_TAGS = 12;
 
 /**
  * Tags, most-used first, with per-tag note counts. Its own component (not part
- * of AppSidebar) so its subscriptions — the shared tag store and the open
- * note's save flag — re-render this group alone.
+ * of AppSidebar) so its subscription to the shared tag store re-renders this
+ * group alone.
  */
 export function TagsSection() {
-  const { entries } = useVaultListing();
   const tags = useTags((s) => s.tags);
   const loaded = useTags((s) => s.loaded);
   const [expanded, setExpanded] = useState(true);
 
-  // Structural refreshes (window focus, app writes, delegation completion,
-  // "Refresh vault") are when files appear/vanish, so the tag set can move.
+  // Tags are a projection of the knowledge index, so this group refreshes off
+  // the index's own push — the same subscription the links panels and the
+  // tasks view use. Nothing here needs to guess at when the tag set moved.
   useEffect(() => {
     refreshTags();
-  }, [entries]);
-
-  // …but a `#tag` typed into an EXISTING note changes no listing, so also
-  // refresh when a save completes (the false edge of `saving`, which is also
-  // the mount state — that's what performs the initial load). Save-completed
-  // is the right beat: the host reconciles the knowledge index off the same
-  // write.
-  const saving = useOpenNote((s) => s.editor.saving);
-  useEffect(() => {
-    if (!saving) refreshTags();
-  }, [saving]);
+    return getBridge().onKnowledgeUpdated(() => refreshTags());
+  }, []);
 
   // Nothing to browse yet: stay silent rather than showing an empty group.
   if (!loaded || tags.length === 0) return null;

--- a/apps/desktop/src/renderer/workspace/graph-view.tsx
+++ b/apps/desktop/src/renderer/workspace/graph-view.tsx
@@ -7,8 +7,8 @@
 // Interactions: wheel zooms about the cursor, drag pans, click opens the node
 // (phantom nodes offer to create the note), Esc returns to the editor. Nodes
 // are sized by degree; phantoms draw dashed; the open note gets a
-// highlight ring. Data refreshes on onKnowledgeUpdated, preserving layout
-// positions by node id.
+// highlight ring. Data refreshes on onKnowledgeUpdated — debounced, and with
+// a stale in-flight response dropped — preserving layout positions by node id.
 //
 // The request is BOUNDED (see MAX_NODES/MAX_EDGES): the whole graph of a 50k
 // vault is ~42MB of JSON and 400k links into d3-force. A vault that fits under
@@ -31,6 +31,7 @@ import {
 import { confirm } from "@repo/ui/components/confirm-dialog";
 
 import { getBridge } from "@renderer/lib/bridge";
+import { createDebouncer } from "@renderer/lib/debounce";
 import { useTheme } from "@renderer/lib/use-theme";
 import { useViewStore } from "@renderer/stores/view-store";
 import { openDocPath } from "@renderer/workspace/open-doc";
@@ -73,6 +74,11 @@ function nodeRadius(node: SimNode): number {
  * a vault under them transfers whole. */
 const MAX_NODES = 2000;
 const MAX_EDGES = 8000;
+
+/** How long a knowledge push waits for a quieter one behind it. Comfortably
+ * longer than the index's progress cadence, so a rebuild yields one refresh at
+ * the end rather than one per tick. */
+const REFRESH_DEBOUNCE_MS = 400;
 
 /** The affordance's numbers, non-null exactly when something was dropped. */
 type Shortfall = {
@@ -294,23 +300,36 @@ export default function GraphView() {
       simRef.current = sim;
     };
 
+    let requestSeq = 0;
     const refresh = () => {
       // Read the open note at request time rather than closing over it: the
       // effect runs once, and navigation leaves this surface anyway.
       const focus = activePathRef.current;
+      const seq = ++requestSeq;
       bridge
         .getLinkGraph({
           maxNodes: MAX_NODES,
           maxEdges: MAX_EDGES,
           ...(focus !== null && { focus }),
         })
-        .then((graph) => apply(graph, focus !== null))
+        .then((graph) => {
+          // Assembling a whole-vault graph is not cheap, so a slower earlier
+          // request must never land over a newer one's layout.
+          if (seq === requestSeq) apply(graph, focus !== null);
+          return undefined;
+        })
         .catch(() => {});
     };
+
+    // First paint is immediate; later pushes coalesce. The index emits
+    // progress through hydration and rebuild, and one assembly per tick would
+    // pile whole-vault work on top of the very rebuild it is watching.
     refresh();
-    const unsubscribe = bridge.onKnowledgeUpdated(refresh);
+    const debounced = createDebouncer(refresh, REFRESH_DEBOUNCE_MS);
+    const unsubscribe = bridge.onKnowledgeUpdated(() => debounced.schedule());
     return () => {
       disposed = true;
+      debounced.cancel();
       unsubscribe();
       simRef.current?.stop();
       simRef.current = null;

--- a/apps/desktop/src/renderer/workspace/tasks-view.tsx
+++ b/apps/desktop/src/renderer/workspace/tasks-view.tsx
@@ -26,15 +26,12 @@ import type { Delegation } from "@repo/bridge/delegation";
 
 import { DelegateButton, DelegationStatusBadge } from "@renderer/delegation/status-badge";
 import { getBridge } from "@renderer/lib/bridge";
-import { useDiskState } from "@renderer/lib/use-disk-state";
+import { parseStoredString, useDiskState } from "@renderer/lib/use-disk-state";
 import { findDelegation, useDelegationStore } from "@renderer/stores/delegation-store";
 import { useViewStore } from "@renderer/stores/view-store";
 import { openDocPath } from "@renderer/workspace/open-doc";
 import { useOpenNote } from "@renderer/workspace/open-note-store";
 import { useVaultActions } from "@renderer/workspace/vault-context";
-
-const parseString = (value: unknown): string | undefined =>
-  typeof value === "string" ? value : undefined;
 
 /** Group a bucket's rows by their note, input order preserved. */
 function byNote(
@@ -86,8 +83,8 @@ export default function TasksView() {
     return () => window.removeEventListener("keydown", onKey);
   }, [setSurface]);
 
-  const [dailyFolder] = useDiskState(DAILY_FOLDER_KEY, DEFAULT_DAILY_FOLDER, parseString);
-  const [dailyFormat] = useDiskState(DAILY_FORMAT_KEY, DEFAULT_DAILY_FORMAT, parseString);
+  const [dailyFolder] = useDiskState(DAILY_FOLDER_KEY, DEFAULT_DAILY_FOLDER, parseStoredString);
+  const [dailyFormat] = useDiskState(DAILY_FORMAT_KEY, DEFAULT_DAILY_FORMAT, parseStoredString);
 
   const groups = useMemo(
     () => groupTasks(entries ?? [], { dailyFolder, dailyFormat }, formatIsoDate(new Date())),

--- a/apps/desktop/src/renderer/workspace/use-note-templates.ts
+++ b/apps/desktop/src/renderer/workspace/use-note-templates.ts
@@ -5,11 +5,8 @@ import { formatIsoDate, periodicNotePath } from "@repo/notes/daily-path";
 import { CADENCES, applyTemplate, type Cadence } from "@repo/bridge/daily-notes";
 
 import { getBridge } from "@renderer/lib/bridge";
-import { useDiskState } from "@renderer/lib/use-disk-state";
+import { parseStoredString, useDiskState } from "@renderer/lib/use-disk-state";
 import { useVaultActions } from "@renderer/workspace/vault-context";
-
-const parseString = (value: unknown): string | undefined =>
-  typeof value === "string" ? value : undefined;
 
 /** Read a template note's raw bytes, or null when it doesn't exist / is
  * unreadable — the seed is optional in every flow. */
@@ -60,8 +57,8 @@ export function useCreateFromTemplate(): (templatePath: string, rawName: string)
 export function useOpenPeriodicNote(cadence: Cadence): () => void {
   const { createFile } = useVaultActions();
   const config = CADENCES[cadence];
-  const [folder] = useDiskState(config.folderKey, config.defaultFolder, parseString);
-  const [format] = useDiskState(config.formatKey, config.defaultFormat, parseString);
+  const [folder] = useDiskState(config.folderKey, config.defaultFolder, parseStoredString);
+  const [format] = useDiskState(config.formatKey, config.defaultFormat, parseStoredString);
   return useCallback(() => {
     void (async () => {
       const now = new Date();

--- a/apps/desktop/src/renderer/workspace/vault-context.tsx
+++ b/apps/desktop/src/renderer/workspace/vault-context.tsx
@@ -251,8 +251,8 @@ export function VaultProvider({ children }: { children: ReactNode }) {
   );
 
   /** Flush the open note's pending edits (clearing the debounce). True when
-   * clean. A pending AI suggestion session on the file is settled first
-   * first: reject-all reverts only the suggestion-marked ranges, so typing
+   * clean. A pending AI suggestion session on the file is settled first:
+   * reject-all reverts only the suggestion-marked ranges, so typing
    * the user interleaved during the review persists while the AI marks
    * disappear — without this, the flush would write the frozen pre-session
    * buffer and the typing would die with the unmounting editor. */

--- a/packages/bridge/src/daily-notes.ts
+++ b/packages/bridge/src/daily-notes.ts
@@ -31,10 +31,16 @@ export const DAILY_TEMPLATE_PATH = "templates/daily.md";
  * different folder + filename format. */
 export type Cadence = "daily" | "weekly" | "monthly";
 
-/** Everything that differs between cadences, in one record per cadence — the
- * point of the lookup table below is that there is exactly ONE place to look
- * when adding "quarterly", instead of three parallel constant sets and three
- * parallel hooks/commands/settings rows to keep in step. */
+/** Everything that differs between cadences, in one record per cadence, so a
+ * cadence's folder key, filename format, template path and command label are
+ * defined once rather than spread across parallel constant sets.
+ *
+ * Adding "quarterly" is still more than editing the table below: the renderer
+ * keeps its own per-cadence records (the palette's command map, the Settings
+ * rows, the open-periodic hook). Every one of them is keyed
+ * `Record<Cadence, …>`, so the compiler names each site that needs the new
+ * member — the table does not remove those sites, it makes missing one a
+ * type error instead of a silent gap. */
 export type CadenceConfig = {
   /** Discriminant — a config always knows which cadence it describes. */
   readonly cadence: Cadence;

--- a/packages/notes/src/knowledge/link-extract.ts
+++ b/packages/notes/src/knowledge/link-extract.ts
@@ -206,13 +206,34 @@ function textOf(node: Nodes): string {
 // Nested `a/b/c` and dashes are allowed; a trailing `/` or `-` is not captured.
 // Unicode letters/numbers count — the pipeline already runs with the `u` flag
 // (search-index tokenizer), so it costs nothing here.
-// Exported because the editor's tag-chip decoration must highlight EXACTLY
-// what this index counts. It scans Slate text runs rather than mdast text
-// nodes, so the walkers genuinely can't be shared — but a second copy of the
-// grammar would drift into chips over text that is not a tag, so the two share
-// this one regex. It is stateful (`g` flag): callers must use `matchAll`, or
-// reset `lastIndex` before `exec`.
-export const INLINE_TAG_RE = /(?<![\p{L}\p{N}_/#])#(\p{L}[\p{L}\p{N}_-]*(?:\/[\p{L}\p{N}_-]+)*)/gu;
+// Module-private: the pattern alone is not the grammar — the trailing-dash trim
+// below is part of it — so `inlineTagSpans` is the only seam a second consumer
+// gets. Stateful (`g` flag): scan it with `matchAll`.
+const INLINE_TAG_RE = /(?<![\p{L}\p{N}_/#])#(\p{L}[\p{L}\p{N}_-]*(?:\/[\p{L}\p{N}_-]+)*)/gu;
+
+/** A `#tag` occurrence inside one text run: `[start, end)` covers the `#` and
+ * the tag name, and `tag` is the name alone. */
+export type InlineTagSpan = { start: number; end: number; tag: string };
+
+/** Every `#tag` in one plain-text run, in order — the ONE inline-tag scanner.
+ * Pure string math, no mdast: the index walks mdast `text` nodes and the
+ * editor's chip decoration walks Slate text runs, so the WALKERS genuinely
+ * can't be shared, but the token grammar must not drift between them, so both
+ * come through here. */
+export function inlineTagSpans(text: string): InlineTagSpan[] {
+  const spans: InlineTagSpan[] = [];
+  for (const match of text.matchAll(INLINE_TAG_RE)) {
+    const start = match.index;
+    const raw = match[1];
+    if (start === undefined || raw === undefined) continue;
+    // A trailing dash is captured by the name class but reads as punctuation,
+    // not part of the tag (`#bar-` → `bar`); a trailing `/` never is.
+    const tag = raw.replace(/-+$/, "");
+    if (tag === "") continue;
+    spans.push({ start, end: start + 1 + tag.length, tag });
+  }
+  return spans;
+}
 
 /** The leading `yaml` node's typed properties, parsed ONCE per scanDoc pass,
  * or null when the doc has no frontmatter block. Each `frontmatter*` extractor
@@ -292,12 +313,7 @@ function frontmatterPrivate(parsed: ParsedProperties | null): boolean {
 function collectInlineTags(node: Nodes, out: string[], suppressed: boolean): void {
   if (node.type === "text") {
     if (suppressed) return;
-    for (const match of node.value.matchAll(INLINE_TAG_RE)) {
-      // A trailing dash is captured by the name class but reads as punctuation,
-      // not part of the tag (`#bar-` → `bar`); a trailing `/` never is.
-      const tag = match[1]?.replace(/-+$/, "");
-      if (tag !== undefined && tag !== "") out.push(tag);
-    }
+    for (const { tag } of inlineTagSpans(node.value)) out.push(tag);
     return;
   }
   const nextSuppressed =

--- a/packages/notes/src/knowledge/link-graph-index.ts
+++ b/packages/notes/src/knowledge/link-graph-index.ts
@@ -518,7 +518,7 @@ export class LinkGraphIndex {
  * graph stays global, it just can't lose the open note to the cap.
  *
  * Edges are the ones induced by the kept nodes; if that still exceeds
- * `maxEdges`, the outermost go first (see {@link edgeDistance}). */
+ * `maxEdges`, the outermost go first. */
 export function boundGraph(graph: LinkGraph, bounds: GraphBounds): BoundedLinkGraph {
   const totalNodes = graph.nodes.length;
   const totalEdges = graph.edges.length;
@@ -528,37 +528,45 @@ export function boundGraph(graph: LinkGraph, bounds: GraphBounds): BoundedLinkGr
     return { nodes: graph.nodes, edges: graph.edges, totalNodes, totalEdges };
   }
 
-  // Insertion order IS selection order, and selection order is distance from
-  // the focus — which is what an edge cut wants to order by.
-  const rank = new Map<string, number>();
-  for (const id of selectNodes(graph, bounds.focus, maxNodes)) rank.set(id, rank.size);
+  const rank = selectNodes(graph, bounds.focus, maxNodes);
 
-  const induced = graph.edges.filter((edge) => rank.has(edge.source) && rank.has(edge.target));
-  const edges =
+  // An edge is induced when BOTH endpoints were selected — and that same pair
+  // of lookups is its cut order: an edge becomes drawable only once its LATER
+  // endpoint is selected, so the later rank is exactly its distance from the
+  // focus. Scoring here rather than in a second pass keeps the "both endpoints
+  // are ranked" invariant TOTAL, with no unreachable missing-endpoint case.
+  const induced: Array<{ edge: GraphEdge; at: number }> = [];
+  for (const edge of graph.edges) {
+    const source = rank.get(edge.source);
+    const target = rank.get(edge.target);
+    if (source === undefined || target === undefined) continue;
+    induced.push({ edge, at: Math.max(source, target) });
+  }
+  const kept =
     induced.length <= maxEdges
       ? induced
-      : induced
-          .map((edge) => ({ edge, at: edgeDistance(edge, rank) }))
-          .toSorted((a, b) => a.at - b.at)
-          .slice(0, maxEdges)
-          .map((entry) => entry.edge);
+      : induced.toSorted((a, b) => a.at - b.at).slice(0, maxEdges);
 
   // Kept nodes stay even when the edge cut leaves them isolated: dropping them
   // would make the reported node count a lie.
-  return { nodes: graph.nodes.filter((node) => rank.has(node.id)), edges, totalNodes, totalEdges };
+  return {
+    nodes: graph.nodes.filter((node) => rank.has(node.id)),
+    edges: kept.map((entry) => entry.edge),
+    totalNodes,
+    totalEdges,
+  };
 }
 
-/** An edge becomes drawable only once its LATER endpoint is selected, so the
- * later rank is exactly its distance from the focus. */
-function edgeDistance(edge: GraphEdge, rank: ReadonlyMap<string, number>): number {
-  return Math.max(rank.get(edge.source) ?? 0, rank.get(edge.target) ?? 0);
-}
-
-/** Up to `maxNodes` node ids, nearest the focus first and highest-degree
- * after — in selection order. */
-function selectNodes(graph: LinkGraph, focus: string | undefined, maxNodes: number): Set<string> {
-  const kept = new Set<string>();
-  if (maxNodes <= 0) return kept;
+/** Up to `maxNodes` node ids mapped to their SELECTION ORDER: breadth-first
+ * from the focus, then highest-degree to fill the budget. The rank is the
+ * insertion index, so it doubles as distance from the focus for the edge cut. */
+function selectNodes(
+  graph: LinkGraph,
+  focus: string | undefined,
+  maxNodes: number,
+): Map<string, number> {
+  const rank = new Map<string, number>();
+  if (maxNodes <= 0) return rank;
 
   // A focus that names no node contributes nothing, so the adjacency map (the
   // one O(edges) allocation here) is built only when it will actually be
@@ -567,27 +575,40 @@ function selectNodes(graph: LinkGraph, focus: string | undefined, maxNodes: numb
     const adjacency = buildAdjacency(graph.edges);
     const queue = [focus];
     let head = 0;
-    while (head < queue.length && kept.size < maxNodes) {
+    while (head < queue.length && rank.size < maxNodes) {
       const id = queue[head++];
-      if (id === undefined || kept.has(id)) continue;
-      kept.add(id);
+      if (id === undefined || rank.has(id)) continue;
+      rank.set(id, rank.size);
       for (const neighbour of adjacency.get(id) ?? []) {
         // Never queue more candidates than the remaining budget can consume —
         // one hub with a 20k in-degree would otherwise make a bounded answer
         // cost a whole-vault frontier.
         if (queue.length - head >= maxNodes) break;
-        if (!kept.has(neighbour)) queue.push(neighbour);
+        if (!rank.has(neighbour)) queue.push(neighbour);
       }
     }
   }
 
-  if (kept.size < maxNodes) {
-    for (const node of graph.nodes.toSorted((a, b) => b.degree - a.degree)) {
-      if (kept.size >= maxNodes) break;
-      kept.add(node.id);
+  // Degree fill by COUNTING SORT: bucket every node by its degree, then walk
+  // the buckets high to low. Pushes preserve node order within a bucket, so
+  // this selects EXACTLY what a stable descending sort would — in
+  // O(nodes + maxDegree) instead of O(n log n), and it stops the moment the
+  // budget is full rather than ordering the whole vault first. The bucket array
+  // can't outgrow the graph: edges are deduped per (source, target, kind), so a
+  // degree is at most a small multiple of the node count.
+  if (rank.size < maxNodes) {
+    let maxDegree = 0;
+    for (const node of graph.nodes) maxDegree = Math.max(maxDegree, node.degree);
+    const byDegree: Array<GraphNode[] | undefined> = Array.from({ length: maxDegree + 1 });
+    for (const node of graph.nodes) (byDegree[node.degree] ??= []).push(node);
+    for (let degree = maxDegree; degree >= 0 && rank.size < maxNodes; degree--) {
+      for (const node of byDegree[degree] ?? []) {
+        if (rank.size >= maxNodes) break;
+        if (!rank.has(node.id)) rank.set(node.id, rank.size);
+      }
     }
   }
-  return kept;
+  return rank;
 }
 
 /** Undirected neighbour lists. The graph is drawn undirected, so traversal is

--- a/packages/notes/src/knowledge/sql-knowledge-store.ts
+++ b/packages/notes/src/knowledge/sql-knowledge-store.ts
@@ -167,15 +167,23 @@ CREATE VIRTUAL TABLE search_fts USING fts5(
 // bm25() returns lower-is-better (negative) ranks; weights mirror the pure
 // SearchIndex's TITLE_WEIGHT/HEADING_WEIGHT/BODY_WEIGHT so a title hit beats a
 // body-only hit. Path tiebreak keeps ordering deterministic.
-const SEARCH_SQL = `
+//
+// The renderer's search and the agent's differ by ONE extra WHERE term, so both
+// are cut from this template: the bm25 weights and the snippet config MUST
+// agree between them, or the agent ranks and quotes hits differently from what
+// the user sees. That term is the only interpolation and both call sites pass a
+// literal — every VALUE still binds through `?`.
+const searchSql = (privacyTerm: string): string => `
 SELECT path, title,
   snippet(search_fts, 2, '', '', '…', 12) AS snip,
   bm25(search_fts, 10.0, 4.0, 1.0) AS rank
 FROM search_fts
-WHERE search_fts MATCH ?
+WHERE search_fts MATCH ?${privacyTerm}
 ORDER BY rank, path
 LIMIT ?
 `;
+
+const SEARCH_SQL = searchSql("");
 
 // The agent-facing variant: `private: true` docs are excluded INSIDE the query,
 // so the limit applies to public hits and a private path/snippet can never even
@@ -189,15 +197,7 @@ LIMIT ?
 // 198s, against ~77ms for the same query unfiltered. As a stored column the
 // filter is a residual test on rows the cursor already produced, so the
 // agent-facing search costs what the renderer's does.
-const SEARCH_PUBLIC_SQL = `
-SELECT path, title,
-  snippet(search_fts, 2, '', '', '…', 12) AS snip,
-  bm25(search_fts, 10.0, 4.0, 1.0) AS rank
-FROM search_fts
-WHERE search_fts MATCH ? AND is_private = 0
-ORDER BY rank, path
-LIMIT ?
-`;
+const SEARCH_PUBLIC_SQL = searchSql(" AND is_private = 0");
 
 // Hydration reads. Both `files` pages are keyset-paginated (`path > ?` against
 // the PK index) rather than OFFSET-paginated, so page N costs the same as page

--- a/packages/server/src/__tests__/docs-links.test.ts
+++ b/packages/server/src/__tests__/docs-links.test.ts
@@ -11,6 +11,15 @@
 // seam) and this walk needs the filesystem. packages/server is already where
 // the repo-wide derived tests live, and it needs no manifest change to run.
 //
+// Extraction is the vault's own `scanDoc` rather than a bespoke regex: it is
+// the tested extractor this repo already ships and depends on, it hands back
+// every destination percent-decoded with the `#fragment` split off and
+// external/scheme/fragment-only ones already dropped, and it excludes fenced
+// blocks and inline code for free — micromark never runs text constructs
+// inside them. It also reports the source LINE, so a failure names the line to
+// fix. Wiki links are skipped: `[[target]]` is vault syntax resolved against a
+// vault, not a path relative to the file it sits in.
+//
 // Scope is deliberately narrow — markdown LINK DESTINATIONS only. Backtick-
 // quoted paths are the more common citation form in these docs and rot the same
 // way, but a backtick span also carries command names, globs, vault-relative
@@ -27,6 +36,8 @@
 import { describe, expect, it } from "vitest";
 import fs from "node:fs";
 import path from "node:path";
+
+import { scanDoc } from "@repo/notes/knowledge/link-extract";
 
 const REPO_ROOT = path.resolve(import.meta.dirname, "../../../..");
 
@@ -49,12 +60,6 @@ const SKIP_DIR_NAMES = new Set([
  * `assets/*.png` among them) and their bytes may never be touched. */
 const SKIP_PREFIX = "apps/desktop/src/renderer/__tests__/fixtures/";
 
-/** `[text](dest)` / `![alt](dest)`, tolerating `<dest>` and a `"title"`. */
-const MD_LINK = /\[[^\]]*\]\(\s*<?([^)<>\s]+)>?(?:\s+"[^"]*")?\s*\)/g;
-
-/** Anything with a URI scheme (http, mailto, inteligir, vault-app, ws…). */
-const HAS_SCHEME = /^[a-z][a-z0-9+.-]*:/i;
-
 function walk(dir: string, out: string[]): void {
   for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
     const full = path.join(dir, entry.name);
@@ -64,37 +69,6 @@ function walk(dir: string, out: string[]): void {
       out.push(full);
     }
   }
-}
-
-/** Drop fenced blocks and inline code spans: a `[]()` inside either is being
- * shown, not asserted. Line-based rather than one regex so an unterminated
- * fence at EOF degrades to "rest of file is code" instead of matching nothing.
- * Inline stripping is single-line and single-backtick — good enough, because a
- * miss only re-admits a link, and a real link is what we want to check. */
-function stripCode(markdown: string): string {
-  const out: string[] = [];
-  let fence: string | null = null;
-  for (const line of markdown.split("\n")) {
-    const marker = /^\s*(`{3,}|~{3,})/.exec(line)?.[1];
-    if (fence === null) {
-      if (marker === undefined) out.push(line.replace(/`[^`\n]*`/g, ""));
-      else {
-        fence = marker;
-        out.push("");
-      }
-      continue;
-    }
-    // A closing fence is the same character, at least as long as the opener.
-    if (
-      marker !== undefined &&
-      marker.length >= fence.length &&
-      marker.startsWith(fence.slice(0, 1))
-    ) {
-      fence = null;
-    }
-    out.push("");
-  }
-  return out.join("\n");
 }
 
 function repoRelative(file: string): string {
@@ -110,24 +84,22 @@ describe("docs links", () => {
     const broken: string[] = [];
     let checked = 0;
     for (const file of scanned) {
-      const body = stripCode(fs.readFileSync(file, "utf8"));
-      for (const match of body.matchAll(MD_LINK)) {
-        const raw = match[1];
-        if (raw === undefined || raw.startsWith("#") || HAS_SCHEME.test(raw)) continue;
-        // Drop a `#heading` fragment; a pure fragment already left above.
-        const target = decodeURIComponent(raw.split("#")[0] ?? "");
-        if (target === "") continue;
+      for (const link of scanDoc(fs.readFileSync(file, "utf8")).links) {
+        if (link.kind === "wiki") continue;
         checked += 1;
         // A leading `/` means repo root here — GitHub would resolve it at the
         // site root, i.e. off the repo entirely, so either reading is a bug.
-        const resolved = target.startsWith("/")
-          ? path.join(REPO_ROOT, target)
-          : path.resolve(path.dirname(file), target);
-        if (!fs.existsSync(resolved)) broken.push(`${repoRelative(file)} → ${raw}`);
+        const resolved = link.target.startsWith("/")
+          ? path.join(REPO_ROOT, link.target)
+          : path.resolve(path.dirname(file), link.target);
+        if (!fs.existsSync(resolved)) {
+          broken.push(`${repoRelative(file)}:${link.line} → ${link.target}`);
+        }
       }
     }
 
-    // Floors, so a regex or walk regression can't quietly make this vacuous.
+    // Floors, so an extraction or walk regression can't quietly make this
+    // vacuous.
     expect(scanned.length).toBeGreaterThan(20);
     expect(checked).toBeGreaterThan(10);
     expect(

--- a/packages/server/src/__tests__/knowledge-corpus.ts
+++ b/packages/server/src/__tests__/knowledge-corpus.ts
@@ -1,0 +1,130 @@
+// ---------------------------------------------------------------------------
+// The synthetic vault the knowledge cost-shape suites measure against —
+// knowledge-query-perf.test.ts (incremental resolution, graph assembly, FTS
+// search) and knowledge-hydration.test.ts (paged hydration). ONE corpus on
+// purpose: each suite's header documents numbers taken against "the same"
+// corpus, and two hand-rolled generators make that claim silently false the
+// first time either is tuned.
+//
+// Per doc: 8 links (7 resolving inside the corpus, the 8th an embed that
+// dangles; one carries a display alias and one a heading anchor), 4 headings,
+// 3 tags, 1 doc alias, 3 GFM tasks, and `private` on every 17th — ~20
+// persisted rows, the shape that makes resolution, the graph and hydration all
+// expensive. Bodies carry "the" in every doc (a term FTS5 must rank the whole
+// corpus for) and `body-<id>` in exactly one.
+//
+// Not a `.test.ts` file: the package's vitest include is `src/**/*.test.ts`,
+// so this is a module the suites import, never a suite of its own.
+// ---------------------------------------------------------------------------
+
+import { DatabaseSync } from "node:sqlite";
+
+import type { StoredDocRow } from "@repo/notes/knowledge/knowledge-store";
+import type { DocProjection, StoredLink } from "@repo/notes/knowledge/projection";
+import type { SqlDriver, SqlKnowledgeStore } from "@repo/notes/knowledge/sql-knowledge-store";
+
+/** Vault path of doc `i` — zero-padded so path order is index order. */
+export function docPath(i: number): string {
+  return `notes/note-${String(i).padStart(6, "0")}.md`;
+}
+
+/** Doc `i`'s projection in a `total`-doc corpus. `revision` perturbs the link
+ * snippets, so re-projecting a doc is a real change rather than a no-op. */
+export function syntheticProjection(i: number, total: number, revision = 0): DocProjection {
+  const id = String(i).padStart(6, "0");
+  return {
+    title: `Note ${id}`,
+    headings: [`Note ${id}`, "Context", "Details", "Next steps"],
+    links: Array.from({ length: 8 }, (_, k): StoredLink => {
+      const target =
+        k === 7
+          ? `missing-${String((i * 7 + k) % 5000).padStart(6, "0")}`
+          : `note-${String((i + k * 37) % total).padStart(6, "0")}`;
+      return {
+        kind: "wiki",
+        embed: k === 7,
+        target,
+        line: 10 + k,
+        snippet: `rev${revision}: see [[${target}]] for the rest`,
+        ...(k === 0 ? { alias: "the note" } : {}),
+        ...(k === 1 ? { anchor: "Details" } : {}),
+      };
+    }),
+    tags: ["project", "meta", `bucket-${i % 50}`],
+    aliases: [`alias-${id}`],
+    private: i % 17 === 0,
+    tasks: Array.from({ length: 3 }, (_, k) => ({
+      checked: k === 0,
+      text: `task ${k} of ${id}`,
+      raw: `- [ ] task ${k} of ${id}`,
+      line: 30 + k,
+      ordinal: k,
+      wikiTargets: [`2026-01-0${(k % 9) + 1}`],
+    })),
+  };
+}
+
+/** Doc `i`'s body: "the" appears in every doc, `body-<id>` in exactly one. */
+function syntheticBody(i: number): string {
+  const id = String(i).padStart(6, "0");
+  return `# Note ${id}\n\nbody-${id} the quick brown fox ${"filler word the ".repeat(20)}\n`;
+}
+
+/** Doc `i`'s persisted row in a `total`-doc corpus. */
+function syntheticRow(i: number, total: number): StoredDocRow {
+  return {
+    path: docPath(i),
+    fingerprint: {
+      mtimeMs: 1_700_000_000_000 + i,
+      size: syntheticBody(i).length,
+      ino: 5000 + i,
+    },
+    contentHash: `hash-${String(i).padStart(6, "0")}`,
+    projection: syntheticProjection(i, total),
+  };
+}
+
+/** Fill a store with `docs` synthetic docs and `others` non-doc files, in
+ * transactions of 1000 — a per-doc transaction dominates the seed at corpus
+ * sizes the benchmarks use. */
+export function seedStore(store: SqlKnowledgeStore, docs: number, others = 0): void {
+  for (let start = 0; start < docs; start += 1000) {
+    store.transaction(() => {
+      for (let i = start; i < Math.min(start + 1000, docs); i++) {
+        store.upsertDoc(syntheticRow(i, docs), syntheticBody(i));
+      }
+    });
+  }
+  if (others === 0) return;
+  store.transaction(() => {
+    for (let i = 0; i < others; i++) {
+      store.upsertOther(`assets/pic-${String(i).padStart(6, "0")}.png`);
+    }
+  });
+}
+
+/** A node:sqlite driver over an in-memory database (the production one is
+ * private to sqlite-knowledge-store). `reset()` honours the port's contract —
+ * destroy the instance and reopen empty — so a suite that trips the store's
+ * recovery path lands on a genuinely blank database, not a half-wiped one.
+ * File/WAL lifecycle is out of scope here; sqlite-knowledge-store.test.ts owns
+ * that. Wrap the returned driver to instrument individual calls. */
+export function memorySqlDriver(): SqlDriver {
+  let db = new DatabaseSync(":memory:");
+  return {
+    exec: (sql) => {
+      db.exec(sql);
+    },
+    run: (sql, params) => {
+      db.prepare(sql).run(...params);
+    },
+    all: (sql, params) => db.prepare(sql).all(...params),
+    reset: () => {
+      db.close();
+      db = new DatabaseSync(":memory:");
+    },
+    close: () => {
+      db.close();
+    },
+  };
+}

--- a/packages/server/src/__tests__/knowledge-hydration.test.ts
+++ b/packages/server/src/__tests__/knowledge-hydration.test.ts
@@ -9,9 +9,9 @@
 // That is machine-independent, unlike a millisecond ceiling (this repo's perf
 // convention — see knowledge-perf-oracle.test.ts, "not timing tests").
 //
-// Wall-clock numbers, MacBook / Node 24, synthetic vault, 8 links + 4 headings
-// + 3 tags + 1 alias + 3 tasks per doc (≈20 persisted rows/doc), measured by
-// the `bench` case below (page size = the manager's 500):
+// Wall-clock numbers, MacBook / Node 24, over the shared synthetic corpus
+// (knowledge-corpus.ts — ≈20 persisted rows/doc), measured by the `bench` case
+// below (page size = the manager's 500):
 //
 //                    worst SINGLE call     whole hydration
 //   50k  monolithic        1198 ms             1202 ms
@@ -32,10 +32,8 @@ import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { DatabaseSync } from "node:sqlite";
 
 import type { StoredDocRow } from "@repo/notes/knowledge/knowledge-store";
-import type { DocProjection } from "@repo/notes/knowledge/projection";
 import {
   createSqlKnowledgeStore,
   type HydrationPage,
@@ -45,6 +43,7 @@ import {
 
 import { KnowledgeManager } from "../knowledge/knowledge-manager";
 import { createSqliteKnowledgeStore } from "../knowledge/sqlite-knowledge-store";
+import { memorySqlDriver, seedStore } from "./knowledge-corpus";
 import { VaultManager } from "@repo/vault/vault";
 
 const ROOT = "/test/vault";
@@ -66,96 +65,30 @@ afterEach(() => {
 // ---- An instrumented driver: every read's row count is recorded ---------------
 
 type CountingDriver = SqlDriver & {
-  /** Rows returned by the single largest `all()` since the last reset. */
+  /** Rows returned by the single largest `all()` since the last `resetPeak`. */
   peakRows: () => number;
-  reset: () => void;
+  /** Zero the instrumentation. Distinct from the driver's own `reset`, which
+   * destroys the database — shadowing that would silently disarm the store's
+   * recovery path. */
+  resetPeak: () => void;
 };
 
-/** A minimal node:sqlite driver (the production one is private to
- * sqlite-knowledge-store) wrapped in read instrumentation. In-memory only —
- * these tests never exercise the file/WAL lifecycle, which
- * sqlite-knowledge-store.test.ts owns. */
+/** The shared in-memory driver wrapped in read instrumentation. */
 function countingDriver(): CountingDriver {
-  const db = new DatabaseSync(":memory:");
+  const base = memorySqlDriver();
   let peak = 0;
   return {
-    exec: (sql) => {
-      db.exec(sql);
-    },
-    run: (sql, params) => {
-      db.prepare(sql).run(...params);
-    },
+    ...base,
     all: (sql, params) => {
-      const rows = db.prepare(sql).all(...params);
+      const rows = base.all(sql, params);
       peak = Math.max(peak, rows.length);
       return rows;
     },
-    reset: () => {
+    resetPeak: () => {
       peak = 0;
     },
     peakRows: () => peak,
-    close: () => {
-      db.close();
-    },
   };
-}
-
-// ---- Synthetic corpus ----------------------------------------------------------
-
-/** ~20 persisted rows per doc — the shape that makes hydration expensive. */
-function synthetic(i: number): { row: StoredDocRow; body: string } {
-  const id = String(i).padStart(6, "0");
-  const projection: DocProjection = {
-    title: `Note ${id}`,
-    headings: [`Note ${id}`, "Context", "Details", "Next steps"],
-    links: Array.from({ length: 8 }, (_, k) => ({
-      kind: "wiki" as const,
-      embed: k === 7,
-      target: `note-${String((i + k * 37) % 1_000_000).padStart(6, "0")}`,
-      line: 10 + k,
-      snippet: `see [[note-${id}]] for the rest`,
-      ...(k === 0 ? { alias: "the note" } : {}),
-      ...(k === 1 ? { anchor: "Details" } : {}),
-    })),
-    tags: ["project", "meta", `bucket-${i % 50}`],
-    aliases: [`alias-${id}`],
-    private: i % 17 === 0,
-    tasks: Array.from({ length: 3 }, (_, k) => ({
-      checked: k === 0,
-      text: `task ${k} of ${id}`,
-      raw: `- [ ] task ${k} of ${id}`,
-      line: 30 + k,
-      ordinal: k,
-      wikiTargets: [`2026-01-0${(k % 9) + 1}`],
-    })),
-  };
-  const body = `# Note ${id}\n\nbody-${id} ${"filler word ".repeat(20)}\n`;
-  return {
-    row: {
-      path: `notes/note-${id}.md`,
-      fingerprint: { mtimeMs: 1_700_000_000_000 + i, size: body.length, ino: 5000 + i },
-      contentHash: `hash-${id}`,
-      projection,
-    },
-    body,
-  };
-}
-
-/** Fill a store with `docs` synthetic docs and `others` non-doc files. */
-function seed(store: SqlKnowledgeStore, docs: number, others: number): void {
-  for (let start = 0; start < docs; start += 1000) {
-    store.transaction(() => {
-      for (let i = start; i < Math.min(start + 1000, docs); i++) {
-        const { row, body } = synthetic(i);
-        store.upsertDoc(row, body);
-      }
-    });
-  }
-  store.transaction(() => {
-    for (let i = 0; i < others; i++) {
-      store.upsertOther(`assets/pic-${String(i).padStart(6, "0")}.png`);
-    }
-  });
 }
 
 function drain(store: SqlKnowledgeStore, pageDocs: number): HydrationPage[] {
@@ -186,7 +119,7 @@ describe("hydration cursor", () => {
     const driver = countingDriver();
     closers.push(driver.close);
     const store = createSqlKnowledgeStore(driver, ROOT);
-    seed(store, 25, 7);
+    seedStore(store, 25, 7);
     const oneShot = store.loadAll();
     expect(oneShot.docs).toHaveLength(25);
     expect(oneShot.others).toHaveLength(7);
@@ -225,12 +158,12 @@ describe("hydration cursor", () => {
       const driver = countingDriver();
       closers.push(driver.close);
       const store = createSqlKnowledgeStore(driver, ROOT);
-      seed(store, docs, docs);
-      driver.reset();
+      seedStore(store, docs, docs);
+      driver.resetPeak();
       drain(store, 100);
       const paged = driver.peakRows();
       // A monolithic read, as an oracle: one unbounded sweep per child table.
-      driver.reset();
+      driver.resetPeak();
       driver.all("SELECT source_path, target FROM links ORDER BY source_path, ord", []);
       peaks.set(docs, { paged, monolithic: driver.peakRows() });
     }
@@ -372,7 +305,7 @@ describe.skipIf(process.env["KNOWLEDGE_BENCH_DOCS"] === undefined)("hydration be
     const store = createSqliteKnowledgeStore(path.join(tmp, "bench.sqlite"), ROOT);
     closers.push(() => store.dispose());
     const buildStart = performance.now();
-    seed(store, BENCH_DOCS, 0);
+    seedStore(store, BENCH_DOCS);
     const buildMs = performance.now() - buildStart;
 
     // The monolithic baseline: one page the size of the corpus. Against it,

--- a/packages/server/src/__tests__/knowledge-query-perf.test.ts
+++ b/packages/server/src/__tests__/knowledge-query-perf.test.ts
@@ -10,9 +10,9 @@
 // These live in @repo/server rather than beside LinkGraphIndex because the
 // second half needs the node:sqlite store to exercise FTS5.
 //
-// MacBook / Node 24, synthetic 50k-doc vault, 8 links + 4 headings + 3 tags +
-// 1 alias per doc (400k links, 55k graph nodes). Absolute values move ±30% with
-// machine load; the ratios do not.
+// MacBook / Node 24, the shared synthetic corpus (knowledge-corpus.ts) at 50k
+// docs — 400k links, 55k graph nodes. Absolute values move ±30% with machine
+// load; the ratios do not.
 //
 //                                              scoped   whole-corpus
 //   re-resolve, 1 doc edited                   0.1 ms         545 ms
@@ -46,7 +46,6 @@ import { describe, expect, it } from "vitest";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { DatabaseSync } from "node:sqlite";
 
 import { isDocPath } from "@repo/notes/knowledge/doc-file";
 import {
@@ -57,61 +56,17 @@ import {
 } from "@repo/notes/knowledge/link-graph-index";
 import type { DocProjection, StoredLink } from "@repo/notes/knowledge/projection";
 import { relatedNotes } from "@repo/notes/knowledge/related-notes";
-import {
-  createSqlKnowledgeStore,
-  type SqlDriver,
-  type SqlKnowledgeStore,
-} from "@repo/notes/knowledge/sql-knowledge-store";
+import { createSqlKnowledgeStore, type SqlDriver } from "@repo/notes/knowledge/sql-knowledge-store";
 import { extnamePath } from "@repo/notes/knowledge/vault-path";
 
 import { createSqliteKnowledgeStore } from "../knowledge/sqlite-knowledge-store";
+import { docPath, memorySqlDriver, seedStore, syntheticProjection } from "./knowledge-corpus";
 
 const BENCH_DOCS = Number(process.env["KNOWLEDGE_BENCH_DOCS"] ?? 10_000);
 
-// ---- Synthetic corpus ----------------------------------------------------------
-
-function docPath(i: number): string {
-  return `notes/note-${String(i).padStart(6, "0")}.md`;
-}
-
-/** `total` docs' worth of links, 7 of 8 resolving inside the corpus and the
- * 8th dangling — the shape that makes both resolution and the graph expensive.
- * `revision` perturbs the snippets so a re-projection is a real change. */
-function projection(i: number, total: number, revision = 0): DocProjection {
-  const id = String(i).padStart(6, "0");
-  return {
-    title: `Note ${id}`,
-    headings: [`Note ${id}`, "Context", "Details", "Next steps"],
-    links: Array.from({ length: 8 }, (_, k): StoredLink => {
-      const target =
-        k === 7
-          ? `missing-${String((i * 7 + k) % 5000).padStart(6, "0")}`
-          : `note-${String((i + k * 37) % total).padStart(6, "0")}`;
-      return {
-        kind: "wiki",
-        embed: k === 7,
-        target,
-        line: 10 + k,
-        snippet: `rev${revision}: see [[${target}]] for the rest`,
-      };
-    }),
-    tags: ["project", "meta", `bucket-${i % 50}`],
-    aliases: [`alias-${id}`],
-    private: i % 17 === 0,
-    tasks: [],
-  };
-}
-
-/** "the" is in every doc (a term FTS5 must rank the whole corpus for);
- * `body-<id>` is in exactly one. */
-function body(i: number): string {
-  const id = String(i).padStart(6, "0");
-  return `# Note ${id}\n\nbody-${id} the quick brown fox ${"filler word the ".repeat(20)}\n`;
-}
-
 function seedIndex(docs: number): LinkGraphIndex {
   const index = new LinkGraphIndex();
-  for (let i = 0; i < docs; i++) index.applyDoc(docPath(i), projection(i, docs));
+  for (let i = 0; i < docs; i++) index.applyDoc(docPath(i), syntheticProjection(i, docs));
   return index;
 }
 
@@ -156,22 +111,38 @@ function withCountedLinks(base: DocProjection, onResolve: () => void): DocProjec
   return { ...base, links: countingLinks(base.links, onResolve) };
 }
 
+/** A `docs`-doc index whose every doc counts its own re-resolutions, already
+ * folded once so the counts start from a fully resolved state. `applyCounted`
+ * re-projects a doc keeping it counted. */
+function seedCounted(docs: number): {
+  index: LinkGraphIndex;
+  resolves: Map<string, number>;
+  applyCounted: (i: number, proj: DocProjection) => void;
+} {
+  const resolves = new Map<string, number>();
+  const index = new LinkGraphIndex();
+  const applyCounted = (i: number, proj: DocProjection): void => {
+    const p = docPath(i);
+    index.applyDoc(
+      p,
+      withCountedLinks(proj, () => {
+        resolves.set(p, (resolves.get(p) ?? 0) + 1);
+      }),
+    );
+  };
+  for (let i = 0; i < docs; i++) applyCounted(i, syntheticProjection(i, docs));
+  index.backlinks(docPath(0)); // the one whole-corpus fold
+  return { index, resolves, applyCounted };
+}
+
 describe("incremental link resolution", () => {
   it("re-projecting a doc re-resolves that doc's links and nothing else", () => {
-    const resolves = new Map<string, number>();
-    const index = new LinkGraphIndex();
-    const bump = (p: string) => (): void => {
-      resolves.set(p, (resolves.get(p) ?? 0) + 1);
-    };
-    for (let i = 0; i < 20; i++) {
-      index.applyDoc(docPath(i), withCountedLinks(projection(i, 20), bump(docPath(i))));
-    }
-    index.backlinks(docPath(0)); // the one whole-corpus fold
+    const { index, resolves, applyCounted } = seedCounted(20);
     expect([...resolves.values()]).toEqual(Array.from({ length: 20 }, () => 1));
 
     // A body edit — same path, same aliases.
     resolves.clear();
-    index.applyDoc(docPath(3), withCountedLinks(projection(3, 20, 1), bump(docPath(3))));
+    applyCounted(3, syntheticProjection(3, 20, 1));
     index.backlinks(docPath(0));
     expect([...resolves.entries()]).toEqual([[docPath(3), 1]]);
 
@@ -184,19 +155,10 @@ describe("incremental link resolution", () => {
   });
 
   it("a changed alias re-resolves the whole corpus — it can re-point any link", () => {
-    const resolves = new Map<string, number>();
-    const index = new LinkGraphIndex();
-    const bump = (p: string) => (): void => {
-      resolves.set(p, (resolves.get(p) ?? 0) + 1);
-    };
-    for (let i = 0; i < 20; i++) {
-      index.applyDoc(docPath(i), withCountedLinks(projection(i, 20), bump(docPath(i))));
-    }
-    index.backlinks(docPath(0));
+    const { index, resolves, applyCounted } = seedCounted(20);
 
     resolves.clear();
-    const renamedAlias: DocProjection = { ...projection(3, 20, 1), aliases: ["something else"] };
-    index.applyDoc(docPath(3), withCountedLinks(renamedAlias, bump(docPath(3))));
+    applyCounted(3, { ...syntheticProjection(3, 20, 1), aliases: ["something else"] });
     index.backlinks(docPath(0));
     expect(resolves.size).toBe(20);
 
@@ -213,7 +175,7 @@ describe("incremental link resolution", () => {
     const others: string[] = [];
     const index = new LinkGraphIndex();
     const apply = (i: number, revision: number, over?: Partial<DocProjection>): void => {
-      const proj = { ...projection(i, total, revision), ...over };
+      const proj = { ...syntheticProjection(i, total, revision), ...over };
       applied.set(docPath(i), proj);
       index.applyDoc(docPath(i), proj);
     };
@@ -283,9 +245,9 @@ describe("incremental link resolution", () => {
     const index = seedIndex(total);
     index.backlinks(docPath(0));
     const applied = new Map<string, DocProjection>();
-    for (let i = 0; i < total; i++) applied.set(docPath(i), projection(i, total));
+    for (let i = 0; i < total; i++) applied.set(docPath(i), syntheticProjection(i, total));
     for (let i = 0; i < total; i++) {
-      const proj = projection(i, total, 1);
+      const proj = syntheticProjection(i, total, 1);
       applied.set(docPath(i), proj);
       index.applyDoc(docPath(i), proj);
     }
@@ -349,7 +311,7 @@ describe("graph assembly", () => {
     // Parallel links (same pair, same kind) and a self-link: the count/degree
     // rules the per-source collapse has to preserve.
     const twin: DocProjection = {
-      ...projection(0, total, 1),
+      ...syntheticProjection(0, total, 1),
       links: [
         { kind: "wiki", embed: false, target: "note-000001", line: 1, snippet: "a" },
         { kind: "wiki", embed: false, target: "note-000001", line: 2, snippet: "b" },
@@ -368,34 +330,21 @@ describe("graph assembly", () => {
 
 // ---- The agent-facing search's query plan -------------------------------------------
 
-/** A node:sqlite driver that remembers the SQL it was asked to run, so a test
- * can EXPLAIN the store's own statements without the store exporting them. */
+/** The shared in-memory driver, remembering the SQL it was asked to run so a
+ * test can EXPLAIN the store's own statements without the store exporting
+ * them. `explain` reads around the recorder, so it never logs itself. */
 function recordingDriver(): SqlDriver & { queries: string[]; explain: (sql: string) => string[] } {
-  const db = new DatabaseSync(":memory:");
+  const base = memorySqlDriver();
   const queries: string[] = [];
   return {
+    ...base,
     queries,
-    exec: (sql) => {
-      db.exec(sql);
-    },
-    run: (sql, params) => {
-      db.prepare(sql).run(...params);
-    },
     all: (sql, params) => {
       queries.push(sql);
-      return db.prepare(sql).all(...params);
+      return base.all(sql, params);
     },
     explain: (sql) =>
-      db
-        .prepare(`EXPLAIN QUERY PLAN ${sql}`)
-        .all("x", 10)
-        .map((row) => String(row["detail"])),
-    reset: () => {
-      db.exec("DROP TABLE IF EXISTS files");
-    },
-    close: () => {
-      db.close();
-    },
+      base.all(`EXPLAIN QUERY PLAN ${sql}`, ["x", 10]).map((row) => String(row["detail"])),
   };
 }
 
@@ -408,17 +357,7 @@ describe("agent-facing search", () => {
     const driver = recordingDriver();
     try {
       const store = createSqlKnowledgeStore(driver, "/test/vault");
-      for (let i = 0; i < 20; i++) {
-        store.upsertDoc(
-          {
-            path: docPath(i),
-            fingerprint: { mtimeMs: i, size: 1, ino: i },
-            contentHash: `hash-${i}`,
-            projection: projection(i, 20),
-          },
-          body(i),
-        );
-      }
+      seedStore(store, 20);
       driver.queries.length = 0;
       const hits = store.search("the", 10, { excludePrivate: true });
       expect(hits.length).toBeGreaterThan(0);
@@ -434,24 +373,6 @@ describe("agent-facing search", () => {
 });
 
 // ---- The documented benchmark ---------------------------------------------------------
-
-function seedStore(store: SqlKnowledgeStore, docs: number): void {
-  for (let start = 0; start < docs; start += 1000) {
-    store.transaction(() => {
-      for (let i = start; i < Math.min(start + 1000, docs); i++) {
-        store.upsertDoc(
-          {
-            path: docPath(i),
-            fingerprint: { mtimeMs: 1_700_000_000_000 + i, size: 100, ino: 5000 + i },
-            contentHash: `hash-${i}`,
-            projection: projection(i, docs),
-          },
-          body(i),
-        );
-      }
-    });
-  }
-}
 
 function since(start: number): string {
   return `${(performance.now() - start).toFixed(1)}ms`;
@@ -473,7 +394,7 @@ describe.skipIf(process.env["KNOWLEDGE_BENCH_DOCS"] === undefined)("query benchm
     // it, which falls back to the whole-corpus fold.
     const reresolve = (docs: number, revision: number): string => {
       for (let i = 0; i < docs; i++)
-        index.applyDoc(docPath(i), projection(i, BENCH_DOCS, revision));
+        index.applyDoc(docPath(i), syntheticProjection(i, BENCH_DOCS, revision));
       const start = performance.now();
       index.backlinks(docPath(1));
       return since(start);

--- a/packages/server/src/boot/agent-knowledge-port.ts
+++ b/packages/server/src/boot/agent-knowledge-port.ts
@@ -15,14 +15,14 @@
 //      hit is probed against disk and kept ONLY when it reads "public" now.
 //
 // Refusal shape: the port drops SILENTLY everywhere. get_backlinks on a
-// private target returns [] and
-// the tool returns an empty JSON array, indistinguishable from a note with none, so
-// the response never confirms a guessed path exists or is private. The
-// explicit "this note is private" refusal lives ONLY on the direct file-tool
-// gate (privacy/gate.ts). That gate IS a per-path existence/privacy oracle for
-// a model-GUESSED path (private → refusal, absent → the tool's own ENOENT) —
-// an ACCEPTED hole, documented in docs/privacy.md: paths only, near-inherent
-// to per-path gating, and already reachable via `bash ls`.
+// private target returns [] and the tool returns an empty JSON array,
+// indistinguishable from a note with none, so the response never confirms a
+// guessed path exists or is private. The explicit "this note is private"
+// refusal lives ONLY on the direct file-tool gate (privacy/gate.ts). That gate
+// IS a per-path existence/privacy oracle for a model-GUESSED path (private →
+// refusal, absent → the tool's own ENOENT) — an ACCEPTED hole, documented in
+// docs/privacy.md: paths only, near-inherent to per-path gating, and already
+// reachable via `bash ls`.
 //
 // This lives on its own, outside agent-wiring, so the guarantee is testable
 // without host singletons — __tests__/knowledge-privacy.test.ts stringifies
@@ -71,26 +71,51 @@ export function buildAgentKnowledgePort(deps: {
    * user-facing rename handler uses, injected so the two paths can't drift. */
   afterRename: (from: string, to: string) => void;
 }): KnowledgePort {
-  const isPublicNow = (rel: string): boolean => deps.probe(rel) === "public";
+  /** One memo, scoped to ONE port call. The probe is a full file read plus a
+   * realpath of the target, and a single query can name the same note many
+   * times over — a hub note that links its index twenty times would otherwise
+   * pay twenty identical disk round-trips inside one call. Sound because a
+   * filter runs to completion synchronously: no write can interleave within a
+   * call, so the memo can never answer something the un-memoized probe would
+   * not have. It must NOT outlive the call — that is the whole point of the
+   * live re-probe (layer 2 above). */
+  const openProbe = (): {
+    verdict: (rel: string) => PrivacyProbe;
+    isPublic: (rel: string) => boolean;
+  } => {
+    const memo = new Map<string, PrivacyProbe>();
+    const verdict = (rel: string): PrivacyProbe => {
+      const seen = memo.get(rel);
+      if (seen !== undefined) return seen;
+      const fresh = deps.probe(rel);
+      memo.set(rel, fresh);
+      return fresh;
+    };
+    return { verdict, isPublic: (rel) => verdict(rel) === "public" };
+  };
   return {
-    search: (query, limit) =>
-      deps
+    search: (query, limit) => {
+      const live = openProbe();
+      return deps
         .queries()
         .search(query, limit, EXCLUDE)
-        .filter((hit) => isPublicNow(hit.path)),
+        .filter((hit) => live.isPublic(hit.path));
+    },
     backlinks: (path) => {
+      const live = openProbe();
       // A private/unreadable TARGET yields [] — silently (see header).
-      const target = deps.probe(path);
+      const target = live.verdict(path);
       if (target === "private" || target === "indeterminate") return [];
       return deps
         .queries()
         .backlinks(path, EXCLUDE)
-        .filter((entry) => isPublicNow(entry.sourcePath));
+        .filter((entry) => live.isPublic(entry.sourcePath));
     },
     forwardLinks: (path) => {
+      const live = openProbe();
       // A private/unreadable SUBJECT yields [] — silently, exactly like
       // backlinks (see header).
-      const subject = deps.probe(path);
+      const subject = live.verdict(path);
       if (subject === "private" || subject === "indeterminate") return [];
       // Layer (1) does not exist for this query — forwardLinks takes no
       // PrivacyOpts (see KnowledgeQueries) — so the live probe below is the
@@ -104,26 +129,33 @@ export function buildAgentKnowledgePort(deps: {
       //
       // A DANGLING entry (targetPath null) passes through untouched: no file
       // stands behind it, so there is nothing to be private, and the tool
-      // renders it as explicitly unresolved. "absent" fails isPublicNow too,
-      // so a target deleted since the last index pass drops exactly the way a
-      // private one does — that ambiguity is what keeps the omission from
-      // being a privacy oracle.
+      // renders it as explicitly unresolved. "absent" fails the public check
+      // too, so a target deleted since the last index pass drops exactly the
+      // way a private one does — that ambiguity is what keeps the omission
+      // from being a privacy oracle.
       return deps
         .queries()
         .forwardLinks(path)
-        .filter((entry) => entry.targetPath === null || isPublicNow(entry.targetPath));
+        .filter((entry) => entry.targetPath === null || live.isPublic(entry.targetPath));
     },
     relatedNotes: (path) => {
+      const live = openProbe();
       // A private/unreadable SUBJECT yields [] — silently, exactly like
       // backlinks (see header): "no related notes" never confirms a path.
-      const target = deps.probe(path);
+      const target = live.verdict(path);
       if (target === "private" || target === "indeterminate") return [];
       return deps
         .queries()
         .relatedNotes(path, EXCLUDE)
-        .filter((entry) => isPublicNow(entry.path));
+        .filter((entry) => live.isPublic(entry.path));
     },
-    notesWithTag: (tag) => deps.queries().notesWithTag(tag, EXCLUDE).filter(isPublicNow),
+    notesWithTag: (tag) => {
+      const live = openProbe();
+      return deps
+        .queries()
+        .notesWithTag(tag, EXCLUDE)
+        .filter((path) => live.isPublic(path));
+    },
     rename: (from, to) => renameNote(deps, from, to),
   };
 }

--- a/packages/server/src/knowledge/knowledge-manager.ts
+++ b/packages/server/src/knowledge/knowledge-manager.ts
@@ -50,6 +50,7 @@ import type { TagCount } from "@repo/notes/knowledge/tag-index";
 import type { StoredFingerprint } from "@repo/notes/knowledge/knowledge-store";
 import type { HydrationCursor, SqlKnowledgeStore } from "@repo/notes/knowledge/sql-knowledge-store";
 import { projectDoc, type DocProjection } from "@repo/notes/knowledge/projection";
+import { yieldToEventLoop } from "@repo/storage/yield-to-event-loop";
 
 import { emitEvent } from "../events";
 import { getVaultManager, type VaultManager } from "@repo/vault/vault";
@@ -515,12 +516,6 @@ export class KnowledgeManager {
 
 function sha256(text: string): string {
   return crypto.createHash("sha256").update(text).digest("hex");
-}
-
-function yieldToEventLoop(): Promise<void> {
-  return new Promise((resolve) => {
-    setImmediate(resolve);
-  });
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/server/src/transport/ws-host.ts
+++ b/packages/server/src/transport/ws-host.ts
@@ -31,6 +31,7 @@ import {
   type ReqFrame,
   type SendFrame,
 } from "@repo/bridge/ws-protocol";
+import { yieldToEventLoop } from "@repo/storage/yield-to-event-loop";
 import type { HostEvents } from "../boot/create-host";
 import type { WireHandler } from "../handlers/handler-registry";
 import { LOCAL_DEVICE_ID, type DeviceSession, type TokenValidator } from "./device-auth";
@@ -335,7 +336,7 @@ export function startWsHost(options: WsHostOptions): WsHost {
       // Defer past the current turn's microtasks: the res frame answering the
       // config change that triggered this rebind (and the just-broadcast evt
       // frame) must reach the socket before it starts closing.
-      await new Promise<void>((resolve) => setImmediate(resolve));
+      await yieldToEventLoop();
       if (closed) return;
       await stopServer("rebind");
       listen();

--- a/packages/storage/README.md
+++ b/packages/storage/README.md
@@ -37,9 +37,11 @@ src/
   secrets.ts         # SecretStore: key→credential map at ~/.inteligir/secrets.json,
                      #   encrypted at rest via the injected SecretCipher (Electron
                      #   safeStorage), marked-plaintext fallback when no cipher
+  yield-to-event-loop.ts # setImmediate hop for budgeted sweeps: the one shape
+                     #   long synchronous scans use to stay interruptible
 ```
 
-Exports map = exactly these seven subpaths; no barrel.
+Exports map = exactly these eight subpaths; no barrel.
 
 ## Invariants
 

--- a/packages/storage/package.json
+++ b/packages/storage/package.json
@@ -2,7 +2,7 @@
   "name": "@repo/storage",
   "version": "0.1.0",
   "private": true,
-  "description": "Node fs/json substrate for the Inteligir host: the versioned JsonStore over ~/.inteligir (atomic writes, quarantine-and-reset recovery, owner-only modes), the atomic-write primitive, the host lock, the boot-time permission sweep (hardenAppDir), the agent.log console tee, and the encrypted SecretStore. Leaf substrate — no capability imports; upward needs (secret cipher, session dirs, recovery notifier) are injected by the composing host.",
+  "description": "Node fs/json substrate for the Inteligir host: the versioned JsonStore over ~/.inteligir (atomic writes, quarantine-and-reset recovery, owner-only modes), the atomic-write primitive, the host lock, the boot-time permission sweep (hardenAppDir), the agent.log console tee, the encrypted SecretStore, and the shared event-loop yield long sweeps slice on. Leaf substrate — no capability imports; upward needs (secret cipher, session dirs, recovery notifier) are injected by the composing host.",
   "type": "module",
   "exports": {
     "./agent-log": "./src/agent-log.ts",
@@ -11,7 +11,8 @@
     "./harden-app-dir": "./src/harden-app-dir.ts",
     "./host-lock": "./src/host-lock.ts",
     "./json-store": "./src/json-store.ts",
-    "./secrets": "./src/secrets.ts"
+    "./secrets": "./src/secrets.ts",
+    "./yield-to-event-loop": "./src/yield-to-event-loop.ts"
   },
   "scripts": {
     "clean": "git clean -xdf .cache .turbo dist node_modules",

--- a/packages/storage/src/yield-to-event-loop.ts
+++ b/packages/storage/src/yield-to-event-loop.ts
@@ -1,0 +1,17 @@
+// ---------------------------------------------------------------------------
+// The one yield long synchronous sweeps use between slices. Lives in the leaf
+// substrate so every sweep in the host spells it the same way — the vault stat
+// sweep, the knowledge hydration/projection batches, and anything that follows.
+// ---------------------------------------------------------------------------
+
+/** Hand the event loop a turn between slices of a long sweep.
+ *
+ * `setImmediate`, NOT `setTimeout(resolve, 0)`: a timer is clamped to ~1ms, so
+ * a sweep budgeted in 15ms slices would pay a per-slice millisecond tax for
+ * nothing. And not a bare `await` either — a microtask hop never lets timers or
+ * I/O callbacks run, so it is not a yield at all. */
+export function yieldToEventLoop(): Promise<void> {
+  return new Promise((resolve) => {
+    setImmediate(resolve);
+  });
+}

--- a/packages/vault/src/__tests__/crawl-cost.test.ts
+++ b/packages/vault/src/__tests__/crawl-cost.test.ts
@@ -11,7 +11,8 @@
 //      the syscall count of a listing is one readdir per directory — nothing
 //      per file. Stats are filled in lazily and memoized on the snapshot, so
 //      the consumers that need them (knowledge reconcile, the sync hash cache)
-//      pay one stat per file BETWEEN them, not one each.
+//      pay one stat per DOC BETWEEN them, not one each — and nothing at all for
+//      the non-docs, whose identity nobody reads.
 //   2. The stat sweep behind listWithStats() runs in slices with event-loop
 //      yields, so no single synchronous step grows with the vault.
 //
@@ -70,19 +71,25 @@ function seed(files: number, folders: number): void {
   }
 }
 
-/** Count `fs.statSync` calls made while `run` executes. */
-function countStats<T>(run: () => T): { result: T; stats: number } {
+/** A live count of `fs.statSync` calls. A handle rather than a wrapper around
+ * `run()`, because the async sweeps under test have to be awaited INSIDE the
+ * spy's lifetime and a wrapper can only span a synchronous call. `restore()`
+ * belongs in a `finally` at every site — a failed expectation must not leak the
+ * mock into the next test. */
+function statSpy(): { count: () => number; reset: () => void; restore: () => void } {
   const real = fs.statSync.bind(fs);
   let stats = 0;
   const spy = vi.spyOn(fs, "statSync").mockImplementation((target, options) => {
     stats++;
     return real(target, options);
   });
-  try {
-    return { result: run(), stats };
-  } finally {
-    spy.mockRestore();
-  }
+  return {
+    count: () => stats,
+    reset: () => {
+      stats = 0;
+    },
+    restore: () => spy.mockRestore(),
+  };
 }
 
 /** Watch the event loop: how many turns it got, and the longest stretch it was
@@ -116,37 +123,58 @@ describe("vault crawl cost", () => {
 
     // A cold crawl, then the cached one, then the sync-facing listing: none of
     // them may cost a stat per file.
-    const cold = countStats(() => mgr.list());
-    expect(cold.result).toHaveLength(40);
-    expect(cold.stats).toBe(0);
-    expect(countStats(() => mgr.list()).stats).toBe(0);
-    expect(countStats(() => mgr.listAllPaths()).stats).toBe(0);
+    const stats = statSpy();
+    try {
+      expect(mgr.list()).toHaveLength(40);
+      expect(stats.count()).toBe(0);
+      mgr.list();
+      mgr.listAllPaths();
+      expect(stats.count()).toBe(0);
+    } finally {
+      stats.restore();
+    }
   });
 
-  it("stats each file at most once per snapshot, shared across consumers", async () => {
+  it("stats each doc at most once per snapshot, shared across consumers", async () => {
     const mgr = newManager();
     seed(40, 4);
     const paths = mgr.listAllPaths();
 
-    // The knowledge reconcile's sweep: one stat per file, no more.
-    const real = fs.statSync.bind(fs);
-    let stats = 0;
-    const spy = vi.spyOn(fs, "statSync").mockImplementation((target, options) => {
-      stats++;
-      return real(target, options);
-    });
+    // The knowledge reconcile's sweep: one stat per doc, no more.
+    const stats = statSpy();
     try {
       const listing = await mgr.listWithStats();
       expect(listing).toHaveLength(40);
-      expect(stats).toBe(40);
+      expect(stats.count()).toBe(40);
 
       // The sync hash cache asking for the same files inside the same snapshot
       // window reuses the memo instead of sweeping again.
-      stats = 0;
+      stats.reset();
       for (const p of paths) expect(mgr.statFingerprint(p)).not.toBeNull();
-      expect(stats).toBe(0);
+      expect(stats.count()).toBe(0);
     } finally {
-      spy.mockRestore();
+      stats.restore();
+    }
+  });
+
+  // Non-docs are tracked by path alone, so the sweep must not spend a syscall
+  // on them — and must not drop one whose stat would have failed, which the
+  // reconcile would read as a deletion and re-add on the very next pass.
+  it("does not stat non-docs, and lists them without identities", async () => {
+    const mgr = newManager();
+    mgr.writeText("note.md", "x");
+    mgr.writeText("assets/pic.png", "x");
+
+    const stats = statSpy();
+    try {
+      const listing = await mgr.listWithStats();
+      expect(listing.map((e) => e.path)).toEqual(["assets/pic.png", "note.md"]);
+      expect(stats.count()).toBe(1); // the doc only
+      for (const entry of listing) {
+        expect("mtimeMs" in entry).toBe(entry.kind === "doc");
+      }
+    } finally {
+      stats.restore();
     }
   });
 

--- a/packages/vault/src/vault.ts
+++ b/packages/vault/src/vault.ts
@@ -34,6 +34,7 @@ import { type Static, Type } from "@sinclair/typebox";
 
 import { atomicWrite } from "@repo/storage/atomic-write";
 import { JsonStore, inteligirPath, type FsAdapter } from "@repo/storage/json-store";
+import { yieldToEventLoop } from "@repo/storage/yield-to-event-loop";
 import { classifyFileChange, SelfSaveRegistry } from "./classify-file-change";
 import { isDocPath } from "@repo/notes/knowledge/doc-file";
 import type { VaultEntry } from "@repo/bridge/ipc-registry";
@@ -92,9 +93,14 @@ type VaultWalkEntry = { path: string; name: string; kind: VaultEntry["kind"] };
  * moving at least one of these. */
 type StatIdentity = { mtimeMs: number; size: number; ino: number };
 
-/** A listed vault file with its stat identity — the knowledge reconcile's diff
- * basis. */
-export type VaultStatEntry = VaultWalkEntry & StatIdentity;
+/** A listed vault file as the knowledge reconcile sees it. Only `doc` entries
+ * carry a stat identity — a doc's CONTENT is what gets re-projected when the
+ * identity moves, while a non-doc is tracked by path alone, so stat-ing one is
+ * a syscall nobody reads. Discriminated on `kind` so an unstat'd doc and a
+ * stat'd non-doc are both unrepresentable. */
+export type VaultListingEntry =
+  | (VaultWalkEntry & { kind: "doc" } & StatIdentity)
+  | (VaultWalkEntry & { kind: "other" });
 
 /** How long a walk snapshot may be reused. Bounds staleness for sync's
  * snapshot-served fingerprints; a refresh burst (window focus fans into
@@ -109,11 +115,13 @@ const STAT_SLICE_BUDGET_MS = 15;
 type VaultSnapshot = {
   at: number;
   root: string;
-  entries: VaultWalkEntry[];
-  /** Membership set over `entries`: tells `statFingerprint` whether a path came
-   * out of the crawl (already confined under the root) or has to go through the
-   * `resolve()` funnel. */
-  crawled: Set<string>;
+  /** The crawl's files, keyed by vault-relative path, in sorted path order
+   * (every listing serves that order straight off the iterator). Keyed rather
+   * than an array because membership is a second question asked of the same
+   * data: `statFingerprint` needs to know whether a path came out of the crawl
+   * (already confined under the root) or has to go through the `resolve()`
+   * funnel. */
+  entries: Map<string, VaultWalkEntry>;
   /** Stat identities, filled LAZILY by `statOf` and memoized here — so a
    * refresh burst pays each file's stat at most once no matter how many
    * consumers ask, and files nobody asks about cost nothing. */
@@ -256,7 +264,11 @@ export class VaultManager {
    * Drives the sidebar file tree. Served from the shared TTL snapshot so a
    * refresh burst crawls once. */
   list(): VaultEntry[] {
-    return this.getSnapshot().entries.map((e) => ({ path: e.path, name: e.name, kind: e.kind }));
+    return Array.from(this.getSnapshot().entries.values(), (e) => ({
+      path: e.path,
+      name: e.name,
+      kind: e.kind,
+    }));
   }
 
   /** Every file path under the vault (same crawl as list(), minus the entry
@@ -274,15 +286,15 @@ export class VaultManager {
   listAllPaths(): string[] {
     const snapshot = this.getSnapshot();
     if (!snapshot.complete) throw new VaultListingIncompleteError(snapshot.root);
-    return snapshot.entries.map((e) => e.path);
+    return Array.from(snapshot.entries.keys());
   }
 
-  /** The listing WITH stat identities — the knowledge reconcile's diff basis.
-   * Freshness follows the snapshot TTL: external edits surface on the next
-   * refresh trigger, exactly the ephemeral-liveness contract.
+  /** The listing WITH stat identities on the DOCS — the knowledge reconcile's
+   * diff basis. Freshness follows the snapshot TTL: external edits surface on
+   * the next refresh trigger, exactly the ephemeral-liveness contract.
    *
-   * ASYNC because one stat per file is the crawl's dominant syscall cost, and
-   * a whole-vault sweep in one uninterruptible call is a multi-hundred-
+   * ASYNC because one stat per doc is the crawl's dominant syscall cost, and a
+   * whole-vault sweep in one uninterruptible call is a multi-hundred-
    * millisecond stall on the host's only thread at 50k notes. The sweep runs in
    * `STAT_SLICE_BUDGET_MS` slices with event-loop yields between them
    * (SqlKnowledgeStore.hydrate's idiom), so no single synchronous step grows
@@ -290,20 +302,24 @@ export class VaultManager {
    * started on — a snapshot dropped mid-sweep still yields a coherent listing,
    * and the next refresh picks up whatever moved.
    *
-   * Lenient like list(): a file that can't be stat'd is simply absent, because
-   * derived knowledge self-heals on the next refresh. Only sync
-   * (`listAllPaths`) must refuse a partial, and it never stats at all. */
-  async listWithStats(): Promise<VaultStatEntry[]> {
+   * Lenient like list(): a DOC that can't be stat'd is simply absent, because
+   * derived knowledge self-heals on the next refresh. Non-docs never stat, so
+   * nothing can thin them out of the listing — a flaky mount would otherwise
+   * make the reconcile see an asset as deleted and re-add it every pass. Only
+   * sync (`listAllPaths`) must refuse a partial, and it never stats at all. */
+  async listWithStats(): Promise<VaultListingEntry[]> {
     // The slice clock starts BEFORE the walk: a cold call pays for its own
     // crawl, so charging that to the first slice makes the sweep yield right
     // after it rather than stacking a full slice on top of it.
     let sliceStart = Date.now();
     const snapshot = this.getSnapshot();
-    const entries: VaultStatEntry[] = [];
-    for (const entry of snapshot.entries) {
-      const identity = this.statOf(snapshot, entry.path);
-      if (identity !== null) {
-        entries.push({ path: entry.path, name: entry.name, kind: entry.kind, ...identity });
+    const entries: VaultListingEntry[] = [];
+    for (const entry of snapshot.entries.values()) {
+      if (entry.kind === "doc") {
+        const identity = this.statOf(snapshot, entry.path);
+        if (identity !== null) entries.push({ ...entry, kind: "doc", ...identity });
+      } else {
+        entries.push({ ...entry, kind: "other" });
       }
       if (Date.now() - sliceStart >= STAT_SLICE_BUDGET_MS) {
         await yieldToEventLoop();
@@ -331,11 +347,9 @@ export class VaultManager {
   // fail the pass loudly if those are unreadable too.
   private getSnapshot(): VaultSnapshot {
     const root = this.getRoot();
-    const cached = this.snapshot;
-    if (cached && cached.root === root && Date.now() - cached.at <= SNAPSHOT_TTL_MS) {
-      return cached;
-    }
-    let entries: VaultWalkEntry[] = [];
+    const fresh = this.freshSnapshot(root);
+    if (fresh !== null) return fresh;
+    const entries = new Map<string, VaultWalkEntry>();
     // A missing root is an INCOMPLETE crawl, not an empty vault — it feeds the
     // completeness flag (listAllPaths throws; list serves the empty partial)
     // rather than silently reading as "every file was deleted".
@@ -343,16 +357,15 @@ export class VaultManager {
     if (fs.existsSync(root)) {
       const walked = this.walk(root);
       complete = walked.complete;
-      entries = walked.entries;
-      entries.sort((a, b) => a.path.localeCompare(b.path));
+      // Keyed AFTER the sort, so iteration order is the sorted order every
+      // listing serves.
+      walked.entries.sort((a, b) => a.path.localeCompare(b.path));
+      for (const entry of walked.entries) entries.set(entry.path, entry);
     }
-    const crawled = new Set<string>();
-    for (const entry of entries) crawled.add(entry.path);
     const snapshot: VaultSnapshot = {
       at: Date.now(),
       root,
       entries,
-      crawled,
       stats: new Map(),
       complete,
     };
@@ -362,6 +375,16 @@ export class VaultManager {
     // the transient error has cleared.
     this.snapshot = complete ? snapshot : null;
     return snapshot;
+  }
+
+  // The cached snapshot when it is still serviceable — same root, inside the
+  // TTL — else null. The root is a PARAMETER because getRoot() reads the
+  // settings store: the caller that has already resolved it passes it in
+  // instead of paying for it twice.
+  private freshSnapshot(root: string): VaultSnapshot | null {
+    const cached = this.snapshot;
+    if (cached === null || cached.root !== root) return null;
+    return Date.now() - cached.at <= SNAPSHOT_TTL_MS ? cached : null;
   }
 
   // The stat identity of a CRAWLED path, memoized onto its snapshot so every
@@ -516,13 +539,8 @@ export class VaultManager {
    * (ignored files opened directly, non-listing spellings) falls through to a
    * resolve()-confined live stat, never to a false null. */
   statFingerprint(rel: string): string | null {
-    const cached = this.snapshot;
-    if (
-      cached &&
-      cached.root === this.getRoot() &&
-      Date.now() - cached.at <= SNAPSHOT_TTL_MS &&
-      cached.crawled.has(rel)
-    ) {
+    const cached = this.freshSnapshot(this.getRoot());
+    if (cached !== null && cached.entries.has(rel)) {
       const identity = this.statOf(cached, rel);
       return identity === null ? null : fingerprintOf(identity);
     }
@@ -841,13 +859,6 @@ function fingerprintOf(identity: StatIdentity): string {
  * filesystem root. */
 function childPath(dir: string, name: string): string {
   return dir.endsWith(path.sep) ? dir + name : dir + path.sep + name;
-}
-
-/** Hand the event loop a turn between slices of a long sweep. */
-function yieldToEventLoop(): Promise<void> {
-  return new Promise((resolve) => {
-    setImmediate(resolve);
-  });
 }
 
 /** Canonical path with symlinks resolved. For a path that doesn't exist yet,


### PR DESCRIPTION
`/simplify` over `fd7670d9..HEAD` — four parallel review angles (reuse, simplification, efficiency, altitude), 22 findings deduped, **24 applied, 2 skipped**. Net **−64 lines**.

Two findings are critiques of code this session added. Both are real.

## The privacy probe was per link *occurrence*

`forwardLinks` called `isPublicNow` once per occurrence, and each probe is a `readFileSync` plus two `realpathSync` of the target note. A hub note linking the same target twenty times paid **twenty identical disk round-trips inside one call**. Worse, the `LINKS_MAX` / `BACKLINKS_MAX` caps I added sit one layer *above* the port — so they bounded the output but never the work.

Every filtering port method (`search`, `backlinks`, `forwardLinks`, `relatedNotes`, `notesWithTag`) now opens a per-call memo, shared with its subject/target pre-check. Semantics are unaffected: each filter runs to completion synchronously, so no write can interleave and the memo can never observe a state the raw probe wouldn't have.

## The graph view stampeded the rebuild it was watching

`refresh()` fired an unawaited `getLinkGraph` per `onKnowledgeUpdated` with no coalescing — and `KnowledgeManager` emits progress every **250ms** during hydration and rebuild. Bursts stacked whole-vault graph assemblies on top of the rebuild that triggered them. I cut that payload 44× last PR and left a stampede in front of it.

Now debounced, with a monotonic sequence token so a slow earlier response can't land over a newer one's layout (the pattern this renderer already uses in four other places). First paint stays immediate.

## Tags shouldn't have been special

The feature invented three ad-hoc refresh triggers — vault listing, open-note `saving`, and its own — instead of subscribing to `onKnowledgeUpdated` like every other knowledge-derived surface. Now matches `links-panel` and `tasks-view` exactly. `refreshTags` holds array identity when the list is unchanged, so the higher cadence costs no renders.

## Reuse

- The inline-tag **scanner** moved to `@repo/notes` beside the pattern, and `INLINE_TAG_RE` is module-private again. Exporting the regex was meant to stop grammar drift, but the trailing-dash trim — which *is* part of the grammar — had been copy-pasted anyway. The scanner is the real seam.
- `yieldToEventLoop` is one shared primitive in `@repo/storage` rather than three re-derivations. Three copies means no contract, and the next site is free to reach for `setTimeout(resolve, 0)` — a clamped timer that turns a 15ms-slice sweep into a per-slice tax.
- The two knowledge perf suites shared one synthetic corpus. They had *identical* constants and both headers claimed measurements against "the same" corpus, with nothing making that true. Their `SqlDriver.reset()` stubs also both violated the documented contract (one shadowed the DB method, one left six tables behind) — fixed in the shared driver.

## Simplification

`selectNodes` returns the rank `Map` directly instead of a `Set` the caller re-derived; the degree fill is a counting sort; `edgeDistance`'s unreachable `?? 0` fallbacks are gone, with the induced filter and cut score collapsed into one pass; `SEARCH_SQL`/`SEARCH_PUBLIC_SQL` cut from one template so the bm25 weights can't drift; `VaultSnapshot.crawled` deleted in favour of a `Map`; the snapshot freshness predicate extracted.

## Skipped, deliberately

- **Pushing the caps down into `KnowledgePort`** — changes a published interface bound by the agent tools and the harness, for strictly less than the memoization already delivers.
- **Exporting `syntheticBody`/`syntheticRow`** from the shared corpus — `seedStore` is their only consumer, and server's knip config would redden the gate on unused exports of a non-test module.

## Verification

Full `pnpm verify` green; byte-pinned fixtures untouched.

- Selection order proven byte-identical by an **8,400-case randomized differential** (old Set path vs new Map + counting sort, across random graphs × focus ∈ {none, unknown, random} × maxNodes ∈ {0,1,2,5,13,n,n+5}) — zero mismatches.
- The `Map` conversion measured on the crawl benchmark at 50k files, old/new interleaved 3× on the same box; deltas sit inside the baseline's own run-to-run spread.
- The regenerated SQL compared byte-for-byte against the two prior literals.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014tQQ3Jt3xQ9XdmXcFtXkDt


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refactors to cut redundant disk work and coalesce knowledge-driven updates. Graph stays responsive during rebuilds; tags and tools stay in step with the index.

- **Refactors**
  - Memoized per-call privacy probes in the agent port; applied to `search`, `backlinks`, `forwardLinks`, `relatedNotes`, and `notesWithTag`.
  - Graph view refresh debounced on `onKnowledgeUpdated` with a sequence guard; first paint remains immediate.
  - Tags list refreshes off `onKnowledgeUpdated`; stable array identity avoids no-op renders.
  - Moved the inline tag scanner to `@repo/notes/knowledge/link-extract` and consume it in the editor; pattern is module-private again.
  - Added `@repo/storage/yield-to-event-loop` and adopted it in the knowledge manager and `ws-host`.
  - Unified FTS search SQL via a template so bm25/snippet settings match between public and agent queries.
  - Simplified link-graph assembly: `selectNodes` returns a rank `Map`, degree fill via counting sort, and a single-pass edge cut; vault snapshot entries use a `Map` with an extracted freshness check.
  - Tests share a single synthetic corpus; docs link check now uses `scanDoc`.

<sup>Written for commit d9a75b8cd17433f7fb71376968df7a539b9e7135. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kyh/inteligir/pull/482?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

