### PR TITLE
docs: the agent is not sandboxed, by decision

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -486,6 +486,19 @@ before following it.
 Plan files and ADR docs are not tracked in this repo; this section is the
 record for the decisions code comments cite.
 
+- **The agent is NOT sandboxed, and never will be.** `bash`, `execute`,
+  `browser` and `peekaboo` have real machine access by design — that access is
+  the product, the same bargain Claude Desktop makes. A filesystem sandbox was
+  considered as the "real" `private: true` boundary and DECLINED. The
+  consequence is stated rather than hidden: `private: true` is a
+  leak-prevention feature for AI surfaces, NOT a security boundary
+  (`docs/privacy.md` is the contract), and the per-tool gate is instruction
+  plus a best-effort literal-path screen. It follows that the agent grant's
+  "never granted" tier and its inline confirmations are POLICY, not
+  enforcement — they govern what the agent does deliberately, and a model with
+  a shell can reach around both. Describe them that way; do not sell them as a
+  boundary.
+
 - **Vault liveness: ephemeral listing + one open-note watcher.**
   NO recursive filesystem watcher, ever. The vault LISTING is an on-demand
   crawl (TTL-shared snapshot) refreshed on window focus, app structural

--- a/docs/privacy.md
+++ b/docs/privacy.md
@@ -62,10 +62,11 @@ boundary**. Read the "What it does NOT do" list before relying on it.
   We block a command that literally names a private note's path, and
   AGENTS.md instructs the model never to work around a privacy refusal — but
   `cat ./vault/*.md`, pipes, and subshells are not (and cannot soundly be)
-  parsed. Real closure needs a sandbox; until then this is instruction, not
-  enforcement. The same applies to `execute` (sandboxed TypeScript with fs
-  access via the executor), `browser`, and `peekaboo` — and peekaboo can
-  screenshot a private note that is open on your screen.
+  parsed. This is instruction, not enforcement, and it stays that way: a
+  filesystem sandbox was considered and DECLINED, because the agent's real
+  machine access is the product. The same applies to `execute` (TypeScript
+  with fs access via the executor), `browser`, and `peekaboo` — and peekaboo
+  can screenshot a private note that is open on your screen.
 - **Filenames still leak to the shell.** `bash ls vault/` shows private
   notes' names; only the knowledge tools hide paths.
 - **Sync uploads it unencrypted.** Vault sync (off by default) mirrors

--- a/packages/agent/src/privacy/extension.ts
+++ b/packages/agent/src/privacy/extension.ts
@@ -19,7 +19,8 @@
  * inactive grep/find/ls) are soundly gated, via a live frontmatter probe per
  * call. bash, execute, browser, and peekaboo get a best-effort literal-path
  * screen ONLY — `cat` with a glob, a pipe, or a screenshot of a private note
- * on screen all bypass it. Without a sandbox those tools can still leak
+ * on screen all bypass it. With no sandbox (declined by design) those tools
+ * can still leak
  * private content; AGENTS.md instructs the model not to, it does not prevent
  * it. docs/privacy.md is the honest statement of scope.
  */

--- a/packages/agent/src/privacy/gate.ts
+++ b/packages/agent/src/privacy/gate.ts
@@ -22,7 +22,8 @@
 //    vault-relative path — nothing more. Command parsing can never be sound:
 //    `cat ./vault/*.md`, pipes, $(...), cd, encodings, and a peekaboo
 //    screenshot of a private note on screen ALL bypass this heuristic. The
-//    honest statement: without a sandbox these tools can still read private
+//    honest statement: with no sandbox (declined by design — the agent's real
+//    machine access is the product) these tools can still read private
 //    notes; the AGENTS.md rule instructs the model not to, it does not
 //    prevent it. Do NOT present this heuristic as a security boundary.
 //  - vaultRealRoot unresolvable (null): FAIL CLOSED — anything lexically


### PR DESCRIPTION
Closes #452 as **declined**, not deferred.

`bash`, `execute`, `browser` and `peekaboo` have real machine access by design — that access is the product, the same bargain Claude Desktop makes.

## What changed

The docs promised a sandbox was coming. `docs/privacy.md` said *"Real closure needs a sandbox; until then this is instruction, not enforcement"* — which reads as a deferral. There is no until.

- `docs/privacy.md`, `privacy/gate.ts`, `privacy/extension.ts`: the sandbox is recorded as **declined by design**, not pending.
- `CLAUDE.md` § Decisions: a new entry stating it, and its consequence.

Nothing about the enforcement behaviour changes — the per-tool gate, the live-disk probe and the pi-path-parity drift guard all stay exactly as they are. This is the honesty fix, not a code change.

## The consequence, stated

`private: true` is a **leak-prevention feature for AI surfaces, not a security boundary** — which `docs/privacy.md` already contracted, so this only removes the escape hatch that implied otherwise.

It also settles something the agent-grant audit flagged: the grant table's **never-granted tier and inline confirmations are policy, not enforcement.** They govern what the agent does deliberately; a model holding a shell can reach around both. #513 has to describe them that way rather than sell them as a boundary.

`pnpm verify` exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clarifies the agent is not sandboxed and won't be; `bash`, `execute`, `browser`, and `peekaboo` have real machine access by design. Updates docs and inline comments to say `private: true` is leak-prevention, not a security boundary; tool gates remain instruction plus a best-effort path screen; no behavior changes.

<sup>Written for commit 515b2ef35fe77f67afed232c9a800a8d7e6115f6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kyh/inteligir/pull/516?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

