### PR TITLE
feat(connectors): surface "Add a server" instead of hiding it

### DIFF
--- a/apps/desktop/src/renderer/settings/connectors-panel.tsx
+++ b/apps/desktop/src/renderer/settings/connectors-panel.tsx
@@ -1,6 +1,6 @@
 // Built-in Extensions panel. Connectors lead — they're the only place to
-// connect Google etc., so they're always visible and first. Skills follow. The
-// developer surface (custom add-connector escape hatch, bundled CLI binaries)
+// connect a server, so they're always visible and first. Skills follow. The
+// developer surface (bundled CLI binaries, overriding the Google OAuth client)
 // lives behind a "Developer tools" toggle persisted in ui-state.
 
 import { useState } from "react";

--- a/apps/desktop/src/renderer/settings/extensions/connectors-section.tsx
+++ b/apps/desktop/src/renderer/settings/extensions/connectors-section.tsx
@@ -40,10 +40,9 @@ function setMembership(
 
 type ConnectorsSectionProps = SectionProps & {
   /**
-   * Show the developer-only escape hatch (the "Add custom connector" button +
-   * dialog). The installed custom-integrations list stays visible regardless —
-   * users must always be able to see and remove what's connected, including
-   * anything the agent installed.
+   * Show the developer-only affordance — overriding the bundled Google OAuth
+   * client with your own. Adding a server is NOT behind this: connecting an
+   * arbitrary MCP server is the product, not an escape hatch.
    */
   showAdvanced: boolean;
 };
@@ -364,35 +363,33 @@ export function ConnectorsSection({ onError, showAdvanced }: ConnectorsSectionPr
         </div>
       )}
 
-      {showAdvanced && (
-        <>
-          <div className="flex flex-wrap gap-1.5">
-            <Button
-              variant="outline"
-              size="sm"
-              onClick={() => setCustomOpen(true)}
-              className="h-7 text-[10px]"
-            >
-              <PlusIcon className="size-3" />
-              Add custom connector
-            </Button>
-            <Button
-              variant="outline"
-              size="sm"
-              onClick={() => void openGoogleOverride()}
-              className="h-7 text-[10px]"
-            >
-              Use your own Google OAuth client
-            </Button>
-          </div>
+      <div className="flex flex-wrap gap-1.5">
+        <Button
+          variant="outline"
+          size="sm"
+          onClick={() => setCustomOpen(true)}
+          className="h-7 text-[10px]"
+        >
+          <PlusIcon className="size-3" />
+          Add a server
+        </Button>
+        {showAdvanced && (
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={() => void openGoogleOverride()}
+            className="h-7 text-[10px]"
+          >
+            Use your own Google OAuth client
+          </Button>
+        )}
+      </div>
 
-          <AddCustomConnectorDialog
-            open={customOpen}
-            onOpenChange={setCustomOpen}
-            onAdded={refreshAll}
-          />
-        </>
-      )}
+      <AddCustomConnectorDialog
+        open={customOpen}
+        onOpenChange={setCustomOpen}
+        onAdded={refreshAll}
+      />
       <SecretPromptDialog
         connector={apiKeyTarget}
         label={apiKeyLabel}


### PR DESCRIPTION
Part of #503, which is **rescoped** — see the issue comment. Nothing was deleted.

Connecting an arbitrary MCP server is one of the six stated product requirements. It turns out to be **already fully built**: `add-custom-connector-dialog.tsx` defaults to `mcp`, lists MCP first, and auto-detects the connector type from a pasted URL.

It just sat behind a "Developer tools" toggle, underneath the catalog, documented in the code as a "developer-only escape hatch".

- **"Add a server" is now always visible.**
- The toggle keeps what is genuinely advanced: bundled CLI binaries, and overriding the bundled Google OAuth client with your own.

`pnpm verify` exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Surface "Add a server" in Connectors so anyone can connect an MCP server without enabling Developer tools. Addresses a core requirement in Linear #503.

- **New Features**
  - Show the "Add a server" button by default (opens existing `AddCustomConnectorDialog`, defaults to `mcp`, auto-detects from pasted URL).
  - Keep only advanced actions behind the toggle: overriding the bundled Google OAuth client and bundled CLI binaries.

<sup>Written for commit 4efd95039b430e196f217b28d4e49e9b220a6338. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kyh/inteligir/pull/511?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

