### PR TITLE
fix(release): make the packaged fuse check actually run

### DIFF
--- a/apps/desktop/scripts/verify-packaged-runtime-deps.mjs
+++ b/apps/desktop/scripts/verify-packaged-runtime-deps.mjs
@@ -18,7 +18,14 @@ import { existsSync, readdirSync, readFileSync, statSync } from "node:fs";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
-import { FuseState, FuseV1Options, getCurrentFuseWire } from "@electron/fuses";
+import { FuseV1Options, getCurrentFuseWire } from "@electron/fuses";
+
+// @electron/fuses is CommonJS and re-exports only FuseV1Options / FuseVersion /
+// flipFuses / getCurrentFuseWire from its root — its FuseState enum lives in an
+// unexported module, so the two wire values are named here. The wire stores each
+// fuse as the ASCII digit, not a boolean.
+const DISABLE = 0x30; // "0"
+const ENABLE = 0x31; // "1"
 
 // The fuse state electron-builder.yml's `electronFuses` block must produce, read
 // back off the SHIPPED BINARY rather than off the config — a config-only check
@@ -30,20 +37,20 @@ import { FuseState, FuseV1Options, getCurrentFuseWire } from "@electron/fuses";
 // renderer still loads over file://, so it must stay enabled. Assert nothing
 // about it here rather than pinning a value we intend to change.
 const EXPECTED_FUSES = [
-  [FuseV1Options.RunAsNode, FuseState.DISABLE, "runAsNode"],
+  [FuseV1Options.RunAsNode, DISABLE, "runAsNode"],
   [
     FuseV1Options.EnableNodeOptionsEnvironmentVariable,
-    FuseState.DISABLE,
+    DISABLE,
     "enableNodeOptionsEnvironmentVariable",
   ],
-  [FuseV1Options.EnableNodeCliInspectArguments, FuseState.DISABLE, "enableNodeCliInspectArguments"],
-  [FuseV1Options.EnableCookieEncryption, FuseState.ENABLE, "enableCookieEncryption"],
+  [FuseV1Options.EnableNodeCliInspectArguments, DISABLE, "enableNodeCliInspectArguments"],
+  [FuseV1Options.EnableCookieEncryption, ENABLE, "enableCookieEncryption"],
   [
     FuseV1Options.EnableEmbeddedAsarIntegrityValidation,
-    FuseState.ENABLE,
+    ENABLE,
     "enableEmbeddedAsarIntegrityValidation",
   ],
-  [FuseV1Options.OnlyLoadAppFromAsar, FuseState.ENABLE, "onlyLoadAppFromAsar"],
+  [FuseV1Options.OnlyLoadAppFromAsar, ENABLE, "onlyLoadAppFromAsar"],
 ];
 
 // Resolve paths relative to the desktop app root (this script's parent
@@ -168,21 +175,20 @@ if (process.env.INTELIGIR_SKIP_NOTARY_CHECK === "1") {
   }
 }
 
-// Electron fuses, read off the app's own Mach-O executable. A regression here
-// is invisible in dev (fuses only exist in a packaged binary) and silently
-// re-opens the code-execution surface the hardened runtime is supposed to shut.
-const appExecutable = join(
-  app,
-  "Contents",
-  "MacOS",
-  readdirSync(join(app, "Contents", "MacOS"))[0],
-);
-const wire = await getCurrentFuseWire(appExecutable);
+// Electron fuses, read off the shipped bundle. A regression here is invisible in
+// dev (fuses only exist in a packaged binary) and silently re-opens the
+// code-execution surface the hardened runtime is supposed to shut.
+//
+// getCurrentFuseWire takes the .app BUNDLE, not the executable inside it — on
+// macOS the wire lives in the embedded Electron Framework, which it resolves
+// itself. Handing it Contents/MacOS/<exe> makes it look for the framework under
+// that path and fail with ENOENT.
+const wire = await getCurrentFuseWire(app);
 const fuseFailures = [];
 for (const [fuse, expected, label] of EXPECTED_FUSES) {
   const actual = wire[fuse];
   if (actual !== expected) {
-    const want = expected === FuseState.ENABLE ? "enabled" : "disabled";
+    const want = expected === ENABLE ? "enabled" : "disabled";
     fuseFailures.push(`${label} should be ${want} (wire value ${String(actual)})`);
   }
 }


### PR DESCRIPTION
The `electronFuses` verification I added in #475 was itself broken. Two defects, both only reachable from a real packaged build — which is the gap the check exists to close, and exactly why it shipped broken.

## What was wrong

1. **`@electron/fuses` is CommonJS.** It re-exports only `FuseV1Options`, `FuseVersion`, `flipFuses` and `getCurrentFuseWire` from its root — `FuseState` lives in an unexported module. The named ESM import threw `SyntaxError` at load, so `verify:packaged` died before asserting anything. My earlier `import('@electron/fuses').then(…)` probe resolved `getCurrentFuseWire` fine, which is what made me think named imports worked; the enums aren't picked up by Node's cjs-module-lexer.
2. **Wrong path.** `getCurrentFuseWire` takes the `.app` **bundle**, not the executable inside it — on macOS the wire lives in the embedded Electron Framework, which it resolves itself. Passing `Contents/MacOS/<exe>` made it look for the framework beneath that path and fail with `ENOENT`.

## Verified against a real signed, notarized build

`pnpm -F @repo/desktop release` (`--publish never`) ran end to end:

```
[verify-packaged] OK: notarization ticket stapled
[verify-packaged] OK: Gatekeeper accepted
[verify-packaged] OK: 6 Electron fuses set as configured
[verify-packaged] All checks passed
```

Plus, on the shipped artifact:

- `codesign --verify --deep --strict` → valid on disk, satisfies its Designated Requirement.
- Shipped entitlements no longer carry `allow-dyld-environment-variables`. The remaining six are apple-events, allow-jit, allow-unsigned-executable-memory, disable-library-validation, audio-input, network.client.
- The app **launches** and reaches `setting_up -> ready` in 1.9s, main process plus renderer helpers, zero crash reports. That clears the risk flagged in #475: `enableEmbeddedAsarIntegrityValidation` and `onlyLoadAppFromAsar` fail closed, and neither does.
- The fuses are **enforced**, not merely present in the wire: `ELECTRON_RUN_AS_NODE=1 … -e 'console.log("RAN_AS_NODE")'` does not execute the script, and `--inspect=9333` opens no debugger port.

## Still unverified

**Voice STT.** The sherpa native addon is asar-unpacked and correctly signed (`codesign --verify --deep` covers it, and all four dylibs carry signatures), but confirming it actually *loads* means clicking the mic, which turns on the microphone — not something I'll do unprompted. One click in the packaged app closes it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014tQQ3Jt3xQ9XdmXcFtXkDt


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the packaged release fuse verification so it actually runs by correcting the `@electron/fuses` import and passing the `.app` bundle to `getCurrentFuseWire`. This prevents silent regressions in Electron fuse settings during release.

- **Bug Fixes**
  - Use CJS-compatible access to `@electron/fuses` and define local wire values for ENABLE/DISABLE (ASCII "1"/"0") since `FuseState` isn’t exported, avoiding a load-time SyntaxError.
  - Call `getCurrentFuseWire(app)` with the `.app` bundle (not `Contents/MacOS/<exe>`), fixing the framework resolution and ENOENT failure on macOS.

<sup>Written for commit e9ff3e7242566deec3df34499b07f0f60f1e5249. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kyh/inteligir/pull/483?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

