### PR TITLE
feat(agent): adopt agent-native conventions — skills UI, budgets, guards

### DIFF
--- a/.claude/skills/add-bridge-channel/SKILL.md
+++ b/.claude/skills/add-bridge-channel/SKILL.md
@@ -1,0 +1,237 @@
+---
+name: add-bridge-channel
+description: Add a channel to the Bridge — the host↔UI IPC contract behind every renderer and mobile call. Covers the registry entry in @repo/bridge, the host handler in @repo/server, the dev-harness fixture stub, event emission + reconnect hydration, and the remote-device allowlist decision. Use when a UI surface needs data or an action the host owns, or when host-side state must push to the UI.
+allowed-tools: Bash(*), Read, Edit, Write
+---
+
+# Add a Bridge channel
+
+The Bridge is the ONLY way the renderer (and the Expo companion) reaches the
+host. `packages/bridge/src/ipc-registry.ts` is its single source of truth: each
+entry pairs a TypeBox payload schema with a result/event type, and the `Bridge`
+type, the ws transport's dispatch, and the host handler map are all DERIVED from
+it. A channel is not "wired up" until three files agree, and the compiler
+enforces all three.
+
+## Read first
+
+- `packages/bridge/src/ipc-registry.ts` — the registry, the entry helpers
+  (`invoke` / `invokeVoid` / `send` / `event`), the method partitions, and the
+  remote allowlists.
+- `packages/server/src/handlers/handler-registry.ts` — `collectHandlers`, which
+  validates payloads and throws at boot on a missing or duplicate handler.
+- `apps/desktop/dev/fixture-bridge.ts` — the header's stub convention.
+- CLAUDE.md § "Remote-device capability is an ALLOWLIST, never a blocklist".
+
+## The four entry kinds
+
+```ts
+invoke<Schema, Result>(schema); // UI → host, payload, awaited result
+invokeVoid<Result>(); // UI → host, no payload, awaited result
+send<Schema>(schema); // UI → host, fire-and-forget (throws are swallowed + logged)
+event<Payload>(); // host → UI push; no handler, emitted via emitEvent
+```
+
+Pick `invoke` unless the call genuinely has nothing to say back. Failure that
+the UI must branch on is a **VALUE, not a throw** — `toggleVaultTask` returns
+`{ok:false, reason}` because the host has already self-healed and the renderer
+needs to know which refusal it hit. Reserve throws for programmer error.
+
+## Files to touch
+
+The worked example below is `toggleVaultTask` (invoke) and its sibling
+`onKnowledgeUpdated` (event) — read them end to end in the tree; they are the
+smallest complete pair.
+
+### 1. Registry entry — `packages/bridge/src/ipc-registry.ts`
+
+Schema near the other schemas, entry in the domain-grouped registry block.
+`additionalProperties: false` on every object schema.
+
+```ts
+// Guarded task toggle — keyed by ORDINAL (delegation's anchor key; survives
+// line shifts and duplicate identical lines) plus the exact recorded line.
+const ToggleTaskSchema = Type.Object(
+  {
+    path: Type.String(),
+    /** Position among the file's GFM task items (find-task-line's counting). */
+    ordinal: Type.Number({ minimum: 0 }),
+    /** The task's exact untrimmed source line (terminator excluded) as the
+     * projection recorded it — the write proceeds only on byte equality. */
+    expectedRaw: Type.String(),
+  },
+  { additionalProperties: false },
+);
+
+/** toggleVaultTask's verdict. Failures are VALUES, never throws: the host has
+ * already kicked an index refresh, so the renderer refetches + toasts. */
+export type ToggleTaskResult =
+  | { ok: true; checked: boolean }
+  | { ok: false; reason: "line-missing" | "line-changed" | "not-a-checkbox"; error: string };
+```
+
+```ts
+  toggleVaultTask: invoke<typeof ToggleTaskSchema, ToggleTaskResult>(ToggleTaskSchema),
+```
+
+The doc comment on the entry is the channel's contract — the renderer author
+reads it instead of the handler. Say what the host guarantees and what a
+failure means.
+
+### 2. Host handler — `packages/server/src/handlers/<domain>-handlers.ts`
+
+One `register<Domain>Handlers(handle)` per domain file, all called from
+`register-handlers.ts`. The registrar is per-method typed: the payload and
+result types come from the registry, so a typo'd method name is a compile error.
+
+```ts
+export function registerKnowledgeHandlers(handle: HandlerRegistrar): void {
+  handle("listVaultTasks", () => getKnowledgeManager().tasks());
+  handle("toggleVaultTask", ({ path, ordinal, expectedRaw }): ToggleTaskResult => {
+    ...
+  });
+}
+```
+
+Adding a whole new domain = a new `*-handlers.ts` plus one line in
+`registerAllHandlers`. Reach host services through their `getX()` singletons
+(`getVaultManager()`, `getKnowledgeManager()`) — that is the deliberate model,
+not an omission (CLAUDE.md § "Host services are process-global `getX()`
+singletons ON PURPOSE").
+
+Two channels are NOT host-owned: `DESKTOP_SHELL_METHODS` (the `vault-app://`
+token mint/revoke) are implemented by the Electron shell and passed to
+`startWsHost` as `shellHandlers` (`apps/desktop/src/main/index.ts`). Only add
+to that set when the handler must touch main-process state the host package
+cannot see.
+
+### 3. Fixture stub — `apps/desktop/dev/fixture-bridge.ts`
+
+The harness's Bridge is typed `: Bridge`, so this file **fails typecheck until
+the channel is covered**. The convention from its header:
+
+> Make the stub DO something real against the in-memory state, or throw
+> `unavailable("<feature>")` naming the gap. Never silently return
+> `[]`/undefined/false where the real host would act — a stub that answers
+> wrong is worse than an error that names itself.
+
+The toggle stub runs the SAME pure core the host handler does, over the
+in-memory vault:
+
+```ts
+    toggleVaultTask: async ({ path, ordinal, expectedRaw }) => {
+      const content = vault.get(path);
+      if (content === undefined) {
+        return { ok: false, reason: "line-missing", error: `no such file: ${path}` };
+      }
+      const result = toggleTaskAtOrdinal(content, ordinal, expectedRaw);
+      ...
+    },
+```
+
+Events subscribe through the file's `Emitter`: `onKnowledgeUpdated:
+knowledgeEvents.subscribe`.
+
+### 4. The caller — renderer or mobile
+
+Renderer code reaches the Bridge only through `getBridge()`
+(`apps/desktop/src/renderer/lib/bridge.ts`); it never imports electron, node, or
+`@repo/server` (lint-enforced, and the dep edge does not exist).
+
+```ts
+const result = await getBridge()
+  .toggleVaultTask({ path: task.path, ordinal: task.ordinal, expectedRaw: task.raw })
+  .catch(() => null);
+```
+
+Mobile needs no per-channel work: `apps/mobile` dials the same host through the
+generic `createWsBridge`, so the derived `Bridge` type carries the new method
+automatically — subject to the allowlist in step 6.
+
+### 5. Events only — emit, and decide about hydration
+
+Host code emits through `packages/server/src/events.ts`; the ws host subscribes
+and fans out.
+
+```ts
+      () => emitEvent("onKnowledgeUpdated", {}),
+```
+
+If the event carries **state a late-joining client must not be stale about**,
+pair it with the getter that answers the same shape in `HYDRATED_EVENTS`:
+
+```ts
+export const HYDRATED_EVENTS = {
+  onRemoteAccessChanged: "getRemoteAccessState",
+  onSyncStateChanged: "getSyncState",
+  ...
+} as const satisfies { readonly [E in EventMethod]?: HydrationGetter<E> };
+```
+
+`HydrationGetter<E>` proves the getter's result type EQUALS the event payload in
+both directions, so the pair cannot drift. Pure invalidation pings
+(`onKnowledgeUpdated`) need no entry — the client refetches anyway.
+
+### 6. Remote-device allowlist — decide, and default to NO
+
+`REMOTE_ALLOWED_METHODS` / `REMOTE_ALLOWED_EVENTS` are the ONLY things a paired
+phone may reach. They are allowlists so a new channel is unreachable until
+someone names it on purpose. **The default answer is: do not add it.** Adding
+one is a deliberate act with a threat model attached — say in the PR why a
+network-reachable device needs it, and remember the ws host enforces the lists at
+three points (invoke/send dispatch, event broadcast, reconnect hydration).
+
+## Rules
+
+- Never widen a payload with `Type.Any()`. `Type.Unknown()` emits the same wire
+  schema but forces the handler to narrow; `Any` puts a real `any` into the
+  derived `Bridge` type and exempts every caller from the repo's no-any rule.
+  See `BinaryAudioSchema` for the one place `unknown` is correct and why.
+- Never renumber a `BINARY_CHANNELS` tag — those are wire values. Retire and
+  take the next.
+- Don't add a `dispatch.get(...)` or a fresh `authedSockets` loop in
+  `ws-host.ts`. Route through `resolveHandler()` / `sendEvent()`; a second gate
+  call site is how holes appear.
+- Deleting a channel is also three files plus its callers — leave no orphan
+  registry entry.
+- Naming a channel in prose (a doc, this skill) counts as a CALLER to the
+  dead-channel guard, which scans `docs/` and `.claude/` too. Don't write a
+  channel's name into documentation to keep a test green.
+
+## Verify
+
+Static, narrow first:
+
+```bash
+pnpm --filter @repo/bridge typecheck    # registry compiles, derived Bridge type is sound
+pnpm --filter @repo/desktop typecheck   # fixture-bridge covers the channel (dev/ is in tsconfig)
+pnpm --filter @repo/server test         # handler completeness + gate guards
+pnpm --filter @repo/bridge test         # ws protocol
+```
+
+`pnpm --filter @repo/server test` is the one that matters. It runs:
+
+- `src/__tests__/register-handlers.test.ts` — the real handler groups cover
+  exactly `HOST_METHODS`.
+- `src/__tests__/handler-registry.test.ts` — the partitions add up
+  (host + desktop-shell = every non-event method) and `collectHandlers` throws
+  by name on a gap.
+- `src/__tests__/no-dead-channels.test.ts` — every registry method has a caller
+  outside the registry, the handlers dir, and the fixture.
+- `src/transport/__tests__/no-ungated-dispatch.test.ts` — the remote gate still
+  has exactly two chokepoints.
+- `src/transport/__tests__/ws-transport.test.ts` — a real client over the real
+  host.
+
+Then drive it. Type-checks are not feature-correct:
+
+```bash
+pnpm --filter @repo/desktop dev:harness   # localhost:5173, fixture Bridge
+```
+
+…and for anything the fixture can only approximate, the real app —
+`pnpm dev:desktop` then `agent-browser connect 9222`. Any Bridge method can be
+called directly from `agent-browser eval` via `window.bridgeBootstrap`; see the
+`e2e-drive` skill.
+
+Before committing: `pnpm format:fix && pnpm verify` (format FIRST, never after).

--- a/.claude/skills/add-editor-node/SKILL.md
+++ b/.claude/skills/add-editor-node/SKILL.md
@@ -1,0 +1,275 @@
+---
+name: add-editor-node
+description: Add a node type to the Plate editor — the Base + React kit pair, the base-kit composition, the Slate↔mdast rule, the MDX vocabulary gate in @repo/notes, an insert surface, and the byte-pinned round-trip fixtures that prove it. Use when a new block or inline needs to render and, above all, survive a save byte-for-byte.
+allowed-tools: Bash(*), Read, Edit, Write
+---
+
+# Add an editor node type
+
+Notes are markdown on disk. A node type is therefore not a component — it is a
+**byte contract**: parse → Slate → serialize must land on the same bytes, and
+must be idempotent. Get this wrong and a user's file silently reflows (or a
+block silently disappears) on the first autosave.
+
+Two editors exist and must stay identical: the headless mirror (`BASE_KIT`,
+which the parse/serialize gate builds) and the live editor (`EDITOR_KIT`). Both
+are composed from the SAME kit files, one exporting both halves. `kit-parity`
+turns that premise into CI.
+
+## Read first
+
+- `apps/desktop/src/renderer/editor/kits/base-kit.ts` and `editor-kit.ts` — the
+  two compositions and the comments explaining why they mirror.
+- `apps/desktop/src/renderer/editor/markdown/md-rules.ts` — the header's rule
+  dispatch note: **deserialize routes by mdast type (JSX by tag name), serialize
+  by the Slate node's plugin key.** That asymmetry explains half the file.
+- `packages/notes/src/markdown/vocabulary.ts` — the whole gate, ~100 lines.
+- `apps/desktop/src/renderer/__tests__/markdown-roundtrip.test.ts` — the fixture
+  matrix contract, stated at the top of the file.
+- CLAUDE.md § "UI — one fixed workspace" for where the pipeline sits.
+
+## Decide first: does the node have bytes, and in what syntax?
+
+- **MDX component** (`<toggle>`, `<column_group>`, `<video>`, `<date>`) — the
+  normal case. Needs a vocabulary allowlist entry and usually an `MD_RULES`
+  rule.
+- **Standard markdown / GFM** (headings, tables, task items) — remark already
+  parses it; you need a kit and possibly a serialize override, no vocabulary
+  change.
+- **Custom inline syntax** (`[[wiki-links]]`) — needs a remark micromark
+  extension in `packages/notes/src/markdown/` plus a slot in
+  `MD_REMARK_PLUGINS` (`md-plugins.ts`, where **plugin order is load-bearing**
+  and pinned by the fixtures).
+- **Render-only, never serialized** (the `#tag` chips) — a decoration, no Base
+  half at all. `TagChipKit` is the precedent; it is deliberately absent from
+  `BASE_KIT` because a leaf decoration never reaches the value.
+
+The vocabulary is a LOCKED list. Adding a tag to it means every vault file
+containing that tag now opens Rich instead of Raw — a one-way promise that the
+pipeline can represent it losslessly. Do not add one casually.
+
+## Files to touch
+
+Worked example: `date` (an inline void with a deserialize-only rule and a flow
+edge case) and `callout` / `toggle` (MDX flow blocks).
+
+### 1. The kit — `editor/kits/<name>-kit.tsx`
+
+One file, both halves. The Base half is headless; the React half is the SAME
+plugin `.withComponent(...)`, so metadata cannot diverge:
+
+```ts
+export const CalloutBaseKit = [CalloutBasePlugin];
+
+export const CalloutKit = [CalloutBasePlugin.withComponent(CalloutElement)];
+```
+
+For a node Plate already ships, import both halves from the package:
+
+```ts
+export const DateBaseKit = [BaseDatePlugin];
+export const DateKit = [DatePlugin.withComponent(DateElement)];
+```
+
+For a bespoke one, `createSlatePlugin` — and **register `isInline` / `isVoid`
+if it is one**. A missing registration lets Slate normalization DELETE the node
+from a canonical file on first edit; `kit-parity` asserts it explicitly:
+
+```ts
+const wikiLinkBasePlugin = createSlatePlugin({
+  key: "wikiLink",
+  node: { isElement: true, isInline: true, isVoid: true },
+});
+```
+
+Live-editor-only behavior (input rules, `overrideEditor` transforms, the
+`normalizeNode` that repairs a parsed shape) belongs on the React half ONLY —
+the headless gate must never normalize, or a file's bytes change just by being
+opened. `toggle-kit.tsx` states this in its `normalizeNode` comment.
+
+### 2. The component — `editor/nodes/<name>-node.tsx`
+
+A `PlateElement` wrapper reading attributes off `props.element` with `typeof`
+narrows (the repo bans `as`):
+
+```tsx
+export function CalloutElement(props: PlateElementProps) {
+  const variant =
+    typeof props.element.variant === "string" ? props.element.variant.toLowerCase() : "";
+```
+
+**Never import vault-context, the open-note store, or transclusion eagerly from
+a kit or its component.** `base-kit.ts` composes the kits, so an eager reach-back
+closes an import cycle whose failure mode is an `undefined` kit export at module
+init. Use `React.lazy(() => import(...))` — `wiki-link-kit.tsx` is the pattern —
+and `apps/desktop/src/__tests__/editor-import-cycles.test.ts` enforces it (oxlint
+and knip do not detect cycles).
+
+### 3. Compose — `base-kit.ts` AND `editor-kit.ts`
+
+Add the Base half to `BASE_KIT`, the React half to `EDITOR_KIT`, in the same
+relative position. `EDITOR_KIT` must stay a plugin SUPERSET of `BASE_KIT`;
+`kit-parity` fails on drift, and if the node is part of the MDX vocabulary its
+plugin key must also join `VOCABULARY_PLUGIN_KEYS` in that test.
+
+### 4. The markdown rule — `editor/markdown/md-rules.ts`
+
+Only if the node has bytes. Check whether `@platejs/markdown`'s `defaultRules`
+already handles it: `column`, `column_group`, `date`, `equation`,
+`inline_equation` are free from defaults (fixture-test them, do NOT redefine).
+Some defaults are wrong for this repo and get wrapped with delegation (`a`,
+`table`, `blockquote`), and some ship a type-table entry with no rule at all:
+
+```ts
+  // Plate maps `toggle` in its type table but ships NO rule — serializing a
+  // toggle without this one silently DROPS the block (probe-proven).
+  toggle: {
+    deserialize: (node, deco, options) => ({
+      children: convertChildrenDeserialize(node.children, deco, options),
+      type: "toggle",
+      ...parseAttributes(node.attributes),
+    }),
+    serialize: (node, options) => jsxFlowSerialize(node, options, { name: "toggle" }),
+  },
+```
+
+A rule may be one-directional. `date` overrides deserialize only, because the
+default serializer's `<date value="…" />` on its own line re-parses as a FLOW
+element and must be wrapped back into a paragraph to round-trip:
+
+```ts
+const chip: TElement = defaultDateDeserialize(node, deco, options);
+if (node.type !== "mdxJsxFlowElement") return chip;
+return { children: [{ text: "" }, chip, { text: "" }], type: "p" };
+```
+
+Pull every `defaultRules` handler you delegate to into a module-level const with
+a throw if it is missing — that is how a `@platejs/markdown` bump fails loudly at
+import instead of silently corrupting files.
+
+### 5. The vocabulary gate — `packages/notes/src/markdown/vocabulary.ts`
+
+MDX nodes only. Anything outside this scan sends the whole file to Raw mode
+rather than being mangled — that is the safety property, so widening it is the
+risky direction.
+
+```ts
+const ALLOWED_FLOW_TAGS = new Set([
+  "callout",
+  "toggle",
+  "column_group",
+  "column",
+  "video",
+  "media_embed",
+  "file",
+  "date",
+]);
+const ALLOWED_TEXT_TAGS = new Set(["date"]);
+```
+
+Attributes are gated too. Unknown attribute NAMES are fine on flow tags (their
+rules spread string props both directions), but the value must be a plain string
+`mdxJsxAttribute` — bare booleans, braced expressions and spreads do not survive
+`parseAttributes`/`propsToAttributes`. If your rule DROPS unknown attributes the
+way Plate's `date` rule does, add a per-tag allowlist like `DATE_ATTRS`;
+otherwise the first rich save deletes user content.
+
+### 6. An insert surface
+
+Slash menu entries live in `GROUPS` in `editor/slash-menu.tsx`; the insert
+transform belongs in the kit file next to the node it builds
+(`insertDate`, `insertToggle`, `insertColumnGroup`). Inline voids go in via
+`insertVoidAndEscape` (`editor/insert-void.ts`) so the caret can escape:
+
+```ts
+export function insertDate(editor: PlateEditor): void {
+  const iso = formatIsoDate(new Date());
+  insertVoidAndEscape(editor, { children: [{ text: "" }], date: iso, type: KEYS.date });
+  editor.tf.insertText(" ");
+}
+```
+
+Block menu / turn-into and the floating toolbar are separate surfaces — wire
+only the ones the node actually needs.
+
+### 7. Fixtures — `apps/desktop/src/renderer/__tests__/fixtures/roundtrip/`
+
+**Their bytes ARE the test contract** (trailing spaces, indentation, line
+endings). oxfmt ignores the directory (`.oxfmtrc.json` `ignorePatterns`) and so
+must you — formatting them is corruption, and so is hand-typing them.
+
+Three classes, one file per behavior:
+
+| dir          | shape                | asserts                                                                              |
+| ------------ | -------------------- | ------------------------------------------------------------------------------------ |
+| `canonical/` | `<name>.md`          | `roundTrip(src) === src` (mod trailing newline), idempotent, `canonical && richSafe` |
+| `churn/`     | `<stem>.{in,out}.md` | `roundTrip(in) === out` and `roundTrip(out) === out`                                 |
+| `raw/`       | `<name>.<kind>.md`   | `richSafe === false`, `rawReason.kind` = the filename's second-to-last segment       |
+
+Generate the bytes through the pipeline (`roundTrip` / `toCanonical` from
+`editor/markdown/markdown-doc.ts`), never by hand. Add at least a canonical
+fixture for the node's happy form, and — if the node has an empty or degenerate
+state — a churn pair proving normalization settles. Read the `column` rule's
+comment in `md-rules.ts` for the shape of that trap: an empty column that
+serialized as expanded blank content re-parsed to zero children and re-emitted
+self-closed, a non-idempotent first pass that knocks the file to Raw on the
+next autosave.
+
+`canonical/kitchen-sink.md` is also the dev harness's full-vocabulary sample
+note (`fixture-bridge.ts` imports it) — a vocabulary addition belongs there so
+the harness exercises it.
+
+## Rules
+
+- A serializer change that reshapes ANY byte of a canonical fixture is a
+  regression. Fix the serializer; re-pin the fixture only as a conscious
+  canonical-form revision, said out loud in the commit.
+- `deserializeMd` from `@platejs/markdown` is BANNED in app code — its regex
+  `htmlToJsx` pre-pass is fence-unaware and rewrites HTML inside fenced blocks.
+  Parse through `parseMdast` + `scanVocabulary` + `mdastToSlate`
+  (`markdown-kit.ts` replaces the stock paste parser for this reason).
+- Transient state (AI marks, combobox inputs, open/collapsed) never touches the
+  node or the bytes. `toggle`'s open state lives in the plugin's `openIds`
+  store precisely so a collapse cannot dirty the document.
+- Single-dollar math stays OFF and thematic breaks never emit `---` at byte 0 —
+  both are locked decisions in `md-plugins.ts`. Don't relitigate them from a
+  node's convenience.
+- Files stay `.md`. The vocabulary is fixed; unknown JSX, expressions and HTML
+  comments go to Raw by design, not by omission.
+
+## Verify
+
+```bash
+pnpm --filter @repo/desktop test    # the whole pipeline: fixtures, parity, adversarial, corpus
+pnpm --filter @repo/notes test      # vocabulary + remark stack, if you touched packages/notes
+pnpm --filter @repo/desktop typecheck
+```
+
+The desktop suite is the gate. What each part catches:
+
+- `__tests__/markdown-roundtrip.test.ts` — the canonical/churn/raw matrix.
+- `__tests__/kit-parity.test.ts` — shared `MarkdownPlugin` by reference, the
+  vocabulary plugin keys present in BOTH kits, `EDITOR_KIT ⊇ BASE_KIT`, and
+  inline/void metadata agreeing element-by-element over the corpus.
+- `__tests__/markdown-fixpoint.test.ts`, `markdown-roundtrip-property.test.ts`,
+  `markdown-adversarial.test.ts` — generated and hostile inputs; a new node
+  reaches them for free.
+- `__tests__/markdown-corpus.test.ts` — real markdown from this repo plus every
+  harness sample note, each pinned to an explicit expected classification, so a
+  pipeline change that moves a file between classes is a red diff.
+- `__tests__/editor-kits.test.ts` — the live-editor transforms (insert,
+  normalize) that feed serialization.
+- `src/__tests__/editor-import-cycles.test.ts` — no eager cycle around the kits.
+
+Then drive it, because passing tests are not feature-correct:
+
+```bash
+pnpm --filter @repo/desktop dev:harness    # localhost:5173
+```
+
+Insert the node from its surface, type around it, and **toggle Raw mode** to
+read the bytes back — the byte-stability invariant is the thing UI regressions
+break. Reload to confirm the saved bytes re-open Rich, not Raw.
+
+Before committing: `pnpm format:fix && pnpm verify` (format FIRST — a
+`format:fix` after green gates rewrites the byte-pinned fixtures and ships red).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -77,16 +77,22 @@ packages/        # libraries — boundaries are PACKAGE facts (deps + exports ma
   ui/            # Shared UI components (@repo/ui) — web-only (Base UI + Tailwind)
 ```
 
-Dep DAG (all edges): notes, installer, storage, ui are leaves; bridge→notes;
+Dep DAG (every edge between `packages/`, pinned against the manifests by
+`dep-dag.test.ts`): notes, installer, storage, ui are leaves; bridge→notes;
 vault→storage+notes+bridge; agent→bridge+installer+notes;
 voice→storage+bridge; connectors→installer+storage+bridge (agent never
 imports connectors: code-mode reaches the daemon through the injected
 ExecutorPort; the boot-computed fail-closed dev-flag gate is single-source
 in @repo/bridge/dev-flags); sync→vault+storage+notes+bridge;
 server→agent+bridge+connectors+notes+storage+sync+vault+voice.
-The renderer and mobile depend on @repo/bridge (+notes/ui) ONLY — never
-@repo/server — so "no node in the UI's contract" is an unresolvable-import
-fact, not a lint opinion. The extracted host packages (storage, vault, voice,
+The renderer and mobile reach the backend through @repo/bridge (+notes/ui)
+ONLY — never @repo/server — but "no node in the UI's contract" is enforced
+differently per app. For mobile it is an unresolvable-import fact: @repo/mobile
+depends on bridge+notes and nothing else. Desktop cannot claim that — the app
+package DOES depend on @repo/server because main composes the host — so the
+renderer's freedom from it is `no-restricted-imports` over `renderer/**` +
+`dev/**`, plus `dep-dag.test.ts` for `renderer/__tests__/**`, where that lint
+override is switched off. The extracted host packages (storage, vault, voice,
 connectors, sync) sit BELOW server: they never import @repo/server (that
 would be a package cycle) or electron — upward needs cross module-scoped
 install seams the composition root fills (setSecretCipherProvider,
@@ -122,8 +128,9 @@ pnpm verify           # The whole gate, mirroring CI (see Quality Gates)
 
 **`docs/development.md` is the full dev guide**: the two run modes (fixture
 harness / Electron), ports + `~/.inteligir` shared state +
-`host.lock`, the fixture byte-pinning rule, verification patterns, and the
-add-a-Bridge-channel / add-a-node-type checklists.
+`host.lock`, the fixture byte-pinning rule, and verification patterns. The
+two change checklists are skills, not prose — `.claude/skills/add-bridge-channel`
+and `.claude/skills/add-editor-node` carry the worked recipes.
 
 ## Agent-driven development
 
@@ -418,6 +425,17 @@ tool. Chat is a single persistent thread; the open note is auto-attached as
 context (agent-side only). `Cmd+K` rolls a fresh thread. Two more no-tools pi
 sessions serve the editor: inline-AI/intent classification, and an ephemeral
 in-memory session for ghost-text on a fast model.
+`vault/AGENTS.md` is the user's standing instructions — seeded once per vault
+root, loaded into the chat + delegation sessions as an extra context file
+(`packages/server/src/agent-instructions/`), skipped when marked
+`private: true`, and the file the bundled prompt nudges the agent to append
+durable memory to. Instruction files reach the model VERBATIM in every turn's
+system prompt (nothing in pi truncates them —
+`packages/agent/src/__tests__/agents-file-budget.test.ts`), so their bytes are
+a recurring per-turn cost. Repo-authored instruction files are held to a
+budget by that test; `vault/AGENTS.md` is the one the host must bound at
+runtime instead, because the agent appends to it unattended — the loader keeps
+the head (standing instructions) and sheds the tail (accumulated memory).
 **Private notes** (`private: true` frontmatter, `docs/privacy.md` is the
 contract): excluded from every AI surface on this device, fail-closed — the
 agent's file tools refuse them (per-call live-disk probe in pi's `tool_call`

--- a/apps/desktop/dev/fixture-bridge.ts
+++ b/apps/desktop/dev/fixture-bridge.ts
@@ -18,7 +18,7 @@ import type { Delegation, ListDelegationsResult } from "@repo/bridge/delegation"
 import { GHOST_TEXT_ENABLED_UI_STATE, type AiIntent } from "@repo/bridge/inline-ai";
 import type { ChatHistoryEntry } from "@repo/bridge/chat-log";
 import type { ChatSessionSummary } from "@repo/bridge/chat-sessions";
-import type { Bridge, VaultEntry } from "@repo/bridge/ipc-registry";
+import type { Bridge, SkillInfo, VaultEntry } from "@repo/bridge/ipc-registry";
 import type { RemoteAccessState } from "@repo/bridge/remote-access";
 import type { ListRoutinesResult, Routine } from "@repo/bridge/routines";
 import {
@@ -739,6 +739,46 @@ export function createFixtureBridge(openKnowledgeStore: (root: string) => Knowle
       },
     ],
   };
+
+  // Skills — one bundled row and two added rows so the listing renders both
+  // sources and all three budget outcomes (a real vault would have to hold 50+
+  // skills to produce the `not-loaded` one, which is why it is seeded here
+  // rather than left to chance); createSkill appends here so the Add flow
+  // round-trips like the host's does.
+  const trimmedDescription = "Summarize the open note into a short digest (dev-harness fixture).";
+  const fixtureSkills: SkillInfo[] = [
+    {
+      name: "browser",
+      description: "Drive a browser: open pages, click, screenshot (dev-harness fixture).",
+      scope: "user",
+      filePath: "/fixture/.inteligir/skills/agent-browser/SKILL.md",
+      source: "bundled",
+      updatedAt: Date.parse("2026-07-24T10:00:00.000Z"),
+      budget: { kind: "loaded" },
+    },
+    {
+      name: "summarize-note",
+      description: trimmedDescription,
+      scope: "user",
+      filePath: "/fixture/.inteligir/skills/summarize-note/SKILL.md",
+      source: "added",
+      updatedAt: Date.parse("2026-07-27T16:45:00.000Z"),
+      budget: {
+        kind: "description-trimmed",
+        promptChars: trimmedDescription.length,
+        originalChars: 2400,
+      },
+    },
+    {
+      name: "weekly-review",
+      description: "Draft the weekly review from this week's daily notes (dev-harness fixture).",
+      scope: "project",
+      filePath: "/fixture/vault/.pi/skills/weekly-review/SKILL.md",
+      source: "added",
+      updatedAt: null,
+      budget: { kind: "not-loaded", reason: "skill-count" },
+    },
+  ];
 
   // AI provider — an in-memory mirror of the host's provider-service so the
   // Settings AI section is fully drivable: switch (defaults the model like
@@ -1722,20 +1762,49 @@ export function createFixtureBridge(openKnowledgeStore: (root: string) => Knowle
     },
     onRemoteAccessChanged: remoteAccessEvents.subscribe,
 
-    // Skills / integrations — one seeded row each so the Settings panels
-    // render their POPULATED state ("zero installed" is a legitimate state,
-    // but the harness should demo rows). Repair mutates real binaries on the
-    // host, so it rejects loudly instead of pretending to succeed.
-    listSkills: async () => ({
-      skills: [
-        {
-          name: "summarize-note",
-          description: "Summarize the open note into a short digest (dev-harness fixture).",
-          scope: "user",
-          filePath: "/fixture/.inteligir/skills/summarize-note/SKILL.md",
-        },
-      ],
-    }),
+    // Skills / integrations — seeded rows so the Settings panels render their
+    // POPULATED state ("zero installed" is a legitimate state, but the harness
+    // should demo rows). Repair mutates real binaries on the host, so it
+    // rejects loudly instead of pretending to succeed.
+    listSkills: async () => ({ skills: [...fixtureSkills] }),
+    createSkill: async ({ name, description }) => {
+      const slug = name
+        .toLowerCase()
+        .replace(/[^a-z0-9]+/g, "-")
+        .replace(/^-+|-+$/g, "");
+      if (slug.length === 0) throw new Error("A skill name needs letters or digits.");
+      if (fixtureSkills.some((skill) => skill.name === slug)) {
+        throw new Error(`A skill named "${slug}" already exists.`);
+      }
+      // The host clamps a description to the per-skill cap before it ever
+      // reaches a listing, so the fixture clamps too — a harness that echoed
+      // the raw input would hide the trimmed state the real table must render.
+      const cap = 1536;
+      const clamped = description.length <= cap ? description : `${description.slice(0, cap - 1)}…`;
+      const skill: SkillInfo = {
+        name: slug,
+        description: clamped,
+        scope: "user",
+        filePath: `/fixture/.inteligir/skills/${slug}/SKILL.md`,
+        source: "added",
+        updatedAt: Date.now(),
+        budget:
+          clamped === description
+            ? { kind: "loaded" }
+            : {
+                kind: "description-trimmed",
+                promptChars: clamped.length,
+                originalChars: description.length,
+              },
+      };
+      fixtureSkills.push(skill);
+      // The host returns a fresh listing, which is name-ordered — a fixture
+      // that appended would teach the UI an ordering the product never has.
+      fixtureSkills.sort(
+        (a, b) => a.name.localeCompare(b.name) || a.filePath.localeCompare(b.filePath),
+      );
+      return { skill, skills: [...fixtureSkills] };
+    },
     listIntegrations: async () => [{ name: "fixture-cli", expected: "1.2.3", installed: "1.2.3" }],
     repairIntegrations: async () => {
       throw unavailable("integrations repair");

--- a/apps/desktop/src/renderer/settings/extensions/skills-section.test.tsx
+++ b/apps/desktop/src/renderer/settings/extensions/skills-section.test.tsx
@@ -1,0 +1,175 @@
+// The skills table (jsdom). What matters here is what the previous listing
+// could not say: a budget state that kept the agent from seeing a skill is
+// visible and explained, "no skills" and "couldn't read skills" are different
+// states, and a rejected create shows the host's own sentence.
+// Runs the real section over the dev-harness fixture Bridge, with the one
+// method under test overridden per case.
+
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+
+// No vitest globals in this repo, so testing-library can't auto-cleanup.
+afterEach(cleanup);
+
+import type { Bridge, SkillInfo } from "@repo/bridge/ipc-registry";
+import { createSqlKnowledgeStore } from "@repo/notes/knowledge/sql-knowledge-store";
+import { createFixtureBridge } from "../../../../dev/fixture-bridge";
+import { createWasmSqlDriver, loadSqlite3 } from "../../../../dev/wasm-sql-driver";
+import { installBridge } from "@renderer/lib/bridge";
+import { SkillsSection } from "./skills-section";
+
+const sqlite3 = await loadSqlite3();
+const newBridge = (): Bridge =>
+  createFixtureBridge((root) => createSqlKnowledgeStore(createWasmSqlDriver(sqlite3), root));
+
+function renderSection(bridge: Bridge) {
+  installBridge(bridge);
+  return render(<SkillsSection />);
+}
+
+const LOADED_SKILL: SkillInfo = {
+  name: "weekly-review",
+  description: "Draft the weekly review.",
+  scope: "user",
+  filePath: "/skills/weekly-review/SKILL.md",
+  source: "added",
+  updatedAt: Date.parse("2026-07-24T10:00:00.000Z"),
+  budget: { kind: "loaded" },
+};
+
+describe("skills table", () => {
+  it("renders one row per skill with its source, and no badge when it loaded whole", async () => {
+    renderSection({ ...newBridge(), listSkills: async () => ({ skills: [LOADED_SKILL] }) });
+
+    const row = await screen.findByRole("button", { name: /weekly-review/ });
+    expect(row.textContent).toBe("weekly-review");
+    expect(screen.getByRole("columnheader", { name: "Skill" })).toBeTruthy();
+    expect(screen.getByRole("cell", { name: "Added" })).toBeTruthy();
+  });
+
+  it("renders an em dash when the file's mtime is unreadable", async () => {
+    renderSection({
+      ...newBridge(),
+      listSkills: async () => ({ skills: [{ ...LOADED_SKILL, updatedAt: null }] }),
+    });
+
+    await screen.findByRole("button", { name: /weekly-review/ });
+    expect(screen.getByRole("cell", { name: "—" })).toBeTruthy();
+  });
+
+  it("badges a trimmed description and explains the loss when the row expands", async () => {
+    renderSection({
+      ...newBridge(),
+      listSkills: async () => ({
+        skills: [
+          {
+            ...LOADED_SKILL,
+            budget: { kind: "description-trimmed", promptChars: 24, originalChars: 2400 },
+          },
+        ],
+      }),
+    });
+
+    const toggle = await screen.findByRole("button", { name: /weekly-review/ });
+    expect(toggle.textContent).toContain("shortened");
+    expect(toggle.getAttribute("aria-expanded")).toBe("false");
+
+    fireEvent.click(toggle);
+    await waitFor(() => expect(toggle.getAttribute("aria-expanded")).toBe("true"));
+    expect(screen.getByText(/received 24 of this description's 2400 characters/)).toBeTruthy();
+    expect(screen.getByText("Draft the weekly review.")).toBeTruthy();
+  });
+
+  it("badges a skill the agent never received and says it cannot be invoked", async () => {
+    renderSection({
+      ...newBridge(),
+      listSkills: async () => ({
+        skills: [{ ...LOADED_SKILL, budget: { kind: "not-loaded", reason: "skill-count" } }],
+      }),
+    });
+
+    const toggle = await screen.findByRole("button", { name: /weekly-review/ });
+    expect(toggle.textContent).toContain("not loaded");
+
+    fireEvent.click(toggle);
+    await waitFor(() => expect(screen.getByText(/cannot invoke it/)).toBeTruthy());
+  });
+
+  it("shows the empty state when there are no skills", async () => {
+    renderSection({ ...newBridge(), listSkills: async () => ({ skills: [] }) });
+
+    await screen.findByText(/No skills yet\./);
+    expect(screen.queryByRole("table")).toBeNull();
+  });
+
+  it("shows a failed read as an error rather than as an empty vault", async () => {
+    renderSection({
+      ...newBridge(),
+      listSkills: () => Promise.reject(new Error("skills folder unreadable")),
+    });
+
+    await screen.findByText("skills folder unreadable");
+    expect(screen.queryByText(/No skills yet\./)).toBeNull();
+  });
+});
+
+describe("adding a skill", () => {
+  it("surfaces the host's rejection sentence verbatim", async () => {
+    renderSection({
+      ...newBridge(),
+      listSkills: async () => ({ skills: [LOADED_SKILL] }),
+      createSkill: () => Promise.reject(new Error('A skill named "weekly-review" already exists.')),
+    });
+
+    fireEvent.click(await screen.findByRole("button", { name: "Add skill…" }));
+    fireEvent.change(screen.getByPlaceholderText("Weekly review"), {
+      target: { value: "Weekly Review" },
+    });
+    fireEvent.change(screen.getByPlaceholderText("When the agent should reach for this skill."), {
+      target: { value: "Draft the weekly review." },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Create skill" }));
+
+    await screen.findByText('A skill named "weekly-review" already exists.');
+  });
+
+  it("re-renders from the returned listing and reports the slug the host chose", async () => {
+    const created: SkillInfo = { ...LOADED_SKILL, name: "weekly-review" };
+    renderSection({
+      ...newBridge(),
+      listSkills: async () => ({ skills: [] }),
+      createSkill: async () => ({ skill: created, skills: [created] }),
+    });
+
+    await screen.findByText(/No skills yet\./);
+    fireEvent.click(screen.getByRole("button", { name: "Add skill…" }));
+    fireEvent.change(screen.getByPlaceholderText("Weekly review"), {
+      target: { value: "Weekly Review" },
+    });
+    fireEvent.change(screen.getByPlaceholderText("When the agent should reach for this skill."), {
+      target: { value: "Draft the weekly review." },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Create skill" }));
+
+    await screen.findByRole("table");
+    // The host slugifies, so the confirmation quotes what came back, never the
+    // "Weekly Review" that was typed.
+    expect(screen.getByText(/Created/).textContent).toContain("weekly-review");
+  });
+
+  it("refuses an empty description before it reaches the host", async () => {
+    renderSection({
+      ...newBridge(),
+      listSkills: async () => ({ skills: [] }),
+      createSkill: () => Promise.reject(new Error("the host should not have been called")),
+    });
+
+    fireEvent.click(await screen.findByRole("button", { name: "Add skill…" }));
+    fireEvent.change(screen.getByPlaceholderText("Weekly review"), {
+      target: { value: "Weekly Review" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Create skill" }));
+
+    await screen.findByText("A name and a description are both required.");
+  });
+});

--- a/apps/desktop/src/renderer/settings/extensions/skills-section.tsx
+++ b/apps/desktop/src/renderer/settings/extensions/skills-section.tsx
@@ -1,73 +1,388 @@
-// Skills are read-only — discovered from disk by pi at startup. The agent
-// uses them as prompting/guidance, distinct from tools (which take arguments).
+// Skills are folders of instructions pi discovers at startup — prompting, not
+// tools. The listing is a table because the interesting facts are comparable
+// across rows (when it changed, where it came from, whether the agent actually
+// got it); the description is not, so it lives in the row's detail rather than
+// a fourth column that would truncate to nothing at this width.
 
-import { useEffect, useMemo, useState } from "react";
+import { Fragment, useCallback, useEffect, useId, useState } from "react";
+import { AlertTriangleIcon, ChevronRightIcon } from "lucide-react";
+import { Badge } from "@repo/ui/components/badge";
+import { Button } from "@repo/ui/components/button";
+import { Input } from "@repo/ui/components/input";
 import { Label } from "@repo/ui/components/label";
+import { Textarea } from "@repo/ui/components/textarea";
+import { cn } from "@repo/ui/lib/utils";
 
 import { getBridge } from "@renderer/lib/bridge";
-import type { SkillInfo } from "@repo/bridge/ipc-registry";
+import type {
+  SkillBudgetState,
+  SkillInfo,
+  SkillScope,
+  SkillSource,
+} from "@repo/bridge/ipc-registry";
 
-const SKILL_SCOPE_LABELS: Record<string, string> = {
+/** Mirrors the `description` cap in the createSkill wire schema — a longer one
+ * is rejected host-side, so the form refuses it before the round trip. */
+const MAX_DESCRIPTION_CHARS = 1536;
+
+const SKILL_SCOPE_LABELS: Record<SkillScope, string> = {
   user: "User",
   project: "Project",
   temporary: "Temporary",
 };
 
-function groupSkillsByScope(skills: SkillInfo[]): Map<string, SkillInfo[]> {
-  const groups = new Map<string, SkillInfo[]>();
-  for (const skill of skills) {
-    const key = SKILL_SCOPE_LABELS[skill.scope] ?? skill.scope;
-    const list = groups.get(key) ?? [];
-    list.push(skill);
-    groups.set(key, list);
+// "Bundled" vs "Added" is the whole truth the host can tell: there is no
+// author or publisher behind a skill folder.
+const SKILL_SOURCE_LABELS: Record<SkillSource, string> = {
+  bundled: "Bundled",
+  added: "Added",
+};
+
+/** What a non-`loaded` budget state has to say for itself. `null` is the
+ * overwhelmingly common case and renders no chrome at all. */
+type BudgetNotice = { tone: "info" | "warning"; badge: string; detail: string };
+
+function budgetNotice(budget: SkillBudgetState): BudgetNotice | null {
+  switch (budget.kind) {
+    case "loaded":
+      return null;
+    case "description-trimmed":
+      return {
+        tone: "info",
+        badge: "shortened",
+        detail: `The agent's prompt received ${budget.promptChars} of this description's ${budget.originalChars} characters. The skill still runs — shorten the description in SKILL.md so the agent sees all of it.`,
+      };
+    case "not-loaded":
+      return { tone: "warning", badge: "not loaded", detail: notLoadedDetail(budget.reason) };
+    default: {
+      const unreachable: never = budget;
+      return unreachable;
+    }
   }
-  return groups;
 }
 
+function notLoadedDetail(reason: "skill-count"): string {
+  switch (reason) {
+    case "skill-count":
+      return "Too many skills on disk for the agent's prompt, so this one never reached it and the agent cannot invoke it. Remove skills you don't use.";
+    default: {
+      const unreachable: never = reason;
+      return unreachable;
+    }
+  }
+}
+
+function formatUpdated(updatedAt: number | null): string {
+  if (updatedAt === null) return "—";
+  return new Date(updatedAt).toLocaleDateString(undefined, {
+    year: "2-digit",
+    month: "numeric",
+    day: "numeric",
+  });
+}
+
+function errorMessage(error: unknown, fallback: string): string {
+  return error instanceof Error && error.message !== "" ? error.message : fallback;
+}
+
+/** The listing is one of three things, never a failure disguised as an empty
+ * vault — "no skills" and "couldn't read them" say different things to a user. */
+type Listing =
+  | { kind: "loading" }
+  | { kind: "ready"; skills: SkillInfo[] }
+  | { kind: "failed"; message: string };
+
+type Draft = { name: string; description: string; instructions: string };
+
+const EMPTY_DRAFT: Draft = { name: "", description: "", instructions: "" };
+
+/** Saving and showing a validation error are mutually exclusive by
+ * construction, and a draft only exists while the form is open. */
+type Form =
+  | { kind: "closed" }
+  | { kind: "editing"; draft: Draft; error: string | null }
+  | { kind: "saving"; draft: Draft };
+
 export function SkillsSection() {
-  const [skills, setSkills] = useState<SkillInfo[] | null>(null);
+  const [listing, setListing] = useState<Listing>({ kind: "loading" });
+  const [form, setForm] = useState<Form>({ kind: "closed" });
+  const [expanded, setExpanded] = useState<string | null>(null);
+  const [created, setCreated] = useState<string | null>(null);
+  const detailIdBase = useId();
 
   useEffect(() => {
     void getBridge()
       .listSkills()
-      .then((list) => setSkills(list.skills))
-      .catch(() => setSkills([]));
+      .then((list) => setListing({ kind: "ready", skills: list.skills }))
+      .catch((error: unknown) =>
+        setListing({ kind: "failed", message: errorMessage(error, "Could not read skills.") }),
+      );
   }, []);
 
-  const groups = useMemo(() => (skills ? groupSkillsByScope(skills) : null), [skills]);
+  const handleCreate = useCallback(async (draft: Draft) => {
+    const name = draft.name.trim();
+    const description = draft.description.trim();
+    if (name === "" || description === "") {
+      setForm({ kind: "editing", draft, error: "A name and a description are both required." });
+      return;
+    }
+    if (description.length > MAX_DESCRIPTION_CHARS) {
+      setForm({
+        kind: "editing",
+        draft,
+        error: `The description must be ${MAX_DESCRIPTION_CHARS} characters or fewer.`,
+      });
+      return;
+    }
+    setForm({ kind: "saving", draft });
+    try {
+      const result = await getBridge().createSkill({
+        name,
+        description,
+        instructions: draft.instructions,
+      });
+      setListing({ kind: "ready", skills: result.skills });
+      setCreated(result.skill.name);
+      setExpanded(result.skill.filePath);
+      setForm({ kind: "closed" });
+    } catch (error: unknown) {
+      setForm({
+        kind: "editing",
+        draft,
+        error: errorMessage(error, "Could not create the skill."),
+      });
+    }
+  }, []);
+
+  const draft = form.kind === "closed" ? null : form.draft;
 
   return (
     <div className="flex flex-col gap-2">
-      <Label className="text-xs font-medium text-muted-foreground">Skills</Label>
-      {skills === null || groups === null ? (
+      <div className="flex items-center justify-between gap-2">
+        <Label className="text-xs font-medium text-muted-foreground">Skills</Label>
+        {/* Stays MOUNTED while the form is open, hidden by class: a button that
+            unmounts itself on click detaches the press target before Base UI's
+            outside-press check resolves, and the whole Settings dialog closes. */}
+        <Button
+          variant="ghost"
+          size="sm"
+          onClick={() => {
+            setCreated(null);
+            setForm({ kind: "editing", draft: EMPTY_DRAFT, error: null });
+          }}
+          className={cn(
+            "h-auto px-2 py-0.5 text-[10px] text-muted-foreground",
+            draft !== null && "hidden",
+          )}
+        >
+          Add skill…
+        </Button>
+      </div>
+
+      <p className="text-[10px] leading-relaxed text-muted-foreground">
+        Folders of instructions the agent follows for a recurring job. It reads them when it starts,
+        so a new or edited skill applies from the next agent session.
+      </p>
+
+      {listing.kind === "loading" && (
         <div className="text-[10px] text-muted-foreground">Loading…</div>
-      ) : skills.length === 0 ? (
-        <div className="rounded-[10px] bg-muted px-3 py-2 text-[10px] text-muted-foreground">
-          No skills installed.
+      )}
+
+      {listing.kind === "failed" && (
+        <div className="rounded-[10px] bg-muted px-3 py-2 text-[10px] text-destructive">
+          {listing.message}
         </div>
-      ) : (
-        <div className="flex flex-col gap-2">
-          {[...groups.entries()].map(([scope, items]) => (
-            <div key={scope} className="flex flex-col gap-1.5">
-              <span className="text-[10px] font-medium uppercase tracking-wide text-muted-foreground">
-                {scope}
+      )}
+
+      {listing.kind === "ready" &&
+        (listing.skills.length === 0 ? (
+          <div className="rounded-[10px] bg-muted px-3 py-2 text-[10px] text-muted-foreground">
+            No skills yet. Add one to teach the agent a job you repeat.
+          </div>
+        ) : (
+          <div className="overflow-hidden rounded-[10px] bg-muted">
+            <table className="w-full table-fixed border-collapse text-left">
+              <thead>
+                <tr className="text-[10px] font-medium uppercase tracking-wide text-muted-foreground">
+                  <th scope="col" className="px-3 py-1.5 font-medium">
+                    Skill
+                  </th>
+                  <th scope="col" className="w-20 px-3 py-1.5 font-medium">
+                    Updated
+                  </th>
+                  <th scope="col" className="w-20 px-3 py-1.5 font-medium">
+                    Source
+                  </th>
+                </tr>
+              </thead>
+              <tbody>
+                {listing.skills.map((skill, index) => {
+                  const notice = budgetNotice(skill.budget);
+                  const isOpen = expanded === skill.filePath;
+                  const detailId = `${detailIdBase}-${index}`;
+                  return (
+                    <Fragment key={skill.filePath}>
+                      <tr className="border-t border-border">
+                        <td className="px-3 py-1.5">
+                          <button
+                            type="button"
+                            aria-expanded={isOpen}
+                            aria-controls={detailId}
+                            onClick={() => setExpanded(isOpen ? null : skill.filePath)}
+                            className="flex w-full min-w-0 items-center gap-1 text-left"
+                          >
+                            <ChevronRightIcon
+                              className={cn(
+                                "size-3 shrink-0 text-muted-foreground transition-transform",
+                                isOpen && "rotate-90",
+                              )}
+                            />
+                            <span className="truncate text-xs text-foreground">{skill.name}</span>
+                            {notice !== null && (
+                              <Badge
+                                variant={notice.tone === "warning" ? "destructive" : "secondary"}
+                                className="h-4 shrink-0 gap-0.5 px-1.5 text-[9px] font-normal"
+                              >
+                                {notice.tone === "warning" && (
+                                  <AlertTriangleIcon className="size-2.5" />
+                                )}
+                                {notice.badge}
+                              </Badge>
+                            )}
+                          </button>
+                        </td>
+                        <td
+                          className="px-3 py-1.5 text-[10px] tabular-nums text-muted-foreground"
+                          title={
+                            skill.updatedAt === null
+                              ? "Modification time unavailable"
+                              : new Date(skill.updatedAt).toLocaleString()
+                          }
+                        >
+                          {formatUpdated(skill.updatedAt)}
+                        </td>
+                        <td className="px-3 py-1.5 text-[10px] text-muted-foreground">
+                          {SKILL_SOURCE_LABELS[skill.source]}
+                        </td>
+                      </tr>
+                      {isOpen && (
+                        <tr className="border-t border-border/50">
+                          <td colSpan={3} id={detailId} className="px-3 pb-2 pt-1">
+                            <div className="flex flex-col gap-1">
+                              <p className="text-[10px] leading-relaxed text-muted-foreground">
+                                {skill.description === ""
+                                  ? "No description — the agent has only the name to go on."
+                                  : skill.description}
+                              </p>
+                              {notice !== null && (
+                                <p
+                                  className={cn(
+                                    "text-[10px] leading-relaxed",
+                                    notice.tone === "warning"
+                                      ? "text-destructive"
+                                      : "text-muted-foreground",
+                                  )}
+                                >
+                                  {notice.detail}
+                                </p>
+                              )}
+                              <p className="break-all font-mono text-[9px] text-muted-foreground/70">
+                                {SKILL_SCOPE_LABELS[skill.scope]} · {skill.filePath}
+                              </p>
+                            </div>
+                          </td>
+                        </tr>
+                      )}
+                    </Fragment>
+                  );
+                })}
+              </tbody>
+            </table>
+          </div>
+        ))}
+
+      {created !== null && draft === null && (
+        <p className="text-[10px] leading-relaxed text-muted-foreground">
+          Created <span className="font-mono">{created}</span>. The agent picks it up the next time
+          it starts.
+        </p>
+      )}
+
+      {draft !== null && (
+        <div className="flex flex-col gap-2 rounded-[10px] bg-muted px-3 py-2">
+          <div className="flex flex-col gap-1">
+            <span className="text-[10px] text-muted-foreground">Name</span>
+            <Input
+              value={draft.name}
+              onChange={(e) =>
+                setForm({ kind: "editing", draft: { ...draft, name: e.target.value }, error: null })
+              }
+              placeholder="Weekly review"
+              className="h-7 text-xs"
+            />
+            <span className="text-[9px] text-muted-foreground/70">
+              Saved as a folder name — “Weekly review” becomes weekly-review.
+            </span>
+          </div>
+          <div className="flex flex-col gap-1">
+            <span className="text-[10px] text-muted-foreground">
+              Description
+              <span className="ml-1 tabular-nums text-muted-foreground/70">
+                {draft.description.length}/{MAX_DESCRIPTION_CHARS}
               </span>
-              {items.map((skill) => (
-                <div
-                  key={skill.filePath}
-                  className="flex min-w-0 flex-col rounded-[10px] bg-muted px-3 py-2"
-                  title={skill.description}
-                >
-                  <span className="truncate text-xs text-foreground">{skill.name}</span>
-                  {skill.description && (
-                    <span className="line-clamp-3 text-[10px] text-muted-foreground">
-                      {skill.description}
-                    </span>
-                  )}
-                </div>
-              ))}
-            </div>
-          ))}
+            </span>
+            <Textarea
+              value={draft.description}
+              onChange={(e) =>
+                setForm({
+                  kind: "editing",
+                  draft: { ...draft, description: e.target.value },
+                  error: null,
+                })
+              }
+              placeholder="When the agent should reach for this skill."
+              className="min-h-12 text-xs"
+            />
+          </div>
+          <div className="flex flex-col gap-1">
+            <span className="text-[10px] text-muted-foreground">Instructions</span>
+            <Textarea
+              value={draft.instructions}
+              onChange={(e) =>
+                setForm({
+                  kind: "editing",
+                  draft: { ...draft, instructions: e.target.value },
+                  error: null,
+                })
+              }
+              placeholder="The steps to follow. Can be left empty and written later in SKILL.md."
+              className="min-h-16 text-xs"
+            />
+          </div>
+          {form.kind === "editing" && form.error !== null && (
+            <p className="rounded-[8px] bg-card px-2.5 py-1.5 text-[10px] text-destructive">
+              {form.error}
+            </p>
+          )}
+          <div className="flex items-center justify-end gap-1 border-t border-border pt-2">
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={() => setForm({ kind: "closed" })}
+              className="h-auto px-2 py-0.5 text-[10px] text-muted-foreground"
+            >
+              Cancel
+            </Button>
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={() => void handleCreate(draft)}
+              disabled={form.kind === "saving"}
+              className="h-auto px-2 py-0.5 text-[10px] text-foreground"
+            >
+              {form.kind === "saving" ? "Creating…" : "Create skill"}
+            </Button>
+          </div>
         </div>
       )}
     </div>

--- a/apps/desktop/src/renderer/settings/self-unmounting-toggles.test.tsx
+++ b/apps/desktop/src/renderer/settings/self-unmounting-toggles.test.tsx
@@ -34,6 +34,7 @@ import { createFixtureBridge } from "../../../dev/fixture-bridge";
 import { createWasmSqlDriver, loadSqlite3 } from "../../../dev/wasm-sql-driver";
 import { installBridge } from "@renderer/lib/bridge";
 import { AccountSection } from "./sections/account-section";
+import { SkillsSection } from "./extensions/skills-section";
 import { RoutinesSection } from "./sections/routines-section";
 
 const sqlite3 = await loadSqlite3();
@@ -102,5 +103,17 @@ describe("routines section", () => {
     expect(add.isConnected).toBe(true);
     // The form it reveals is present.
     expect(screen.getByPlaceholderText("Morning briefing")).toBeTruthy();
+  });
+});
+
+describe("skills section", () => {
+  it("'Add skill…' hides rather than unmounting when the form opens", async () => {
+    renderSection(<SkillsSection />);
+    const add = await screen.findByRole("button", { name: "Add skill…" });
+
+    expectSurvivesOwnClick(add);
+    await waitFor(() => expect(add.className).toContain("hidden"));
+    expect(add.isConnected).toBe(true);
+    expect(screen.getByPlaceholderText("Weekly review")).toBeTruthy();
   });
 });

--- a/docs/development.md
+++ b/docs/development.md
@@ -120,24 +120,17 @@ Type-checks passing isn't feature-correct. Drive the running app:
   `packages/server/src/__tests__/knowledge-privacy.test.ts`
   (outbound-payload assertions).
 
-## Making changes — checklists
+## Making changes — the two cross-cutting recipes
 
-**Adding a Bridge channel** (the most common cross-cutting change):
+Both live as skills, so the steps sit next to the code they name rather than
+rotting in prose here:
 
-1. Registry entry in `packages/bridge/src/ipc-registry.ts` (TypeBox payload +
-   result/event type).
-2. Host handler in `packages/server/src/handlers/` (grouped by domain;
-   `collectHandlers` throws at boot on missing/duplicate).
-3. Fixture implementation in `apps/desktop/dev/fixture-bridge.ts` (typed
-   `: Bridge` — fails typecheck until covered).
-   The ws transport dispatches from the host handler map automatically.
-
-**Adding an editor node type**: Base + React halves in one
-`apps/desktop/src/renderer/editor/kits/*-kit.tsx`; add the Base half to `base-kit.ts`
-(kit-parity tests fail on drift); a markdown rule in
-`editor/markdown/md-rules.ts` if the node has bytes; vocabulary allowlist in
-`@repo/notes/markdown/vocabulary` (`packages/notes/src/markdown/vocabulary.ts`)
-for MDX nodes; round-trip fixtures proving canonical/idempotent behavior.
+- **Adding a Bridge channel** — `.claude/skills/add-bridge-channel/`. Registry
+  entry, host handler, dev-harness fixture stub, event emission + reconnect
+  hydration, and the remote-device allowlist decision.
+- **Adding an editor node type** — `.claude/skills/add-editor-node/`. The
+  Base + React kit pair, the `base-kit`/`editor-kit` composition, the Slate↔mdast
+  rule, the MDX vocabulary gate, and the byte-pinned round-trip fixtures.
 
 ## Tests
 

--- a/docs/privacy.md
+++ b/docs/privacy.md
@@ -23,7 +23,10 @@ boundary**. Read the "What it does NOT do" list before relying on it.
   fallbacks — `packages/agent/src/privacy/pi-path-parity.ts`), so an alias spelling of a
   private path probes the file pi will actually open; a drift-guard test
   pins our resolver against pi's installed one so a pi upgrade can't
-  silently reopen the gap.
+  silently reopen the gap. A second guard drives the refusal through pi's
+  own extension runner and agent loop, so an upgrade that stopped honouring
+  a block — or started swallowing the fail-closed throw — fails a test
+  rather than quietly turning the gate into a no-op.
 - **`search_vault` / `get_backlinks` / `get_links` / `related_notes` drop it entirely.**
   Private notes are excluded inside the index query and every surviving hit
   is re-probed against live disk — no path, no title, no snippet ever

--- a/packages/agent/src/__tests__/agents-file-budget.test.ts
+++ b/packages/agent/src/__tests__/agents-file-budget.test.ts
@@ -1,0 +1,201 @@
+// ---------------------------------------------------------------------------
+// AGENTS-FILE BUDGET — what we ship into every system prompt.
+//
+// Nothing in the path bounds an AGENTS.md. pi's DefaultResourceLoader reads
+// each context file whole (agentDir + every cwd ancestor), our
+// `agentsFilesOverride` appends the user's vault file to that list, and
+// buildSystemPrompt concatenates every byte verbatim into
+// `<project_instructions path="…">`. There is no cap, no slice, no warning at
+// any layer — so a "truncation guard" would guard nothing, and the only
+// failure mode left is COST: these bytes are re-sent on every turn of every
+// session, including the ghost-text session that runs at typing cadence.
+//
+// So this file pins the two things that are actually load-bearing:
+//   1. that pi still truncates nothing (drive pi's REAL buildSystemPrompt —
+//      if an upgrade ever starts slicing, the budget story below changes and
+//      this fails loudly instead of silently losing instructions);
+//   2. a two-sided budget on the context bytes THIS REPO authors — a ceiling
+//      so growth is a decision rather than a drift, and a floor so a
+//      packaging or edit accident that empties the file fails here rather
+//      than degrading every answer quietly.
+//
+// It does NOT bound the user's vault/AGENTS.md, which is unbounded input
+// reaching the same prompt — that needs a cap in the host loader, not a test.
+//
+// pi's internals are not public exports, so system-prompt.js is reached by
+// file path (as pi-path-parity.test.ts does). A throwing locator IS the
+// signal: pi moved the module — re-verify by hand before touching it.
+// ---------------------------------------------------------------------------
+
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+import { beforeAll, describe, expect, it } from "vitest";
+
+import { AGENT_INSTRUCTIONS_SKELETON } from "@repo/bridge/agent-instructions";
+
+// ---- Budgets ---------------------------------------------------------------
+
+/**
+ * Ceiling for the bundled agent AGENTS.md — the file seeded into `AGENT_DIR`
+ * and therefore loaded into EVERY pi session (chat, delegation, inline AI,
+ * ghost text). At ~12k chars today it is roughly 3k tokens spent per turn;
+ * the headroom here is deliberate slack, not an invitation. Growing past it
+ * means trading tokens on the app's highest-frequency prompt, so it should be
+ * a decision with a reason, not a paragraph someone appended.
+ */
+const BUNDLED_INSTRUCTIONS_MAX_CHARS = 16_000;
+
+/**
+ * Floor for the same file. The failure this catches is the opposite one: a
+ * packaging step or an edit that leaves a stub behind. Nothing downstream
+ * notices — the agent simply gets dumber — so the loss is pinned here.
+ */
+const BUNDLED_INSTRUCTIONS_MIN_CHARS = 4_000;
+
+/**
+ * Ceiling for the vault skeleton. These bytes are seeded into the user's own
+ * AGENTS.md and read back into chat + delegation, so they are prompt too —
+ * but they are starter prose the user is meant to replace, and long starter
+ * prose reads as a form to fill in rather than an invitation to edit.
+ */
+const SKELETON_MAX_CHARS = 1_500;
+
+// ---- Repo-authored context files -------------------------------------------
+
+const BUNDLED_RESOURCES_DIR = fileURLToPath(new URL("../../resources/agent", import.meta.url));
+
+/** pi's context-file candidates, in the order it probes a directory
+ * (resource-loader.js::loadContextFileFromDir). It takes the FIRST match and
+ * ignores the rest. */
+const PI_CONTEXT_FILE_CANDIDATES = new Set(["AGENTS.md", "AGENTS.MD", "CLAUDE.md", "CLAUDE.MD"]);
+
+function bundledInstructions(): string {
+  const file = path.join(BUNDLED_RESOURCES_DIR, "AGENTS.md");
+  if (!fs.existsSync(file)) {
+    throw new Error(`bundled agent instructions missing at ${file} — setup.ts seeds this file`);
+  }
+  return fs.readFileSync(file, "utf8");
+}
+
+// ---- pi's real prompt builder ----------------------------------------------
+
+type ContextFile = { path: string; content: string };
+type BuildSystemPrompt = (options: {
+  cwd: string;
+  contextFiles: ContextFile[];
+  customPrompt?: string;
+  selectedTools: string[];
+  toolSnippets: Record<string, string>;
+  promptGuidelines: string[];
+}) => string;
+
+const PI_PKG = fileURLToPath(
+  new URL("../../node_modules/@earendil-works/pi-coding-agent", import.meta.url),
+);
+
+function piFile(...segments: string[]): string {
+  const file = path.join(PI_PKG, "dist", ...segments);
+  if (!fs.existsSync(file)) {
+    throw new Error(
+      `pi's dist/${segments.join("/")} not found at ${file} — pi moved it; re-verify by hand ` +
+        `whether context files are still injected whole before updating this locator.`,
+    );
+  }
+  return file;
+}
+
+/** Parse-at-boundary for a deep import: demand the export exists and is
+ * callable. The structural shape above is unverifiable at runtime — the
+ * assertions below are what actually exercise it. */
+function isBuildSystemPrompt(value: unknown): value is BuildSystemPrompt {
+  return typeof value === "function";
+}
+
+function pickBuildSystemPrompt(mod: unknown): BuildSystemPrompt {
+  if (typeof mod !== "object" || mod === null) {
+    throw new Error("pi's system-prompt module did not load — re-verify by hand");
+  }
+  const fn: unknown = Reflect.get(mod, "buildSystemPrompt");
+  if (!isBuildSystemPrompt(fn)) {
+    throw new Error(
+      "pi no longer exports a callable buildSystemPrompt() — re-verify by hand whether " +
+        "context files are still injected whole before updating this test",
+    );
+  }
+  return fn;
+}
+
+let buildSystemPrompt: BuildSystemPrompt;
+
+beforeAll(async () => {
+  const mod: unknown = await import(
+    /* @vite-ignore */ pathToFileURL(piFile("core/system-prompt.js")).href
+  );
+  buildSystemPrompt = pickBuildSystemPrompt(mod);
+});
+
+// ---- The constraint --------------------------------------------------------
+
+describe("pi injects context files whole", () => {
+  /** Far larger than any instruction file this repo ships, so a cap anywhere
+   * in pi's prompt path would have to bite. */
+  const OVERSIZED = "x".repeat(200_000);
+
+  function promptWith(customPrompt?: string): string {
+    return buildSystemPrompt({
+      cwd: "/workspace",
+      contextFiles: [{ path: "./vault/AGENTS.md", content: OVERSIZED }],
+      selectedTools: [],
+      toolSnippets: {},
+      promptGuidelines: [],
+      ...(customPrompt === undefined ? {} : { customPrompt }),
+    });
+  }
+
+  it("passes an oversized context file through verbatim (default prompt)", () => {
+    const prompt = promptWith();
+    expect(prompt).toContain(`<project_instructions path="./vault/AGENTS.md">`);
+    expect(prompt).toContain(OVERSIZED);
+  });
+
+  it("passes an oversized context file through verbatim (custom prompt)", () => {
+    expect(promptWith("SYSTEM")).toContain(OVERSIZED);
+  });
+});
+
+// ---- The budget ------------------------------------------------------------
+
+describe("repo-authored context bytes", () => {
+  it("keeps the bundled agent instructions within budget", () => {
+    const chars = bundledInstructions().length;
+    expect(
+      chars,
+      `packages/agent/resources/agent/AGENTS.md is ${chars} chars — it is re-sent on every ` +
+        `turn of every session, including ghost text. Cut something, or raise ` +
+        `BUNDLED_INSTRUCTIONS_MAX_CHARS with a reason.`,
+    ).toBeLessThanOrEqual(BUNDLED_INSTRUCTIONS_MAX_CHARS);
+  });
+
+  it("catches a bundled-instructions file that lost its content", () => {
+    expect(bundledInstructions().length).toBeGreaterThanOrEqual(BUNDLED_INSTRUCTIONS_MIN_CHARS);
+  });
+
+  it("keeps the seeded vault skeleton within budget", () => {
+    expect(AGENT_INSTRUCTIONS_SKELETON.length).toBeLessThanOrEqual(SKELETON_MAX_CHARS);
+  });
+
+  it("ships exactly one file pi will load from the bundled resources dir", () => {
+    const shipped = fs
+      .readdirSync(BUNDLED_RESOURCES_DIR, { withFileTypes: true })
+      .filter((entry) => entry.isFile())
+      .map((entry) => entry.name)
+      .filter((name) => PI_CONTEXT_FILE_CANDIDATES.has(name));
+    expect(
+      shipped,
+      "pi loads the FIRST context-file candidate it finds in a directory and silently " +
+        "ignores the others — a second one here would never reach the prompt.",
+    ).toEqual(["AGENTS.md"]);
+  });
+});

--- a/packages/agent/src/__tests__/bundles.test.ts
+++ b/packages/agent/src/__tests__/bundles.test.ts
@@ -34,4 +34,34 @@ describe("EXTENSION_BUNDLES", () => {
     const names = EXTENSION_BUNDLES.map((b) => b.name);
     expect(names).toEqual([...names].toSorted());
   });
+
+  // pi hands every `tool_call` handler the SAME mutable `input` object and
+  // re-validates nothing after the chain runs, so a second handler could
+  // rewrite the path the privacy gate just probed and the tool would execute
+  // against a note the gate never saw. Privacy being the only subscriber is
+  // what makes that unreachable — this pins it. Source-text, so a handler
+  // registered indirectly would slip past; it catches the ordinary case.
+  it("registers exactly one tool_call subscriber — the privacy gate", () => {
+    const subscribers = fs
+      .readdirSync(AGENT_DIR, { withFileTypes: true })
+      .filter((e) => e.isDirectory() && fs.existsSync(path.join(AGENT_DIR, e.name, "extension.ts")))
+      .filter((e) =>
+        fs
+          .readdirSync(path.join(AGENT_DIR, e.name), { recursive: true })
+          .filter((f): f is string => typeof f === "string" && f.endsWith(".ts"))
+          .some((f) =>
+            fs.readFileSync(path.join(AGENT_DIR, e.name, f), "utf8").includes('on("tool_call"'),
+          ),
+      )
+      .map((e) => e.name)
+      .toSorted();
+
+    expect(
+      subscribers,
+      "A second tool_call subscriber shares one mutable `input` with the privacy gate and pi\n" +
+        "does not re-validate between handlers — whichever runs after the gate can redirect the\n" +
+        "call to an unprobed path. Before allowing one: prove it cannot mutate `input`, and pin\n" +
+        "the ordering so privacy runs last.",
+    ).toEqual(["privacy"]);
+  });
 });

--- a/packages/agent/src/__tests__/pi-tool-call-contract.test.ts
+++ b/packages/agent/src/__tests__/pi-tool-call-contract.test.ts
@@ -1,0 +1,358 @@
+// ---------------------------------------------------------------------------
+// BLOCKABLE-CONTRACT GUARD — the whole privacy model rests on this.
+//
+// privacy/extension.ts refuses a tool call by returning `{ block: true }`
+// from pi's `tool_call` hook (and by THROWING when a probe or a checkpoint
+// capture fails). That only keeps private notes away from the model while pi
+// still honours both: a `block` that stopped preventing execution, or a throw
+// that got swallowed into "allow", would silently turn the gate into a
+// no-op — the code would look identical and every unit test over the pure
+// decision core would still pass.
+//
+// So this drives the INSTALLED pi's own machinery, not a description of it:
+//   - pi-coding-agent's ExtensionRunner.emitToolCall — the dispatcher that
+//     returns the first blocking result and (unlike its user_bash sibling)
+//     does NOT catch handler throws;
+//   - pi-agent-core's agent loop — the layer that turns a block into an error
+//     tool result and skips tool.execute entirely.
+// The CONTROL case (same fixture, no hook) executes the tool, so a broken
+// fixture fails loudly instead of passing the block cases for free.
+//
+// Between them sits agent-session's `beforeToolCall` installer, which only
+// rethrows; instantiating a whole AgentSession to prove three lines is not
+// worth it, so its rethrow is pinned as a source tripwire below.
+//
+// pi's internals are not public exports, so they are reached by file path
+// (as pi-path-parity.test.ts does). If a locator throws, that IS the signal:
+// pi moved the module — re-verify the contract by hand before touching it.
+// ---------------------------------------------------------------------------
+
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+import { buildToolCallHandler } from "../privacy/extension";
+import type { PrivacyPort, PrivacyProbe } from "../extension";
+
+// @repo/agent declares the dependency, so pnpm links pi under this package's
+// own node_modules; pi-agent-core is pi's own dependency and therefore a
+// sibling of pi's REAL package dir under the same scope directory.
+const PI_PKG = fileURLToPath(
+  new URL("../../node_modules/@earendil-works/pi-coding-agent", import.meta.url),
+);
+
+function piFile(...segments: string[]): string {
+  const file = path.join(PI_PKG, "dist", ...segments);
+  if (!fs.existsSync(file)) {
+    throw new Error(
+      `pi's dist/${segments.join("/")} not found at ${file} — pi moved it; re-verify the ` +
+        `tool_call blockable contract by hand before updating this locator.`,
+    );
+  }
+  return file;
+}
+
+function piAgentCoreFile(...segments: string[]): string {
+  const file = path.join(fs.realpathSync(PI_PKG), "..", "pi-agent-core", "dist", ...segments);
+  if (!fs.existsSync(file)) {
+    throw new Error(
+      `pi-agent-core's dist/${segments.join("/")} not found at ${file} — the install layout ` +
+        `or the package changed; re-verify the tool_call blockable contract by hand.`,
+    );
+  }
+  return file;
+}
+
+// ---- Boundary types for the untyped deep imports -------------------------------
+
+type ToolCallHookEvent = {
+  type: "tool_call";
+  toolName: string;
+  toolCallId: string;
+  input: Record<string, unknown>;
+};
+type ToolCallHookResult = { block?: boolean; reason?: string };
+type ToolCallHook = (event: ToolCallHookEvent) => ToolCallHookResult | undefined;
+
+/** The subset of pi's ExtensionRunner this drives. `extensions` is pi's loaded
+ * -extension record shape: a handler map keyed by event name. */
+type ExtensionRunnerCtor = new (
+  extensions: { path: string; handlers: Map<string, ToolCallHook[]> }[],
+  runtime: unknown,
+  cwd: string,
+  sessionManager: unknown,
+  modelRegistry: unknown,
+) => { emitToolCall(event: ToolCallHookEvent): Promise<ToolCallHookResult | undefined> };
+
+type LoopToolResult = { content: { type: string; text?: string }[] };
+type LoopTool = {
+  name: string;
+  label: string;
+  description: string;
+  parameters: Record<string, unknown>;
+  execute: (id: string, args: Record<string, unknown>) => Promise<LoopToolResult>;
+};
+type LoopMessage = {
+  role: string;
+  content: unknown;
+  toolName?: string;
+  isError?: boolean;
+};
+type BeforeToolCall = (args: {
+  toolCall: { id: string; name: string; arguments: Record<string, unknown> };
+  args: Record<string, unknown>;
+}) => Promise<ToolCallHookResult | undefined>;
+type RunAgentLoop = (
+  prompts: LoopMessage[],
+  context: { systemPrompt: string; tools: LoopTool[]; messages: LoopMessage[] },
+  config: Record<string, unknown>,
+  emit: (event: unknown) => void,
+  signal: AbortSignal | undefined,
+  streamFn: () => unknown,
+) => Promise<LoopMessage[]>;
+
+/** Parse-at-boundary for a deep import: demand the named export EXISTS and is
+ * callable. The structural shape above is unverifiable at runtime — every
+ * assertion in this file is what actually exercises it. */
+function pickCallable<T>(mod: unknown, name: string, isT: (value: unknown) => value is T): T {
+  if (typeof mod !== "object" || mod === null) {
+    throw new Error(`pi module did not load — re-verify the tool_call blockable contract`);
+  }
+  const value: unknown = Reflect.get(mod, name);
+  if (!isT(value)) {
+    throw new Error(
+      `pi no longer exports a callable ${name}() — re-verify the tool_call blockable ` +
+        `contract by hand before updating this test`,
+    );
+  }
+  return value;
+}
+
+function isRunnerCtor(value: unknown): value is ExtensionRunnerCtor {
+  return typeof value === "function";
+}
+
+function isRunAgentLoop(value: unknown): value is RunAgentLoop {
+  return typeof value === "function";
+}
+
+async function loadModule(file: string): Promise<unknown> {
+  return await import(/* @vite-ignore */ pathToFileURL(file).href);
+}
+
+// ---- The privacy world under test ----------------------------------------------
+
+/** Content that must never reach the model when the note is private. */
+const SECRET_BODY = "TOP SECRET: the launch codes";
+
+let vaultRoot: string;
+let secretPath: string;
+let ExtensionRunner: ExtensionRunnerCtor;
+let runAgentLoop: RunAgentLoop;
+
+function privacyPort(overrides?: Partial<PrivacyPort>): PrivacyPort {
+  return {
+    probe: (rel): PrivacyProbe => (rel === "secret.md" ? "private" : "public"),
+    vaultRealRoot: () => vaultRoot,
+    vaultLexicalRoot: () => vaultRoot,
+    privateIndexPaths: () => ["secret.md"],
+    ...overrides,
+  };
+}
+
+/** pi's loaded-extension record, carrying the REAL privacy handler. */
+function privacyExtensions(
+  port: PrivacyPort,
+): { path: string; handlers: Map<string, ToolCallHook[]> }[] {
+  return [
+    {
+      path: "privacy",
+      handlers: new Map([["tool_call", [buildToolCallHandler(port, null)]]]),
+    },
+  ];
+}
+
+function newRunner(port: PrivacyPort): InstanceType<ExtensionRunnerCtor> {
+  return new ExtensionRunner(privacyExtensions(port), {}, vaultRoot, {}, {});
+}
+
+function readEvent(): ToolCallHookEvent {
+  return {
+    type: "tool_call",
+    toolName: "read",
+    toolCallId: "call-1",
+    input: { path: secretPath },
+  };
+}
+
+beforeAll(async () => {
+  ExtensionRunner = pickCallable(
+    await loadModule(piFile("core", "extensions", "runner.js")),
+    "ExtensionRunner",
+    isRunnerCtor,
+  );
+  runAgentLoop = pickCallable(
+    await loadModule(piAgentCoreFile("agent-loop.js")),
+    "runAgentLoop",
+    isRunAgentLoop,
+  );
+
+  vaultRoot = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), "pi-tool-call-contract-")));
+  secretPath = path.join(vaultRoot, "secret.md");
+  fs.writeFileSync(secretPath, `---\nprivate: true\n---\n\n${SECRET_BODY}\n`);
+});
+
+afterAll(() => {
+  fs.rmSync(vaultRoot, { recursive: true, force: true });
+});
+
+// ---- Layer 1: pi's extension dispatcher ----------------------------------------
+
+describe("pi tool_call dispatch (ExtensionRunner)", () => {
+  it("returns the gate's block result for a private note", async () => {
+    const result = await newRunner(privacyPort()).emitToolCall(readEvent());
+    expect(result?.block).toBe(true);
+    expect(result?.reason).toContain("private");
+    expect(JSON.stringify(result)).not.toContain(SECRET_BODY);
+  });
+
+  it("allows a public note (the dispatcher is not blocking everything)", async () => {
+    const event = { ...readEvent(), input: { path: path.join(vaultRoot, "public.md") } };
+    expect(await newRunner(privacyPort()).emitToolCall(event)).toBeUndefined();
+  });
+
+  it("propagates a throwing handler instead of swallowing it into an allow", async () => {
+    // FAIL-CLOSED by construction: the gate deliberately does not try/catch,
+    // because a probe (or a checkpoint capture) that blows up must stop the
+    // call. emitToolCall must therefore reject — unlike emitUserBash, which
+    // catches handler errors and continues.
+    const exploding = privacyPort({
+      probe: () => {
+        throw new Error("probe exploded");
+      },
+    });
+    await expect(newRunner(exploding).emitToolCall(readEvent())).rejects.toThrow("probe exploded");
+  });
+});
+
+// ---- Layer 2: agent-session's installer ----------------------------------------
+
+describe("pi agent-session tool hook installer", () => {
+  it("rethrows out of beforeToolCall rather than returning undefined", () => {
+    // Source tripwire, not a behavioural test: a whole AgentSession is far too
+    // much fixture for three lines. If pi ever catches here and returns, a
+    // throwing gate handler becomes an ALLOW — so a bump that reshapes this
+    // must be re-verified by hand, and failing here is how that happens.
+    const source = fs.readFileSync(piFile("core", "agent-session.js"), "utf8");
+    const start = source.indexOf("this.agent.beforeToolCall");
+    const end = source.indexOf("this.agent.afterToolCall", start);
+    expect(start, "pi no longer installs beforeToolCall in agent-session.js").toBeGreaterThan(-1);
+    expect(end, "pi no longer installs afterToolCall in agent-session.js").toBeGreaterThan(start);
+    const installer = source.slice(start, end);
+    expect(installer).toContain("emitToolCall");
+    for (const clause of installer.split("catch").slice(1)) {
+      expect(clause, "pi's beforeToolCall installer swallows a handler throw").toContain("throw");
+    }
+  });
+});
+
+// ---- Layer 3: the agent loop honours the block ----------------------------------
+
+type LoopOutcome = { executed: boolean; results: LoopMessage[] };
+
+/** What agent-session installs as `beforeToolCall`: forward the call to the
+ * extension runner, verbatim, letting a throw through. */
+function sessionHook(runner: InstanceType<ExtensionRunnerCtor>): BeforeToolCall {
+  return (event) =>
+    runner.emitToolCall({
+      type: "tool_call",
+      toolName: event.toolCall.name,
+      toolCallId: event.toolCall.id,
+      input: event.args,
+    });
+}
+
+/** Drive ONE real pi turn whose scripted assistant message calls `read` on the
+ * private note, with the given pre-execution hook. */
+async function runOneToolTurn(beforeToolCall: BeforeToolCall | undefined): Promise<LoopOutcome> {
+  let executed = false;
+  const tool: LoopTool = {
+    name: "read",
+    label: "Read",
+    description: "Read a file",
+    parameters: {
+      type: "object",
+      properties: { path: { type: "string" } },
+      required: ["path"],
+      additionalProperties: false,
+    },
+    execute: async () => {
+      executed = true;
+      return { content: [{ type: "text", text: SECRET_BODY }] };
+    },
+  };
+  const assistant = {
+    role: "assistant",
+    api: "test",
+    provider: "test",
+    model: "test",
+    stopReason: "toolUse",
+    content: [{ type: "toolCall", id: "call-1", name: "read", arguments: { path: secretPath } }],
+    usage: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, cost: {} },
+  };
+  const messages: LoopMessage[] = [];
+  const returned = await runAgentLoop(
+    [{ role: "user", content: "read the note" }],
+    { systemPrompt: "", tools: [tool], messages },
+    {
+      model: { id: "test", provider: "test", api: "test" },
+      convertToLlm: (input: LoopMessage[]) => input,
+      shouldStopAfterTurn: () => true,
+      ...(beforeToolCall ? { beforeToolCall } : {}),
+    },
+    () => {},
+    undefined,
+    () => ({
+      [Symbol.asyncIterator]: async function* () {},
+      result: () => assistant,
+    }),
+  );
+  return { executed, results: returned.filter((message) => message.role === "toolResult") };
+}
+
+function resultText(message: LoopMessage | undefined): string {
+  return JSON.stringify(message?.content ?? null);
+}
+
+describe("pi agent loop honours the tool_call verdict", () => {
+  it("CONTROL: with no hook the tool executes and its output reaches the model", async () => {
+    const outcome = await runOneToolTurn(undefined);
+    expect(outcome.executed).toBe(true);
+    expect(outcome.results).toHaveLength(1);
+    expect(resultText(outcome.results[0])).toContain(SECRET_BODY);
+  });
+
+  it("a blocked call never executes, and the model gets the reason as an error", async () => {
+    const outcome = await runOneToolTurn(sessionHook(newRunner(privacyPort())));
+    expect(outcome.executed).toBe(false);
+    expect(outcome.results).toHaveLength(1);
+    expect(outcome.results[0]?.isError).toBe(true);
+    expect(resultText(outcome.results[0])).toContain("private");
+    expect(resultText(outcome.results[0])).not.toContain(SECRET_BODY);
+  });
+
+  it("a throwing hook never executes the tool either (fail closed)", async () => {
+    const exploding = privacyPort({
+      probe: () => {
+        throw new Error("probe exploded");
+      },
+    });
+    const outcome = await runOneToolTurn(sessionHook(newRunner(exploding)));
+    expect(outcome.executed).toBe(false);
+    expect(outcome.results[0]?.isError).toBe(true);
+    expect(resultText(outcome.results[0])).not.toContain(SECRET_BODY);
+  });
+});

--- a/packages/agent/src/__tests__/skill-authoring.test.ts
+++ b/packages/agent/src/__tests__/skill-authoring.test.ts
@@ -1,0 +1,125 @@
+// ---------------------------------------------------------------------------
+// Authoring a skill writes a directory named from a text field, and that
+// directory's contents get read into every turn's system prompt. Two things
+// are pinned here: the name can never address a path outside the skills
+// folder, and the frontmatter can never be rewritten by its own values.
+// ---------------------------------------------------------------------------
+
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterAll, describe, expect, it } from "vitest";
+
+import { renderSkillFile, toSkillSlug, writeNewSkill } from "../skill-authoring";
+
+const tmpDirs: string[] = [];
+
+function makeSkillsDir(): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "skill-authoring-"));
+  tmpDirs.push(dir);
+  return path.join(dir, "skills");
+}
+
+afterAll(() => {
+  for (const dir of tmpDirs) fs.rmSync(dir, { recursive: true, force: true });
+});
+
+describe("toSkillSlug", () => {
+  it("folds a display name to a spec-shaped folder name", () => {
+    expect(toSkillSlug("Summarize Note")).toBe("summarize-note");
+    expect(toSkillSlug("  Weekly   Review!  ")).toBe("weekly-review");
+    expect(toSkillSlug("PDF→Markdown")).toBe("pdf-markdown");
+  });
+
+  it("dissolves every character a path could be built from", () => {
+    for (const hostile of [
+      "../../../etc/passwd",
+      "a/../../b",
+      "C:\\Windows\\System32",
+      "~/.ssh/id_rsa",
+      ".hidden",
+    ]) {
+      const slug = toSkillSlug(hostile);
+      expect(slug).not.toBeNull();
+      expect(slug).toMatch(/^[a-z0-9]+(?:-[a-z0-9]+)*$/);
+    }
+  });
+
+  it("returns null when nothing usable survives", () => {
+    expect(toSkillSlug("")).toBeNull();
+    expect(toSkillSlug("   ")).toBeNull();
+    expect(toSkillSlug("///")).toBeNull();
+    expect(toSkillSlug("..")).toBeNull();
+    expect(toSkillSlug("…")).toBeNull();
+  });
+});
+
+describe("renderSkillFile", () => {
+  it("quotes frontmatter values so they cannot rewrite the frontmatter", () => {
+    const file = renderSkillFile({
+      slug: "hostile",
+      description: 'Ends here"\n---\nname: other\ndescription: injected\n---\n',
+      body: "steps",
+    });
+    const frontmatter = file.split("---\n")[1] ?? "";
+
+    expect(frontmatter.split("\n").filter((line) => line.startsWith("name:"))).toHaveLength(1);
+    expect(frontmatter).not.toContain("injected\n");
+    expect(file.endsWith("steps\n")).toBe(true);
+  });
+
+  it("writes a placeholder body when there are no instructions yet", () => {
+    expect(renderSkillFile({ slug: "empty", description: "d", body: "   " })).toContain("# empty");
+  });
+});
+
+describe("writeNewSkill", () => {
+  it("writes SKILL.md inside the skills folder and reports where", () => {
+    const skillsDir = makeSkillsDir();
+    fs.mkdirSync(skillsDir, { recursive: true });
+
+    const written = writeNewSkill(skillsDir, {
+      name: "Weekly Review",
+      description: "Draft the weekly review.",
+      instructions: "Read this week's daily notes, then draft the review.",
+    });
+
+    expect(written.slug).toBe("weekly-review");
+    expect(written.filePath).toBe(path.join(skillsDir, "weekly-review", "SKILL.md"));
+    expect(fs.readFileSync(written.filePath, "utf8")).toContain('name: "weekly-review"');
+  });
+
+  it("keeps a traversal-shaped name inside the skills folder", () => {
+    const skillsDir = makeSkillsDir();
+    fs.mkdirSync(skillsDir, { recursive: true });
+
+    const written = writeNewSkill(skillsDir, {
+      name: "../../escape",
+      description: "d",
+      instructions: "",
+    });
+    expect(path.dirname(path.dirname(written.filePath))).toBe(skillsDir);
+  });
+
+  it("refuses a name with nothing to slugify", () => {
+    const skillsDir = makeSkillsDir();
+    fs.mkdirSync(skillsDir, { recursive: true });
+    expect(() =>
+      writeNewSkill(skillsDir, { name: "///", description: "d", instructions: "" }),
+    ).toThrow(/no letters or digits/);
+  });
+
+  it("never overwrites an existing skill", () => {
+    const skillsDir = makeSkillsDir();
+    fs.mkdirSync(skillsDir, { recursive: true });
+    const input = { name: "Notes Triage", description: "d", instructions: "original" };
+    writeNewSkill(skillsDir, input);
+
+    expect(() => writeNewSkill(skillsDir, { ...input, instructions: "replacement" })).toThrow(
+      /already exists/,
+    );
+    expect(fs.readFileSync(path.join(skillsDir, "notes-triage", "SKILL.md"), "utf8")).toContain(
+      "original",
+    );
+  });
+});

--- a/packages/agent/src/__tests__/skill-budget.test.ts
+++ b/packages/agent/src/__tests__/skill-budget.test.ts
@@ -1,0 +1,293 @@
+// ---------------------------------------------------------------------------
+// Skill prompt budget. `~/.inteligir/skills` is user-writable and every skill
+// in it costs prompt on EVERY turn, so the loader bounds the set. Three
+// contracts pinned here:
+//   1. The budget sheds DESCRIPTIONS, not skills — a skill the model knows by
+//      name alone is still invocable, so every name survives right up to the
+//      count backstop, and no skill ever leaves the listing silently.
+//   2. Deterministic selection (never readdir order) and a notice per change.
+//   3. Settings↔agent parity — the Settings listing and the agent's resource
+//      loader are two independent call paths into pi, and they must apply the
+//      SAME budget or Settings advertises more than the model ever saw.
+// ---------------------------------------------------------------------------
+
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterAll, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { IPC } from "@repo/bridge/ipc-registry";
+import {
+  applySkillBudget,
+  MAX_SKILL_DESCRIPTION_CHARS,
+  MAX_SKILLS,
+  MAX_TOTAL_SKILL_DESCRIPTION_CHARS,
+  MIN_GRANTED_DESCRIPTION_CHARS,
+  skillBudgetNotices,
+  type BudgetableSkill,
+  type BudgetedSkill,
+} from "../pi/skill-budget";
+import { budgetSkills, budgetSkillsOverride, listSkills } from "../pi/skills";
+
+const REPO_ROOT = path.resolve(import.meta.dirname, "../../../..");
+const tmpDirs: string[] = [];
+
+function makeTmpDir(): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "skill-budget-"));
+  tmpDirs.push(dir);
+  return dir;
+}
+
+afterAll(() => {
+  for (const dir of tmpDirs) fs.rmSync(dir, { recursive: true, force: true });
+});
+
+beforeEach(() => {
+  vi.restoreAllMocks();
+  vi.spyOn(console, "warn").mockImplementation(() => {});
+});
+
+function skill(name: string, descriptionChars: number): BudgetableSkill {
+  return {
+    name,
+    description: "d".repeat(descriptionChars),
+    filePath: `/skills/${name}/SKILL.md`,
+  };
+}
+
+/** `skill-01` … so lexicographic order is also numeric order. */
+function numbered(count: number, descriptionChars: number): BudgetableSkill[] {
+  return Array.from({ length: count }, (_, i) =>
+    skill(`skill-${String(i + 1).padStart(3, "0")}`, descriptionChars),
+  );
+}
+
+function seedSkillsDir(root: string, skills: readonly BudgetableSkill[]): void {
+  for (const s of skills) {
+    const dir = path.join(root, "skills", s.name);
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(
+      path.join(dir, "SKILL.md"),
+      `---\nname: ${s.name}\ndescription: ${s.description}\n---\n\nbody\n`,
+    );
+  }
+}
+
+function promptChars<T extends BudgetableSkill>(entries: readonly BudgetedSkill<T>[]): number {
+  return entries
+    .filter((entry) => entry.budget.kind !== "not-loaded")
+    .reduce((sum, entry) => sum + entry.skill.description.length, 0);
+}
+
+describe("applySkillBudget", () => {
+  it("passes an under-budget set through untouched", () => {
+    const skills = numbered(3, 100);
+    const { skills: kept, entries } = applySkillBudget(skills);
+    expect(kept).toEqual(skills);
+    expect(entries.map((entry) => entry.budget)).toEqual([
+      { kind: "loaded" },
+      { kind: "loaded" },
+      { kind: "loaded" },
+    ]);
+  });
+
+  it("selects by name, not by the order the caller enumerated", () => {
+    const skills = numbered(MAX_SKILLS + 5, 10);
+    const shuffled = skills.toReversed();
+    expect(applySkillBudget(shuffled).skills.map((s) => s.name)).toEqual(
+      applySkillBudget(skills).skills.map((s) => s.name),
+    );
+  });
+
+  it("returns every input skill, however far over budget the set is", () => {
+    const skills = numbered(MAX_SKILLS + 12, MAX_SKILL_DESCRIPTION_CHARS);
+    const { entries } = applySkillBudget(skills);
+    expect(entries.map((entry) => entry.skill.name)).toEqual(skills.map((s) => s.name));
+  });
+
+  it("sheds description characters rather than skills when the total is blown", () => {
+    // Every skill alone is under the per-skill cap; together they are 3x the
+    // total budget. The old model dropped the tail; this one keeps all of them.
+    const each = 1000;
+    const count = Math.min(MAX_SKILLS, Math.floor((MAX_TOTAL_SKILL_DESCRIPTION_CHARS * 3) / each));
+    const { skills: kept, entries } = applySkillBudget(numbered(count, each));
+
+    expect(kept).toHaveLength(count);
+    expect(entries.every((entry) => entry.budget.kind === "description-trimmed")).toBe(true);
+    expect(promptChars(entries)).toBeLessThanOrEqual(MAX_TOTAL_SKILL_DESCRIPTION_CHARS);
+  });
+
+  it("never shrinks a description below the guaranteed fair share", () => {
+    const { entries } = applySkillBudget(numbered(MAX_SKILLS, MAX_SKILL_DESCRIPTION_CHARS));
+    for (const entry of entries) {
+      expect(entry.skill.description.length).toBeGreaterThanOrEqual(MIN_GRANTED_DESCRIPTION_CHARS);
+    }
+  });
+
+  it("leaves a short description whole and clips only its verbose neighbours", () => {
+    const small = skill("zz-small", 40);
+    const { entries } = applySkillBudget([
+      ...numbered(MAX_SKILLS - 1, MAX_SKILL_DESCRIPTION_CHARS),
+      small,
+    ]);
+    const smallEntry = entries.find((entry) => entry.skill.name === "zz-small");
+
+    expect(smallEntry?.skill.description).toBe(small.description);
+    expect(smallEntry?.budget).toEqual({ kind: "loaded" });
+    expect(entries.filter((entry) => entry.budget.kind === "description-trimmed")).toHaveLength(
+      MAX_SKILLS - 1,
+    );
+  });
+
+  it("caps the skill count as a backstop and still reports the overflow", () => {
+    const over = 7;
+    const { skills: kept, entries } = applySkillBudget(numbered(MAX_SKILLS + over, 10));
+    const notLoaded = entries.filter((entry) => entry.budget.kind === "not-loaded");
+
+    expect(kept).toHaveLength(MAX_SKILLS);
+    expect(kept.map((s) => s.name)).toEqual(numbered(MAX_SKILLS, 10).map((s) => s.name));
+    expect(notLoaded).toHaveLength(over);
+    expect(notLoaded.map((entry) => entry.budget)).toEqual(
+      Array.from({ length: over }, () => ({ kind: "not-loaded", reason: "skill-count" })),
+    );
+  });
+
+  it("truncates an over-long description instead of dropping the skill", () => {
+    const original = skill("verbose", MAX_SKILL_DESCRIPTION_CHARS * 2);
+    const { skills: kept, entries } = applySkillBudget([original]);
+
+    expect(kept[0]?.name).toBe("verbose");
+    expect(kept[0]?.description).toHaveLength(MAX_SKILL_DESCRIPTION_CHARS);
+    expect(kept[0]?.description.endsWith("…")).toBe(true);
+    expect(entries[0]?.budget).toEqual({
+      kind: "description-trimmed",
+      promptChars: MAX_SKILL_DESCRIPTION_CHARS,
+      originalChars: MAX_SKILL_DESCRIPTION_CHARS * 2,
+    });
+    expect(original.description).toHaveLength(MAX_SKILL_DESCRIPTION_CHARS * 2);
+  });
+
+  it("clamps the description of a skill the count ceiling excluded too", () => {
+    const entries = applySkillBudget([
+      ...numbered(MAX_SKILLS, 10),
+      skill("zz-overflow", MAX_SKILL_DESCRIPTION_CHARS * 2),
+    ]).entries;
+    const overflow = entries.at(-1);
+
+    expect(overflow?.budget).toEqual({ kind: "not-loaded", reason: "skill-count" });
+    expect(overflow?.skill.description).toHaveLength(MAX_SKILL_DESCRIPTION_CHARS);
+  });
+
+  it("reports every shortening and exclusion as a notice carrying the skill's path", () => {
+    const { entries } = applySkillBudget([
+      ...numbered(MAX_SKILLS + 1, 10),
+      skill("zz", MAX_SKILL_DESCRIPTION_CHARS * 2),
+    ]);
+    const notices = skillBudgetNotices(entries);
+
+    expect(notices.length).toBe(entries.filter((e) => e.budget.kind !== "loaded").length);
+    for (const notice of notices) expect(notice.path).toMatch(/SKILL\.md$/);
+  });
+
+  it("emits no notices when everything fits", () => {
+    expect(skillBudgetNotices(applySkillBudget(numbered(2, 50)).entries)).toEqual([]);
+  });
+});
+
+describe("Settings ↔ agent parity", () => {
+  it("the Settings listing returns exactly the budgeted set", () => {
+    const agentDir = makeTmpDir();
+    const cwd = makeTmpDir();
+    const onDisk = numbered(MAX_SKILLS + 6, 20);
+    seedSkillsDir(agentDir, onDisk);
+
+    const listed = listSkills({ cwd, agentDir, bundledSkillsDir: path.join(cwd, "resources") });
+    const budgeted = applySkillBudget(onDisk);
+
+    expect(listed.map((s) => s.name)).toEqual(budgeted.entries.map((e) => e.skill.name));
+    expect(listed.map((s) => s.budget)).toEqual(budgeted.entries.map((e) => e.budget));
+  });
+
+  it("the agent's resource-loader override applies the same budget", () => {
+    const onDisk = numbered(MAX_SKILLS + 6, 20);
+    const loaded = onDisk.map((s) => ({
+      ...s,
+      baseDir: path.dirname(s.filePath),
+      sourceInfo: {
+        path: s.filePath,
+        source: "local",
+        scope: "user" as const,
+        origin: "top-level" as const,
+      },
+      disableModelInvocation: false,
+    }));
+    const base = { skills: loaded, diagnostics: [{ type: "warning" as const, message: "pre" }] };
+
+    const result = budgetSkillsOverride(base);
+    expect(result.skills.map((s) => s.name)).toEqual(
+      applySkillBudget(onDisk).skills.map((s) => s.name),
+    );
+    expect(result.diagnostics[0]).toEqual({ type: "warning", message: "pre" });
+    expect(result.diagnostics.length).toBeGreaterThan(1);
+  });
+
+  it("logs every exclusion so a missing skill leaves a trace in agent.log", () => {
+    const warn = vi.mocked(console.warn);
+    budgetSkills(numbered(MAX_SKILLS + 2, 10));
+    expect(warn).toHaveBeenCalledTimes(2);
+    expect(warn.mock.calls[0]?.[0]).toContain("not available to the agent");
+  });
+
+  it("keeps the agent's session loader wired to the shared budget seam", () => {
+    // Behavioural tests cover both budget functions; only the WIRING can
+    // regress silently — an edit dropping `skillsOverride` would leave the
+    // Settings list bounded and the agent's prompt unbounded.
+    const source = fs.readFileSync(path.join(REPO_ROOT, "packages/agent/src/pi/agent.ts"), "utf8");
+    expect(source).toContain("skillsOverride: budgetSkillsOverride");
+  });
+});
+
+describe("listSkills projection", () => {
+  it("labels a seeded copy of a shipped skill as bundled and everything else as added", () => {
+    const agentDir = makeTmpDir();
+    const cwd = makeTmpDir();
+    const resources = makeTmpDir();
+
+    seedSkillsDir(agentDir, [skill("shipped", 30), skill("mine", 30)]);
+    // The app's shipped set — folder names only; seeding COPIES them, so the
+    // seeded file's own path can never say where it came from.
+    fs.mkdirSync(path.join(resources, "skills", "shipped"), { recursive: true });
+
+    const bySource = new Map(
+      listSkills({ cwd, agentDir, bundledSkillsDir: path.join(resources, "skills") }).map((s) => [
+        s.name,
+        s.source,
+      ]),
+    );
+    expect(bySource.get("shipped")).toBe("bundled");
+    expect(bySource.get("mine")).toBe("added");
+  });
+
+  it("carries the SKILL.md mtime as epoch milliseconds", () => {
+    const agentDir = makeTmpDir();
+    const cwd = makeTmpDir();
+    seedSkillsDir(agentDir, [skill("dated", 30)]);
+    const filePath = path.join(agentDir, "skills", "dated", "SKILL.md");
+    const mtime = new Date("2026-07-24T10:00:00.000Z");
+    fs.utimesSync(filePath, mtime, mtime);
+
+    const listed = listSkills({ cwd, agentDir, bundledSkillsDir: path.join(cwd, "resources") });
+    expect(listed[0]?.updatedAt).toBe(mtime.getTime());
+  });
+});
+
+describe("createSkill wire schema", () => {
+  it("caps a submitted description at the same limit the budget clamps to", () => {
+    // @repo/bridge cannot import @repo/agent, so the wire schema restates the
+    // cap as a literal. Accepting a longer one would write a description the
+    // very next listing clips back out.
+    expect(IPC.createSkill.payload.properties.description.maxLength).toBe(
+      MAX_SKILL_DESCRIPTION_CHARS,
+    );
+  });
+});

--- a/packages/agent/src/knowledge-tools/extension.ts
+++ b/packages/agent/src/knowledge-tools/extension.ts
@@ -24,6 +24,7 @@
 
 import { Type, type Static } from "@sinclair/typebox";
 
+import { NotePathSchema } from "@repo/bridge/ipc-registry";
 import type { SearchResult } from "@repo/notes/knowledge/knowledge-index";
 
 import type { PiExtensionBundle } from "../extension";
@@ -92,25 +93,6 @@ const SearchVaultSchema = Type.Object({
   ),
 });
 
-const GetBacklinksSchema = Type.Object({
-  path: Type.String({
-    description: "Vault-relative note path (e.g. 'notes/ideas.md') to find links pointing to it.",
-  }),
-});
-
-const GetLinksSchema = Type.Object({
-  path: Type.String({
-    description:
-      "Vault-relative note path (e.g. 'notes/ideas.md') whose outgoing links to resolve.",
-  }),
-});
-
-const RelatedNotesSchema = Type.Object({
-  path: Type.String({
-    description: "Vault-relative note path (e.g. 'notes/ideas.md') to find notes related to it.",
-  }),
-});
-
 const RenameNoteSchema = Type.Object({
   from: Type.String({
     description: "Current vault-relative path of the file to rename or move (e.g. 'notes/old.md').",
@@ -171,8 +153,8 @@ const knowledgeExtension: PiExtensionBundle = {
           "Notes that link TO the given vault-relative note path (wiki-links and markdown " +
           `links). ${RESULT_SHAPE_NOTE} Each element is \`{path}\`; at most ${BACKLINKS_MAX} ` +
           "are returned.",
-        parameters: GetBacklinksSchema,
-        execute: async (_toolCallId, params: Static<typeof GetBacklinksSchema>) => {
+        parameters: NotePathSchema,
+        execute: async (_toolCallId, params: Static<typeof NotePathSchema>) => {
           const hits = ports.knowledge.backlinks(params.path);
           // De-dupe by source path — a note can link to the target on several
           // lines, but the agent only needs the set of linking notes.
@@ -194,8 +176,8 @@ const knowledgeExtension: PiExtensionBundle = {
           "is `{path}` for a resolved target, or `{target, unresolved: true}` for a link " +
           `whose note does not exist yet. Targets are de-duped; at most ${LINKS_MAX} are ` +
           "returned.",
-        parameters: GetLinksSchema,
-        execute: async (_toolCallId, params: Static<typeof GetLinksSchema>) => {
+        parameters: NotePathSchema,
+        execute: async (_toolCallId, params: Static<typeof NotePathSchema>) => {
           const entries = ports.knowledge.forwardLinks(params.path);
           // De-dupe the way the renderer's Links panel groups: by resolved
           // target path, and by RAW TARGET TEXT when the link dangles, so
@@ -226,8 +208,8 @@ const knowledgeExtension: PiExtensionBundle = {
           `get_backlinks are the tools for those). Use this for 'what else touches this topic?'. ` +
           `${RESULT_SHAPE_NOTE} Each element is \`{path, reasons}\`, reasons being an ` +
           "array of strings.",
-        parameters: RelatedNotesSchema,
-        execute: async (_toolCallId, params: Static<typeof RelatedNotesSchema>) => {
+        parameters: NotePathSchema,
+        execute: async (_toolCallId, params: Static<typeof NotePathSchema>) => {
           const hits = ports.knowledge.relatedNotes(params.path);
           // `reasons` stays an array rather than a "; "-joined string: the same
           // delimiter argument as the row separator, one level down.

--- a/packages/agent/src/pi/agent.ts
+++ b/packages/agent/src/pi/agent.ts
@@ -14,6 +14,7 @@ import type { Api, AssistantMessage, ImageContent, Model } from "@earendil-works
 import { toErrorMessage } from "@repo/bridge/wire-helpers";
 
 import { prepareRuntimeForSelection, resolveModelSelection, type ModelSelection } from "./model";
+import { budgetSkillsOverride } from "./skills";
 
 export type PiAgentStatus = "starting" | "idle" | "busy" | "error";
 
@@ -112,6 +113,10 @@ export class PiAgent {
       cwd: this.config.cwd,
       agentDir: this.config.agentDir,
       extensionFactories: factories,
+      // `<agentDir>/skills` is user-writable and every skill it holds costs
+      // prompt on every turn — bound it, and bound it through the same seam
+      // the Settings listing runs so the two cannot drift.
+      skillsOverride: budgetSkillsOverride,
       ...(extraAgentsFiles !== undefined
         ? {
             agentsFilesOverride: (base: { agentsFiles: AgentsFileEntry[] }) => ({

--- a/packages/agent/src/pi/skill-budget.ts
+++ b/packages/agent/src/pi/skill-budget.ts
@@ -1,0 +1,186 @@
+// Skills are user-writable input to the system prompt: `~/.inteligir/skills`
+// is a folder anyone (the user, an agent, an installer) can drop a SKILL.md
+// into, and every loaded skill's name + description + path is injected into
+// EVERY turn's prompt. Nothing upstream bounds that — pi warns when a
+// description exceeds the Agent Skills spec's limit but loads the skill
+// anyway — so the bound lives here, as ONE pure function both the agent's
+// resource loader and the Settings listing run, so the list the user sees is
+// the set the model is told about.
+//
+// What the bound sheds is DESCRIPTION CHARACTERS, not skills. A skill the
+// model knows by name alone is still invocable; a skill missing from the
+// listing cannot be reached at all. So the total budget is spread across the
+// whole set by fair share (water-filling): short descriptions survive intact
+// and only the longest are clipped, never below
+// MAX_TOTAL_SKILL_DESCRIPTION_CHARS / MAX_SKILLS characters each. The skill
+// COUNT ceiling is the one thing that can still keep a skill out of the
+// prompt, and it is a backstop against a pathological folder rather than a
+// routine trim.
+
+import type { SkillBudgetState } from "@repo/bridge/ipc-registry";
+
+/** The fields the budget reasons about. pi's `Skill` and the Bridge's
+ * `SkillInfo` both satisfy it, which is what lets one function serve both
+ * the agent path and the Settings path. */
+export type BudgetableSkill = {
+  name: string;
+  description: string;
+  filePath: string;
+};
+
+/** Per-skill description cap. Descriptions are clipped to it before anything
+ * else, so no caller — prompt or listing — is ever handed an unbounded one. */
+export const MAX_SKILL_DESCRIPTION_CHARS = 1536;
+
+/** Total description budget across all skills, in characters. The bundled
+ * browser skill's description is ~410 chars, so this holds ~39 skills of that
+ * size (~4k tokens) — spent on every single turn, which is what makes the
+ * ceiling worth having. Past it, descriptions shrink; the skills stay. */
+export const MAX_TOTAL_SKILL_DESCRIPTION_CHARS = 16_000;
+
+/** Cap on how many skills reach the prompt at all. Descriptions shrink to fit
+ * long before this bites; what it bounds is the per-entry name + absolute path
+ * (~150 chars each) and the dilution of the model's selection. Far above the
+ * bundled skill plus a hand-curated personal set. */
+export const MAX_SKILLS = 50;
+
+/** Fair share, so the guaranteed floor is a number and not a hope: with the
+ * count ceiling in force, water-filling can never grant a description less
+ * than this — enough to route the model to the skill. */
+export const MIN_GRANTED_DESCRIPTION_CHARS = Math.floor(
+  MAX_TOTAL_SKILL_DESCRIPTION_CHARS / MAX_SKILLS,
+);
+
+export type BudgetedSkill<T extends BudgetableSkill> = {
+  /** The skill as the prompt receives it — description already clamped. */
+  skill: T;
+  budget: SkillBudgetState;
+};
+
+export type SkillBudgetResult<T extends BudgetableSkill> = {
+  /** Every input skill, name-ordered and annotated — including any the count
+   * ceiling kept out of the prompt. The Settings listing renders this. */
+  entries: BudgetedSkill<T>[];
+  /** Just the skills the prompt receives. */
+  skills: T[];
+};
+
+/** Total order over skills, so which skills survive an over-budget folder is
+ * a function of their names alone — never of readdir order, which varies by
+ * filesystem and would make the prompt differ between machines and between
+ * boots on the same machine. */
+function compareSkills(a: BudgetableSkill, b: BudgetableSkill): number {
+  if (a.name !== b.name) return a.name < b.name ? -1 : 1;
+  if (a.filePath !== b.filePath) return a.filePath < b.filePath ? -1 : 1;
+  return 0;
+}
+
+/** Clip to `limit` characters, the last of which is an ellipsis so a clipped
+ * description reads as clipped to the model. */
+function clip(description: string, limit: number): string {
+  if (description.length <= limit) return description;
+  if (limit <= 1) return "";
+  return `${description.slice(0, limit - 1)}…`;
+}
+
+function withDescription<T extends BudgetableSkill>(skill: T, description: string): T {
+  return description === skill.description ? skill : { ...skill, description };
+}
+
+/**
+ * Water-fill `total` characters across `lengths`: shortest first, each taking
+ * at most an equal share of what is left over. A verbose description cannot
+ * starve its neighbours, and because the share only grows as short entries
+ * hand back their surplus, every entry is granted at least
+ * `floor(total / lengths.length)` characters.
+ */
+function allocate(lengths: readonly number[], total: number): number[] {
+  const shortestFirst = lengths
+    .map((length, index) => ({ length, index }))
+    .toSorted((a, b) => a.length - b.length || a.index - b.index);
+  const granted: number[] = Array.from({ length: lengths.length }, () => 0);
+  let remaining = total;
+  let unallocated = lengths.length;
+  for (const { length, index } of shortestFirst) {
+    const grant = Math.min(length, Math.floor(remaining / unallocated));
+    granted[index] = grant;
+    remaining -= grant;
+    unallocated -= 1;
+  }
+  return granted;
+}
+
+/**
+ * Bound the prompt cost of a skill set. Returns every skill — name-ordered,
+ * descriptions clamped — annotated with what the prompt actually got, plus the
+ * subset that reached the prompt at all. Nothing is silently lost: a skill
+ * past the count ceiling still comes back, marked `not-loaded`.
+ */
+export function applySkillBudget<T extends BudgetableSkill>(
+  skills: readonly T[],
+): SkillBudgetResult<T> {
+  const ordered = skills.toSorted(compareSkills);
+  // The per-skill cap applies to listed and unlisted skills alike — it bounds
+  // what crosses the wire as much as what reaches the model.
+  const listed = ordered.slice(0, MAX_SKILLS).map((skill) => ({
+    skill,
+    capped: clip(skill.description, MAX_SKILL_DESCRIPTION_CHARS),
+  }));
+  const granted = allocate(
+    listed.map((entry) => entry.capped.length),
+    MAX_TOTAL_SKILL_DESCRIPTION_CHARS,
+  );
+
+  const entries: BudgetedSkill<T>[] = listed.map(({ skill, capped }, index) => {
+    const description = clip(capped, granted[index] ?? capped.length);
+    return {
+      skill: withDescription(skill, description),
+      budget:
+        description === skill.description
+          ? { kind: "loaded" }
+          : {
+              kind: "description-trimmed",
+              promptChars: description.length,
+              originalChars: skill.description.length,
+            },
+    };
+  });
+
+  const overflow: BudgetedSkill<T>[] = ordered.slice(MAX_SKILLS).map((skill) => ({
+    skill: withDescription(skill, clip(skill.description, MAX_SKILL_DESCRIPTION_CHARS)),
+    budget: { kind: "not-loaded", reason: "skill-count" },
+  }));
+
+  return {
+    entries: [...entries, ...overflow],
+    skills: entries.map((entry) => entry.skill),
+  };
+}
+
+/** A budget outcome worth telling someone about, shaped for both pi's
+ * `ResourceDiagnostic` and a log line. */
+export type SkillBudgetNotice = { message: string; path: string };
+
+const NOT_LOADED_REASON_TEXT = {
+  "skill-count": `more than ${MAX_SKILLS} skills found`,
+} as const;
+
+/** One notice per skill the budget changed. Empty when everything fit, which
+ * is the normal case — callers can log the whole array unconditionally. */
+export function skillBudgetNotices<T extends BudgetableSkill>(
+  entries: readonly BudgetedSkill<T>[],
+): SkillBudgetNotice[] {
+  const notices: SkillBudgetNotice[] = [];
+  for (const { skill, budget } of entries) {
+    if (budget.kind === "loaded") continue;
+    notices.push({
+      path: skill.filePath,
+      message:
+        budget.kind === "not-loaded"
+          ? `skill "${skill.name}" is not available to the agent: ${NOT_LOADED_REASON_TEXT[budget.reason]}`
+          : `skill "${skill.name}" description shortened to ${budget.promptChars} characters ` +
+            `(was ${budget.originalChars}) to fit the skill listing budget`,
+    });
+  }
+  return notices;
+}

--- a/packages/agent/src/pi/skills.ts
+++ b/packages/agent/src/pi/skills.ts
@@ -1,20 +1,114 @@
-import { loadSkills } from "@earendil-works/pi-coding-agent";
+import fs from "node:fs";
+import path from "node:path";
 
-import type { SkillInfo } from "@repo/bridge/ipc-registry";
+import { loadSkills } from "@earendil-works/pi-coding-agent";
+import type { ResourceDiagnostic, Skill } from "@earendil-works/pi-coding-agent";
+
+import type { SkillInfo, SkillSource } from "@repo/bridge/ipc-registry";
+import {
+  applySkillBudget,
+  skillBudgetNotices,
+  type BudgetableSkill,
+  type BudgetedSkill,
+} from "./skill-budget";
 
 export type ListSkillsOptions = {
   /** Working directory — project skills live under `<cwd>/.pi/skills`. */
   cwd: string;
   /** Agent config directory — user skills live under `<agentDir>/skills`. */
   agentDir: string;
+  /** Directory of the skills the app SHIPS (`<resources>/agent/skills`). Read
+   * only for its folder NAMES: seeding copies those folders into
+   * `<agentDir>/skills`, so the copy's path can't say where it came from. */
+  bundledSkillsDir: string;
 };
+
+/**
+ * Apply the prompt budget and surface what it changed: pi's diagnostics for
+ * the session, plus the console (teed to `~/.inteligir/logs/agent.log`) so a
+ * shortened or unloaded skill is discoverable outside a running session.
+ *
+ * The ONE entry point for budgeting. Both callers — the agent's resource
+ * loader and the Settings listing — go through it, so Settings can never
+ * advertise more of a skill than the model was told about.
+ */
+export function budgetSkills<T extends BudgetableSkill>(
+  skills: readonly T[],
+): { entries: BudgetedSkill<T>[]; skills: T[]; diagnostics: ResourceDiagnostic[] } {
+  const { entries, skills: kept } = applySkillBudget(skills);
+  const notices = skillBudgetNotices(entries);
+  for (const notice of notices) {
+    console.warn(`[agent] skill budget: ${notice.message} — ${notice.path}`);
+  }
+  return {
+    entries,
+    skills: kept,
+    diagnostics: notices.map(({ message, path: noticePath }) => ({
+      type: "warning",
+      message,
+      path: noticePath,
+    })),
+  };
+}
+
+/** pi resource-loader hook (`DefaultResourceLoaderOptions.skillsOverride`):
+ * the budget applied to the skills a session is about to load, with its
+ * notices appended to the loader's own diagnostics. */
+export function budgetSkillsOverride(base: {
+  skills: Skill[];
+  diagnostics: ResourceDiagnostic[];
+}): { skills: Skill[]; diagnostics: ResourceDiagnostic[] } {
+  const budgeted = budgetSkills(base.skills);
+  return {
+    skills: budgeted.skills,
+    diagnostics: [...base.diagnostics, ...budgeted.diagnostics],
+  };
+}
+
+/** Folder names under the app's shipped skills dir. Missing dir (dev checkout
+ * without built resources) → nothing is bundled, which reads as "added": a
+ * wrong label is better than a fabricated one. */
+function bundledFolderNames(dir: string): ReadonlySet<string> {
+  try {
+    return new Set(
+      fs
+        .readdirSync(dir, { withFileTypes: true })
+        .filter((entry) => entry.isDirectory())
+        .map((entry) => entry.name),
+    );
+  } catch {
+    return new Set();
+  }
+}
+
+/** epoch ms of the SKILL.md itself — pi's `Skill` carries no mtime, so the
+ * host stats the file it already knows the path of. */
+function lastModified(filePath: string): number | null {
+  try {
+    return fs.statSync(filePath).mtimeMs;
+  } catch {
+    return null;
+  }
+}
+
+function skillSource(
+  skill: Skill,
+  userSkillsRoot: string,
+  bundled: ReadonlySet<string>,
+): SkillSource {
+  const folder = path.resolve(skill.baseDir);
+  if (path.dirname(folder) !== userSkillsRoot) return "added";
+  return bundled.has(path.basename(folder)) ? "bundled" : "added";
+}
 
 /**
  * Discover skills the same way pi does at session start, straight from disk so
  * it works regardless of agent lifecycle state. Covers both the user scope
  * (`<agentDir>/skills`) and the project scope (`<cwd>/.pi/skills`), with name
- * collisions already resolved. Returns the IPC contract's `SkillInfo` — a
- * plain projection of pi's `Skill` that serializes over the Bridge.
+ * collisions already resolved, then applies the same prompt budget a session
+ * does. Returns the IPC contract's `SkillInfo` — a plain projection of pi's
+ * `Skill` that serializes over the Bridge, carrying what the budget did to
+ * each one so a row can say so.
  */
 export function listSkills(options: ListSkillsOptions): SkillInfo[] {
   const { skills } = loadSkills({
@@ -23,10 +117,15 @@ export function listSkills(options: ListSkillsOptions): SkillInfo[] {
     skillPaths: [],
     includeDefaults: true,
   });
-  return skills.map((s) => ({
-    name: s.name,
-    description: s.description,
-    scope: s.sourceInfo.scope,
-    filePath: s.filePath,
+  const userSkillsRoot = path.resolve(options.agentDir, "skills");
+  const bundled = bundledFolderNames(options.bundledSkillsDir);
+  return budgetSkills(skills).entries.map(({ skill, budget }) => ({
+    name: skill.name,
+    description: skill.description,
+    scope: skill.sourceInfo.scope,
+    filePath: skill.filePath,
+    source: skillSource(skill, userSkillsRoot, bundled),
+    updatedAt: lastModified(skill.filePath),
+    budget,
   }));
 }

--- a/packages/agent/src/privacy/extension.ts
+++ b/packages/agent/src/privacy/extension.ts
@@ -2,19 +2,18 @@
  * Privacy extension — enforces `private: true` at the agent tool boundary
  * for BOTH agents (chat and delegation register the same EXTENSION_BUNDLES).
  *
- * Mechanism: pi's blockable `tool_call` event (parity last verified against
- * pi 0.80.10).
+ * Mechanism: pi's blockable `tool_call` event (verified against pi 0.82).
  * The handler fires before every tool executes; returning `{ block: true,
  * reason }` short-circuits the run and the model receives the reason as an
  * error tool result (pi-agent-core agent-loop.js prepareToolCall →
  * createErrorToolResult). A THROWING handler is caught into the same error
  * result — so a probe that blows up still blocks: fail-closed by
  * construction. We therefore do NOT try/catch around the decision; a throw
- * IS the safe outcome. Re-verify this contract in the installed package on
- * every pi version bump (docs/extensions.md "tool_call";
- * dist/core/agent-session.js _installAgentToolHooks (throws rethrown);
- * dist/core/extensions/runner.js emitToolCall (no catch);
- * pi-agent-core dist/agent-loop.js prepareToolCall (catch → error result)).
+ * IS the safe outcome. Both halves are pinned against the INSTALLED package
+ * by __tests__/pi-tool-call-contract.test.ts, which drives this handler
+ * through pi's own ExtensionRunner and agent loop — a version bump that
+ * stops honouring a block, or starts swallowing a throw, fails there instead
+ * of silently turning this gate into a no-op.
  *
  * SOUNDNESS (read this before trusting it): only read/edit/write (and the
  * inactive grep/find/ls) are soundly gated, via a live frontmatter probe per

--- a/packages/agent/src/privacy/pi-path-parity.ts
+++ b/packages/agent/src/privacy/pi-path-parity.ts
@@ -4,8 +4,8 @@
 // pi's file tools do NOT open the literal `path` argument. They first run
 // expandPath (dist/core/tools/path-utils.js → dist/utils/paths.js
 // normalizePath: map unicode spaces — NBSP/en/em/… — to ASCII space, strip a
-// leading `@`, expand `~`, and — since 0.80 — convert `file://` URLs to
-// filesystem paths), and `read` additionally retries filesystem-fallback
+// leading `@`, expand `~`, and convert `file://` URLs to filesystem paths),
+// and `read` additionally retries filesystem-fallback
 // variants (AM/PM narrow no-break space, NFD, curly quote) until one exists.
 // A gate that resolves the RAW string probes a DIFFERENT file than the tool
 // reads: `read({path:"@vault/secret.md"})` classified "outside the vault"
@@ -13,9 +13,10 @@
 // ./vault — a confirmed full-content bypass, with NBSP/`~`/NFD/`file://`
 // variants as siblings of the same root cause.
 //
-// pi does not export path-utils (package exports are "." and "./hooks" only),
-// so this module REPLICATES it line-for-line (0.80.x semantics: unicode
-// spaces → `@`-strip → `~` via join() → file:// URL → resolve()-normalized).
+// pi does not export path-utils (package exports are "." and "./rpc-entry"
+// only), so this module REPLICATES it line-for-line (pi 0.82 semantics:
+// unicode spaces → `@`-strip → `~` via join() → file:// URL →
+// resolve()-normalized).
 // The replication is pinned by __tests__/pi-path-parity.test.ts, which
 // imports pi's REAL path-utils.js from the installed package and asserts
 // both resolvers agree on a battery of adversarial inputs — a pi upgrade
@@ -92,7 +93,7 @@ function normalizePiBaseDir(dir: string): string {
   return dir;
 }
 
-/** pi's resolveReadPath: expand, resolve against cwd (0.80 runs BOTH the
+/** pi's resolveReadPath: expand, resolve against cwd (pi runs BOTH the
  * absolute and the relative branch through path.resolve, so `..`/`.`/double
  * separators normalize exactly as pi's do), then — when the literal doesn't
  * exist — retry the macOS AM/PM, NFD, curly-quote, and NFD+curly filename

--- a/packages/agent/src/setup.ts
+++ b/packages/agent/src/setup.ts
@@ -22,7 +22,13 @@ import {
   type ExtensionSetupContext,
 } from "./extension";
 import { AGENT_DIR, BIN_DIR, EXTENSIONS_DIR, WORKSPACE_DIR } from "./paths";
-import type { IntegrationInfo, SetupProgress, SkillInfo } from "@repo/bridge/ipc-registry";
+import { writeNewSkill, type NewSkill } from "./skill-authoring";
+import type {
+  IntegrationInfo,
+  SetupProgress,
+  SkillCreated,
+  SkillInfo,
+} from "@repo/bridge/ipc-registry";
 
 /** Where the app's bundled agent assets (skills/, AGENTS.md) live, resolved
  * by the shell (HostPlatform) and injected by boot/agent-wiring.ts.
@@ -131,13 +137,42 @@ export async function repairIntegrations(
 }
 
 // ---------------------------------------------------------------------------
-// Skills — read-only listing
+// Skills — listing + authoring
 // ---------------------------------------------------------------------------
+
+/** The folder a user's own skills live in — the same one seedResources()
+ * seeds bundled skills into, so a listing row's source is decided by name
+ * against the shipped set rather than by two competing paths. */
+function userSkillsDir(): string {
+  return path.join(AGENT_DIR, "skills");
+}
 
 /**
  * Skills available to the agent, read from disk via pi's own discovery so the
  * list is correct whether or not an agent session is currently running.
  */
-export function listSkills(): SkillInfo[] {
-  return listSkillsFromDisk({ cwd: WORKSPACE_DIR, agentDir: AGENT_DIR });
+export function listSkills(resources: BundledResources): SkillInfo[] {
+  return listSkillsFromDisk({
+    cwd: WORKSPACE_DIR,
+    agentDir: AGENT_DIR,
+    bundledSkillsDir: path.join(resources.dir, "skills"),
+  });
+}
+
+/**
+ * Write a new skill into `~/.inteligir/skills` and return it alongside the
+ * refreshed listing. A running agent session loaded its skills at start, so
+ * the new one reaches the model on the next start — which is what the Settings
+ * copy tells the user.
+ */
+export function createSkill(resources: BundledResources, skill: NewSkill): SkillCreated {
+  const dir = userSkillsDir();
+  fs.mkdirSync(dir, { recursive: true });
+  const { slug } = writeNewSkill(dir, skill);
+  const skills = listSkills(resources);
+  const created = skills.find((entry) => entry.name === slug);
+  if (created === undefined) {
+    throw new Error(`Skill "${slug}" was written but did not load — check its SKILL.md.`);
+  }
+  return { skill: created, skills };
 }

--- a/packages/agent/src/skill-authoring.ts
+++ b/packages/agent/src/skill-authoring.ts
@@ -1,0 +1,111 @@
+// ---------------------------------------------------------------------------
+// Writing a new skill into `<agentDir>/skills`.
+//
+// A skill's folder name is attacker-adjacent input: it comes from a text field
+// and names a directory the agent's system prompt will later read from. So the
+// name never reaches the filesystem — a SLUG derived from it does, through a
+// character class that cannot express a separator or a `..`, checked again
+// against the resolved parent. Both halves are here, pure and testable,
+// because path confinement asserted in a unit test is worth more than path
+// confinement asserted in a code comment.
+// ---------------------------------------------------------------------------
+
+import fs from "node:fs";
+import path from "node:path";
+
+/** Agent Skills spec: lowercase alphanumerics and single interior hyphens. */
+const SKILL_SLUG = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
+const MAX_SLUG_CHARS = 64;
+
+export type NewSkill = {
+  /** Display name as typed; slugified before it touches disk. */
+  name: string;
+  description: string;
+  /** SKILL.md body. Empty gets a placeholder. */
+  instructions: string;
+};
+
+export type WrittenSkill = {
+  /** The folder name, which is also the name the agent invokes. */
+  slug: string;
+  filePath: string;
+};
+
+/**
+ * Fold a display name down to a skill folder name, or null when nothing
+ * usable survives. Every character outside `[a-z0-9]` becomes a separator, so
+ * `.`, `/`, `\` and every unicode lookalike are gone before a path is built
+ * from the result.
+ */
+export function toSkillSlug(name: string): string | null {
+  const slug = name
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .slice(0, MAX_SLUG_CHARS)
+    .replace(/-+$/, "");
+  return SKILL_SLUG.test(slug) ? slug : null;
+}
+
+/** YAML double-quoted scalars are JSON strings, so quoting through
+ * JSON.stringify is what stops a description containing `:`, a newline or a
+ * quote from rewriting the frontmatter it lands in. */
+function yamlString(value: string): string {
+  return JSON.stringify(value);
+}
+
+/** Render a SKILL.md. `name` is the slug: pi falls back to the folder name
+ * only when frontmatter has none, and a listing whose name differs from the
+ * folder is confusing on both surfaces. */
+export function renderSkillFile(skill: {
+  slug: string;
+  description: string;
+  body: string;
+}): string {
+  const body = skill.body.trim();
+  const front = [
+    "---",
+    `name: ${yamlString(skill.slug)}`,
+    `description: ${yamlString(skill.description)}`,
+    "---",
+    "",
+  ].join("\n");
+  return `${front}${body.length > 0 ? body : placeholderBody(skill.slug)}\n`;
+}
+
+function placeholderBody(slug: string): string {
+  return [
+    `# ${slug}`,
+    "",
+    "Describe what the agent should do when this skill applies — the steps, the",
+    "tools to reach for, and anything it must not do.",
+  ].join("\n");
+}
+
+/**
+ * Write a new skill folder under `skillsDir`. Throws (never overwrites) when
+ * the name yields no slug or the folder is taken; `wx` closes the gap between
+ * the existence check and the write.
+ */
+export function writeNewSkill(skillsDir: string, skill: NewSkill): WrittenSkill {
+  const slug = toSkillSlug(skill.name);
+  if (slug === null) {
+    throw new Error(`"${skill.name}" has no letters or digits to name a skill folder.`);
+  }
+  const root = path.resolve(skillsDir);
+  const dir = path.resolve(root, slug);
+  if (path.dirname(dir) !== root) {
+    throw new Error("Refusing to write a skill outside the skills folder.");
+  }
+  if (fs.existsSync(dir)) {
+    throw new Error(`A skill named "${slug}" already exists.`);
+  }
+  fs.mkdirSync(dir, { recursive: true });
+  const filePath = path.join(dir, "SKILL.md");
+  fs.writeFileSync(
+    filePath,
+    renderSkillFile({ slug, description: skill.description, body: skill.instructions }),
+    { flag: "wx" },
+  );
+  return { slug, filePath };
+}

--- a/packages/bridge/src/__tests__/vault-path-schemas.test.ts
+++ b/packages/bridge/src/__tests__/vault-path-schemas.test.ts
@@ -1,0 +1,85 @@
+// The vault/knowledge channels that carry a single `path`. Two schemas serve
+// them — NotePathSchema (a markdown note) and the kind-agnostic VaultPathSchema
+// — and the split exists to describe the argument, NOT to validate it
+// differently. These tests pin both halves of that: identical structure once
+// descriptions are stripped, and identical Value.Check verdicts.
+
+import { describe, expect, it } from "vitest";
+import { Value } from "@sinclair/typebox/value";
+import type { TSchema } from "@sinclair/typebox";
+
+import { isRecord } from "../wire-helpers";
+import { IPC, NotePathSchema } from "../ipc-registry";
+
+/** The wire shape every path channel emits. Descriptions are stripped before
+ * the compare, so adding model-facing prose can never masquerade as a
+ * validation change — anything else showing up here IS one. */
+const PATH_PAYLOAD = {
+  type: "object",
+  properties: { path: { type: "string" } },
+  required: ["path"],
+  additionalProperties: false,
+};
+
+function stripDescriptions(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(stripDescriptions);
+  if (!isRecord(value)) return value;
+  return Object.fromEntries(
+    Object.entries(value)
+      .filter(([key]) => key !== "description")
+      .map(([key, inner]) => [key, stripDescriptions(inner)]),
+  );
+}
+
+/** JSON-serialize (dropping TypeBox's symbol Kind markers), then drop every
+ * `description` key at any depth. */
+function structureOf(schema: TSchema): unknown {
+  const json: unknown = JSON.parse(JSON.stringify(schema));
+  return stripDescriptions(json);
+}
+
+const NOTE_PATH_CHANNELS = [
+  IPC.probeNotePrivacy,
+  IPC.getBacklinks,
+  IPC.getForwardLinks,
+  IPC.getRelatedNotes,
+];
+
+const VAULT_PATH_CHANNELS = [
+  IPC.readVaultDoc,
+  IPC.getVaultFileFacts,
+  IPC.deleteVaultEntry,
+  IPC.readVaultAsset,
+];
+
+describe("single-path vault channel payloads", () => {
+  it("validate identically — the split is prose, not shape", () => {
+    for (const channel of [...NOTE_PATH_CHANNELS, ...VAULT_PATH_CHANNELS]) {
+      expect(structureOf(channel.payload)).toEqual(PATH_PAYLOAD);
+    }
+  });
+
+  it("describes the argument for a model on both schemas", () => {
+    for (const channel of [...NOTE_PATH_CHANNELS, ...VAULT_PATH_CHANNELS]) {
+      const properties = channel.payload["properties"];
+      const path: unknown = isRecord(properties) ? properties["path"] : undefined;
+      const description: unknown = isRecord(path) ? path["description"] : undefined;
+      expect(typeof description).toBe("string");
+    }
+  });
+
+  it("accepts a relative path and refuses anything else", () => {
+    for (const channel of [...NOTE_PATH_CHANNELS, ...VAULT_PATH_CHANNELS]) {
+      expect(Value.Check(channel.payload, { path: "notes/ideas.md" })).toBe(true);
+      expect(Value.Check(channel.payload, {})).toBe(false);
+      expect(Value.Check(channel.payload, { path: 1 })).toBe(false);
+      expect(Value.Check(channel.payload, { path: "a.md", extra: true })).toBe(false);
+    }
+  });
+
+  it("hands the knowledge channels the schema the agent tools import", () => {
+    for (const channel of NOTE_PATH_CHANNELS) {
+      expect(channel.payload).toBe(NotePathSchema);
+    }
+  });
+});

--- a/packages/bridge/src/ipc-registry.ts
+++ b/packages/bridge/src/ipc-registry.ts
@@ -125,18 +125,76 @@ export type IntegrationInfo = {
   installed: string | null;
 };
 
+/** Where pi discovered a skill. */
+export type SkillScope = "user" | "project" | "temporary";
+
+/** Where a skill came from, as far as the app can honestly tell. There is no
+ * publisher or author concept here: "bundled" means the app ships that skill
+ * and seeded it into `<agentDir>/skills` on first run, "added" means someone
+ * else put it there (the user, an agent, an installer). Seeding COPIES, so the
+ * copy's path cannot reveal its origin — the shipped folder names are the only
+ * honest signal, and anything outside `<agentDir>/skills` is "added" by
+ * definition. */
+export type SkillSource = "bundled" | "added";
+
+/** What the agent's system prompt actually received for a skill.
+ *
+ * The listing budget sheds description CHARACTERS before it sheds skills — a
+ * skill the model knows by name alone is still invocable, a skill missing from
+ * the listing is not — so `description-trimmed` is the routine outcome and
+ * `not-loaded` is the backstop for a pathological skills folder. */
+export type SkillBudgetState =
+  /** Whole description reached the prompt. */
+  | { kind: "loaded" }
+  /** Name reached the prompt; the description was clipped to `promptChars`. */
+  | { kind: "description-trimmed"; promptChars: number; originalChars: number }
+  /** Nothing reached the prompt — the agent cannot invoke this skill. */
+  | { kind: "not-loaded"; reason: "skill-count" };
+
 /** Plain projection of pi's `Skill` so callers can serialize it over IPC. */
 export type SkillInfo = {
   name: string;
+  /** The description as the prompt received it — already clamped by the
+   * budget. `budget` says whether that is all of what is on disk. */
   description: string;
-  /** "user" (<agentDir>/skills) or "project" (<cwd>/.pi/skills). */
-  scope: string;
+  scope: SkillScope;
   filePath: string;
+  source: SkillSource;
+  /** SKILL.md mtime as epoch MILLISECONDS, or null when it can't be stat'd.
+   * A number on purpose: formatting a date is the renderer's job and the wire
+   * stays locale-free. */
+  updatedAt: number | null;
+  budget: SkillBudgetState;
 };
 
 export type SkillsList = {
   skills: SkillInfo[];
 };
+
+/** Result of createSkill: the skill that was just written, plus the refreshed
+ * listing so the caller needs no follow-up round trip. */
+export type SkillCreated = {
+  skill: SkillInfo;
+  skills: SkillInfo[];
+};
+
+// `name` is a display name, not a path — the host slugifies it and refuses
+// anything that doesn't reduce to a `[a-z0-9-]` folder name, so no traversal
+// can cross this schema. `description` is capped at the Agent Skills
+// description limit, which is also @repo/agent's MAX_SKILL_DESCRIPTION_CHARS
+// (skill-budget.test.ts pins the two together — @repo/bridge cannot import
+// @repo/agent, and a description written over the cap would be clipped back
+// out on the very next listing).
+const CreateSkillSchema = Type.Object(
+  {
+    name: Type.String({ minLength: 1, maxLength: 64 }),
+    description: Type.String({ minLength: 1, maxLength: 1536 }),
+    /** SKILL.md body — the instructions themselves. Empty gets a placeholder
+     * body, so a caller can scaffold first and write later. */
+    instructions: Type.String({ maxLength: 100_000 }),
+  },
+  { additionalProperties: false },
+);
 
 const NotificationsPatchSchema = Type.Object(
   { enabled: Type.Optional(Type.Boolean()) },
@@ -243,7 +301,36 @@ export type RestoreAgentEditsResult = { ok: true } | { ok: false; error: string 
 // vault-relative; main confines them under the vault root.
 // ---------------------------------------------------------------------------
 
-const VaultPathSchema = Type.Object({ path: Type.String() }, { additionalProperties: false });
+/** A vault-relative path to ONE markdown note — the unit the knowledge queries
+ * and the privacy probe are asked about. Exported: the agent's knowledge tools
+ * take this exact argument and hand the schema to a model, so the prose that
+ * tells the model what a valid path looks like lives HERE, once, instead of
+ * being restated per tool (agent/knowledge-tools/extension.ts). */
+export const NotePathSchema = Type.Object(
+  {
+    path: Type.String({
+      description:
+        "Path to a markdown note, relative to the vault root — e.g. 'notes/ideas.md'. " +
+        "Never absolute, never escaping the vault.",
+    }),
+  },
+  { additionalProperties: false },
+);
+
+/** A vault-relative path to ONE file of any kind — a note, an image, an HTML
+ * app. Deliberately not `NotePathSchema`: these channels read/stat/trash
+ * whatever the path names, so promising a model (or a reader) "a note" would
+ * be a narrower contract than the handler behind it. */
+const VaultPathSchema = Type.Object(
+  {
+    path: Type.String({
+      description:
+        "Path to a single file — note or attachment — relative to the vault root, " +
+        "e.g. 'assets/diagram.png'. Names a file, never a folder.",
+    }),
+  },
+  { additionalProperties: false },
+);
 // The currently open note the host should watch for external edits (null clears
 // it). Only this ONE file is watched — the rest of the vault is an ephemeral
 // snapshot refreshed on demand (vault liveness — CLAUDE.md § Decisions).
@@ -532,7 +619,7 @@ export const IPC = {
    * path needs it: a sync pull or agent write can flip a note `private: true`
    * on disk before the open-note watcher refreshes the editor buffer, and a
    * private note's PATH must not reach the model either. */
-  probeNotePrivacy: invoke<typeof VaultPathSchema, NotePrivacyProbe>(VaultPathSchema),
+  probeNotePrivacy: invoke<typeof NotePathSchema, NotePrivacyProbe>(NotePathSchema),
   /** Tell the host which note is open so it watches that single file for
    * external edits (vault liveness — CLAUDE.md § Decisions). Pass
    * `{ path: null }` when no note is open. */
@@ -547,13 +634,13 @@ export const IPC = {
 
   // Knowledge — link + search indexes over the vault, kept fresh from vault
   // change events. Queries are cheap index reads.
-  getBacklinks: invoke<typeof VaultPathSchema, BacklinkEntry[]>(VaultPathSchema),
-  getForwardLinks: invoke<typeof VaultPathSchema, ForwardLinkEntry[]>(VaultPathSchema),
+  getBacklinks: invoke<typeof NotePathSchema, BacklinkEntry[]>(NotePathSchema),
+  getForwardLinks: invoke<typeof NotePathSchema, ForwardLinkEntry[]>(NotePathSchema),
   /** Ranked "related notes" for one note — shared link targets, co-citation,
    * shared tags, lexical similarity — each entry carrying human-readable
    * `reasons`. Direct link neighbors are excluded by design (the Links and
    * Backlinks panels already surface them). */
-  getRelatedNotes: invoke<typeof VaultPathSchema, RelatedNoteEntry[]>(VaultPathSchema),
+  getRelatedNotes: invoke<typeof NotePathSchema, RelatedNoteEntry[]>(NotePathSchema),
   /** Vault link graph, shaped for a force-graph renderer (unresolved targets
    * appear as flagged phantom nodes). The caller's bounds are applied HOST-side,
    * before serialization — the whole graph is ~42MB of JSON at 50k notes, so a
@@ -767,6 +854,11 @@ export const IPC = {
 
   // Skills
   listSkills: invokeVoid<SkillsList>(),
+  /** Scaffold a new skill: `<agentDir>/skills/<slug>/SKILL.md` with valid
+   * frontmatter, where <slug> is derived host-side from `name`. The agent
+   * picks it up on its next start. Rejects when the slug is empty or already
+   * taken — never overwrites an existing skill. */
+  createSkill: invoke<typeof CreateSkillSchema, SkillCreated>(CreateSkillSchema),
 
   // Integrations
   listIntegrations: invokeVoid<IntegrationInfo[]>(),

--- a/packages/server/src/__tests__/agent-instructions.test.ts
+++ b/packages/server/src/__tests__/agent-instructions.test.ts
@@ -9,6 +9,7 @@ import { describe, expect, it } from "vitest";
 
 import { AGENT_INSTRUCTIONS_SKELETON } from "@repo/bridge/agent-instructions";
 import {
+  boundInstructionsContent,
   loadInstructionsFrom,
   seedInstructionsInto,
   type InstructionsVault,
@@ -67,6 +68,45 @@ describe("loadInstructionsFrom", () => {
   it("treats unparseable frontmatter as private (fail-closed)", () => {
     const vault = fakeVault(new Map([["AGENTS.md", "---\n{ not yaml\n---\n\nBody.\n"]]));
     expect(loadInstructionsFrom(vault)).toBeNull();
+  });
+
+  it("bounds an over-budget file before it reaches the prompt", () => {
+    const oversized = `# Rules\n\nAlways answer in Spanish.\n${"- remembered fact\n".repeat(2_000)}`;
+    const entry = loadInstructionsFrom(fakeVault(new Map([["AGENTS.md", oversized]])));
+    expect(entry).not.toBeNull();
+    expect(entry?.content.length).toBeLessThan(oversized.length);
+    expect(entry?.content).toContain("Always answer in Spanish.");
+    expect(entry?.content).toContain("exceeded its instruction budget");
+  });
+});
+
+const over = (chars: number) => "x".repeat(chars);
+
+describe("boundInstructionsContent", () => {
+  it("passes a within-budget file through byte-identically", () => {
+    const content = "# Rules\n\nBe terse.\n";
+    expect(boundInstructionsContent(content)).toEqual({ content, droppedChars: 0 });
+  });
+
+  it("keeps the head — standing instructions survive, appended memory is shed", () => {
+    const content = `MUST: answer in Spanish.\n${"- fact\n".repeat(5_000)}`;
+    const { content: bounded, droppedChars } = boundInstructionsContent(content);
+    expect(bounded).toContain("MUST: answer in Spanish.");
+    expect(droppedChars).toBeGreaterThan(0);
+    expect(bounded.length).toBeLessThan(content.length);
+  });
+
+  it("cuts on a line boundary so no half-rule reaches the model", () => {
+    const line = `${over(100)}\n`;
+    const { content } = boundInstructionsContent(line.repeat(1_000));
+    const body = content.slice(0, content.indexOf("[vault/AGENTS.md"));
+    for (const l of body.split("\n").filter(Boolean)) expect(l).toHaveLength(100);
+  });
+
+  it("reports the dropped byte count", () => {
+    const content = over(20_000);
+    const { droppedChars } = boundInstructionsContent(content);
+    expect(droppedChars).toBe(content.length - 16_000);
   });
 });
 

--- a/packages/server/src/__tests__/dep-dag.test.ts
+++ b/packages/server/src/__tests__/dep-dag.test.ts
@@ -1,0 +1,209 @@
+// ---------------------------------------------------------------------------
+// Dep-DAG guard. CLAUDE.md's "Dep DAG (every edge…)" paragraph is the record
+// agents read before deciding where code may live — and it is the one piece of
+// prose in this repo that restates data the compiler already owns. A `pnpm add`
+// inside a package cannot break it, so the paragraph silently becomes fiction
+// and every later "which package may import which" decision is made against a
+// stale map.
+//
+// So the paragraph is parsed, not trusted: each `x→a+b+c` clause and the
+// "… are leaves" clause is checked against the real @repo/* edges in every
+// packages/*/package.json, in BOTH directions. An undocumented dep fails; a
+// documented edge that no longer exists fails; a new package that the paragraph
+// never mentions fails. The prose stays hand-written (it carries WHY, which no
+// generator can emit) — only its factual claims are pinned.
+//
+// The second case is the UI's backend boundary, which CLAUDE.md states and
+// whose enforcement differs per app. Mobile is a package fact — @repo/mobile
+// lists no @repo/server, so the import cannot resolve. Desktop is not: the app
+// package DOES list @repo/server because main composes the host, so the
+// renderer's freedom from it is lint (`no-restricted-imports` over
+// `renderer/**` + `dev/**`) — and .oxlintrc.json switches that rule OFF under
+// `renderer/__tests__/**`. This test covers the hole that override leaves.
+//
+// Lives in @repo/server for the same reason as its siblings: it walks the
+// filesystem, and @repo/bridge and @repo/notes are lint-banned from node:*.
+// ---------------------------------------------------------------------------
+
+import { describe, expect, it } from "vitest";
+import fs from "node:fs";
+import path from "node:path";
+
+const REPO_ROOT = path.resolve(import.meta.dirname, "../../../..");
+const CLAUDE_MD = path.join(REPO_ROOT, "CLAUDE.md");
+
+const SCOPE = "@repo/";
+
+/** `vault→storage+notes+bridge` — the paragraph's edge notation. */
+const EDGE_CLAUSE = /\b([a-z][a-z-]*)→([a-z][a-z-]*(?:\+[a-z][a-z-]*)*)/g;
+/** `notes, installer, storage, ui are leaves` — the zero-edge packages. */
+const LEAF_CLAUSE = /\b([a-z][a-z, -]*?) are leaves\b/;
+
+/** A `@repo/server` module specifier in an import/require/dynamic-import. Prose
+ * mentions of the package in comments are not imports and must not count. */
+const SERVER_IMPORT = /["']@repo\/server(?:\/[^"']*)?["']/;
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function fieldKeys(field: unknown): string[] {
+  return isRecord(field) ? Object.keys(field) : [];
+}
+
+interface Manifest {
+  /** Package name with the `@repo/` scope stripped — the paragraph's notation. */
+  readonly short: string;
+  readonly workspaceDeps: ReadonlySet<string>;
+}
+
+/** Every dependency field counts: a devDependency is as real an edge as a
+ * runtime one for "can this package import that one". */
+function readManifest(file: string): Manifest | null {
+  const parsed: unknown = JSON.parse(fs.readFileSync(file, "utf8"));
+  if (!isRecord(parsed) || typeof parsed.name !== "string") return null;
+  const deps = [
+    ...fieldKeys(parsed.dependencies),
+    ...fieldKeys(parsed.devDependencies),
+    ...fieldKeys(parsed.peerDependencies),
+  ];
+  return {
+    short: parsed.name.startsWith(SCOPE) ? parsed.name.slice(SCOPE.length) : parsed.name,
+    workspaceDeps: new Set(
+      deps.filter((dep) => dep.startsWith(SCOPE)).map((dep) => dep.slice(SCOPE.length)),
+    ),
+  };
+}
+
+/** Derived from disk, so a new package is swept without extending a hand list. */
+function manifests(group: string): Manifest[] {
+  const groupDir = path.join(REPO_ROOT, group);
+  const found: Manifest[] = [];
+  for (const entry of fs.readdirSync(groupDir, { withFileTypes: true })) {
+    if (!entry.isDirectory()) continue;
+    const file = path.join(groupDir, entry.name, "package.json");
+    if (!fs.existsSync(file)) continue;
+    const manifest = readManifest(file);
+    if (manifest !== null) found.push(manifest);
+  }
+  return found;
+}
+
+function dagParagraph(): string {
+  const doc = fs.readFileSync(CLAUDE_MD, "utf8");
+  const start = doc.indexOf("Dep DAG");
+  expect(start, "CLAUDE.md no longer has a `Dep DAG` paragraph").toBeGreaterThan(-1);
+  const end = doc.indexOf("\n\n", start);
+  return doc.slice(start, end === -1 ? undefined : end);
+}
+
+function documentedEdges(paragraph: string): Map<string, ReadonlySet<string>> {
+  const edges = new Map<string, ReadonlySet<string>>();
+
+  const leaves = LEAF_CLAUSE.exec(paragraph);
+  const leafList = leaves?.[1];
+  if (leafList !== undefined) {
+    for (const leaf of leafList.split(",").map((name) => name.trim())) {
+      if (leaf.length > 0) edges.set(leaf, new Set());
+    }
+  }
+
+  for (const match of paragraph.matchAll(EDGE_CLAUSE)) {
+    const source = match[1];
+    const targets = match[2];
+    if (source === undefined || targets === undefined) continue;
+    edges.set(source, new Set(targets.split("+")));
+  }
+  return edges;
+}
+
+function sourceFiles(dir: string, out: string[]): void {
+  if (!fs.existsSync(dir)) return;
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      sourceFiles(full, out);
+    } else if (/\.(tsx?|mjs)$/.test(entry.name)) {
+      out.push(full);
+    }
+  }
+}
+
+describe("dep DAG", () => {
+  it("CLAUDE.md's Dep DAG paragraph matches the real package.json edges", () => {
+    const paragraph = dagParagraph();
+    const documented = documentedEdges(paragraph);
+    const packages = manifests("packages");
+
+    // Floors, so a notation change that stops the parse from matching anything
+    // cannot make this vacuously green.
+    expect(
+      documented.size,
+      "parsed no edges out of the Dep DAG paragraph — the notation changed",
+    ).toBeGreaterThanOrEqual(8);
+    expect(packages.length).toBeGreaterThanOrEqual(8);
+
+    const problems: string[] = [];
+    const real = new Set(packages.map((manifest) => manifest.short));
+
+    for (const { short, workspaceDeps } of packages.toSorted((a, b) =>
+      a.short.localeCompare(b.short),
+    )) {
+      const claimed = documented.get(short);
+      if (claimed === undefined) {
+        problems.push(`  ${short}: missing from the paragraph (list its edges, or as a leaf)`);
+        continue;
+      }
+      const undocumented = [...workspaceDeps].filter((dep) => !claimed.has(dep)).toSorted();
+      const phantom = [...claimed].filter((dep) => !workspaceDeps.has(dep)).toSorted();
+      if (undocumented.length > 0) {
+        problems.push(
+          `  ${short}: depends on ${undocumented.join(", ")}, paragraph does not say so`,
+        );
+      }
+      if (phantom.length > 0) {
+        problems.push(`  ${short}: paragraph claims ${phantom.join(", ")}, package.json does not`);
+      }
+    }
+
+    for (const short of [...documented.keys()].toSorted()) {
+      if (!real.has(short)) {
+        problems.push(`  ${short}: named in the paragraph, no such package under packages/`);
+      }
+    }
+
+    expect(
+      problems,
+      `CLAUDE.md's Dep DAG paragraph disagrees with packages/*/package.json — fix\n` +
+        `the dependency or the paragraph, whichever one is wrong:\n${problems.join("\n")}`,
+    ).toEqual([]);
+  });
+
+  it("the UI surfaces never reach @repo/server", () => {
+    const mobile = manifests("apps").find((manifest) => manifest.short === "mobile");
+    expect(mobile, "no @repo/mobile package found").toBeDefined();
+    expect(
+      mobile?.workspaceDeps.has("server"),
+      "@repo/mobile must not depend on @repo/server — the mobile app's freedom " +
+        "from the node host is a package fact, not a lint opinion",
+    ).toBe(false);
+
+    // Desktop cannot make the same claim: apps/desktop DOES depend on
+    // @repo/server for main. Lint holds the renderer to the Bridge, and is
+    // switched off under renderer/__tests__ — hence this walk.
+    const rendererFiles: string[] = [];
+    sourceFiles(path.join(REPO_ROOT, "apps/desktop/src/renderer"), rendererFiles);
+    sourceFiles(path.join(REPO_ROOT, "apps/desktop/dev"), rendererFiles);
+    expect(rendererFiles.length).toBeGreaterThan(50);
+
+    const importers = rendererFiles
+      .filter((file) => SERVER_IMPORT.test(fs.readFileSync(file, "utf8")))
+      .map((file) => `  ${path.relative(REPO_ROOT, file).split(path.sep).join("/")}`);
+
+    expect(
+      importers,
+      `Renderer/harness files importing @repo/server — the UI is host-agnostic ` +
+        `and reaches the backend only through the injected Bridge:\n${importers.join("\n")}`,
+    ).toEqual([]);
+  });
+});

--- a/packages/server/src/__tests__/no-dead-channels.test.ts
+++ b/packages/server/src/__tests__/no-dead-channels.test.ts
@@ -27,12 +27,18 @@ import { IPC_METHODS } from "@repo/bridge/ipc-registry";
 
 const REPO_ROOT = path.resolve(import.meta.dirname, "../../../..");
 
-/** Files that mention every method by construction — supply, not demand. */
+/** Files that mention every method by construction — supply, not demand.
+ * The blueprints are here because they quote real channels as WORKED EXAMPLES
+ * of the mechanism, never as callers: a channel named only by a blueprint is
+ * dead, and counting the mention as demand would prop it up forever. A new
+ * blueprint that quotes channel names belongs in this list too. */
 const SUPPLY = new Set(
   [
     "packages/bridge/src/ipc-registry.ts",
     "apps/desktop/dev/fixture-bridge.ts",
     "packages/server/src/__tests__/no-dead-channels.test.ts",
+    ".claude/skills/add-bridge-channel/SKILL.md",
+    ".claude/skills/add-editor-node/SKILL.md",
   ].map((rel) => path.join(REPO_ROOT, rel)),
 );
 

--- a/packages/server/src/agent-instructions/agent-instructions.ts
+++ b/packages/server/src/agent-instructions/agent-instructions.ts
@@ -5,7 +5,9 @@
 //   - loadUserAgentInstructions(): read vault/AGENTS.md at session start and
 //     hand it to the Agent as an extra context file (chat + delegation only —
 //     app-machine.ts / background-agent.ts inject it; the editor-AI and
-//     ghost-text sessions never get it). Absent file = null = no-op.
+//     ghost-text sessions never get it). Absent file = null = no-op. The bytes
+//     are budget-bounded on the way through: this is the only context file
+//     that both grows on its own and has no cap anywhere else in the path.
 //   - seedUserAgentInstructions(): write the friendly skeleton into a vault
 //     that has never had one, exactly once per vault root. A durable
 //     seeded-roots mark (versioned JsonStore, ~/.inteligir) makes deletion
@@ -31,6 +33,47 @@ import { notePrivacy } from "@repo/notes/markdown/frontmatter";
 import { isEnoent } from "@repo/storage/fs-errors";
 import { JsonStore, inteligirPath } from "@repo/storage/json-store";
 import { getVaultManager } from "@repo/vault/vault";
+
+// ---- Budget ----------------------------------------------------------------
+
+/**
+ * Ceiling for vault/AGENTS.md — the one context file on this path that nothing
+ * else bounds. It is not merely user-authored: the bundled prompt tells the
+ * agent to append a bullet under `## Memory` whenever it learns something
+ * durable, so the file grows on its own, every session, unattended, and every
+ * byte is re-sent on every turn of chat and delegation. The ceiling matches
+ * the one the repo holds its own bundled instructions to (see
+ * agents-file-budget.test.ts) — same order of cost, one number to remember.
+ */
+const USER_INSTRUCTIONS_MAX_CHARS = 16_000;
+
+/**
+ * What the model sees in place of the bytes that did not fit. It names the
+ * file and asks for consolidation because the agent is the only party that
+ * can fix the cause — it wrote the overflow.
+ */
+const TRUNCATION_NOTICE =
+  "\n\n[vault/AGENTS.md exceeded its instruction budget and was cut here. " +
+  "Everything above is intact; anything below was dropped. Tell the user their " +
+  "AGENTS.md is too long and offer to consolidate its Memory section.]\n";
+
+/**
+ * Bound the instruction bytes, keeping the HEAD. The agent appends memory to
+ * the END of the file, so dropping the tail sheds machine-accumulated recall
+ * and preserves the user's standing instructions — losing "answer in Spanish"
+ * is a violation, losing last week's remembered fact is a degradation. Cuts
+ * land on a line boundary so the model never reads half a rule.
+ */
+export function boundInstructionsContent(content: string): {
+  content: string;
+  droppedChars: number;
+} {
+  if (content.length <= USER_INSTRUCTIONS_MAX_CHARS) return { content, droppedChars: 0 };
+  const head = content.slice(0, USER_INSTRUCTIONS_MAX_CHARS);
+  const lastBreak = head.lastIndexOf("\n");
+  const kept = lastBreak > 0 ? head.slice(0, lastBreak) : head;
+  return { content: kept + TRUNCATION_NOTICE, droppedChars: content.length - kept.length };
+}
 
 // ---- Loader ----------------------------------------------------------------
 
@@ -68,7 +111,14 @@ export function loadInstructionsFrom(vault: InstructionsVault): AgentsFileEntry 
     return null;
   }
   if (notePrivacy(content) !== "public") return null;
-  return { path: AGENT_INSTRUCTIONS_AGENT_PATH, content };
+  const bounded = boundInstructionsContent(content);
+  if (bounded.droppedChars > 0) {
+    console.warn(
+      `[agent-instructions] vault/AGENTS.md over budget — dropped ${bounded.droppedChars} chars ` +
+        `(${content.length} > ${USER_INSTRUCTIONS_MAX_CHARS})`,
+    );
+  }
+  return { path: AGENT_INSTRUCTIONS_AGENT_PATH, content: bounded.content };
 }
 
 /** Live-singleton binding used by app-machine.ts and background-agent.ts. */

--- a/packages/server/src/handlers/skills-handlers.ts
+++ b/packages/server/src/handlers/skills-handlers.ts
@@ -1,10 +1,14 @@
-import { listIntegrations, listSkills, repairIntegrations } from "@repo/agent/setup";
+import { createSkill, listIntegrations, listSkills, repairIntegrations } from "@repo/agent/setup";
 import { emitEvent } from "../events";
 import { getAgentPorts, getBundledResources } from "../boot/agent-wiring";
 import type { HandlerRegistrar } from "./handler-registry";
 
 export function registerSkillsHandlers(handle: HandlerRegistrar): void {
-  handle("listSkills", () => ({ skills: listSkills() }));
+  handle("listSkills", () => ({ skills: listSkills(getBundledResources()) }));
+  // Authoring, not file management: the skills folder is inside ~/.inteligir,
+  // which the app owns — writing a valid SKILL.md is a capability the host
+  // already has, where revealing the folder would need a new shell one.
+  handle("createSkill", (payload) => createSkill(getBundledResources(), payload));
 
   // Integrations (CLI binaries).
   handle("listIntegrations", () => listIntegrations(getAgentPorts()));

--- a/packages/storage/src/__tests__/harden-app-dir.test.ts
+++ b/packages/storage/src/__tests__/harden-app-dir.test.ts
@@ -45,6 +45,10 @@ function buildLegacyInstall(): string {
   writeFile(path.join(root, "indexes", "deadbeef.sqlite-wal"), 0o644);
   writeFile(path.join(root, "indexes", "deadbeef.sqlite-shm"), 0o644);
   fs.chmodSync(path.join(root, "indexes"), 0o755);
+  // Last-synced note bytes. The per-vault suffix puts this dir out of reach of
+  // any exact-name list, which is exactly how it escaped the sweep.
+  writeFile(path.join(root, "sync-blobs-deadbeefcafe0001", "0a1b2c"), 0o644);
+  fs.chmodSync(path.join(root, "sync-blobs-deadbeefcafe0001"), 0o755);
   // Must be left alone: executables keep the owner exec bit, and non-store
   // top-level files (AGENTS.md) are not data files.
   writeFile(path.join(root, "bin", "some-tool"), 0o755);
@@ -74,6 +78,8 @@ describe("hardenAppDir", () => {
     expect(mode(path.join(root, "indexes", "deadbeef.sqlite"))).toBe(0o600);
     expect(mode(path.join(root, "indexes", "deadbeef.sqlite-wal"))).toBe(0o600);
     expect(mode(path.join(root, "indexes", "deadbeef.sqlite-shm"))).toBe(0o600);
+    expect(mode(path.join(root, "sync-blobs-deadbeefcafe0001"))).toBe(0o700);
+    expect(mode(path.join(root, "sync-blobs-deadbeefcafe0001", "0a1b2c"))).toBe(0o600);
 
     // Untouched: the exec bit survives, docs stay as they were.
     expect(mode(path.join(root, "bin", "some-tool"))).toBe(0o755);

--- a/packages/storage/src/harden-app-dir.ts
+++ b/packages/storage/src/harden-app-dir.ts
@@ -26,7 +26,7 @@
 import fs from "node:fs";
 import path from "node:path";
 
-import { inteligirPath } from "./json-store";
+import { SYNC_BLOBS_DIR_PREFIX, inteligirPath } from "./json-store";
 
 /** Subdirectories holding note content, transcripts, or credentials — the
  * durable owner-only boundary for files third parties create inside them. */
@@ -46,6 +46,19 @@ function chmodQuiet(target: string, mode: number): void {
     fs.chmodSync(target, mode);
   } catch {
     // Best-effort — never block boot on a permission fix.
+  }
+}
+
+/** Directory names directly inside `dir` starting with `prefix`; [] when the
+ * dir doesn't exist. */
+function listDirs(dir: string, prefix: string): string[] {
+  try {
+    return fs
+      .readdirSync(dir, { withFileTypes: true })
+      .filter((entry) => entry.isDirectory() && entry.name.startsWith(prefix))
+      .map((entry) => entry.name);
+  } catch {
+    return [];
   }
 }
 
@@ -100,5 +113,14 @@ export function hardenAppDir(sessionDirs: readonly string[], root: string = inte
   const indexes = path.join(root, "indexes");
   for (const name of listFiles(indexes)) {
     chmodQuiet(path.join(indexes, name), 0o600);
+  }
+  // Last-synced note bytes, one dir per synced vault. The name carries a
+  // per-vault suffix, so PRIVATE_DIRS — an exact-name list — structurally
+  // cannot reach it; matching the prefix is the only way these get swept.
+  for (const dir of listDirs(root, SYNC_BLOBS_DIR_PREFIX)) {
+    chmodQuiet(path.join(root, dir), 0o700);
+    for (const name of listFiles(path.join(root, dir))) {
+      chmodQuiet(path.join(root, dir, name), 0o600);
+    }
   }
 }

--- a/packages/storage/src/json-store.ts
+++ b/packages/storage/src/json-store.ts
@@ -22,6 +22,12 @@ export function shortPathKey(input: string): string {
   return crypto.createHash("sha256").update(input).digest("hex").slice(0, 16);
 }
 
+/** Prefix of the per-vault last-synced blob dirs. Declared here rather than
+ * beside the writer so the permission sweep and the writer cannot drift: the
+ * dirs hold raw note bytes but carry a per-vault suffix, which puts them out
+ * of reach of any exact-name list. */
+export const SYNC_BLOBS_DIR_PREFIX = "sync-blobs-";
+
 export type FsAdapter = {
   read: (filePath: string) => string | null;
   write: (filePath: string, content: string, mode?: number) => void;

--- a/packages/sync/src/sync-manager.ts
+++ b/packages/sync/src/sync-manager.ts
@@ -23,7 +23,13 @@ import crypto from "node:crypto";
 import fs from "node:fs";
 import path from "node:path";
 
-import { inteligirPath, realFs, shortPathKey, type FsAdapter } from "@repo/storage/json-store";
+import {
+  SYNC_BLOBS_DIR_PREFIX,
+  inteligirPath,
+  realFs,
+  shortPathKey,
+  type FsAdapter,
+} from "@repo/storage/json-store";
 import type { VaultManager } from "@repo/vault/vault";
 import type { SyncPort } from "@repo/notes/sync/sync-port";
 import {
@@ -141,7 +147,7 @@ export function createJsonBaseStore(
 
 /** Per-vault blob directory, keyed exactly like `baseStorePath`. */
 function blobStoreDir(vaultId: string): string {
-  return inteligirPath(`sync-blobs-${shortPathKey(vaultId)}`);
+  return inteligirPath(`${SYNC_BLOBS_DIR_PREFIX}${shortPathKey(vaultId)}`);
 }
 
 /**
@@ -171,8 +177,11 @@ export function createNodeBlobStore(
       const file = fileFor(hash);
       try {
         if (fs.existsSync(file)) return; // content-addressed — already stored
-        fs.mkdirSync(dir, { recursive: true });
-        fs.writeFileSync(file, bytes);
+        // Last-synced note BYTES: the same owner-only boundary json-store's
+        // writes hold, since this lands under ~/.inteligir alongside the
+        // transcripts and snapshots the 0700/0600 rule exists for.
+        fs.mkdirSync(dir, { recursive: true, mode: 0o700 });
+        fs.writeFileSync(file, bytes, { mode: 0o600 });
       } catch {
         // Capture is best-effort — a dropped blob degrades to a conflict copy.
       }

--- a/packages/ui/README.md
+++ b/packages/ui/README.md
@@ -35,8 +35,12 @@ src/
                      joshpuckett/bloom), typeset presets, @source
     typeset.css      typeset-docs / typeset-chat document typography
   __tests__/
-    no-orphan-components.test.ts   see Testing
+    no-orphan-components.test.ts    see Testing
+    components-provenance.test.ts   see Testing
+scripts/
+  provenance.mjs     regenerates / drift-checks the provenance manifest
 components.json      shadcn config — style "base-rhea", base color zinc
+components.provenance.json          see Provenance
 ```
 
 Exports are path-based (`package.json` `exports`):
@@ -81,6 +85,44 @@ Exports are path-based (`package.json` `exports`):
   an ES2024+ builtin would typecheck and then throw in a supported browser.
   Reasoning is inline in `tsconfig.json`.
 
+## Provenance
+
+`components.provenance.json` records, per file under `src/components`, where it
+came from — a shadcn registry item (`origin: "registry"` + the upstream `item`
+name) or written here (`origin: "local"`, today `confirm-dialog` and
+`geometric-orb`) — plus a sha256 of the bytes last accepted for it. The
+registry block mirrors `components.json` (the config the CLI reads) and carries
+the preset id, which lives nowhere else.
+
+```bash
+pnpm --filter @repo/ui provenance          # regenerate (rewrites hashes)
+pnpm --filter @repo/ui provenance:check    # report drift, never fails
+```
+
+The recorded hash is the **last accepted** bytes, not pristine upstream —
+these files were patched to the repo's rules before any record existed. So
+drift means "changed since we last accepted it", which is the useful question
+around a re-pull:
+
+1. **Before** re-pulling, `provenance:check` should be clean. Anything it lists
+   is a local edit nobody recorded — regenerate first, so the re-pull's damage
+   is legible.
+2. **After** `pnpm dlx shadcn@latest add <component>`, the components it lists
+   are exactly the files the pull rewrote — i.e. the local extensions above
+   that need re-applying and the patches back to the repo's strict rules.
+3. Once those are back, regenerate and commit the manifest with the re-pull.
+
+Origin and `item` are hand-curated: nothing on disk distinguishes a registry
+copy from a file written here, so a regenerate carries them forward and only
+refreshes hashes. New files default to `origin: "registry"` and the script says
+so — set a hand-written one to `"local"`. Scope is `src/components` only:
+`globals.css` started from the registry's theme but is now mostly local, and a
+hash of it would report drift permanently.
+
+Drift is **never a gate**. Local edits to vendored files are sanctioned (see
+Invariants), so a failing drift check would fail on the intended state. What is
+enforced is coverage — see Testing.
+
 ## Seams
 
 `ThemeProvider` is **controlled**: it owns OS-preference resolution, the
@@ -92,13 +134,21 @@ no-flash script).
 
 ## Testing
 
-`pnpm --filter @repo/ui test` runs one suite, and it is load-bearing:
+`pnpm --filter @repo/ui test` runs two source-walk suites, both load-bearing.
+
 `src/__tests__/no-orphan-components.test.ts` walks the repo and fails when a
 file under `src/components` has no importer anywhere. It exists because knip
 structurally cannot check it — the `./components/*` exports wildcard makes
 every component a public entry point, so an orphan reads as intentional API.
 Without this suite nothing reports dead vendored components, and they pile up
 in the thousands of lines — each dragging its own pinned npm deps along.
+
+`src/__tests__/components-provenance.test.ts` fails when a component file has
+no entry in `components.provenance.json` (or an entry has no file), and when
+the manifest's registry block disagrees with `components.json`. Coverage only —
+a component that escapes the record has no source identity, so a re-pull cannot
+tell whether it is safe to overwrite. It asserts nothing about the hashes;
+`provenance:check` reports those.
 
 No component renders in-package: behavior is pinned by consumer tests (the
 desktop renderer's `confirm-dialog.test.tsx` and `settings-panel.test.tsx` run

--- a/packages/ui/components.provenance.json
+++ b/packages/ui/components.provenance.json
@@ -1,0 +1,160 @@
+{
+  "generatedBy": "pnpm --filter @repo/ui provenance",
+  "registry": {
+    "url": "https://ui.shadcn.com",
+    "style": "base-rhea",
+    "baseColor": "zinc",
+    "preset": "beqC8BzG"
+  },
+  "hash": "sha256",
+  "components": {
+    "alert-dialog": {
+      "origin": "registry",
+      "item": "alert-dialog",
+      "sha256": "0d1690e61edf659c1924b342e2c382e7f8afe0ebf02f16fdd251128270e644b2"
+    },
+    "attachment": {
+      "origin": "registry",
+      "item": "attachment",
+      "sha256": "cae82de6d926c57cdc718450c82576b01e9561dd7ad22297a35d085616e8abca"
+    },
+    "badge": {
+      "origin": "registry",
+      "item": "badge",
+      "sha256": "ea3dfcdb062f90b234f3e20f7adc96435e8b7c2a34784a11c29c8b62ea3ed95a"
+    },
+    "breadcrumb": {
+      "origin": "registry",
+      "item": "breadcrumb",
+      "sha256": "22b8d8e41dc03fff8c6b33c3a69b42aa3b86b3d3c6dbe129e1621e92c77f7202"
+    },
+    "bubble": {
+      "origin": "registry",
+      "item": "bubble",
+      "sha256": "bf068ca55fc81f1aa1b1c5a814bc8e9be8274c4c19f43797f9e7ccc4355fbaea"
+    },
+    "button": {
+      "origin": "registry",
+      "item": "button",
+      "sha256": "0e9bde4c939142adff4f8ca5605d31876c5814aeec7aadef43dcba024d086a88"
+    },
+    "checkbox": {
+      "origin": "registry",
+      "item": "checkbox",
+      "sha256": "395facccfbb5a3c3f8cc6c03d38e1e57ef530b4a79855e0197c91b10cf0cf605"
+    },
+    "collapsible": {
+      "origin": "registry",
+      "item": "collapsible",
+      "sha256": "1251b05bdf0f9d8118139c3ed7bb0ea60466ee664c2d58e710be9b39032c6f6c"
+    },
+    "command": {
+      "origin": "registry",
+      "item": "command",
+      "sha256": "49522d5035bbed646be4523e9bb4568461df39684ac73f5d19075723baed5001"
+    },
+    "confirm-dialog": {
+      "origin": "local",
+      "sha256": "d85e943f410c75421d450fcee3b62a56d74a2855a1d2c5c0e6a304f44a625a85"
+    },
+    "dialog": {
+      "origin": "registry",
+      "item": "dialog",
+      "sha256": "f3131d895f99d565b9dc0895a2c7949a2f011df5525ad214df6b8c8451b2562c"
+    },
+    "dropdown-menu": {
+      "origin": "registry",
+      "item": "dropdown-menu",
+      "sha256": "b664dce696cb75f58e747f459f36480316ccb269363da40436ea5391ade65b1a"
+    },
+    "geometric-orb": {
+      "origin": "local",
+      "sha256": "cdb22e3e3467f771d4e62f3f020616307fcce4b025af4ca256772547b5ef3e23"
+    },
+    "input": {
+      "origin": "registry",
+      "item": "input",
+      "sha256": "5ca45e0d96efda1ec0338eb257f12cd1b8172841b13d76ff944335e366350e68"
+    },
+    "input-group": {
+      "origin": "registry",
+      "item": "input-group",
+      "sha256": "f4704d4d05ab85f9d7567e85926bd1538697eab907227116520ce57d2446fcb8"
+    },
+    "label": {
+      "origin": "registry",
+      "item": "label",
+      "sha256": "f63065c68988ade6786d4984d4e96050de2cac400972ea0379e884f65200df21"
+    },
+    "message": {
+      "origin": "registry",
+      "item": "message",
+      "sha256": "79b8c6e0f910fe4b29a862241eaabe40604a2f22b98426e8a4827746bdc537e3"
+    },
+    "message-scroller": {
+      "origin": "registry",
+      "item": "message-scroller",
+      "sha256": "dfa9f035a35352b9f29d76bee9f4a7025daf171b8faf95eb8e191e6e5bf4e92c"
+    },
+    "native-select": {
+      "origin": "registry",
+      "item": "native-select",
+      "sha256": "96e8b0d26e74fdf82222de74234b0b1d19b40a50d7d33f05984a9ec86a8ae1b0"
+    },
+    "popover": {
+      "origin": "registry",
+      "item": "popover",
+      "sha256": "530f117f2b1538b7b2548b01c57334b2f486948b5a8279e2561df8291b86247e"
+    },
+    "separator": {
+      "origin": "registry",
+      "item": "separator",
+      "sha256": "a2cf0f3db51bea6f45abbb722e1c41d33274a9a5f5cfbb5f6ed45bf7cda91236"
+    },
+    "sheet": {
+      "origin": "registry",
+      "item": "sheet",
+      "sha256": "9201266008396999ea05547a125c5a8ebcdc336e6ba4b3d3540e3fd980b656ec"
+    },
+    "sidebar": {
+      "origin": "registry",
+      "item": "sidebar",
+      "sha256": "8c66c2360996b618fbfd4332040105215d433dd36bf2e64aded42063da3142df"
+    },
+    "skeleton": {
+      "origin": "registry",
+      "item": "skeleton",
+      "sha256": "1fd4363f2ea8a5e57d6800a05540a5c4519349b4ede7b0bff25cd095d7ec698a"
+    },
+    "sonner": {
+      "origin": "registry",
+      "item": "sonner",
+      "sha256": "e62bb8be7dec7c8c091fd3c148bd5801726f048bdf4c91a4f04d4971f10f56ed"
+    },
+    "spinner": {
+      "origin": "registry",
+      "item": "spinner",
+      "sha256": "e3c765a22a4aef5fa0238cac4a15049198ffbf9056e9221f09d4d1e2b68930ee"
+    },
+    "switch": {
+      "origin": "registry",
+      "item": "switch",
+      "sha256": "a846104435ba79406c1ab6a4bf742e199eac3eacf8686d3dc2b60d530f481fd8"
+    },
+    "tabs": {
+      "origin": "registry",
+      "item": "tabs",
+      "sha256": "792e76a4f65c5d3ecfc11609081efe25824bf58837ec5c409d795b702cb9f802"
+    },
+    "textarea": {
+      "origin": "registry",
+      "item": "textarea",
+      "sha256": "8d767f048df18576c5c8073a52061f720505f041534d792b1c27b26dff641e2a"
+    },
+    "tooltip": {
+      "origin": "registry",
+      "item": "tooltip",
+      "sha256": "2b060c9bf229a9b877320dffb3bc451bafa4c81e63af25368593bb3f18c59e65"
+    }
+  }
+}

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -12,6 +12,8 @@
   },
   "scripts": {
     "clean": "git clean -xdf .cache .turbo dist node_modules",
+    "provenance": "node scripts/provenance.mjs",
+    "provenance:check": "node scripts/provenance.mjs --check",
     "test": "vitest run",
     "typecheck": "tsc --noEmit --emitDeclarationOnly false"
   },

--- a/packages/ui/scripts/provenance.mjs
+++ b/packages/ui/scripts/provenance.mjs
@@ -1,0 +1,159 @@
+// Provenance baseline for `src/components`: where each vendored file came from
+// (shadcn registry item vs hand-written here) and the bytes we last accepted
+// for it. Without it there is no record of what was copied, so a re-pull's
+// damage — a clobbered local extension — is invisible until someone notices
+// the behavior it carried is gone.
+//
+// The recorded hash is the LAST ACCEPTED bytes, not pristine upstream: these
+// files were patched to the repo's rules (no `any`/`as`/`!`) before any record
+// existed, and re-fetching every upstream revision to diff against would need
+// the network and a per-file version pin nothing here has. So drift answers
+// "what changed since we last accepted this file", which is the question a
+// re-pull actually poses.
+//
+// Deliberately NOT a gate. Local edits to vendored files are sanctioned (see
+// the README's invariants), so a check that failed on drift would fail on the
+// intended state. Coverage is the invariant with teeth, and it lives in
+// src/__tests__/components-provenance.test.ts.
+//
+//   node scripts/provenance.mjs           rewrite the manifest (regenerate)
+//   node scripts/provenance.mjs --check   report drift, never fails
+
+import { createHash } from "node:crypto";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const PACKAGE_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const COMPONENTS_DIR = path.join(PACKAGE_ROOT, "src", "components");
+const MANIFEST_PATH = path.join(PACKAGE_ROOT, "components.provenance.json");
+const CONFIG_PATH = path.join(PACKAGE_ROOT, "components.json");
+
+const REGISTRY_URL = "https://ui.shadcn.com";
+
+function readJson(file) {
+  return JSON.parse(fs.readFileSync(file, "utf8"));
+}
+
+function hashOf(name) {
+  const bytes = fs.readFileSync(path.join(COMPONENTS_DIR, `${name}.tsx`));
+  return createHash("sha256").update(bytes).digest("hex");
+}
+
+/** Component basenames, sorted — the manifest's key order is this order. */
+function componentNames() {
+  return fs
+    .readdirSync(COMPONENTS_DIR, { withFileTypes: true })
+    .filter((entry) => entry.isFile() && entry.name.endsWith(".tsx"))
+    .map((entry) => entry.name.replace(/\.tsx$/, ""))
+    .toSorted();
+}
+
+function readManifest() {
+  return fs.existsSync(MANIFEST_PATH) ? readJson(MANIFEST_PATH) : null;
+}
+
+// Origin and the upstream item name are HAND-CURATED — nothing on disk can
+// tell a registry copy from a file written here — so a regenerate carries them
+// forward untouched and only refreshes hashes. New files default to registry
+// origin (the common case) and are announced, because a hand-written component
+// silently recorded as vendored is the one wrong answer that never gets caught.
+function build(previous) {
+  const config = readJson(CONFIG_PATH);
+  const components = {};
+  const added = [];
+
+  for (const name of componentNames()) {
+    const before = previous?.components?.[name];
+    if (!before) added.push(name);
+    const sha256 = hashOf(name);
+    components[name] =
+      before?.origin === "local"
+        ? { origin: "local", sha256 }
+        : { origin: "registry", item: before?.item ?? name, sha256 };
+  }
+
+  const preset = previous?.registry?.preset;
+  return {
+    manifest: {
+      generatedBy: "pnpm --filter @repo/ui provenance",
+      registry: {
+        url: REGISTRY_URL,
+        // Mirrored from components.json, which is the config the shadcn CLI
+        // actually reads; the test asserts they agree.
+        style: config.style,
+        baseColor: config.tailwind.baseColor,
+        // Not derivable from anything on disk: hand-written once, carried forward.
+        ...(preset === undefined ? {} : { preset }),
+      },
+      hash: "sha256",
+      components,
+    },
+    added,
+  };
+}
+
+function serialize(manifest) {
+  return `${JSON.stringify(manifest, null, 2)}\n`;
+}
+
+function regenerate() {
+  const { manifest, added } = build(readManifest());
+  fs.writeFileSync(MANIFEST_PATH, serialize(manifest));
+  console.log(
+    `Wrote ${path.relative(PACKAGE_ROOT, MANIFEST_PATH)} (${
+      Object.keys(manifest.components).length
+    } components).`,
+  );
+  if (added.length > 0) {
+    console.log(
+      `New entries recorded as registry copies: ${added.join(", ")}.\n` +
+        `If any was written here rather than pulled, set its "origin" to "local" by hand.`,
+    );
+  }
+}
+
+function report(label, items, hint) {
+  if (items.length === 0) return;
+  console.log(`\n${label}\n  ${items.join("\n  ")}\n${hint}`);
+}
+
+function check() {
+  const manifest = readManifest();
+  if (manifest === null) {
+    console.error(
+      `No ${path.relative(PACKAGE_ROOT, MANIFEST_PATH)} — run \`pnpm --filter @repo/ui provenance\`.`,
+    );
+    process.exitCode = 1;
+    return;
+  }
+
+  const names = componentNames();
+  const recorded = manifest.components;
+  const drifted = names.filter((name) => recorded[name] && recorded[name].sha256 !== hashOf(name));
+  const unrecorded = names.filter((name) => !recorded[name]);
+  const stale = Object.keys(recorded).filter((name) => !names.includes(name));
+
+  report(
+    `Locally modified since the recorded baseline (${drifted.length}/${names.length}):`,
+    drifted,
+    "  These carry local edits. Re-apply them after a re-pull, then regenerate.",
+  );
+  report(
+    "Not in the manifest:",
+    unrecorded,
+    "  Run `pnpm --filter @repo/ui provenance` and set the origin of anything hand-written.",
+  );
+  report(
+    "In the manifest but no longer on disk:",
+    stale,
+    "  Run `pnpm --filter @repo/ui provenance` to drop them.",
+  );
+
+  if (drifted.length + unrecorded.length + stale.length === 0) {
+    console.log(`All ${names.length} components match the recorded baseline.`);
+  }
+}
+
+if (process.argv.includes("--check")) check();
+else regenerate();

--- a/packages/ui/src/__tests__/components-provenance.test.ts
+++ b/packages/ui/src/__tests__/components-provenance.test.ts
@@ -1,0 +1,123 @@
+// ---------------------------------------------------------------------------
+// Provenance-coverage guard: every file under src/components is recorded in
+// components.provenance.json, and every record still has a file.
+//
+// COVERAGE is the invariant, not content. A vendored component that escapes
+// the record has no source identity at all, so a re-pull cannot tell whether
+// it came from the registry (overwrite freely) or was written here (never
+// overwrite). Drift — a recorded hash no longer matching the bytes — is
+// deliberately NOT asserted: local edits to vendored files are sanctioned
+// (README § Invariants), so failing on drift would fail on the intended state.
+// `pnpm --filter @repo/ui provenance:check` reports it instead.
+//
+// Sibling of the orphan-component guard: assert the architectural rule as a
+// failing test, over a walk of the real tree rather than a maintained list.
+// ---------------------------------------------------------------------------
+
+import { describe, expect, it } from "vitest";
+import fs from "node:fs";
+import path from "node:path";
+
+const PACKAGE_ROOT = path.resolve(import.meta.dirname, "../..");
+const COMPONENTS_DIR = path.join(PACKAGE_ROOT, "src", "components");
+const MANIFEST_PATH = path.join(PACKAGE_ROOT, "components.provenance.json");
+const CONFIG_PATH = path.join(PACKAGE_ROOT, "components.json");
+
+type ProvenanceEntry =
+  | { origin: "registry"; item: string; sha256: string }
+  | { origin: "local"; sha256: string };
+
+type Provenance = {
+  registry: { style: string; baseColor: string };
+  components: Record<string, ProvenanceEntry>;
+};
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+const SHA256 = /^[\da-f]{64}$/;
+
+function parseEntry(name: string, value: unknown): ProvenanceEntry {
+  const fields = isRecord(value) ? value : {};
+  const { origin, item, sha256 } = fields;
+  if (typeof sha256 !== "string" || !SHA256.test(sha256)) {
+    throw new Error(`components.provenance.json: "${name}" has no valid sha256`);
+  }
+  if (origin === "local") return { origin: "local", sha256 };
+  if (origin === "registry" && typeof item === "string") {
+    return { origin: "registry", item, sha256 };
+  }
+  throw new Error(
+    `components.provenance.json: "${name}" needs origin "local", or "registry" with an "item".`,
+  );
+}
+
+/** Parse at the boundary: the manifest is generated data on disk, so the test
+ * refuses a shape it cannot reason about rather than reading through `any`. */
+function parseProvenance(raw: string): Provenance {
+  const value: unknown = JSON.parse(raw);
+  if (!isRecord(value) || !isRecord(value.registry) || !isRecord(value.components)) {
+    throw new Error("components.provenance.json: expected { registry, components }");
+  }
+  const { style, baseColor } = value.registry;
+  if (typeof style !== "string" || typeof baseColor !== "string") {
+    throw new Error("components.provenance.json: registry needs a string style and baseColor");
+  }
+  const components: Record<string, ProvenanceEntry> = {};
+  for (const [name, entry] of Object.entries(value.components)) {
+    components[name] = parseEntry(name, entry);
+  }
+  return { registry: { style, baseColor }, components };
+}
+
+function parseShadcnConfig(raw: string): { style: string; baseColor: string } {
+  const value: unknown = JSON.parse(raw);
+  if (!isRecord(value) || !isRecord(value.tailwind)) {
+    throw new Error("components.json: expected { style, tailwind }");
+  }
+  const { style } = value;
+  const { baseColor } = value.tailwind;
+  if (typeof style !== "string" || typeof baseColor !== "string") {
+    throw new Error("components.json: expected string style and tailwind.baseColor");
+  }
+  return { style, baseColor };
+}
+
+function componentNames(): string[] {
+  return fs
+    .readdirSync(COMPONENTS_DIR, { withFileTypes: true })
+    .filter((entry) => entry.isFile() && entry.name.endsWith(".tsx"))
+    .map((entry) => entry.name.replace(/\.tsx$/, ""))
+    .toSorted();
+}
+
+const REGENERATE = "Run `pnpm --filter @repo/ui provenance` to regenerate.";
+
+describe("component provenance", () => {
+  const provenance = parseProvenance(fs.readFileSync(MANIFEST_PATH, "utf8"));
+
+  it("records every file under src/components", () => {
+    const unrecorded = componentNames().filter((name) => !(name in provenance.components));
+
+    expect(
+      unrecorded,
+      `Vendored components with no provenance record — nothing says where they came from.\n` +
+        `${REGENERATE} A component written HERE needs its origin set to "local" by hand:\n` +
+        unrecorded.map((name) => `  packages/ui/src/components/${name}.tsx`).join("\n"),
+    ).toEqual([]);
+  });
+
+  it("records nothing that is no longer on disk", () => {
+    const names = new Set(componentNames());
+    const stale = Object.keys(provenance.components).filter((name) => !names.has(name));
+
+    expect(stale, `Provenance records for deleted components. ${REGENERATE}`).toEqual([]);
+  });
+
+  it("agrees with components.json on the registry style", () => {
+    // The shadcn CLI reads components.json; the manifest only mirrors it. A
+    // silent divergence would attribute files to a preset they never came from.
+    expect(provenance.registry).toEqual(parseShadcnConfig(fs.readFileSync(CONFIG_PATH, "utf8")));
+  });
+});


### PR DESCRIPTION
Evaluated [BuilderIO/agent-native](https://github.com/BuilderIO/agent-native) as a dependency and rejected it — the reasons are recorded in #485 so it is not re-proposed. Its conventions are adopted here instead.

## Skills

Rebuilt the Settings surface as a table (`SKILL | UPDATED | SOURCE`), matching Claude Desktop's — kebab-case ids rendered raw, no invented toggle. `SkillInfo` widened with `source`, `updatedAt` (epoch ms; formatting is the renderer's job) and a discriminated budget state.

`createSkill` scaffolds a real `SKILL.md`. It writes host-side rather than asking the agent to, because the agent's file tools point at `./vault` while skills live in `~/.inteligir/skills` — "ask the agent" would need a filesystem grant that is its own decision.

**The listing budget now sheds description characters instead of whole skills**, water-filled shortest-first. A skill the model knows by name alone is still invocable; one missing from the listing is not. Settings and the agent run the same budget, so the list shows what the model actually received — a skill whose description was clipped, or which did not load, is visibly badged rather than silently absent.

## Two live problems found

**`vault/AGENTS.md` was an unbounded, self-growing prompt.** Not merely user-authored: the bundled prompt instructs the agent to append durable memory to it every session, and the loader injected the whole file into every turn of chat and delegation. The cap keeps the head and sheds the tail, so truncation drops accumulated recall before it drops standing instructions — losing "answer in Spanish" is a violation, losing last week's remembered fact is a degradation.

**`sync-blobs-<key>/` held last-synced note bytes at 0644.** Written with bare `fs`, bypassing the 0600/0700 substrate, and structurally unreachable by `PRIVATE_DIRS` because the per-vault suffix defeats an exact-name list. Now written 0700/0600 and swept by prefix, with the prefix declared once in `@repo/storage` so writer and sweep cannot drift.

## Guards

- **pi 0.82's `tool_call` contract** — the whole privacy model rests on it and a comment claimed 0.80.10 parity that nothing tested. The contract holds; it is now pinned, and mutation-checked to prove the test is not vacuous.
- **Exactly one `tool_call` subscriber.** pi hands every handler the same mutable `input` and re-validates nothing between them, so a second subscriber could redirect a call past the privacy probe. Privacy being the sole subscriber is what makes that unreachable.
- **Dep DAG** checked against real manifests.
- **Instruction-file budgets** — measured first: pi truncates nothing, so the honest guard is on bytes we author.

## Also

- The two change checklists become `.claude/skills` blueprints, excluded from `no-dead-channels` demand so a worked example cannot prop up a dead channel.
- `NotePathSchema` split off `VaultPathSchema`'s nine users, ending three duplicate declarations in `knowledge-tools`. Three tool schemas now emit `additionalProperties: false` where they previously emitted nothing — a tightening, not a no-op.
- Drift provenance for vendored `packages/ui`.
- `CLAUDE.md` corrected: the renderer's freedom from `@repo/server` is lint-enforced, not a package fact — `apps/desktop` does depend on it, and the override is off under `renderer/__tests__/**`.

## Verification

`pnpm format:fix && pnpm verify` green. The Skills UI was driven in the dev harness and screenshotted across four states — table, budget badges, duplicate-name rejection, and create.

## Not done

`createSkill` and `listSkills` are deliberately **not** in `REMOTE_ALLOWED_METHODS`. A `SKILL.md` is read into the agent's system prompt every turn, so a paired phone that can write one gets persistent unattended prompt injection against an agent holding file tools over the vault.

The detail row shows an absolute path but cannot open it — there is no reveal-in-Finder channel anywhere, and `openExternal` is http(s)-scheme-guarded by design. One capability would make skills, sync conflicts and CLI binaries honest at once.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adopts agent-native conventions: a new Skills UI with unified budgeting, plus strong privacy and dependency guards. Fixes unbounded `AGENTS.md` growth and sync-blob permissions; adds provenance tracking for `@repo/ui`.

- New Features
  - Skills settings rebuilt as a table: SKILL | UPDATED | SOURCE with budget badges; `SkillInfo` now includes `source`, `updatedAt`, and a discriminated budget state.
  - `createSkill` scaffolds a real `SKILL.md` under `~/.inteligir/skills` (host-side, slugged name, path-confined), with tests; not exposed in `REMOTE_ALLOWED_METHODS`.
  - Shared skill budget (`applySkillBudget`) used by both the agent loader and Settings: trims description characters via fair-share water-filling; deterministic selection and notices when clipping occurs.
  - `.claude/skills` blueprints added; `@repo/ui` gains component provenance (`components.provenance.json`) and a `provenance` script.

- Bug Fixes
  - Bound `vault/AGENTS.md` before it reaches the prompt: keep standing instructions at the head and shed tail recall; tests pin the budget and verify no upstream truncation.
  - Fixed `sync-blobs-*` permissions: now 0700/0600 and swept by prefix; prefix declared once in `@repo/storage` (`SYNC_BLOBS_DIR_PREFIX`) to keep writer and sweep in sync.
  - Privacy guards: pinned `tool_call` contract at pi 0.82 with mutation-checked tests; enforced exactly one `tool_call` subscriber to prevent post-probe input mutation.
  - Path-parity guard drives pi’s own resolver to close alias/URL bypasses; dep-DAG assertions validate `packages/*` edges against real manifests; `NotePathSchema` split ends duplicate schemas in knowledge tools.

<sup>Written for commit 493b960a82b3252c243928ddbd1e7404ac9767b8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kyh/inteligir/pull/486?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

