### PR TITLE
fix(vault): keep ignored files in the sync manifest

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -200,7 +200,9 @@ capabilities and hands the agent an injected `AgentPorts`
 folder whose markdown files are canonical. It reads through to disk (never
 quarantines user files) and writes atomically. Liveness is the **ephemeral
 listing** (§ Decisions): NO recursive watcher — the listing is a one-shot crawl
-(respects `.gitignore`, uncapped) refreshed on window focus, app writes,
+(uncapped; `.gitignore` filters the VIEW at read time, never the crawl or the
+sync manifest — absence from the manifest is a DELETE) refreshed on window
+focus, app writes,
 delegation completion, and a "Refresh vault" palette command; only the OPEN
 note gets a (non-recursive) watcher, driven by a pure change classifier with
 self-save filtering, so autosaves generate zero vault-changed traffic. It also

--- a/packages/vault/README.md
+++ b/packages/vault/README.md
@@ -60,8 +60,15 @@ Sole export: `@repo/vault/vault`.
   (`suspendVaultWrites`) so a dirty autosave can't rebuild a default-root
   vault; reads stay allowed.
 - **Discovery ≠ access.** `SKIP_DIRS` (.git, node_modules, .obsidian, .trash)
-  - root `.gitignore`/`.ignore` prune the crawl only; an ignored file the
-    user explicitly opens still reads/writes fine.
+  and dot-entries prune the crawl outright — they are absent from every
+  listing, the manifest included.
+- **Ignore files filter the VIEW, not the manifest.** Files matched by the
+  root `.gitignore`/`.ignore` are withheld from `list()`/`listWithStats()`,
+  but the crawl descends ignored directories and `listAllPaths()` returns
+  every file on disk; an ignored file the user explicitly opens still
+  reads/writes fine. Absence from the manifest is a DELETE to reconcile, so
+  decluttering the sidebar must never fan a permanent deletion out to every
+  device.
 - **Rename is clobber-proof and case-aware.** Occupancy is case/NFC-
   insensitive over the real dir listing, decided by inode so a case-only
   self-rename passes through to one atomic `renameSync`.

--- a/packages/vault/src/__tests__/vault.test.ts
+++ b/packages/vault/src/__tests__/vault.test.ts
@@ -257,29 +257,79 @@ describe("VaultManager", () => {
     expect(mgr.listAllPaths()).toEqual(["flaky.md", "keep.md"]);
   });
 
-  it("respects root .gitignore / .ignore in both list() and listAllPaths()", () => {
+  // Ignoring is a VIEW choice — it declutters the sidebar. Sync reads a path's
+  // absence from the manifest as a local DELETE, so an ignore rule must never
+  // reach it: writing `archive/` into .gitignore would otherwise propagate a
+  // permanent deletion of every file under it to every device (a PARTIAL ignore
+  // slips straight past the engine's empty-listing mass-deletion guard).
+  it("withholds ignored files from list() but keeps them in listAllPaths()", async () => {
     const mgr = newManager();
     mgr.ensureReady();
     mgr.writeText("keep.md", "x");
     mgr.writeText("build/out.md", "x");
+    mgr.writeText("build/nested/deep.md", "x");
     mgr.writeText("logs/today.md", "x");
     mgr.writeText("secret.md", "x");
     fs.writeFileSync(path.join(root, ".gitignore"), "build/\nsecret.md\n");
     fs.writeFileSync(path.join(root, ".ignore"), "logs/\n");
 
-    const paths = mgr.list().map((e) => e.path);
-    expect(paths).toContain("keep.md");
-    expect(paths).not.toContain("build/out.md");
-    expect(paths).not.toContain("logs/today.md");
-    expect(paths).not.toContain("secret.md");
+    const visible = mgr.list().map((e) => e.path);
+    expect(visible).toEqual(["keep.md"]);
     // The ignore files themselves are dot-prefixed, so already excluded.
-    expect(paths).not.toContain(".gitignore");
-    // Ignore filters DISCOVERY, not access: an explicitly-opened ignored file
-    // still reads fine.
+    expect(visible).not.toContain(".gitignore");
+    // Derived knowledge indexes what the user sees, so it agrees with list().
+    expect((await mgr.listWithStats()).map((e) => e.path)).toEqual(visible);
+
+    // Sync sees every file that is actually on disk, still sorted — including
+    // the ones nested under an ignored DIRECTORY, which the crawl must descend.
+    expect(mgr.listAllPaths()).toEqual([
+      "build/nested/deep.md",
+      "build/out.md",
+      "keep.md",
+      "logs/today.md",
+      "secret.md",
+    ]);
+    // ...and can fingerprint each of them off the same crawl.
+    for (const rel of mgr.listAllPaths()) expect(mgr.statFingerprint(rel)).not.toBeNull();
+
+    // Ignore filters the view, not access: an ignored file still reads fine.
     expect(mgr.readText("secret.md")).toBe("x");
-    // Sync sees the same filtered set.
-    expect(mgr.listAllPaths()).toEqual(paths.toSorted((a, b) => a.localeCompare(b)));
   });
+
+  it("keeps .tmp files out of BOTH listings, ignored or not", () => {
+    const mgr = newManager();
+    mgr.ensureReady();
+    mgr.writeText("keep.md", "x");
+    fs.writeFileSync(path.join(root, "keep.md.tmp"), "in-flight");
+    fs.mkdirSync(path.join(root, "build"), { recursive: true });
+    fs.writeFileSync(path.join(root, "build", "out.md.tmp"), "in-flight");
+    fs.writeFileSync(path.join(root, ".gitignore"), "build/\n");
+
+    expect(mgr.list().map((e) => e.path)).toEqual(["keep.md"]);
+    expect(mgr.listAllPaths()).toEqual(["keep.md"]);
+  });
+
+  // Completeness is unchanged by the ignore rules: an unreadable subtree is
+  // still a truncated crawl, and sync must still refuse it.
+  it.skipIf(typeof process.getuid === "function" && process.getuid() === 0)(
+    "listAllPaths() still throws when an IGNORED subtree is unreadable",
+    () => {
+      const mgr = newManager();
+      mgr.writeText("keep.md", "x");
+      mgr.writeText("build/out.md", "x");
+      fs.writeFileSync(path.join(root, ".gitignore"), "build/\n");
+      const ignoredDir = path.join(root, "build");
+      fs.chmodSync(ignoredDir, 0o000);
+      try {
+        expect(() => mgr.listAllPaths()).toThrow(VaultListingIncompleteError);
+        // UI-facing: lenient, and the ignored subtree was never shown anyway.
+        expect(mgr.list().map((e) => e.path)).toEqual(["keep.md"]);
+      } finally {
+        fs.chmodSync(ignoredDir, 0o700);
+      }
+      expect(mgr.listAllPaths()).toEqual(["build/out.md", "keep.md"]);
+    },
+  );
 
   it("repoints the root and persists it across instances", () => {
     const mgr = newManager();

--- a/packages/vault/src/vault.ts
+++ b/packages/vault/src/vault.ts
@@ -71,8 +71,10 @@ function classify(fileName: string): VaultEntry["kind"] {
 // Hard-pruned directories — never walked, never listed, regardless of ignore
 // files. Cheap protection against the classic repo-shaped-vault blowups.
 const SKIP_DIRS = new Set([".git", "node_modules", ".obsidian", ".trash"]);
-// Root-level ignore files parsed (v1) to filter DISCOVERY (not access). A file
-// the user explicitly opens outside the snapshot still reads/writes fine.
+// Root-level ignore files parsed (v1) to filter the VIEW — not access, and not
+// the sync manifest. Matched files are still crawled; they are withheld from
+// the listings the user sees, and a file explicitly opened still reads/writes
+// fine.
 const IGNORE_FILES = [".gitignore", ".ignore"];
 
 /** How a vault change should propagate. `refresh` runs the full pipeline
@@ -122,6 +124,12 @@ type VaultSnapshot = {
    * (already confined under the root) or has to go through the `resolve()`
    * funnel. */
   entries: Map<string, VaultWalkEntry>;
+  /** The subset of `entries` the root ignore files match, directly or through
+   * an ignored ancestor directory. Ignoring is a VIEW choice — it declutters
+   * the sidebar — so these are withheld from every UI-facing listing but stay
+   * in `entries`: sync reads a path's absence from the manifest as a local
+   * DELETE, and a file that is still on disk must never say that. */
+  ignored: ReadonlySet<string>;
   /** Stat identities, filled LAZILY by `statOf` and memoized here — so a
    * refresh burst pays each file's stat at most once no matter how many
    * consumers ask, and files nobody asks about cost nothing. */
@@ -132,6 +140,10 @@ type VaultSnapshot = {
    * manifest source) refuses it, because a truncated listing is
    * indistinguishable from a mass deletion. */
   complete: boolean;
+  /** The first directory the crawl could not read, vault-relative ("." for the
+   * root), or null when the crawl was complete. Carried so a wedged sync names
+   * the offending folder instead of only the vault root. */
+  unreadable: string | null;
 };
 
 /** Thrown by `listAllPaths()` when the crawl could not observe the whole vault
@@ -141,10 +153,11 @@ type VaultSnapshot = {
  * deletion to every device. The UI-facing `list()`/`listWithStats()`
  * stay lenient and serve the partial instead. */
 export class VaultListingIncompleteError extends Error {
-  constructor(root: string) {
+  constructor(root: string, unreadable: string | null) {
     super(
-      `Vault listing incomplete — could not fully read ${root}; ` +
-        "refusing to treat unread files as deleted. Check that the vault folder " +
+      `Vault listing incomplete — could not fully read ${root}` +
+        (unreadable === null ? "" : ` (first unreadable subtree: "${unreadable}")`) +
+        "; refusing to treat unread files as deleted. Check that the folder " +
         "is present and readable, then retry.",
     );
     this.name = "VaultListingIncompleteError";
@@ -264,34 +277,41 @@ export class VaultManager {
    * Drives the sidebar file tree. Served from the shared TTL snapshot so a
    * refresh burst crawls once. */
   list(): VaultEntry[] {
-    return Array.from(this.getSnapshot().entries.values(), (e) => ({
-      path: e.path,
-      name: e.name,
-      kind: e.kind,
-    }));
+    const snapshot = this.getSnapshot();
+    const entries: VaultEntry[] = [];
+    for (const e of snapshot.entries.values()) {
+      if (snapshot.ignored.has(e.path)) continue;
+      entries.push({ path: e.path, name: e.name, kind: e.kind });
+    }
+    return entries;
   }
 
-  /** Every file path under the vault (same crawl as list(), minus the entry
-   * shaping). Sync must see every NON-ignored file — a truncated manifest reads
-   * as deletions: the 3-way reconcile treats "was in base and
-   * remote, missing from local" as a local deletion and propagates it to the
-   * coordinator and every peer. That is exactly why this — and ONLY this,
-   * the sync-facing listing — THROWS on an incomplete crawl (missing root,
-   * unreadable subtree) instead of returning the partial; the engine
-   * surfaces the throw as a failed pass and retries later. Ignore rules
-   * filter what sync tracks by design; SKIP_DIRS + ignore files are the only
-   * exclusions, and they match list(). Nothing here stats, so a per-file stat
-   * hiccup cannot silently thin this listing — only a failed readdir or a
-   * missing root can, and both are refused above. */
+  /** Every file path ON DISK under the vault (same crawl as list(), minus the
+   * entry shaping) — including the ignore-matched ones list() withholds. A
+   * truncated manifest reads as deletions: the 3-way reconcile treats "was in
+   * base and remote, missing from local" as a local deletion and propagates it
+   * to the coordinator and every peer. That is exactly why this — and ONLY
+   * this, the sync-facing listing — THROWS on an incomplete crawl (missing
+   * root, unreadable subtree) instead of returning the partial; the engine
+   * surfaces the throw as a failed pass and retries later. It is also why the
+   * ignore files cannot filter here: adding `archive/` to .gitignore is a
+   * decluttered SIDEBAR, and must never be a vault-wide deletion. SKIP_DIRS,
+   * dot-entries and in-flight `*.tmp` siblings are the only exclusions.
+   * Nothing here stats, so a per-file stat hiccup cannot silently thin this
+   * listing — only a failed readdir or a missing root can, and both are
+   * refused above. */
   listAllPaths(): string[] {
     const snapshot = this.getSnapshot();
-    if (!snapshot.complete) throw new VaultListingIncompleteError(snapshot.root);
+    if (!snapshot.complete)
+      throw new VaultListingIncompleteError(snapshot.root, snapshot.unreadable);
     return Array.from(snapshot.entries.keys());
   }
 
   /** The listing WITH stat identities on the DOCS — the knowledge reconcile's
    * diff basis. Freshness follows the snapshot TTL: external edits surface on
    * the next refresh trigger, exactly the ephemeral-liveness contract.
+   * Ignore-matched files are withheld exactly as in list(): derived knowledge
+   * indexes what the user chose to see, and only sync must track disk.
    *
    * ASYNC because one stat per doc is the crawl's dominant syscall cost, and a
    * whole-vault sweep in one uninterruptible call is a multi-hundred-
@@ -315,6 +335,7 @@ export class VaultManager {
     const snapshot = this.getSnapshot();
     const entries: VaultListingEntry[] = [];
     for (const entry of snapshot.entries.values()) {
+      if (snapshot.ignored.has(entry.path)) continue;
       if (entry.kind === "doc") {
         const identity = this.statOf(snapshot, entry.path);
         if (identity !== null) entries.push({ ...entry, kind: "doc", ...identity });
@@ -354,9 +375,13 @@ export class VaultManager {
     // completeness flag (listAllPaths throws; list serves the empty partial)
     // rather than silently reading as "every file was deleted".
     let complete = false;
+    let ignored: ReadonlySet<string> = new Set();
+    let unreadable: string | null = null;
     if (fs.existsSync(root)) {
       const walked = this.walk(root);
       complete = walked.complete;
+      ignored = walked.ignored;
+      unreadable = walked.unreadable;
       // Keyed AFTER the sort, so iteration order is the sorted order every
       // listing serves.
       walked.entries.sort((a, b) => a.path.localeCompare(b.path));
@@ -366,8 +391,10 @@ export class VaultManager {
       at: Date.now(),
       root,
       entries,
+      ignored,
       stats: new Map(),
       complete,
+      unreadable,
     };
     // Only COMPLETE crawls are cached: leniency may serve an incomplete
     // partial once, but the next call re-crawls — so recovery is immediate
@@ -414,10 +441,11 @@ export class VaultManager {
     this.snapshot = null;
   }
 
-  // The recursive walk behind the snapshot: skips dot-entries, SKIP_DIRS,
-  // ignore-matched paths, and the sibling *.tmp files atomicWrite creates
-  // mid-save. Returns entries in directory-read order (unsorted — the caller
-  // sorts), plus whether every directory read succeeded: a failed readdir still
+  // The recursive walk behind the snapshot: skips dot-entries, SKIP_DIRS and
+  // the sibling *.tmp files atomicWrite creates mid-save, and RECORDS (rather
+  // than skips) the ignore-matched paths so each consumer decides for itself.
+  // Returns entries in directory-read order (unsorted — the caller sorts),
+  // plus whether every directory read succeeded: a failed readdir still
   // skips the subtree (list() stays lenient on the partial) but is RECORDED as
   // incompleteness instead of hidden, so listAllPaths() can refuse to present
   // the truncation as deletions.
@@ -427,16 +455,31 @@ export class VaultManager {
   // instead costs several times every readdir syscall in the crawl combined
   // once a vault is large — the path math dominates this loop, not the
   // filesystem.
-  private walk(root: string): { entries: VaultWalkEntry[]; complete: boolean } {
+  private walk(root: string): {
+    entries: VaultWalkEntry[];
+    ignored: ReadonlySet<string>;
+    complete: boolean;
+    unreadable: string | null;
+  } {
     const out: VaultWalkEntry[] = [];
+    const ignored = new Set<string>();
     let complete = true;
+    let unreadable: string | null = null;
     const ig = this.loadIgnore(root);
-    const visit = (dir: string, prefix: string): void => {
+    // `inherited` carries an ignored ancestor down: gitignore semantics make
+    // everything under an ignored directory ignored, and a re-include pattern
+    // cannot resurrect it.
+    const visit = (dir: string, prefix: string, inherited: boolean): void => {
       let dirents: fs.Dirent[];
       try {
         dirents = fs.readdirSync(dir, { withFileTypes: true });
       } catch {
         complete = false; // unreadable subtree — skip it, but never hide that
+        // Named so a wedged sync is diagnosable: an ignored directory is now
+        // descended, so a chmod-000 or disconnected mount the user thought
+        // they had excluded fails every pass, and the root alone doesn't say
+        // which one. Mirrors mobile's sibling error.
+        unreadable ??= prefix === "" ? "." : prefix;
         return;
       }
       for (const dirent of dirents) {
@@ -445,17 +488,24 @@ export class VaultManager {
         const rel = prefix + name;
         // `ignore` wants a trailing slash to match directory patterns.
         if (dirent.isDirectory()) {
-          if (ig !== null && ig.ignores(`${rel}/`)) continue;
-          visit(childPath(dir, name), `${rel}/`);
+          // An ignored directory is DESCENDED anyway — the readdirs it costs
+          // buy the one thing the sync manifest cannot do without: its files
+          // are on disk, so leaving them unwalked would present them to
+          // reconcile as local deletions to fan out to every device.
+          visit(
+            childPath(dir, name),
+            `${rel}/`,
+            inherited || (ig !== null && ig.ignores(`${rel}/`)),
+          );
         } else if (dirent.isFile()) {
           if (name.endsWith(".tmp")) continue;
-          if (ig !== null && ig.ignores(rel)) continue;
+          if (inherited || (ig !== null && ig.ignores(rel))) ignored.add(rel);
           out.push({ path: rel, name, kind: classify(name) });
         }
       }
     };
-    visit(root, "");
-    return { entries: out, complete };
+    visit(root, "", false);
+    return { entries: out, ignored, complete, unreadable };
   }
 
   // Parse the root ignore files (.gitignore / .ignore) into a matcher, or null
@@ -536,8 +586,10 @@ export class VaultManager {
    * Memoized on the shared snapshot when fresh (so a sync pass and a knowledge
    * pass in the same window stat each file once between them, ≤SNAPSHOT_TTL_MS
    * stale — own writes always invalidate); a path ABSENT from the crawl
-   * (ignored files opened directly, non-listing spellings) falls through to a
-   * resolve()-confined live stat, never to a false null. */
+   * (a non-listing spelling, a file created since) falls through to a
+   * resolve()-confined live stat, never to a false null. Crawl membership is
+   * `entries`, which holds the ignore-matched files too — so the paths sync
+   * lists are exactly the paths it can fingerprint off the memo. */
   statFingerprint(rel: string): string | null {
     const cached = this.freshSnapshot(this.getRoot());
     if (cached !== null && cached.entries.has(rel)) {


### PR DESCRIPTION
## The bug

`listAllPaths()` is documented as the sync manifest source, and it read the same ignore-filtered crawl snapshot the sidebar does. Ignored entries are **excluded, not unread**, so `complete` stayed `true` and nothing caught it.

Add `archive/` to a synced vault's `.gitignore` → every file under it leaves the manifest → the 3-way reconcile reads "in base, absent from local" as a **local delete** → permanent deletions fan out to every device.

The engine's guard at `engine.ts:297` only catches a **fully empty** listing, and its comment deliberately declines to extend that to "much smaller than base" (false-positives on real bulk deletes). So `.gitignore: *` was already caught; a **partial** ignore was not — and that is the plausible case. Nobody gitignores `*`; tidying a folder out of the sidebar is ordinary.

## The fix

`.gitignore` is a **view** choice. Crawl once unfiltered, filter at read:

- `walk()` descends ignored directories instead of `continue`-ing past them, recording what matched in an `ignored` set. `inherited` carries an ignored ancestor down, so gitignore's "a re-include cannot resurrect a file under an ignored dir" semantics hold.
- `list()` / `listWithStats()` filter that set — **sidebar, file tree and knowledge index unchanged**.
- `listAllPaths()` alone widens to everything on disk, still sorted.
- Ignored paths stay in `entries` so `statFingerprint`'s membership check resolves them; otherwise sync could not fingerprint its own files. This was the subtle part.
- `engine.ts`'s guard is untouched and remains the belt-and-suspenders layer.

## Costs, stated plainly

Previously-pruned directories are now walked. And an unreadable **ignored** subtree now fails the pass where it used to be invisible — so the error names the offending folder rather than only the vault root, mirroring mobile's sibling error which already did this.

## Verification

`pnpm verify` exit 0. Vault 52 / server 385 / sync 40 tests pass. New tests cover: a file nested two deep under an ignored dir present in `listAllPaths()` but absent from `list()`; an ignored root file; `.tmp` excluded from both; an unreadable ignored subtree still throwing.

Reviewed by two independent agents, one adversarial and one for completeness. The adversarial reviewer wrote and ran seven further tests, including git re-include semantics and confinement (`statFingerprint("../outside.md")` still null).

## Not fixed here — follow-ups the review surfaced

The reviewers found the same failure **class** in five other places, one of which is worse than this bug. Filing separately.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a data-loss bug where adding `.gitignore` entries removed files from the sync manifest and triggered deletions across devices. Ignored files now stay in the manifest; ignore rules only affect what the UI shows.

- **Bug Fixes**
  - `listAllPaths()` now returns all on-disk files (ignoring only `SKIP_DIRS`, dot-entries, and `*.tmp`) and throws `VaultListingIncompleteError` with the first unreadable subtree when the crawl is incomplete.
  - The crawler descends ignored directories and tracks an `ignored` set; `list()` and `listWithStats()` filter that set so the sidebar and knowledge index are unchanged, while sync sees everything.
  - Ignored paths remain in `entries` so `statFingerprint()` can fingerprint them.
  - Updated docs in `@repo/vault/vault` and added tests covering ignored directories, nested files, `.tmp` behavior, and unreadable ignored subtrees.

<sup>Written for commit 7195309e43a317a22229105e4ac7163dd3b1c63e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kyh/inteligir/pull/507?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

