### PR TITLE
fix(voice): fetch the speech model on first use, name the two mic buttons

### DIFF
--- a/apps/desktop/src/renderer/composer/composer.test.tsx
+++ b/apps/desktop/src/renderer/composer/composer.test.tsx
@@ -165,7 +165,7 @@ describe("Composer (controlled draft)", () => {
     render(<Composer />);
     expandComposer();
 
-    const button = screen.getByRole("button", { name: "Start voice chat" });
+    const button = screen.getByRole("button", { name: "Talk with the agent" });
     expect(button.getAttribute("aria-disabled")).toBe("true");
     fireEvent.click(button);
     expect(toggleVoice).not.toHaveBeenCalled();
@@ -178,7 +178,7 @@ describe("Composer (controlled draft)", () => {
 
     // Collapsed: the pill offers the launcher directly (it hides while TTS is
     // unconfigured — the expanded toolbar's inert button carries the pointer).
-    const button = screen.getByRole("button", { name: "Start voice chat" });
+    const button = screen.getByRole("button", { name: "Talk with the agent" });
     expect(button.hasAttribute("aria-disabled")).toBe(false);
     fireEvent.click(button);
     expect(toggleVoice).toHaveBeenCalledTimes(1);

--- a/apps/desktop/src/renderer/composer/composer.tsx
+++ b/apps/desktop/src/renderer/composer/composer.tsx
@@ -15,6 +15,7 @@ import {
 import { AnimatePresence, motion } from "framer-motion";
 
 import { toast } from "@repo/ui/components/sonner";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@repo/ui/components/tooltip";
 import { cn } from "@repo/ui/lib/utils";
 import {
   Attachment,
@@ -625,9 +626,11 @@ function VoiceChatButton({
   return (
     <PromptInputButton
       tooltip={
-        ttsConfigured === false ? "Add an ElevenLabs API key in Settings → Voice" : "Voice chat"
+        ttsConfigured === false
+          ? "Add an ElevenLabs API key in Settings → Voice"
+          : "Talk with the agent"
       }
-      aria-label="Start voice chat"
+      aria-label="Talk with the agent"
       aria-disabled={disabled || undefined}
       onClick={disabled ? undefined : onToggle}
       className={cn(
@@ -657,8 +660,8 @@ function AttachButton() {
 function MicButton({ onStart }: { onStart: () => void }) {
   return (
     <PromptInputButton
-      tooltip="Voice input"
-      aria-label="Start voice input"
+      tooltip="Dictate a message"
+      aria-label="Dictate a message"
       onClick={onStart}
       className="size-8 shrink-0 rounded-full text-muted-foreground hover:bg-muted hover:text-foreground"
     >
@@ -734,23 +737,27 @@ function CollapsedPill({
         <SparklesIcon className="size-4 shrink-0 text-muted-foreground/70" />
         <span className="text-sm whitespace-nowrap text-muted-foreground">Ask the agent…</span>
       </button>
-      <button
-        type="button"
-        aria-label="Start voice input"
-        onClick={onStartVoice}
-        className="grid size-8 shrink-0 place-items-center rounded-full text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
-      >
-        <MicIcon className="size-4" />
-      </button>
-      {onStartVoiceChat && (
-        <button
-          type="button"
-          aria-label="Start voice chat"
-          onClick={onStartVoiceChat}
+      <Tooltip>
+        <TooltipTrigger
+          aria-label="Dictate a message"
+          onClick={onStartVoice}
           className="grid size-8 shrink-0 place-items-center rounded-full text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
         >
-          <AudioLinesIcon className="size-4" />
-        </button>
+          <MicIcon className="size-4" />
+        </TooltipTrigger>
+        <TooltipContent>Dictate a message</TooltipContent>
+      </Tooltip>
+      {onStartVoiceChat && (
+        <Tooltip>
+          <TooltipTrigger
+            aria-label="Talk with the agent"
+            onClick={onStartVoiceChat}
+            className="grid size-8 shrink-0 place-items-center rounded-full text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+          >
+            <AudioLinesIcon className="size-4" />
+          </TooltipTrigger>
+          <TooltipContent>Talk with the agent</TooltipContent>
+        </Tooltip>
       )}
     </div>
   );

--- a/packages/server/src/__tests__/app-effects.test.ts
+++ b/packages/server/src/__tests__/app-effects.test.ts
@@ -4,7 +4,6 @@ import { runEffect, type EffectDeps } from "../app/app-effects";
 function makeDeps(overrides?: Partial<EffectDeps>): EffectDeps {
   return {
     seedResources: vi.fn<EffectDeps["seedResources"]>().mockResolvedValue(undefined),
-    downloadVoiceModel: vi.fn<() => Promise<void>>().mockResolvedValue(undefined),
     startAgent: vi.fn<() => Promise<void>>().mockResolvedValue(undefined),
     stopAgent: vi.fn<() => Promise<void>>().mockResolvedValue(undefined),
     teardownResources: vi.fn(),

--- a/packages/server/src/__tests__/app-machine.test.ts
+++ b/packages/server/src/__tests__/app-machine.test.ts
@@ -23,7 +23,6 @@ vi.mock("@repo/agent/agent", () => ({
 function fakeDeps(overrides?: Partial<EffectDeps>): EffectDeps {
   return {
     seedResources: vi.fn().mockResolvedValue(undefined),
-    downloadVoiceModel: vi.fn().mockResolvedValue(undefined),
     startAgent: vi.fn().mockResolvedValue(undefined),
     stopAgent: vi.fn().mockResolvedValue(undefined),
     teardownResources: vi.fn(),

--- a/packages/server/src/app/app-effects.ts
+++ b/packages/server/src/app/app-effects.ts
@@ -10,7 +10,6 @@ import type { EffectTag } from "./app-reducer";
 
 export type EffectDeps = {
   seedResources: (onProgress: (p: SetupProgress) => void) => Promise<void>;
-  downloadVoiceModel: () => Promise<void>;
   startAgent: () => Promise<void>;
   stopAgent: () => Promise<void>;
   /** The full ~/.inteligir wipe (RESET only). Suspends vault writes. */
@@ -31,12 +30,6 @@ export type EffectDeps = {
 /** Seed + start — the shared body of SETUP and the re-setup half of RESET.
  * Must not throw past the caller's try (both wrap it). */
 async function runSetup(deps: EffectDeps): Promise<void> {
-  // Fire the speech-model download off the critical path. It's
-  // best-effort (the mic toggle retries) and the renderer subscribes to
-  // onVoiceModelState directly, so awaiting it only delays the agent.
-  void deps.downloadVoiceModel().catch((err: unknown) => {
-    console.warn("[setup] voice model download failed (non-fatal):", err);
-  });
   deps.reportSetupProgress({ step: "Preparing workspace", percent: null });
   await deps.seedResources(deps.reportSetupProgress);
   deps.reportSetupProgress({ step: "Starting agent", percent: null });

--- a/packages/server/src/app/app-machine.ts
+++ b/packages/server/src/app/app-machine.ts
@@ -32,7 +32,6 @@ import { startInlineAiAgent, stopInlineAiAgent } from "./inline-ai";
 import { getDelegationManager } from "../delegation/delegation-manager";
 import { getRoutinesManager } from "../routines/routines-manager";
 import { getNotifications } from "../notifications";
-import { downloadModel } from "@repo/voice/model-download";
 import { parseAgentEvent } from "@repo/bridge/agent-event-parser";
 import type { AppAgentEvent } from "@repo/bridge/agent-events";
 import type { AppState, MachineEvent } from "@repo/bridge/app-state";
@@ -384,16 +383,8 @@ function broadcastAppState(state: AppState): void {
   emitEvent("onAppState", state);
 }
 
-async function downloadVoiceModel(): Promise<void> {
-  const result = await downloadModel();
-  if (!result.ok) {
-    throw new Error(result.error);
-  }
-}
-
 const realDeps: EffectDeps = {
   seedResources: seedAgentResources,
-  downloadVoiceModel,
   startAgent,
   stopAgent,
   teardownResources: teardownAgentResources,

--- a/packages/voice/src/parakeet.ts
+++ b/packages/voice/src/parakeet.ts
@@ -13,11 +13,11 @@
 
 import { join } from "node:path";
 
-import { getModelDir, isModelInstalled } from "./model-download";
+import { downloadModel, getModelDir, isModelInstalled } from "./model-download";
 import { isRecord, toErrorMessage } from "@repo/bridge/wire-helpers";
 
-// sherpa-onnx-node is loaded lazily so the app still boots when the model
-// isn't downloaded yet (the renderer just sees STT unavailable).
+// sherpa-onnx-node is loaded lazily so the app still boots before the model
+// exists — it is fetched on first use, not at setup.
 type OnlineRecognizerCtor = new (config: unknown) => {
   createStream: () => unknown;
   isReady: (stream: unknown) => boolean;
@@ -73,8 +73,14 @@ export async function initParakeet(): Promise<InitResult> {
 }
 
 async function doInit(): Promise<InitResult> {
+  // Fetched on FIRST USE, not at setup: the model is ~457 MB and most sessions
+  // never touch voice, so downloading it during boot spends a user's bandwidth
+  // before they have typed anything. downloadModel() no-ops when installed and
+  // shares one in-flight download across concurrent callers, and its progress
+  // already streams to the renderer over onVoiceModelState.
   if (!isModelInstalled()) {
-    return { ok: false, reason: "Parakeet model not installed." };
+    const download = await downloadModel();
+    if (!download.ok) return { ok: false, reason: download.error };
   }
 
   const modelDir = getModelDir();


### PR DESCRIPTION
Closes #502. Decided in #494 — voice **stays**; these were the two things that made cutting it tempting.

## 1. No more 457 MB on first run

`runSetup` fired `downloadVoiceModel()` unconditionally. It was already off the critical path, but it still spent half a gigabyte of a new user's bandwidth before they had typed a word, for a capability most sessions never touch.

The fetch moves into `doInit()` in `parakeet.ts`, which runs on the first actual voice use. `downloadModel()` already no-ops when installed, already shares one in-flight download across concurrent callers, and its progress already streams to the renderer over `onVoiceModelState` — so nothing else had to move. The `downloadVoiceModel` effect dep and its wiring drop out.

Note the failure mode also improves: `doInit` used to return "Parakeet model not installed" and leave the user stuck. Now it downloads.

## 2. The two mic buttons have names

The collapsed composer showed two same-sized round buttons side by side — one dictates into the draft, the other starts a spoken conversation — with **no tooltips on either**, while the expanded toolbar's equivalent had one. Nothing on screen said which was which.

All three voice affordances now share two names: **"Dictate a message"** and **"Talk with the agent"**, as both tooltip and `aria-label`.

## Verification

`pnpm verify` exit 0. Driven in the browser harness — both tooltips render on hover, confirmed by snapshot and screenshot.

The all-or-nothing constraint is unchanged: dictation and voice chat are the same recognizer, so the model cannot be dropped while keeping the conversation. Read-aloud is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fetch the Parakeet speech model on first voice use instead of during setup, eliminating ~457 MB from first run. Also name both mic buttons for clarity and accessibility.

- **New Features**
  - Added clear labels and tooltips for voice controls: "Dictate a message" and "Talk with the agent" (including `aria-labels`). Collapsed composer uses `@repo/ui/components/tooltip`.

- **Refactors**
  - Moved model fetch into `parakeet.ts` `doInit()`; removed `downloadVoiceModel` from server setup (`app-effects`, `app-machine`).
  - On missing model, `doInit()` now downloads via `downloadModel()` (no-op if installed, shared across callers, progress via `onVoiceModelState`).

<sup>Written for commit 3b9a0c71b52b1b0d10d07758e636604b60a2ba93. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kyh/inteligir/pull/506?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

