### PR TITLE
feat(sync): hold a pass that would delete an unusual number of files

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -513,6 +513,26 @@ record for the decisions code comments cite.
   the originating device already trashed, core's `SyncIo.remove` is
   synchronous by contract, and reconcile preserves conflicting local edits as
   sibling copies.
+- **Sync has THREE independent deletion guards; never merge them.** The
+  empty-listing refusal and the unaccounted-in-base refusal recognize a
+  specific broken LISTING; the deletion gate (`packages/notes/src/sync/engine.ts`)
+  recognizes an implausible RESULT — a plan deleting more than
+  `max(25, 5% of the base manifest)` is held whole, applying nothing and
+  leaving the anchor clean, until a human confirms it. That third layer exists
+  because every listing rule has eventually leaked, and it is the only one that
+  needs no listing invariant to hold. It **bounds the blast radius of a leak;
+  it does not detect one** — it reads a count, never a cause, so a leak that
+  sheds a single path (one case-only rename, one symlink) sits far below the
+  floor and passes straight through. Only an explicit human action may pass
+  `confirmDeletions`, which carries the approved COUNT and waives the gate only
+  up to it, for one pass, never persisted: the confirmed pass re-reconciles, so
+  a plan that grew since the hold holds again with the new number. The
+  debounced, periodic and realtime passes must always be able to do nothing but
+  report the hold. The gate is **per device against that device's own anchor**,
+  so a confirmation on one device CAUSES the hold on every other — desktop
+  (Settings → Sync, plus a global toast on the transition into held) and mobile
+  (the vault screen's status row) each carry their own confirm affordance, and
+  neither may tell the user to go and confirm on the other.
 - **No tag rename/delete UI, ever.** Tags are projections over note bodies
   (inline `#tags` + frontmatter `tags:`); a "rename/delete tag" affordance is
   a bulk content mutation disguised as a filter-chip action. Edit the notes

--- a/apps/desktop/dev/fixture-bridge.ts
+++ b/apps/desktop/dev/fixture-bridge.ts
@@ -722,6 +722,8 @@ export function createFixtureBridge(openKnowledgeStore: (root: string) => Knowle
     status: { phase: "idle" },
     conflicts: [],
   };
+  let syncPasses = 0;
+  let syncDeletionsConfirmed = false;
   // Remote access — no ws server runs in a browser tab, so enabling simulates
   // the listening state and a LAN URL; one pre-paired device makes the device
   // list + Revoke exercisable out of the box.
@@ -1687,14 +1689,40 @@ export function createFixtureBridge(openKnowledgeStore: (root: string) => Knowle
     getAccountCapabilities: async () => ({ socialProviders: ["github", "google"] }),
     syncSignOut: async () => {
       syncState = { ...syncState, signedIn: false, email: null, status: { phase: "idle" } };
+      // Signing back in is the harness's way of restarting the sync story, so
+      // the hold has to come back with it — otherwise it is drivable once per
+      // page load.
+      syncPasses = 0;
+      syncDeletionsConfirmed = false;
       emitSync();
     },
-    syncNow: async () => {
+    syncNow: async ({ confirmDeletions }) => {
       if (!syncState.enabled || !syncState.signedIn) {
         const message = "Enable sync and sign in first.";
         syncState = { ...syncState, status: { phase: "error", message } };
         emitSync();
         return { status: "error", message };
+      }
+      // The deletion gate, over the real fixture vault: the FIRST pass syncs
+      // plainly (the conflict flow below is the harness's common path and must
+      // not be gated behind a scary confirmation), the second stands where a
+      // phantom mass deletion would. The sample names files that actually
+      // exist here, so confirming and dismissing are both drivable; confirming
+      // clears it for the session, exactly as a confirmed pass converges the
+      // real engine's anchor.
+      syncPasses += 1;
+      if (confirmDeletions !== undefined) syncDeletionsConfirmed = true;
+      if (syncPasses > 1 && !syncDeletionsConfirmed) {
+        const paths = [...vault.keys()].toSorted((a, b) => a.localeCompare(b));
+        const outcome = {
+          status: "held",
+          deletions: paths.length,
+          baseCount: paths.length,
+          sample: paths.slice(0, 5),
+        } as const;
+        syncState = { ...syncState, status: { ...outcome, phase: "held" } };
+        emitSync();
+        return outcome;
       }
       // Simulate a pass that hit two conflicts: write real conflict-copy files
       // into the fixture vault (host naming) so the Settings conflict list's

--- a/apps/desktop/src/renderer/settings/sections/sync-section.tsx
+++ b/apps/desktop/src/renderer/settings/sections/sync-section.tsx
@@ -7,7 +7,7 @@ import { getBridge } from "@renderer/lib/bridge";
 import { SettingSwitchRow } from "@renderer/settings/sections/setting-switch-row";
 import { useVaultActions } from "@renderer/workspace/vault-context";
 import { basenamePath } from "@repo/notes/knowledge/vault-path";
-import type { SyncStatus } from "@repo/notes/sync/status";
+import type { HeldSyncStatus, SyncStatus } from "@repo/notes/sync/status";
 import type { SyncState } from "@repo/bridge/sync";
 
 // Human-readable summary of the last reconcile pass for the status line.
@@ -17,6 +17,8 @@ function formatSyncStatus(status: SyncStatus): string {
       return "Not synced yet.";
     case "syncing":
       return "Syncing…";
+    case "held":
+      return `Paused — ${status.deletions} of ${status.baseCount} synced file${status.baseCount === 1 ? "" : "s"} would be deleted.`;
     case "error":
       return `Error: ${status.message}`;
     case "ok": {
@@ -43,6 +45,7 @@ function formatSyncStatus(status: SyncStatus): string {
 export function SyncSection({ onRequestClose }: { onRequestClose?: (() => void) | undefined }) {
   const [state, setSyncView] = useState<SyncState | null>(null);
   const [busy, setBusy] = useState(false);
+  const [dismissedHold, setDismissedHold] = useState<HeldSyncStatus | null>(null);
   const { openFile, deleteEntry } = useVaultActions();
 
   useEffect(() => {
@@ -68,7 +71,29 @@ export function SyncSection({ onRequestClose }: { onRequestClose?: (() => void) 
     const bridge = getBridge();
     setBusy(true);
     try {
-      await bridge.syncNow();
+      await bridge.syncNow({});
+    } finally {
+      setBusy(false);
+    }
+  }, []);
+
+  // Releasing a held pass is the one irreversible act this section offers: the
+  // deletions land on every device. The panel already names what would go, so
+  // the dialog exists to make the count impossible to click past. The approved
+  // COUNT is what crosses the Bridge — the confirmed pass reconciles afresh, so
+  // a plan that grew in the meantime holds again rather than riding this
+  // waiver.
+  const handleConfirmDeletions = useCallback(async (deletions: number) => {
+    const confirmed = await confirm({
+      title: `Delete ${deletions} file${deletions === 1 ? "" : "s"}?`,
+      body: "Sync paused because this pass would delete an unusual number of files. Continue only if you deleted them on purpose. Syncing removes them from this device and from every other device that still has them, permanently — sync deletes are not moved to the trash.",
+      confirmLabel: "Delete and sync",
+      destructive: true,
+    });
+    if (!confirmed) return;
+    setBusy(true);
+    try {
+      await getBridge().syncNow({ confirmDeletions: deletions });
     } finally {
       setBusy(false);
     }
@@ -109,6 +134,11 @@ export function SyncSection({ onRequestClose }: { onRequestClose?: (() => void) 
   const loading = state === null;
   const signedIn = state?.signedIn === true;
   const conflicts = state?.conflicts ?? [];
+  const held = state !== null && state.status.phase === "held" ? state.status : null;
+  // Dismissal covers the REPORT, not the condition: any later state emission —
+  // the periodic pass included, not just a sync the user ran — produces a fresh
+  // status object and brings the panel, and the only confirm affordance, back.
+  const showHold = held !== null && held !== dismissedHold;
 
   return (
     <div className="flex flex-col gap-2">
@@ -148,6 +178,51 @@ export function SyncSection({ onRequestClose }: { onRequestClose?: (() => void) 
               Sync now
             </Button>
           </div>
+
+          {showHold && (
+            <div className="flex flex-col gap-1.5 border-t border-border pt-2">
+              <span className="text-[10px] text-muted-foreground">
+                Sync is paused: this pass would delete {held.deletions} of the {held.baseCount}{" "}
+                files the last sync recorded, on every device. Nothing has been deleted or uploaded.
+                If you meant to remove them, confirm below; otherwise check that your vault folder
+                is intact and sync again.
+              </span>
+              <span className="text-[10px] text-muted-foreground">
+                Files that would be deleted:
+              </span>
+              <ul className="flex flex-col gap-0.5 rounded-[8px] bg-card px-2.5 py-1.5">
+                {held.sample.map((path) => (
+                  <li key={path} className="truncate text-[10px] text-muted-foreground">
+                    {path}
+                  </li>
+                ))}
+                {held.deletions > held.sample.length && (
+                  <li className="text-[10px] text-muted-foreground">
+                    …and {held.deletions - held.sample.length} more
+                  </li>
+                )}
+              </ul>
+              <span className="flex items-center gap-1">
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  onClick={() => void handleConfirmDeletions(held.deletions)}
+                  disabled={busy}
+                  className="h-auto px-2 py-0.5 text-[10px] text-destructive"
+                >
+                  Delete and sync
+                </Button>
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  onClick={() => setDismissedHold(held)}
+                  className="h-auto px-2 py-0.5 text-[10px] text-muted-foreground"
+                >
+                  Not now
+                </Button>
+              </span>
+            </div>
+          )}
 
           {conflicts.length > 0 && (
             <div className="flex flex-col gap-1.5 border-t border-border pt-2">

--- a/apps/desktop/src/renderer/settings/settings-dialog.tsx
+++ b/apps/desktop/src/renderer/settings/settings-dialog.tsx
@@ -1,4 +1,3 @@
-import { useState } from "react";
 import { SettingsIcon } from "lucide-react";
 
 import { Button } from "@repo/ui/components/button";
@@ -13,15 +12,18 @@ import { Tabs, TabsList, TabsTrigger, TabsContent } from "@repo/ui/components/ta
 
 import { ConnectorsPanel } from "@renderer/settings/connectors-panel";
 import { SettingsPanel } from "@renderer/settings/settings-panel";
+import { useViewStore } from "@renderer/stores/view-store";
 
 /**
  * Settings + Connectors, reachable from the workspace gear. Replaces the old
  * settings/extensions widget panels — same content, now a dialog instead of a
  * grid tile. Controlled so panel actions that navigate the workspace (e.g.
- * opening a conflicted note from Settings → Sync) can close it first.
+ * opening a conflicted note from Settings → Sync) can close it first, and so
+ * a notice raised elsewhere in the app can open it (the sync-hold toast).
  */
 export function SettingsDialog() {
-  const [open, setOpen] = useState(false);
+  const open = useViewStore((s) => s.settingsOpen);
+  const setOpen = useViewStore((s) => s.setSettingsOpen);
   return (
     <Dialog open={open} onOpenChange={setOpen}>
       <DialogTrigger

--- a/apps/desktop/src/renderer/stores/view-store.ts
+++ b/apps/desktop/src/renderer/stores/view-store.ts
@@ -19,6 +19,11 @@ type ViewStore = {
   /** The read-only past-chat browser dialog (palette: "Browse past chats"). */
   pastChatsOpen: boolean;
   setPastChatsOpen: (open: boolean) => void;
+  /** The settings dialog. Held here, not in the gear button, so a notice
+   * raised anywhere in the app can send the user to the section that explains
+   * it — today the sync-hold toast. */
+  settingsOpen: boolean;
+  setSettingsOpen: (open: boolean) => void;
 };
 
 export const useViewStore = create<ViewStore>()((set) => ({
@@ -29,4 +34,6 @@ export const useViewStore = create<ViewStore>()((set) => ({
   setSurface: (surface) => set({ surface }),
   pastChatsOpen: false,
   setPastChatsOpen: (pastChatsOpen) => set({ pastChatsOpen }),
+  settingsOpen: false,
+  setSettingsOpen: (settingsOpen) => set({ settingsOpen }),
 }));

--- a/apps/desktop/src/renderer/workspace/use-sync-hold-toast.ts
+++ b/apps/desktop/src/renderer/workspace/use-sync-hold-toast.ts
@@ -1,0 +1,54 @@
+// A held sync pass is the app's quietest failure mode: the whole plan is
+// refused, so this device's PUSHES stop too, and the only surface that reports
+// it — Settings → Sync — is mounted solely while that dialog is open. Sync is
+// off by default and the gate is tuned to fire rarely, which makes silence the
+// wrong default exactly once: on the pass that matters.
+//
+// Fires on the TRANSITION into `held`, never on every held pass. The periodic
+// reconcile re-holds on its own cadence and would otherwise turn this into a
+// metronome; a pass that runs and holds again (a `syncing` phase in between)
+// is a fresh answer to a question the user just asked, so that one does speak.
+
+import { useEffect, useRef } from "react";
+
+import { toast } from "@repo/ui/components/sonner";
+
+import { getBridge } from "@renderer/lib/bridge";
+import { useViewStore } from "@renderer/stores/view-store";
+import type { SyncStatus } from "@repo/notes/sync/status";
+
+/** Mounted once inside the workspace: announces a newly held sync pass and
+ * routes to the section that can release it. */
+export function useSyncHoldToast(): void {
+  const lastPhase = useRef<SyncStatus["phase"] | null>(null);
+
+  useEffect(() => {
+    const announce = (status: SyncStatus): void => {
+      const previous = lastPhase.current;
+      lastPhase.current = status.phase;
+      if (status.phase !== "held" || previous === "held") return;
+      const { deletions, baseCount } = status;
+      toast.warning(
+        `Sync paused — ${deletions} of ${baseCount} synced file${baseCount === 1 ? "" : "s"} would be deleted.`,
+        {
+          description:
+            "Nothing was deleted or uploaded, and this device will not sync again until you decide.",
+          duration: Number.POSITIVE_INFINITY,
+          closeButton: true,
+          action: {
+            label: "Review",
+            onClick: () => useViewStore.getState().setSettingsOpen(true),
+          },
+        },
+      );
+    };
+    // Hydrate once: a hold raised by the boot pass, or surviving a renderer
+    // reload, would otherwise stay silent until the next periodic pass — the
+    // whole time this device is not pushing.
+    void getBridge()
+      .getSyncState()
+      .then((state) => announce(state.status))
+      .catch(() => undefined);
+    return getBridge().onSyncStateChanged((state) => announce(state.status));
+  }, []);
+}

--- a/apps/desktop/src/renderer/workspace/workspace-page.tsx
+++ b/apps/desktop/src/renderer/workspace/workspace-page.tsx
@@ -18,6 +18,7 @@ import { HtmlAppView } from "@renderer/workspace/html-app-view";
 import { useAgentEditUndo } from "@renderer/workspace/use-agent-edit-undo";
 import { useDeepLinkNav } from "@renderer/workspace/use-deep-link";
 import { useOpenDailyNote } from "@renderer/workspace/use-note-templates";
+import { useSyncHoldToast } from "@renderer/workspace/use-sync-hold-toast";
 import { useOpenNote } from "@renderer/workspace/open-note-store";
 import { VaultProvider } from "@renderer/workspace/vault-context";
 import { useAgentStore } from "@renderer/stores/agent-store";
@@ -63,6 +64,13 @@ function DeepLinkNav() {
  * renders nothing. */
 function AgentEditUndo() {
   useAgentEditUndo();
+  return null;
+}
+
+/** The one global report of a sync pass the deletion gate held — Settings →
+ * Sync only exists while its dialog is open. Renders nothing. */
+function SyncHoldToast() {
+  useSyncHoldToast();
   return null;
 }
 
@@ -132,6 +140,7 @@ export function WorkspacePage() {
       <DailyNoteHotkey />
       <DeepLinkNav />
       <AgentEditUndo />
+      <SyncHoldToast />
       <SidebarProvider className="bg-sidebar">
         <AppSidebar onOpenPalette={() => setPaletteOpen(true)} />
         {/* Flush Attio-style editor pane: a full-height column butted against

--- a/apps/mobile/src/app/index.tsx
+++ b/apps/mobile/src/app/index.tsx
@@ -2,6 +2,7 @@ import { Stack, useRouter } from "expo-router";
 import { useCallback, useEffect, useRef, useState } from "react";
 import {
   ActivityIndicator,
+  Alert,
   KeyboardAvoidingView,
   Platform,
   Pressable,
@@ -14,7 +15,8 @@ import {
 } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
 
-import type { SyncStatus } from "@repo/notes/sync/status";
+import type { SyncPassOptions } from "@repo/notes/sync/engine";
+import type { HeldSyncStatus, SyncStatus } from "@repo/notes/sync/status";
 
 import { authClient, clearBearerToken } from "@/lib/auth";
 import { appendCapture } from "@/lib/capture/daily-capture";
@@ -306,6 +308,13 @@ function describeStatus(status: SyncStatus): string {
       return "Syncing…";
     case "ok":
       return `Synced — ↑${status.pushed} ↓${status.pulled} ✕${status.deleted} ⚠${status.conflicts}`;
+    // The confirmation has to live HERE. The gate runs per device against that
+    // device's own anchor, so a desktop confirmation does not clear this
+    // phone's hold — it is what causes it, once those deletes reach the
+    // coordinator. And a hold is held WHOLE: notes captured on this phone stop
+    // leaving it too, until someone releases the pass on this screen.
+    case "held":
+      return `Sync paused — ${status.deletions} of ${status.baseCount} files would be deleted. Nothing was changed. Tap to review.`;
     case "error":
       return `Sync failed: ${status.message}`;
   }
@@ -315,6 +324,7 @@ function VaultScreen() {
   const theme = useTheme();
   const router = useRouter();
   const status = useSyncStatus();
+  const held = status.phase === "held" ? status : null;
   const [files, setFiles] = useState(listVaultFiles);
   const [refreshing, setRefreshing] = useState(false);
 
@@ -333,12 +343,39 @@ function VaultScreen() {
     if (status.phase === "ok") reload();
   }, [status, reload]);
 
-  const runSync = useCallback(async () => {
-    setRefreshing(true);
-    await syncOnce();
-    reload();
-    setRefreshing(false);
-  }, [reload]);
+  const runSync = useCallback(
+    async (opts?: SyncPassOptions) => {
+      setRefreshing(true);
+      await syncOnce(opts);
+      reload();
+      setRefreshing(false);
+    },
+    [reload],
+  );
+
+  // The only place a `confirmDeletions` may originate on this device: the user
+  // read the count and the sample and pressed the destructive action. The
+  // approved COUNT rides along, so a plan that grew since this alert was drawn
+  // holds again instead of being waived by it.
+  const reviewHold = useCallback(
+    (hold: HeldSyncStatus) => {
+      const more = hold.deletions - hold.sample.length;
+      const listing = hold.sample.join("\n") + (more > 0 ? `\n…and ${more} more` : "");
+      Alert.alert(
+        `Delete ${hold.deletions} file${hold.deletions === 1 ? "" : "s"}?`,
+        `This pass would delete ${hold.deletions} of the ${hold.baseCount} files the last sync recorded. Syncing removes them from this device and from every other device that still has them, permanently — sync deletes do not go to the trash.\n\n${listing}`,
+        [
+          { text: "Cancel", style: "cancel" },
+          {
+            text: "Delete and sync",
+            style: "destructive",
+            onPress: () => void runSync({ confirmDeletions: hold.deletions }),
+          },
+        ],
+      );
+    },
+    [runSync],
+  );
 
   const signOut = useCallback(async () => {
     await authClient.signOut();
@@ -354,9 +391,25 @@ function VaultScreen() {
       <HostNavRow />
       <CaptureBox onCaptured={reload} />
       <View style={styles.syncRow}>
-        <Text style={[styles.syncStatus, { color: theme.mutedForeground }]}>
-          {describeStatus(status)}
-        </Text>
+        <Pressable
+          style={({ pressed }) => [
+            styles.syncStatusSlot,
+            pressed && held !== null && styles.pressed70,
+          ]}
+          disabled={held === null}
+          onPress={() => {
+            if (held !== null) reviewHold(held);
+          }}
+        >
+          <Text
+            style={[
+              styles.syncStatus,
+              { color: held !== null ? theme.destructive : theme.mutedForeground },
+            ]}
+          >
+            {describeStatus(status)}
+          </Text>
+        </Pressable>
         <Pressable
           style={({ pressed }) => [
             styles.syncButton,
@@ -476,7 +529,8 @@ const styles = StyleSheet.create({
     paddingHorizontal: SPACE.lg,
     paddingVertical: SPACE.md,
   },
-  syncStatus: { flex: 1, paddingRight: SPACE.md, fontSize: 14 },
+  syncStatusSlot: { flex: 1, paddingRight: SPACE.md },
+  syncStatus: { fontSize: 14 },
   syncButton: {
     borderRadius: RADIUS.md,
     paddingHorizontal: SPACE.lg,

--- a/apps/mobile/src/lib/sync/__tests__/engine.test.ts
+++ b/apps/mobile/src/lib/sync/__tests__/engine.test.ts
@@ -110,7 +110,7 @@ describe("SyncEngine over the RN adapters", () => {
 
   it("mirrors a local delete to the coordinator", async () => {
     // A sibling survives the delete: an empty local listing against a
-    // non-empty base is refused by the engine's mass-deletion guard.
+    // non-empty base is refused by the engine's empty-listing guard.
     vault.writeText("gone.md", "bye");
     vault.writeText("stays.md", "here");
     await newEngine().syncOnce();
@@ -135,7 +135,7 @@ describe("SyncEngine over the RN adapters", () => {
   // A missing vault root makes the `VaultFs` THROW
   // (expo-vault-fs's listDir("") contract) rather than list an empty vault —
   // the pass fails cleanly instead of reconciling "everything was deleted".
-  it("a root-missing vault fails the pass — zero deletes reach the coordinator (#429)", async () => {
+  it("a root-missing vault fails the pass — zero deletes reach the coordinator", async () => {
     vault.writeText("a.md", "AAA");
     vault.writeText("notes/b.md", "BBB");
     await newEngine().syncOnce();

--- a/apps/mobile/src/lib/sync/__tests__/sync-io.test.ts
+++ b/apps/mobile/src/lib/sync/__tests__/sync-io.test.ts
@@ -103,7 +103,7 @@ describe("createSyncIo", () => {
   // The VaultFs contract: a missing ROOT throws (expo-vault-fs's
   // listDir("")), and list() must PROPAGATE it — never swallow it into an
   // empty listing, which the engine would reconcile as a mass deletion.
-  it("propagates a root-missing throw instead of listing an empty vault (#429)", () => {
+  it("propagates a root-missing throw instead of listing an empty vault", () => {
     const vault = memVaultFs();
     vault.writeText("a.md", "A");
     const rootMissing: VaultFs = {

--- a/apps/mobile/src/lib/sync/manager.ts
+++ b/apps/mobile/src/lib/sync/manager.ts
@@ -16,7 +16,7 @@
 import { useSyncExternalStore } from "react";
 
 import { createJsonFileBaseStore } from "@repo/notes/sync/base-store";
-import { SyncEngine, type SyncOutcome } from "@repo/notes/sync/engine";
+import { SyncEngine, type SyncOutcome, type SyncPassOptions } from "@repo/notes/sync/engine";
 import { createHttpSyncPort } from "@repo/notes/sync/http-sync-port";
 import { statusFromOutcome, type SyncStatus } from "@repo/notes/sync/status";
 
@@ -39,9 +39,9 @@ const statusStore = createExternalStore<SyncStatus>({ phase: "idle" });
  * realtime-triggered passes surface exactly like explicit ones; `onOutcome`
  * (below) lands the result status either way. */
 class StatusReportingSyncEngine extends SyncEngine {
-  override syncOnce(): Promise<SyncOutcome> {
+  override syncOnce(opts?: SyncPassOptions): Promise<SyncOutcome> {
     statusStore.set({ phase: "syncing" });
-    return super.syncOnce();
+    return super.syncOnce(opts);
   }
 }
 
@@ -81,15 +81,21 @@ function currentToken(): string | null {
  * Run one reconcile+execute pass against the coordinator. Never throws — a
  * transport/auth failure lands in the status (and the returned outcome) as
  * `{ phase: "error" }`, leaving the base manifest untouched for the next retry.
+ *
+ * `opts.confirmDeletions` releases a held pass and belongs to the vault
+ * screen's confirmation alone. Every AUTOMATIC caller here — the realtime
+ * manager's foreground kick and SSE trigger, pull-to-refresh, the after-save
+ * pass — passes nothing, because a hold nobody is watching may only ever be
+ * reported.
  */
-export async function syncOnce(): Promise<SyncOutcome> {
+export async function syncOnce(opts?: SyncPassOptions): Promise<SyncOutcome> {
   const token = currentToken();
   if (token === null) {
     const message = "not signed in";
     statusStore.set({ phase: "error", message });
     return { status: "error", message };
   }
-  return engineFor(token).syncOnce();
+  return engineFor(token).syncOnce(opts);
 }
 
 /** Kick one engine-debounced pass (the realtime stream's change trigger).

--- a/apps/mobile/src/lib/sync/vault-access.ts
+++ b/apps/mobile/src/lib/sync/vault-access.ts
@@ -16,7 +16,7 @@ const decoder = new TextDecoder();
 /** Every vault-relative file path currently on disk (sorted). LENIENT on a
  * missing vault root — the screens tolerate "nothing there yet" as an empty
  * list, while the SYNC path sees the same condition as a hard error (the
- * mass-deletion guard). Mirrors the desktop's list()-lenient /
+ * empty-listing guard). Mirrors the desktop's list()-lenient /
  * listAllPaths()-strict split. */
 export function listVaultFiles(): VaultPath[] {
   try {

--- a/packages/bridge/src/ipc-registry.ts
+++ b/packages/bridge/src/ipc-registry.ts
@@ -71,6 +71,7 @@ import {
 } from "./routines";
 import type { SyncOutcome } from "@repo/notes/sync/engine";
 import {
+  SyncNowSchema,
   SyncRequestPasswordResetSchema,
   SyncSetConfigSchema,
   SyncSignInSchema,
@@ -821,8 +822,14 @@ export const IPC = {
   getAccountCapabilities: invokeVoid<AccountCapabilities>(),
   /** Clear the local session (best-effort remote revoke). */
   syncSignOut: invokeVoid<void>(),
-  /** Force one reconcile pass now; returns the outcome. */
-  syncNow: invokeVoid<SyncOutcome>(),
+  /** Force one reconcile pass now; returns the outcome. `confirmDeletions` is
+   * the deletion count the user approved, releasing a pass the engine's
+   * deletion gate held — that pass only, and only up to that count.
+   * Absent from REMOTE_ALLOWED_METHODS: a paired phone drives the DESKTOP's
+   * vault, where its user can see none of the files a hold names. The phone
+   * confirms its OWN vault's holds through the mobile sync manager, which is a
+   * different engine on a different device and never crosses this channel. */
+  syncNow: invoke<typeof SyncNowSchema, SyncOutcome>(SyncNowSchema),
   /** Fired on every config / auth / status change so the settings Sync UI is
    * reactive. Same shape as getSyncState. */
   onSyncStateChanged: event<SyncState>(),

--- a/packages/bridge/src/sync.ts
+++ b/packages/bridge/src/sync.ts
@@ -56,6 +56,15 @@ export const SyncSocialSignInSchema = Type.Object(
   { additionalProperties: false },
 );
 
+/** Force one reconcile pass. `confirmDeletions` carries the deletion COUNT the
+ * user approved and waives the engine's deletion gate up to it, for THAT PASS
+ * ONLY — never stored, so a renderer can only ever release the hold it is
+ * currently showing, at the size it is showing. */
+export const SyncNowSchema = Type.Object(
+  { confirmDeletions: Type.Optional(Type.Integer({ minimum: 0 })) },
+  { additionalProperties: false },
+);
+
 /** Password-reset REQUEST: asks the coordinator to email a reset link.
  * The outcome is deliberately existence-blind — see the registry entry. */
 export const SyncRequestPasswordResetSchema = Type.Object(

--- a/packages/notes/src/sync/__tests__/engine-deletion-gate.test.ts
+++ b/packages/notes/src/sync/__tests__/engine-deletion-gate.test.ts
@@ -1,0 +1,232 @@
+// The deletion gate: the layer that bounds what a leaked listing invariant
+// costs. Every mass-deletion bug this vault has shipped looked like a
+// legitimate plan to the crawl that produced it, so these tests never simulate
+// a cause — they assert on the SIZE of the plan alone: an implausible deletion
+// applies NOTHING (not the deletes, not the writes beside them), leaves the
+// base anchor exactly as it was, and waits for a human. The complements matter
+// as much: an ordinary cleanup must not be held, a confirmation must cover only
+// the count it was shown, no automatic trigger may ever confirm one, and the
+// two listing guards must still run first.
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { InMemorySyncPort, MemoryVault, webCryptoHasher } from "./in-memory-sync-port";
+import { SyncEngine, type Clock, type SyncIo, type SyncOutcome } from "../engine";
+import { InMemoryBaseStore } from "../base-store";
+import { InMemoryBaseBlobStore } from "../blob-store";
+
+const VAULT_ID = "vault-1";
+const fixedStamp: Clock = () => "2026-07-05T12-34-56-000Z";
+
+let vault: MemoryVault;
+let base: InMemoryBaseStore;
+let blobs: InMemoryBaseBlobStore;
+let port: InMemorySyncPort;
+let unaccounted: string[];
+
+function newEngine(onOutcome?: (outcome: SyncOutcome) => void): SyncEngine {
+  const io: SyncIo = { ...vault.io, unaccounted: () => unaccounted };
+  return new SyncEngine({
+    vaultId: VAULT_ID,
+    port,
+    io,
+    base,
+    blobs,
+    hash: webCryptoHasher(),
+    stamp: fixedStamp,
+    debounceMs: 0,
+    onOutcome,
+  });
+}
+
+/** Converge `count` notes so the base anchor records them all. */
+async function seedVault(count: number): Promise<void> {
+  for (let i = 0; i < count; i += 1) vault.writeText(`n${i}.md`, `body ${i}`);
+  expect((await newEngine().syncOnce()).status).toBe("ok");
+}
+
+/** Delete `n<from>.md` … `n<to - 1>.md` from the local vault. */
+function deleteLocal(from: number, to: number): void {
+  for (let i = from; i < to; i += 1) vault.delete(`n${i}.md`);
+}
+
+async function remotePaths(): Promise<string[]> {
+  return (await port.listManifest()).files.map((file) => file.path).toSorted();
+}
+
+beforeEach(() => {
+  vault = new MemoryVault();
+  base = new InMemoryBaseStore();
+  blobs = new InMemoryBaseBlobStore();
+  port = new InMemorySyncPort(VAULT_ID);
+  unaccounted = [];
+});
+
+describe("SyncEngine deletion gate", () => {
+  it("holds an over-threshold plan and applies NOTHING", async () => {
+    await seedVault(60);
+    const baseBefore = base.load();
+    deleteLocal(0, 30);
+    // A write alongside the deletions: a held plan is held whole, so this must
+    // not reach the coordinator either.
+    vault.writeText("new.md", "fresh");
+    const deleteSpy = vi.spyOn(port, "deleteFile");
+    const putSpy = vi.spyOn(port, "putFile");
+
+    const out = await newEngine().syncOnce();
+
+    expect(out).toEqual({
+      status: "held",
+      deletions: 30,
+      baseCount: 60,
+      sample: ["n0.md", "n1.md", "n10.md", "n11.md", "n12.md"],
+    });
+    expect(deleteSpy).not.toHaveBeenCalled();
+    expect(putSpy).not.toHaveBeenCalled();
+    expect(await remotePaths()).toHaveLength(60);
+    // The anchor is untouched, so a retry reconciles from the same clean base.
+    expect(base.load()).toEqual(baseBefore);
+  });
+
+  it("applies an ordinary cleanup below the floor untouched", async () => {
+    // The floor is set high on purpose: clearing out a season of daily notes is
+    // a normal act and must never draw a confirmation, or the confirmation
+    // becomes something the user learns to click through.
+    await seedVault(30);
+    deleteLocal(0, 20);
+
+    const out = await newEngine().syncOnce();
+
+    expect(out).toMatchObject({ status: "ok", deleted: 20 });
+    expect(await remotePaths()).toHaveLength(10);
+  });
+
+  it("applies a large-vault delete that stays under the proportional share", async () => {
+    // 600 files → the share (30) has overtaken the floor (25); 28 clears the
+    // floor but stays under the share, so only the proportion lets it through.
+    await seedVault(600);
+    deleteLocal(0, 28);
+
+    const out = await newEngine().syncOnce();
+
+    expect(out).toMatchObject({ status: "ok", deleted: 28 });
+    expect(await remotePaths()).toHaveLength(572);
+  });
+
+  it("counts remote-side deletions too — a peer's mass delete is held locally", async () => {
+    await seedVault(60);
+    // A peer removes half the vault from the coordinator; reconcile would
+    // mirror that by deleting the local copies.
+    const manifest = await port.listManifest();
+    for (const file of manifest.files.slice(0, 30)) {
+      expect((await port.deleteFile(file.path, file.version)).ok).toBe(true);
+    }
+
+    const out = await newEngine().syncOnce();
+
+    expect(out).toMatchObject({ status: "held", deletions: 30, baseCount: 60 });
+    expect(vault.paths()).toHaveLength(60);
+  });
+
+  it("a confirmed pass applies exactly what was held", async () => {
+    await seedVault(60);
+    deleteLocal(0, 30);
+    const held = await newEngine().syncOnce();
+    expect(held).toMatchObject({ status: "held", deletions: 30 });
+
+    const confirmed = await newEngine().syncOnce({ confirmDeletions: 30 });
+
+    expect(confirmed).toMatchObject({ status: "ok", deleted: 30, pushed: 0, pulled: 0 });
+    expect(await remotePaths()).toEqual(vault.paths());
+    expect(await remotePaths()).toHaveLength(30);
+  });
+
+  it("a confirmation covers only the count it was shown — a grown plan holds again", async () => {
+    // The waiver is bound to what the user SAW. A confirmed pass re-crawls and
+    // re-reconciles, so a listing that degraded between the hold and the click
+    // must not ride the old approval: it holds again with the new number, which
+    // is the number the user then gets to approve.
+    await seedVault(60);
+    deleteLocal(0, 30);
+    expect(await newEngine().syncOnce()).toMatchObject({ status: "held", deletions: 30 });
+    const baseBefore = base.load();
+
+    deleteLocal(30, 40);
+    const deleteSpy = vi.spyOn(port, "deleteFile");
+    const out = await newEngine().syncOnce({ confirmDeletions: 30 });
+
+    expect(out).toMatchObject({ status: "held", deletions: 40, baseCount: 60 });
+    expect(deleteSpy).not.toHaveBeenCalled();
+    expect(await remotePaths()).toHaveLength(60);
+    expect(base.load()).toEqual(baseBefore);
+  });
+
+  it("confirmation is per-pass — the NEXT pass is gated again", async () => {
+    await seedVault(60);
+    deleteLocal(0, 30);
+    expect((await newEngine().syncOnce({ confirmDeletions: 30 })).status).toBe("ok");
+
+    // A second mass deletion against the newly converged anchor: nothing about
+    // the earlier confirmation carries over.
+    deleteLocal(30, 56);
+    const out = await newEngine().syncOnce();
+
+    expect(out).toMatchObject({ status: "held", deletions: 26, baseCount: 30 });
+  });
+
+  it("holds a whole-vault deletion behind the EMPTY-listing guard, not this one", async () => {
+    // Layer 1 still owns the empty listing — the gate must not have absorbed
+    // it, because that guard refuses even a confirmed pass.
+    await seedVault(30);
+    deleteLocal(0, 30);
+
+    const out = await newEngine().syncOnce({ confirmDeletions: 30 });
+
+    expect(out).toMatchObject({
+      status: "error",
+      message: expect.stringContaining("mass deletion"),
+    });
+    expect(await remotePaths()).toHaveLength(30);
+  });
+
+  it("holds behind the UNACCOUNTED-in-base refusal, not this one", async () => {
+    // Layer 2 keeps its precedence too. A confirmed pass whose plan the gate
+    // would have waived must still refuse for the unreadable path, because a
+    // path the crawl could not read is not a path the user deleted — and the
+    // remedy the refusal names is the actionable one.
+    await seedVault(60);
+    deleteLocal(0, 30);
+    unaccounted = ["n0.md"];
+    const baseBefore = base.load();
+    const deleteSpy = vi.spyOn(port, "deleteFile");
+
+    const out = await newEngine().syncOnce({ confirmDeletions: 30 });
+
+    expect(out).toMatchObject({ status: "error", message: expect.stringContaining('"n0.md"') });
+    expect(deleteSpy).not.toHaveBeenCalled();
+    expect(await remotePaths()).toHaveLength(60);
+    expect(base.load()).toEqual(baseBefore);
+  });
+
+  it("an automatic (debounced) pass never confirms — it reports the hold", async () => {
+    await seedVault(60);
+    deleteLocal(0, 30);
+
+    const outcomes: SyncOutcome[] = [];
+    let resolveSeen: (() => void) | null = null;
+    const seen = new Promise<void>((resolve) => {
+      resolveSeen = resolve;
+    });
+    const engine = newEngine((outcome) => {
+      outcomes.push(outcome);
+      resolveSeen?.();
+    });
+
+    engine.scheduleSync();
+    await seen;
+
+    expect(outcomes).toHaveLength(1);
+    expect(outcomes[0]).toMatchObject({ status: "held", deletions: 30 });
+    expect(await remotePaths()).toHaveLength(60);
+  });
+});

--- a/packages/notes/src/sync/__tests__/engine.test.ts
+++ b/packages/notes/src/sync/__tests__/engine.test.ts
@@ -163,7 +163,7 @@ describe("SyncEngine.syncOnce", () => {
 
   it("mirrors a local delete to the coordinator", async () => {
     // A sibling survives the delete: an empty local listing against a
-    // non-empty base is refused by the mass-deletion guard (#429, below).
+    // non-empty base is refused by the empty-listing guard below.
     vault.writeText("gone.md", "bye");
     vault.writeText("stays.md", "here");
     await newEngine().syncOnce();
@@ -203,7 +203,7 @@ describe("SyncEngine.syncOnce", () => {
 // the empty listing and assert ZERO ops reach the port and the base anchor is
 // untouched, then pin the guard's edges (a genuinely empty first sync and a
 // legitimate partial delete must NOT trip it).
-describe("SyncEngine mass-deletion guard (#429)", () => {
+describe("SyncEngine empty-listing guard", () => {
   it("empty local listing + non-empty base → error, ZERO deletes reach the port, base untouched", async () => {
     // Converge two files so the base anchor records them.
     vault.writeText("a.md", "AAA");

--- a/packages/notes/src/sync/engine.ts
+++ b/packages/notes/src/sync/engine.ts
@@ -21,7 +21,7 @@
 // ---------------------------------------------------------------------------
 
 import type { LocalFile, LocalManifest, VaultManifest } from "./manifest";
-import type { SyncOp } from "./plan";
+import type { SyncOp, SyncPlan } from "./plan";
 import type { SyncPort, Unsubscribe } from "./sync-port";
 import { ABSENT_VERSION, type Hash, type VaultFile, type VaultPath } from "./vault-file";
 import { conflictCopyName, reconcile } from "./reconcile";
@@ -114,9 +114,58 @@ function applyPhase(op: SyncOp): number {
   return op.side === "local" ? 0 : 2;
 }
 
-/** How many offending paths an unaccounted-for refusal names before it counts
- * the rest — enough to act on, short enough to read in a toast. */
+/** How many offending paths a refusal names before it counts the rest — enough
+ * to act on, short enough to read in a toast. */
 const MAX_NAMED_PATHS = 5;
+
+// ---------------------------------------------------------------------------
+// Deletion gate — the layer that BOUNDS what a leaked listing invariant costs.
+//
+// Every mass-deletion bug this vault has shipped had one shape: the local
+// manifest shrank while nothing left the disk, and the 3-way reconcile read
+// "in base, absent from local" as a permanent delete on every device. Each
+// individual cause (a .gitignore edit, a vault repoint, a case-only rename, a
+// symlink, a pruned dot-entry, a platform exclusion mismatch) was closed by a
+// listing rule — which only holds until the next listing rule leaks. This gate
+// asks a different question, one no crawl can answer wrongly: is the SIZE of
+// this deletion consistent with a human having asked for it?
+//
+// What it is NOT, and must never be described as: a detector. It reads a
+// COUNT, never a cause, so a leak that sheds ONE path — a single case-only
+// rename, one symlink where a note used to be — sits far below the floor and
+// passes straight through, losing that file on every device exactly as it
+// would have without the gate. Catching those is the listing rules' job. This
+// layer caps the blast radius of the ones they miss, and nothing more.
+//
+// Two shapes must both hold. A small vault must not stall on an ordinary
+// cleanup, which is what the absolute floor buys: below it, no plan is ever
+// held, so clearing out a season of daily notes syncs silently. The floor is
+// deliberately high — a confirmation the user meets while tidying is one they
+// learn to click through, and a trained click-through costs more on the one
+// pass that matters than the dialog ever bought. A large vault must not lose
+// hundreds of files to a bug no human would ever confirm, which is what the
+// proportion buys — 5% of a 5,000-note vault is 250 files, so a 400-file
+// phantom deletion holds while a deliberate 100-file purge does not. The floor
+// dominates until 500 files, the proportion after; both are policy, tuned to
+// stay quiet on the deletes users actually make.
+// ---------------------------------------------------------------------------
+const MIN_HELD_DELETIONS = 25;
+const HELD_DELETION_SHARE = 0.05;
+
+/** Vault paths this plan would remove, from EITHER side — a pull that
+ * overwrites local bytes is not a deletion, and a remote delete costs every
+ * other device its copy exactly as a local one does. */
+function plannedDeletions(plan: SyncPlan): VaultPath[] {
+  const paths: VaultPath[] = [];
+  for (const op of plan.ops) {
+    if (op.kind === "delete") paths.push(op.path);
+  }
+  return paths;
+}
+
+function exceedsDeletionGate(deletions: number, baseCount: number): boolean {
+  return deletions > Math.max(MIN_HELD_DELETIONS, HELD_DELETION_SHARE * baseCount);
+}
 
 /** Why a pass refused, in terms the user can act on. The port answers with
  * PATHS, not causes, so the message names the remedy for each shape a platform
@@ -159,7 +208,35 @@ export type SyncOutcome =
        * loser vanished before it could be copied). */
       readonly conflictPaths: readonly VaultPath[];
     }
+  | {
+      /** The plan would have deleted more files than the gate allows without a
+       * human saying so. NOTHING was applied — not the deletes, not the pushes
+       * or pulls beside them — and the base anchor is untouched, so a confirmed
+       * retry reconciles from exactly the same state. */
+      readonly status: "held";
+      readonly deletions: number;
+      /** Files the last sync recorded, for "N of M" phrasing. */
+      readonly baseCount: number;
+      /** A few of the paths that would go, for the confirmation UI. */
+      readonly sample: readonly VaultPath[];
+    }
   | { readonly status: "error"; readonly message: string };
+
+/** Per-pass options. Deliberately not engine state: `confirmDeletions` applies
+ * to ONE pass and is never remembered, so a confirmation can never authorize a
+ * deletion the user never saw. */
+export type SyncPassOptions = {
+  /** Waive the deletion gate for this pass, for AT MOST this many deletions —
+   * the count the user was shown when they approved. A confirmed pass re-crawls
+   * and re-reconciles from scratch, so the plan it produces need not be the
+   * plan that was held: a bigger one is a DIFFERENT deletion the user never
+   * saw, and holds again with the new number rather than riding a waiver
+   * written for a smaller one. ONLY an explicit human action may set it — a
+   * debounced, periodic or realtime-triggered pass that confirmed its own
+   * deletions would be worse than no gate at all, because it would look like
+   * protection. */
+  readonly confirmDeletions?: number | undefined;
+};
 
 export type SyncEngineOptions = {
   /** The remote vault this client syncs. Scopes the SyncPort + the base store. */
@@ -296,7 +373,8 @@ export class SyncEngine {
     this.scheduleSync();
   }
 
-  /** Coalesce a burst of triggers into one sync pass. */
+  /** Coalesce a burst of triggers into one sync pass. Never confirms deletions:
+   * nobody is watching a debounced pass, so it can only ever report a hold. */
   scheduleSync(): void {
     if (this.debounceTimer !== null) clearTimeout(this.debounceTimer);
     this.debounceTimer = setTimeout(() => {
@@ -310,12 +388,16 @@ export class SyncEngine {
   /** Run one reconcile+execute pass. Serialized against other in-flight passes.
    * Never throws — a transport failure comes back as `{ status: "error" }` and
    * leaves the base manifest untouched, so the next pass retries from the last
-   * clean anchor. `onOutcome` fires here — the single exit point for every
-   * pass, explicit or debounced — rather than inside `runOnce()`, so a future
-   * exit path there can't accidentally skip the notification. */
-  syncOnce(): Promise<SyncOutcome> {
+   * clean anchor; a `{ status: "held" }` outcome is the deletion gate refusing
+   * the whole plan on the same terms, and `opts.confirmDeletions` (an explicit
+   * human confirmation of a specific count, never an automatic trigger) waives
+   * it for this pass up to that count.
+   * `onOutcome` fires here — the single exit point for every pass, explicit or
+   * debounced — rather than inside `runOnce()`, so a future exit path there
+   * can't accidentally skip the notification. */
+  syncOnce(opts?: SyncPassOptions): Promise<SyncOutcome> {
     const run = this.queue
-      .then(() => this.runOnce())
+      .then(() => this.runOnce(opts?.confirmDeletions))
       .then((outcome) => {
         try {
           this.onOutcome?.(outcome);
@@ -333,12 +415,12 @@ export class SyncEngine {
     return run;
   }
 
-  private async runOnce(): Promise<SyncOutcome> {
+  private async runOnce(confirmDeletions: number | undefined): Promise<SyncOutcome> {
     try {
       const vaultRoot = this.currentRoot();
       const local = await this.buildLocalManifest();
       const base = this.loadBase(vaultRoot);
-      // MASS-DELETION GUARD: an empty local listing against a non-empty
+      // EMPTY-LISTING GUARD: an empty local listing against a non-empty
       // last-synced base is treated as a failed/truncated vault read (root
       // unmounted, a crawl error), NEVER as the user having deleted every
       // file — reconcile would read each base path as a local delete and fan
@@ -383,6 +465,31 @@ export class SyncEngine {
       }
 
       const plan = reconcile(base, local, remote);
+
+      // DELETION GATE: a plan is a whole; hold it entirely rather than applying
+      // the writes and skipping the deletes, because a half-applied plan
+      // advances nothing the user can reason about. Counted from the reconciled
+      // plan BEFORE any op runs, so no WRITE ever reaches the coordinator — the
+      // manifest listing above has already happened and is the pass's only
+      // remote cost, paid again on every retry until a human decides. A
+      // confirmation covers only the count it was given: this pass re-crawled
+      // and re-reconciled, so a plan that grew since the hold holds again with
+      // the new number for the user to approve on sight.
+      // Independent of the two guards above ON PURPOSE — they recognize
+      // specific broken listings, this one recognizes an implausible RESULT and
+      // needs no listing invariant to be true. It caps what a leaked invariant
+      // costs; it does not find one (a leak shedding a single path is under the
+      // floor and passes straight through).
+      const deletions = plannedDeletions(plan);
+      const waived = confirmDeletions !== undefined && deletions.length <= confirmDeletions;
+      if (!waived && exceedsDeletionGate(deletions.length, base.files.length)) {
+        return {
+          status: "held",
+          deletions: deletions.length,
+          baseCount: base.files.length,
+          sample: deletions.slice(0, MAX_NAMED_PATHS),
+        };
+      }
 
       // The converged coordinator view we advance BASE to: start from the remote
       // snapshot (covers converged + remote-only files) and mutate per applied

--- a/packages/notes/src/sync/status.ts
+++ b/packages/notes/src/sync/status.ts
@@ -22,20 +22,42 @@ export type SyncStatus =
        * counted in `conflicts`, never listed as conflict rows. */
       readonly merged: number;
     }
+  | {
+      /** The deletion gate held the pass — nothing was applied and nothing
+       * will be until a human confirms, so a surface showing this MUST offer
+       * (or point at) that confirmation, never present it as progress. */
+      readonly phase: "held";
+      readonly deletions: number;
+      readonly baseCount: number;
+      readonly sample: readonly string[];
+    }
   | { readonly phase: "error"; readonly message: string };
+
+/** The held variant, so both apps narrow to one shared name. */
+export type HeldSyncStatus = Extract<SyncStatus, { phase: "held" }>;
 
 /** Project one completed pass's outcome to its status. The `syncing`/`idle`
  * phases are lifecycle states the caller sets around the pass — an outcome
- * only ever lands as `ok` or `error`. */
+ * only ever lands as `ok`, `held` or `error`. */
 export function statusFromOutcome(outcome: SyncOutcome): SyncStatus {
-  return outcome.status === "ok"
-    ? {
+  switch (outcome.status) {
+    case "ok":
+      return {
         phase: "ok",
         pushed: outcome.pushed,
         pulled: outcome.pulled,
         deleted: outcome.deleted,
         conflicts: outcome.conflicts,
         merged: outcome.merged,
-      }
-    : { phase: "error", message: outcome.message };
+      };
+    case "held":
+      return {
+        phase: "held",
+        deletions: outcome.deletions,
+        baseCount: outcome.baseCount,
+        sample: outcome.sample,
+      };
+    case "error":
+      return { phase: "error", message: outcome.message };
+  }
 }

--- a/packages/server/src/handlers/sync-handlers.ts
+++ b/packages/server/src/handlers/sync-handlers.ts
@@ -12,5 +12,5 @@ export function registerSyncHandlers(handle: HandlerRegistrar): void {
   );
   handle("getAccountCapabilities", () => getSyncCoordinator().getCapabilities());
   handle("syncSignOut", () => getSyncCoordinator().signOut());
-  handle("syncNow", () => getSyncCoordinator().syncNow());
+  handle("syncNow", (opts) => getSyncCoordinator().syncNow(opts));
 }

--- a/packages/sync/src/sync-coordinator.ts
+++ b/packages/sync/src/sync-coordinator.ts
@@ -19,7 +19,7 @@ import { createNodeHasher, createSyncManager, createVaultSyncIo } from "./sync-m
 import { createHttpSyncPort } from "@repo/notes/sync/http-sync-port";
 import { isConflictCopyPath } from "@repo/notes/sync/reconcile";
 import { statusFromOutcome, type SyncStatus } from "@repo/notes/sync/status";
-import type { SyncEngine, SyncOutcome } from "@repo/notes/sync/engine";
+import type { SyncEngine, SyncOutcome, SyncPassOptions } from "@repo/notes/sync/engine";
 import type {
   AccountCapabilities,
   SyncConflict,
@@ -210,8 +210,12 @@ export class SyncCoordinator {
   /** Kick an explicit pass. Its outcome lands through the SAME `onOutcome`
    * path a debounced pass uses (wired in `rebuild()`) — by the time this
    * `await` resolves, `handleOutcome` has already updated status/conflicts
-   * and emitted, so there is nothing left to do here but return the value. */
-  async syncNow(): Promise<SyncOutcome> {
+   * and emitted, so there is nothing left to do here but return the value.
+   *
+   * The ONLY path that may carry `confirmDeletions`: every other caller of the
+   * engine here (`onVaultChanged`, the periodic timer, the initial kick) is
+   * automatic, and an automatic confirmation would defeat the gate. */
+  async syncNow(opts?: SyncPassOptions): Promise<SyncOutcome> {
     const engine = this.engine;
     if (!engine) {
       const outcome: SyncOutcome = { status: "error", message: DISABLED_REASON };
@@ -221,7 +225,7 @@ export class SyncCoordinator {
     }
     this.status = { phase: "syncing" };
     this.emit();
-    return engine.syncOnce();
+    return engine.syncOnce(opts);
   }
 
   /** Stop the engine (shutdown). Leaves persisted config/session intact. */

--- a/packages/vault/src/__tests__/vault.test.ts
+++ b/packages/vault/src/__tests__/vault.test.ts
@@ -175,7 +175,7 @@ describe("VaultManager", () => {
     expect(all).not.toContain("foo.tmp");
   });
 
-  // ---- Crawl completeness (the sync mass-deletion guard's Layer 1) ----------
+  // ---- Crawl completeness (the sync empty-listing guard's Layer 1) ----------
   // A truncated/empty crawl must NEVER reach the sync manifest as if it were a
   // real state of the vault: reconcile reads "in base, absent from local" as a
   // local delete and fans it out to every device. The shared crawl records
@@ -264,7 +264,7 @@ describe("VaultManager", () => {
   // absence from the manifest as a local DELETE, so an ignore rule must never
   // reach it: writing `archive/` into .gitignore would otherwise propagate a
   // permanent deletion of every file under it to every device (a PARTIAL ignore
-  // slips straight past the engine's empty-listing mass-deletion guard).
+  // slips straight past the engine's empty-listing guard).
   it("withholds ignored files from list() but keeps them in listAllPaths()", async () => {
     const mgr = newManager();
     mgr.ensureReady();


### PR DESCRIPTION
Closes #509.

Six data-loss bugs were fixed in #507 and #508 by tightening listing invariants. Each fix was correct; none of them generalise. The class kept producing instances, and **four of the six were found only by adversarially re-reading code that had just been reviewed**. This is the layer that does not depend on any listing rule staying true.

## Behaviour

A pass whose plan would delete more than `max(25, 5% of the last-synced count)` **applies nothing at all** — not the deletes, not the writes beside them, because a half-applied plan advances nothing anyone can reason about. It reports what it wanted to remove and leaves the base anchor untouched, so retrying is free and a wrong hold costs nothing.

Only an explicit human confirmation releases it, and **the waiver carries the count that was approved**. A plan that grew between the hold and the click holds again with the new number, rather than riding a stale yes.

## Both platforms confirm for themselves

The gate compares against each device's **own** anchor. So a desktop confirmation does not clear a phone's hold — it *causes* one. Delete 30 notes on the desktop, confirm, and the phone's next pass sees 30 local deletes and holds; because the plan is held whole, that phone's own pushes stop too.

The first cut of this shipped with mobile holding and copy that said "confirm on the desktop app", which would have wedged the phone permanently with no way out and no pushes. Two reviewers caught it independently. Mobile now has its own confirmation.

## Visibility

`onSyncStateChanged`'s only subscriber was the Settings dialog, which mounts only while it is open — so a background hold was silent, forever, with pushes stopped. A held pass now raises a persistent toast into the workspace with an action that opens the section that can release it, fired on the **transition** into held so the 5-minute timer does not become a metronome.

## What it is not

**This bounds the blast radius of a listing leak; it does not detect one.** A single case-only rename or one symlink sheds one path and passes straight under the floor. The two guards above it — an empty listing, and a path the crawl could not account for that the base still holds — keep catching what they were written for. All three are independent and the comments now say which fires when.

## Review

Two rounds, four reviewer passes. Beyond the mobile wedge they caught: an unbounded waiver, an invisible held state, a confirm dialog that understated permanence (sync-applied deletes never reach the OS trash), a floor low enough to train click-through, and a direction claim in the copy that was wrong for the very scenario the mobile fix exists for — a remote-originated hold deletes from *this* device, not the others. The copy is now direction-neutral because the outcome carries no side.

`pnpm verify` exit 0. Driven end to end in the harness: first pass syncs plainly, second holds, toast fires, Review opens Settings, confirm converges, sign-out makes the hold re-drivable.

## Known

The toast lands in Settings on the General tab; Sync is several sections down. Targeting it needs either a scroll-into-view hook or the section registry `CLAUDE.md` rules out, so it is left. The sample is capped at five with no "show all".

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a deletion gate to sync: if a pass would delete more than max(25, 5% of the last-synced files), it applies nothing and asks for confirmation. Desktop and mobile now show a clear “sync paused” state with per‑device confirmation and a persistent desktop toast.

- **New Features**
  - Engine (`packages/notes`):
    - Holds a plan that would delete over the threshold; no deletes, pushes, or pulls run, and the base anchor stays clean.
    - Returns a held status with deletion count, base count, and a 5‑file sample.
    - Confirmation is per pass and count‑bound via `confirmDeletions`; a larger plan holds again.
    - Counts deletes from either side (local or remote) and remains independent of the empty‑listing and unaccounted‑path guards.
  - Desktop (`apps/desktop`, `packages/bridge`, `packages/sync`):
    - Settings → Sync shows a “Paused” panel with sample paths and a destructive “Delete and sync” action.
    - A persistent workspace toast announces the first transition to held and opens Settings on “Review”.
    - IPC `syncNow` now accepts `{ confirmDeletions?: number }` (`SyncNowSchema`); remote control of confirmations is disallowed.
  - Mobile (`apps/mobile`):
    - Vault screen shows “Sync paused …” and lets users review and confirm via a destructive alert; taps pass `{ confirmDeletions }` to `syncOnce`.
    - Automatic passes (debounced/periodic/realtime) never confirm; they only report holds.
  - Tests and docs:
    - Added `engine-deletion-gate.test.ts` covering thresholds, per‑pass waivers, remote deletes, and guard precedence.
    - Updated terminology in tests and `CLAUDE.md` to document the three independent deletion guards.

<sup>Written for commit c94678798502689a0ab2c71b8f22007127105ebf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kyh/inteligir/pull/512?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

