### PR TITLE
fix(mobile): stop losing a note edit and a chat message

### DIFF
--- a/apps/desktop/dev/fixture-bridge.ts
+++ b/apps/desktop/dev/fixture-bridge.ts
@@ -917,6 +917,8 @@ export function createFixtureBridge(openKnowledgeStore: (root: string) => Knowle
     knowledgeEvents.emit({});
   };
 
+  const deliveredClientIds = new Set<string>();
+
   const cannedReply = (text: string) => {
     history.push({ role: "user", text });
     setAppState({ phase: "ready", agent: "busy" });
@@ -982,6 +984,13 @@ export function createFixtureBridge(openKnowledgeStore: (root: string) => Knowle
         agentEvents.emit({ type: "agent_end" });
         setAppState({ phase: "ready", agent: "idle" });
         return;
+      }
+      // Mirrors the host's retry gate: a resent command carries the clientId of
+      // the one it repeats, and running it twice would be the duplicate turn
+      // the id exists to prevent.
+      if (command.clientId !== undefined) {
+        if (deliveredClientIds.has(command.clientId)) return;
+        deliveredClientIds.add(command.clientId);
       }
       cannedReply(command.text);
     },

--- a/apps/mobile/src/app/_layout.tsx
+++ b/apps/mobile/src/app/_layout.tsx
@@ -4,6 +4,10 @@ import { useEffect } from "react";
 import { useColorScheme } from "react-native";
 import { SafeAreaProvider } from "react-native-safe-area-context";
 
+// Side-effect import: loading the module restores the chat queue from disk and
+// arms its drain, so a message queued before the app was killed leaves on the
+// next connection whether or not the chat screen is ever opened.
+import "@/lib/chat/outbox";
 import { startHostConnection } from "@/lib/host/connection";
 import { hostEnvironmentStore } from "@/lib/host/expo-environment-store";
 import { themeFor } from "@/lib/theme";

--- a/apps/mobile/src/app/chat.tsx
+++ b/apps/mobile/src/app/chat.tsx
@@ -1,5 +1,5 @@
 import { Stack, useRouter } from "expo-router";
-import { memo, useCallback, useMemo, useRef, useState } from "react";
+import { memo, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
   KeyboardAvoidingView,
   Platform,
@@ -16,7 +16,6 @@ import Markdown from "react-native-markdown-display";
 
 import type { AppAgentEvent } from "@repo/bridge/agent-events";
 import {
-  appendNotice,
   appendUser,
   applyAgentEvent,
   emptyChatLog,
@@ -25,6 +24,13 @@ import {
   type ChatLog,
 } from "@repo/bridge/chat-log";
 import type { ChatHistoryEntry } from "@repo/bridge/chat-log";
+import type { OutboxEntry } from "@/lib/chat/chat-outbox";
+import {
+  dismissUnreadableNotice,
+  enqueueChatMessage,
+  subscribeDelivered,
+  useOutbox,
+} from "@/lib/chat/outbox";
 import { getHostBridge, useHostStatus } from "@/lib/host/connection";
 import { hostStatusDotColor, hostStatusLabel, type HostStatus } from "@/lib/host/status-display";
 import { useHostChannel } from "@/lib/host/use-host-channel";
@@ -38,6 +44,18 @@ import { RADIUS, SPACE, themeFor, useTheme } from "@/lib/theme";
 // mount and on every reconnect; live turns stream through the pure chat-log
 // fold. The composer routes a mid-turn submission as a follow_up, exactly
 // like the desktop.
+//
+// Sending goes through the durable outbox (../lib/chat/outbox.ts), never
+// straight at the bridge: a phone backgrounds mid-request constantly, and the
+// queue is what turns that from a silently lost message into one that
+// delivers on reconnect. That also lets the composer accept a message while
+// the desktop is unreachable.
+//
+// So a submission is NOT a log entry. The transcript is the host's history
+// plus the outbox's own rows, and a message crosses from one to the other only
+// when the host acknowledges it — otherwise a queued message would appear in
+// the log and then vanish at the next reconnect, when the host's history
+// replaces it wholesale.
 // ---------------------------------------------------------------------------
 
 // How close to the end (px) still counts as "at the bottom" for auto-scroll.
@@ -56,16 +74,42 @@ export default function ChatScreen() {
   // reread must not be yanked back down by streaming deltas.
   const nearBottomRef = useRef(true);
 
-  // Live agent events + a history reload on every (re)connect.
+  // Messages acked SINCE the in-flight history request was issued. The host
+  // serves history off the session file, but a dispatch only fires the turn —
+  // pi appends the user entry several awaits later, so a history served right
+  // after an ack legitimately predates it. Both land on one reconnect and the
+  // order is a coin flip; folding these on top stops the reload erasing the
+  // user's own message. Anything acked BEFORE the request was issued is
+  // already on disk, so nothing renders twice.
+  const ackedSinceLoad = useRef<string[]>([]);
+
   useHostChannel<AppAgentEvent, ChatHistoryEntry[]>({
     subscribe: (bridge, onEvent) => bridge.onAgentEvent(onEvent),
-    load: (bridge) => bridge.getAgentHistory(),
+    load: (bridge) => {
+      ackedSinceLoad.current = [];
+      return bridge.getAgentHistory();
+    },
     onEvent: (event) => setLog((current) => applyAgentEvent(current, event)),
-    onLoad: (history) => setLog(logFromHistory(history)),
+    onLoad: (history) => setLog(ackedSinceLoad.current.reduce(appendUser, logFromHistory(history))),
   });
 
+  // An acknowledged message leaves the queue; that is the moment it becomes
+  // part of the conversation, and the next history reload confirms it.
+  useEffect(
+    () =>
+      subscribeDelivered((text) => {
+        ackedSinceLoad.current.push(text);
+        setLog((current) => appendUser(current, text));
+      }),
+    [],
+  );
+
+  const outbox = useOutbox();
   const connected = status === "connected";
-  const canSend = connected && input.trim() !== "";
+  // A started, still-authorized environment accepts messages even while the
+  // socket is down — the outbox holds them.
+  const composing = status !== "none" && status !== "unauthorized";
+  const canSend = composing && input.trim() !== "";
   const streaming = log.streamingId !== null;
 
   // Recreated only when the status changes — not per keystroke/delta render.
@@ -78,17 +122,11 @@ export default function ChatScreen() {
   );
 
   const send = useCallback(() => {
-    const bridge = getHostBridge();
     const text = input.trim();
-    if (bridge === null || text === "") return;
+    if (text === "") return;
     setInput("");
-    setLog((current) => appendUser(current, text));
-    void bridge
-      .sendAgentCommand({ type: log.busy ? "follow_up" : "user_message", text })
-      .catch(() => {
-        setLog((current) => appendNotice(current, "Your message wasn't delivered."));
-      });
-  }, [input, log.busy]);
+    enqueueChatMessage(text);
+  }, [input]);
 
   const interrupt = useCallback(() => {
     // Benign if nothing is running to interrupt — swallow the rejection.
@@ -128,7 +166,7 @@ export default function ChatScreen() {
             scrollRef.current?.scrollToEnd({ animated: !streaming });
           }}
         >
-          {log.items.length === 0 ? (
+          {log.items.length === 0 && outbox.entries.length === 0 ? (
             <View style={styles.empty}>
               <Text style={[styles.emptyTitle, { color: theme.mutedForeground }]}>
                 {connected ? "Chat with your desktop agent." : "Not connected to a desktop."}
@@ -143,10 +181,25 @@ export default function ChatScreen() {
           {log.busy && log.streamingId === null ? (
             <Text style={[styles.pending, { color: theme.mutedForeground }]}>Working…</Text>
           ) : null}
+          {outbox.entries.map((entry) => (
+            <QueuedRow key={entry.id} entry={entry} dark={dark} />
+          ))}
         </ScrollView>
 
+        {outbox.unreadable ? (
+          <Pressable
+            style={[styles.unreadable, { borderTopColor: theme.border }]}
+            onPress={dismissUnreadableNotice}
+          >
+            <Text style={[styles.unreadableText, { color: theme.destructive }]}>
+              Some messages waiting to send couldn’t be read and were set aside. Anything missing
+              will need sending again.
+            </Text>
+          </Pressable>
+        ) : null}
+
         <View style={[styles.composer, { borderTopColor: theme.border }]}>
-          {connected ? (
+          {composing ? (
             <View style={styles.composerRow}>
               <TextInput
                 style={[
@@ -214,21 +267,33 @@ function HeaderStatus({ status }: { status: HostStatus }) {
   );
 }
 
+/** Only reached for the two states the composer refuses outright; every other
+ * status accepts a message and lets the outbox hold it. */
 function composerHint(status: HostStatus): string {
-  switch (status) {
-    case "none":
-      return "Pair with your desktop to chat.";
-    case "unauthorized":
-      return "This device is no longer authorized.";
-    case "connecting":
-    case "disconnected":
-      return "Connecting to your desktop…";
-    case "connected":
-      return "";
-  }
+  return status === "unauthorized"
+    ? "This device is no longer authorized."
+    : "Pair with your desktop to chat.";
 }
 
 // ---- rows -------------------------------------------------------------------
+
+/** A message the desktop has not acknowledged yet: the user's own bubble, held
+ * apart from the conversation until it is really in it. */
+function QueuedRow({ entry, dark }: { entry: OutboxEntry; dark: boolean }) {
+  const theme = themeFor(dark);
+  return (
+    <View style={styles.userRow}>
+      <View style={styles.queued}>
+        <View style={[styles.userBubble, styles.queuedBubble, { backgroundColor: theme.primary }]}>
+          <Text style={[styles.userText, { color: theme.primaryForeground }]}>{entry.text}</Text>
+        </View>
+        <Text style={[styles.queuedLabel, { color: theme.mutedForeground }]}>
+          {entry.state.kind === "sending" ? "Sending…" : "Waiting to send"}
+        </Text>
+      </View>
+    </View>
+  );
+}
 
 // Memoized: the chat-log fold keeps untouched item references stable, so a
 // streaming delta re-renders ONE row, not the whole transcript.
@@ -297,6 +362,12 @@ const styles = StyleSheet.create({
     paddingHorizontal: SPACE.lg,
     paddingVertical: SPACE.md,
   },
+  unreadable: {
+    borderTopWidth: 1,
+    paddingHorizontal: SPACE.lg,
+    paddingVertical: SPACE.sm,
+  },
+  unreadableText: { fontSize: 12, lineHeight: 16 },
   composerRow: { flexDirection: "row", alignItems: "flex-end", gap: SPACE.sm },
   input: {
     flex: 1,
@@ -334,6 +405,9 @@ const styles = StyleSheet.create({
     paddingVertical: 10,
   },
   userText: { fontSize: 16 },
+  queued: { maxWidth: "85%", alignItems: "flex-end", gap: 2 },
+  queuedBubble: { maxWidth: "100%", opacity: 0.55 },
+  queuedLabel: { fontSize: 11 },
   tool: { marginBottom: SPACE.sm, fontSize: 12 },
   errorCard: {
     marginBottom: SPACE.md,

--- a/apps/mobile/src/app/note/[path].tsx
+++ b/apps/mobile/src/app/note/[path].tsx
@@ -1,4 +1,4 @@
-import { Stack, useLocalSearchParams } from "expo-router";
+import { Stack, useLocalSearchParams, useRouter } from "expo-router";
 import { useCallback, useEffect, useState } from "react";
 import {
   Platform,
@@ -13,9 +13,13 @@ import {
 import { SafeAreaView } from "react-native-safe-area-context";
 import Markdown from "react-native-markdown-display";
 
+import type { VaultPath } from "@repo/notes/sync/vault-file";
+
 import { markdownStylesFor } from "@/lib/markdown-styles";
+import { saveNote, type NoteIo, type SaveOutcome } from "@/lib/notes/note-save";
+import { createFsStamp } from "@/lib/sync/clock";
 import { syncOnce } from "@/lib/sync/manager";
-import { readVaultText, writeVaultText } from "@/lib/sync/vault-access";
+import { readVaultTextOrNull, vaultFileExists, writeVaultText } from "@/lib/sync/vault-access";
 import { SPACE, themeFor } from "@/lib/theme";
 
 // ---------------------------------------------------------------------------
@@ -23,14 +27,31 @@ import { SPACE, themeFor } from "@/lib/theme";
 // over the file bytes. This is a LIGHT companion — it renders GFM markdown, but
 // inteligir's custom MDX vocabulary ([[wiki-links]], <toggle>, <column_group>,
 // $$ math, mermaid, alerts) has no mobile renderer and simply shows as its raw
-// source. The full rich editor stays desktop-only. Saving writes the bytes
-// locally, then triggers a sync pass to push them to the coordinator.
+// source. The full rich editor stays desktop-only. Saving goes through
+// ../../lib/notes/note-save, which folds in any change a sync pass landed
+// while the note was open, then triggers a sync pass to push the result.
+//
+// `load.text` is BOTH what read mode renders and the merge base: it holds the
+// exact text this screen last read or wrote at `path`.
+//
+// A save that forked takes the user's words OUT of the editor, so its notice is
+// STICKY — the next successful save or a navigation clears it, never a stray
+// tap — and it carries the way back to the copy that holds them.
 // ---------------------------------------------------------------------------
 
 type LoadState =
   | { readonly kind: "loading" }
   | { readonly kind: "loaded"; readonly text: string }
   | { readonly kind: "missing" };
+
+/** What the banner says, plus the note it can take the user to. */
+type Notice = {
+  readonly message: string;
+  readonly openPath: VaultPath | null;
+};
+
+const io: NoteIo = { read: readVaultTextOrNull, exists: vaultFileExists, write: writeVaultText };
+const stamp = createFsStamp();
 
 export default function NoteScreen() {
   const params = useLocalSearchParams<{ path?: string }>();
@@ -44,30 +65,30 @@ export default function NoteScreen() {
   const [draft, setDraft] = useState("");
   const [editing, setEditing] = useState(false);
   const [saving, setSaving] = useState(false);
+  const [notice, setNotice] = useState<Notice | null>(null);
 
   useEffect(() => {
-    if (path === "") {
+    const text = path === "" ? null : readVaultTextOrNull(path);
+    setNotice(null);
+    if (text === null) {
       setLoad({ kind: "missing" });
       return;
     }
-    try {
-      const text = readVaultText(path);
-      setLoad({ kind: "loaded", text });
-      setDraft(text);
-    } catch {
-      setLoad({ kind: "missing" });
-    }
+    setLoad({ kind: "loaded", text });
+    setDraft(text);
   }, [path]);
 
   const save = useCallback(async () => {
-    if (path === "") return;
+    if (path === "" || load.kind !== "loaded") return;
     setSaving(true);
-    writeVaultText(path, draft);
-    setLoad({ kind: "loaded", text: draft });
+    const outcome = saveNote({ io, path, openedText: load.text, draft, stamp });
+    setLoad({ kind: "loaded", text: outcome.text });
+    setDraft(outcome.text);
+    setNotice(saveNotice(outcome));
     setEditing(false);
     await syncOnce();
     setSaving(false);
-  }, [path, draft]);
+  }, [path, draft, load]);
 
   return (
     <SafeAreaView
@@ -93,6 +114,8 @@ export default function NoteScreen() {
             ) : null,
         }}
       />
+
+      {notice === null ? null : <NoticeBanner notice={notice} dark={dark} />}
 
       {load.kind === "loading" ? (
         <View style={styles.center}>
@@ -123,6 +146,50 @@ export default function NoteScreen() {
   );
 }
 
+/** The sticky report of a save that did not land in the note the user was
+ * editing, with the way to the copy that holds their words. */
+function NoticeBanner({ notice, dark }: { notice: Notice; dark: boolean }) {
+  const router = useRouter();
+  const theme = themeFor(dark);
+  const openPath = notice.openPath;
+  return (
+    <View
+      style={[styles.notice, { backgroundColor: theme.muted, borderBottomColor: theme.border }]}
+    >
+      <Text style={[styles.noticeText, { color: theme.foreground }]}>{notice.message}</Text>
+      {openPath === null ? null : (
+        <Pressable
+          onPress={() => router.push({ pathname: "/note/[path]", params: { path: openPath } })}
+        >
+          <Text style={[styles.noticeAction, { color: theme.foreground }]}>Open your version</Text>
+        </Pressable>
+      )}
+    </View>
+  );
+}
+
+/** What to tell the user about a save that met a concurrent change. Null when
+ * the save was ordinary — silence is the right report for the common case. */
+function saveNotice(outcome: SaveOutcome): Notice | null {
+  switch (outcome.kind) {
+    case "written":
+      return null;
+    case "merged":
+      return {
+        message: "This note also changed on another device. Both sets of edits were kept.",
+        openPath: null,
+      };
+    case "forked": {
+      const name = outcome.copyPath.split("/").pop() ?? outcome.copyPath;
+      const why =
+        outcome.cause === "unreadable"
+          ? "This note couldn’t be read back, so it was left untouched."
+          : "This note also changed on another device, and the two versions couldn’t be combined.";
+      return { message: `${why} Your edits are saved as “${name}”.`, openPath: outcome.copyPath };
+    }
+  }
+}
+
 const styles = StyleSheet.create({
   screen: { flex: 1 },
   headerAction: { fontSize: 16, fontWeight: "600" },
@@ -130,6 +197,14 @@ const styles = StyleSheet.create({
   centerPadded: { paddingHorizontal: SPACE.xxl },
   centerText: { textAlign: "center" },
   status: { fontSize: 14 },
+  notice: {
+    gap: SPACE.xs,
+    borderBottomWidth: 1,
+    paddingHorizontal: SPACE.lg,
+    paddingVertical: SPACE.md,
+  },
+  noticeText: { fontSize: 13, lineHeight: 18 },
+  noticeAction: { fontSize: 13, fontWeight: "600" },
   editor: { flex: 1, paddingHorizontal: SPACE.lg, paddingVertical: SPACE.md, fontSize: 16 },
   // A monospace face for the raw editor, using platform defaults (no bundled font).
   mono: {

--- a/apps/mobile/src/lib/capture/capture-io.ts
+++ b/apps/mobile/src/lib/capture/capture-io.ts
@@ -6,20 +6,14 @@
 // pure module never drags expo-file-system into the node test environment.
 // ---------------------------------------------------------------------------
 
-import { readVaultText, writeVaultText } from "../sync/vault-access";
+import { readVaultTextOrNull, writeVaultText } from "../sync/vault-access";
 import type { CaptureIo } from "./daily-capture";
 
-/** A `CaptureIo` over the local expo vault. `read` maps a missing file to
- * null (vault-access throws) — the seed-from-template path. */
+/** A `CaptureIo` over the local expo vault. A missing file reads as null —
+ * the seed-from-template path. */
 export function createVaultCaptureIo(): CaptureIo {
   return {
-    read: (path) => {
-      try {
-        return readVaultText(path);
-      } catch {
-        return null; // missing (or unreadable) — appendCapture seeds it
-      }
-    },
+    read: (path) => readVaultTextOrNull(path),
     write: (path, text) => {
       writeVaultText(path, text);
     },

--- a/apps/mobile/src/lib/chat/__tests__/chat-outbox.test.ts
+++ b/apps/mobile/src/lib/chat/__tests__/chat-outbox.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  enqueue,
+  nextDispatch,
+  parseOutbox,
+  remove,
+  serializeOutbox,
+  shouldDispatch,
+  withState,
+  type Outbox,
+  type OutboxEntry,
+  type OutboxState,
+} from "../chat-outbox";
+
+function entry(id: string, state: OutboxState = { kind: "pending" }): OutboxEntry {
+  return { id, text: `msg ${id}`, queuedAt: 1, state };
+}
+
+const CONNECTED = { connected: true, inFlight: false };
+
+describe("shouldDispatch", () => {
+  it("dispatches a pending entry over a live, idle connection", () => {
+    expect(shouldDispatch({ state: { kind: "pending" }, ...CONNECTED })).toBe(true);
+  });
+
+  it("holds everything while disconnected", () => {
+    expect(shouldDispatch({ state: { kind: "pending" }, connected: false, inFlight: false })).toBe(
+      false,
+    );
+  });
+
+  it("holds while another entry is awaiting its ack", () => {
+    expect(shouldDispatch({ state: { kind: "pending" }, connected: true, inFlight: true })).toBe(
+      false,
+    );
+  });
+
+  it("never re-sends an entry that is already out", () => {
+    expect(shouldDispatch({ state: { kind: "sending" }, ...CONNECTED })).toBe(false);
+  });
+});
+
+describe("nextDispatch", () => {
+  it("takes the oldest pending entry, keeping submission order", () => {
+    const outbox: Outbox = [entry("a", { kind: "sending" }), entry("b"), entry("c")];
+    expect(nextDispatch(outbox, CONNECTED)?.id).toBe("b");
+  });
+
+  it("is null when nothing may go", () => {
+    expect(nextDispatch([entry("a")], { connected: false, inFlight: false })).toBeNull();
+    expect(nextDispatch([], CONNECTED)).toBeNull();
+  });
+});
+
+describe("queue edits", () => {
+  it("enqueue appends, withState replaces, remove drops", () => {
+    const one = enqueue([], entry("a"));
+    const two = enqueue(one, entry("b"));
+    expect(two.map((item) => item.id)).toEqual(["a", "b"]);
+
+    const sending = withState(two, "a", { kind: "sending" });
+    expect(sending[0]?.state.kind).toBe("sending");
+    expect(sending[1]?.state.kind).toBe("pending");
+
+    expect(remove(sending, "a").map((item) => item.id)).toEqual(["b"]);
+  });
+});
+
+describe("persistence", () => {
+  it("round-trips the queue", () => {
+    const outbox: Outbox = [entry("a"), entry("b")];
+    expect(parseOutbox(serializeOutbox(outbox))).toEqual({ kind: "loaded", outbox });
+  });
+
+  it("re-arms an interrupted send rather than stranding it", () => {
+    const stored = serializeOutbox([entry("a", { kind: "sending" })]);
+    expect(parseOutbox(stored)).toEqual({ kind: "loaded", outbox: [entry("a")] });
+  });
+
+  it("reports a corrupt or foreign file as unreadable, never as an empty queue", () => {
+    expect(parseOutbox("{not json")).toEqual({ kind: "unreadable" });
+    expect(parseOutbox("")).toEqual({ kind: "unreadable" });
+    expect(parseOutbox(JSON.stringify({ version: 99, entries: [entry("a")] }))).toEqual({
+      kind: "unreadable",
+    });
+  });
+
+  it("refuses the whole file rather than silently dropping one bad entry", () => {
+    const stored = JSON.stringify({ version: 2, entries: [{ id: "x" }, entry("a")] });
+    expect(parseOutbox(stored)).toEqual({ kind: "unreadable" });
+  });
+});

--- a/apps/mobile/src/lib/chat/chat-outbox.ts
+++ b/apps/mobile/src/lib/chat/chat-outbox.ts
@@ -1,0 +1,141 @@
+// ---------------------------------------------------------------------------
+// The chat outbox — the durable queue behind the mobile composer. The
+// connection owner drops the bridge when the app backgrounds (host/
+// connection-core.ts), and that path rejects everything queued or in flight;
+// phones background constantly, so a send used to vanish with no retry, no
+// record and no error the user ever saw.
+//
+// So a submission is MINTED and PERSISTED before it is handed to any bridge,
+// and it only leaves the queue when the host acknowledged it. The id is the
+// entry's identity across an app kill, and it also rides the wire: the host
+// drops a command whose clientId it already delivered
+// (server/app/agent-gateway.ts). THAT is what makes every failure the same
+// failure — a send whose outcome is unknown simply goes back to `pending` and
+// retries itself, because a duplicate turn is no longer possible. Nothing here
+// ever asks the user to decide whether their own message went through.
+//
+// An entry carries TEXT ONLY, never a command kind. `follow_up` does not start
+// a turn — pi delivers it at a turn boundary — so a kind frozen at submission
+// and dispatched minutes later can land as a follow-up on an idle agent and sit
+// in the queue forever. The host decides live at dispatch time instead
+// (PiAgent.sendMessage routes to followUp while the session is busy).
+//
+// PURE: the model, the parse/serialize, and the delivery decision, all over
+// plain values with no expo/react imports, so they unit-test on node. The
+// storage + bridge + backoff wiring is ./outbox.ts.
+// ---------------------------------------------------------------------------
+
+export type OutboxState =
+  /** Not currently with a bridge — freshly queued, restored from disk, or
+   * back from a failed attempt. The only state that dispatches. */
+  | { readonly kind: "pending" }
+  /** Handed to a live bridge, awaiting the ack. */
+  | { readonly kind: "sending" };
+
+export type OutboxEntry = {
+  /** Client-minted, persisted before dispatch, sent as the wire's `clientId`;
+   * stable across retries so the host can drop the repeat. */
+  readonly id: string;
+  readonly text: string;
+  /** Epoch ms at submission — the queue's order. */
+  readonly queuedAt: number;
+  readonly state: OutboxState;
+};
+
+export type Outbox = readonly OutboxEntry[];
+
+/** What a persisted queue file yielded. `unreadable` is NOT an empty queue:
+ * bytes are there and could not be understood, which the caller must preserve
+ * and report rather than silently start over from nothing. */
+export type StoredOutbox =
+  | { readonly kind: "loaded"; readonly outbox: Outbox }
+  | { readonly kind: "unreadable" };
+
+/** The persisted file's shape; bumped if the entry shape ever changes. */
+const OUTBOX_VERSION = 2;
+
+export function enqueue(outbox: Outbox, entry: OutboxEntry): Outbox {
+  return [...outbox, entry];
+}
+
+/** Replace one entry's state (no-op for an id that already left the queue). */
+export function withState(outbox: Outbox, id: string, state: OutboxState): Outbox {
+  return outbox.map((entry) => (entry.id === id ? { ...entry, state } : entry));
+}
+
+export function remove(outbox: Outbox, id: string): Outbox {
+  return outbox.filter((entry) => entry.id !== id);
+}
+
+/**
+ * The delivery decision for ONE entry, over the tuple that decides it. Sends
+ * are serialized (`inFlight`) so the agent receives them in the order the user
+ * typed them.
+ */
+export function shouldDispatch(input: {
+  readonly state: OutboxState;
+  readonly connected: boolean;
+  /** True while another entry is already awaiting its ack. */
+  readonly inFlight: boolean;
+}): boolean {
+  if (!input.connected || input.inFlight) return false;
+  return input.state.kind === "pending";
+}
+
+/** The next entry to hand to the bridge, or null when nothing may go now. */
+export function nextDispatch(
+  outbox: Outbox,
+  context: { readonly connected: boolean; readonly inFlight: boolean },
+): OutboxEntry | null {
+  return (
+    outbox.find((entry) =>
+      shouldDispatch({
+        state: entry.state,
+        connected: context.connected,
+        inFlight: context.inFlight,
+      }),
+    ) ?? null
+  );
+}
+
+function isEntry(value: unknown): value is OutboxEntry {
+  if (typeof value !== "object" || value === null) return false;
+  if (!("id" in value) || typeof value.id !== "string" || value.id === "") return false;
+  if (!("text" in value) || typeof value.text !== "string") return false;
+  if (!("queuedAt" in value) || typeof value.queuedAt !== "number") return false;
+  if (!("state" in value) || typeof value.state !== "object" || value.state === null) return false;
+  const kind = "kind" in value.state ? value.state.kind : null;
+  return kind === "pending" || kind === "sending";
+}
+
+/**
+ * Restore the queue from its persisted text. A `sending` entry becomes
+ * `pending`: the process died mid-request, and re-sending is safe because the
+ * host drops the repeat by clientId. Anything the shape check refuses makes
+ * the WHOLE file unreadable rather than a partial queue — a dropped entry is a
+ * message the user typed, and losing it quietly is the bug this module exists
+ * to close.
+ */
+export function parseOutbox(text: string): StoredOutbox {
+  let parsed: unknown = null;
+  try {
+    parsed = JSON.parse(text);
+  } catch {
+    return { kind: "unreadable" };
+  }
+  if (typeof parsed !== "object" || parsed === null) return { kind: "unreadable" };
+  if (!("version" in parsed) || parsed.version !== OUTBOX_VERSION) return { kind: "unreadable" };
+  if (!("entries" in parsed) || !Array.isArray(parsed.entries)) return { kind: "unreadable" };
+  const entries: OutboxEntry[] = [];
+  for (const candidate of parsed.entries) {
+    if (!isEntry(candidate)) return { kind: "unreadable" };
+    entries.push(
+      candidate.state.kind === "sending" ? { ...candidate, state: { kind: "pending" } } : candidate,
+    );
+  }
+  return { kind: "loaded", outbox: entries };
+}
+
+export function serializeOutbox(outbox: Outbox): string {
+  return JSON.stringify({ version: OUTBOX_VERSION, entries: outbox });
+}

--- a/apps/mobile/src/lib/chat/outbox.ts
+++ b/apps/mobile/src/lib/chat/outbox.ts
@@ -1,0 +1,176 @@
+// ---------------------------------------------------------------------------
+// The chat outbox runtime — binds the pure queue (./chat-outbox.ts) to the
+// platform: an expo-file-system document for durability, the host bridge for
+// delivery, and the shared exponential backoff (@repo/bridge/backoff, the same
+// policy the ws reconnect supervisor and the realtime stream use) so a flapping
+// connection isn't hammered.
+//
+// Delivery is serialized — one entry in flight at a time — so the agent
+// receives messages in the order they were typed, and every state change is
+// written through to disk before the next attempt. A failed attempt goes
+// straight back to `pending` and retries; the wire carries the entry's id and
+// the host drops a repeat, so retrying can never run a turn twice.
+//
+// The queue is loaded and drained at MODULE INIT, not on first render: a
+// message queued before the app was killed has to leave without the chat
+// screen ever being opened. The root layout imports this module for that
+// effect.
+// ---------------------------------------------------------------------------
+
+import { useSyncExternalStore } from "react";
+import * as Crypto from "expo-crypto";
+
+import { createBackoff, timeoutSchedule } from "@repo/bridge/backoff";
+import type { Bridge } from "@repo/bridge/ipc-registry";
+
+import { createExternalStore } from "../external-store";
+import { createExpoJsonFile } from "../expo-json-file";
+import { getHostBridge, getHostSnapshot, subscribeHostStatus } from "../host/connection";
+import {
+  enqueue,
+  nextDispatch,
+  parseOutbox,
+  remove,
+  serializeOutbox,
+  withState,
+  type Outbox,
+  type OutboxEntry,
+} from "./chat-outbox";
+
+const OUTBOX_FILE = "chat-outbox.json";
+
+/** What the chat screen renders: the queue, plus whether a queue file had to be
+ * set aside because it could not be read. */
+export type OutboxView = {
+  readonly entries: Outbox;
+  readonly unreadable: boolean;
+};
+
+const file = createExpoJsonFile(OUTBOX_FILE);
+const store = createExternalStore<OutboxView>({ entries: [], unreadable: false });
+const backoff = createBackoff({ baseMs: 1_000, capMs: 30_000, schedule: timeoutSchedule });
+const delivered = new Set<(text: string) => void>();
+
+/** Id of the entry awaiting its ack, or null. */
+let inFlightId: string | null = null;
+
+function entries(): Outbox {
+  return store.get().entries;
+}
+
+/** Publish + persist. A failed write only costs durability, never the send. */
+function setEntries(next: Outbox): void {
+  store.set({ entries: next, unreadable: store.get().unreadable });
+  try {
+    file.write(serializeOutbox(next));
+  } catch {
+    // Best-effort: the in-memory queue still delivers this session.
+  }
+}
+
+function load(): void {
+  const read = file.read();
+  if (read.kind === "absent") return;
+  if (read.kind === "text") {
+    const stored = parseOutbox(read.text);
+    if (stored.kind === "loaded") {
+      store.set({ entries: stored.outbox, unreadable: false });
+      return;
+    }
+  }
+  // Present but unintelligible. Move the bytes aside before anything writes
+  // over them, and say so rather than opening as an empty queue.
+  try {
+    file.quarantine();
+  } catch {
+    // Nothing else to try; the report below is still owed to the user.
+  }
+  store.set({ entries: [], unreadable: true });
+}
+
+function drain(): void {
+  const bridge = getHostBridge();
+  if (bridge === null) return;
+  const connected = getHostSnapshot().status === "connected";
+  const next = nextDispatch(entries(), { connected, inFlight: inFlightId !== null });
+  if (next === null) return;
+
+  inFlightId = next.id;
+  setEntries(withState(entries(), next.id, { kind: "sending" }));
+  void deliver(bridge, next);
+}
+
+async function deliver(bridge: Bridge, entry: OutboxEntry): Promise<void> {
+  const acknowledged = await attempt(bridge, entry);
+  inFlightId = null;
+  if (acknowledged) {
+    setEntries(remove(entries(), entry.id));
+    for (const listener of delivered) listener(entry.text);
+    backoff.reset();
+    drain();
+    return;
+  }
+  setEntries(withState(entries(), entry.id, { kind: "pending" }));
+  backoff.schedule(drain);
+}
+
+/** Hand one entry to the bridge; true once the host acknowledged it. */
+async function attempt(bridge: Bridge, entry: OutboxEntry): Promise<boolean> {
+  try {
+    await bridge.sendAgentCommand({ type: "user_message", text: entry.text, clientId: entry.id });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+subscribeHostStatus(() => {
+  if (getHostSnapshot().status !== "connected") return;
+  // A fresh connection is proof the path works — start the delays over.
+  backoff.reset();
+  drain();
+});
+
+// Boot path: this module is imported for its side effect from the root layout,
+// so a throw here would take the whole app down before any screen mounts. A
+// queue that cannot be read is worth reporting, never worth failing to launch
+// over.
+try {
+  load();
+  drain();
+} catch (err) {
+  console.warn("[outbox] could not restore the queue at startup:", err);
+}
+
+/** Queue one composer submission. Persisted before it is dispatched, so an
+ * app kill mid-send leaves a record instead of a lost message. */
+export function enqueueChatMessage(text: string): void {
+  setEntries(
+    enqueue(entries(), {
+      id: Crypto.randomUUID(),
+      text,
+      queuedAt: Date.now(),
+      state: { kind: "pending" },
+    }),
+  );
+  drain();
+}
+
+/** Called with the text of each message the host acknowledged, so the
+ * transcript can show it as sent exactly when it stops being queued. */
+export function subscribeDelivered(listener: (text: string) => void): () => void {
+  delivered.add(listener);
+  return () => {
+    delivered.delete(listener);
+  };
+}
+
+/** Acknowledge the set-aside-queue report; the file itself stays on disk. */
+export function dismissUnreadableNotice(): void {
+  store.set({ entries: entries(), unreadable: false });
+}
+
+/** Subscribe a React component to the queue. */
+export function useOutbox(): OutboxView {
+  return useSyncExternalStore(store.subscribe, store.get);
+}

--- a/apps/mobile/src/lib/expo-json-file.ts
+++ b/apps/mobile/src/lib/expo-json-file.ts
@@ -1,0 +1,70 @@
+// ---------------------------------------------------------------------------
+// One JSON document under the app's document directory, over Expo's
+// synchronous File API. The read/write pair every persisted mobile store sits
+// on (the sync base manifest, the chat outbox); a fresh `File` instance per
+// call so `exists` reflects current state.
+//
+// The replace goes through a temp sibling written in full and then renamed
+// over the target. Creating the target with `overwrite` and writing into it
+// leaves the document EMPTY between the two calls, and a kill in that window
+// (a phone's normal way of dying) truncates a queue the app promised to keep.
+// The rename itself is remove-then-move natively, so a kill inside THAT window
+// leaves the target absent with the complete payload still at the temp name —
+// `read` adopts it rather than reporting an empty document.
+//
+// `read` reports an unreadable-but-present document as its own state rather
+// than as absence: the two mean opposite things to a durable queue, and
+// collapsing them turns "I could not read your messages" into "you had none".
+// ---------------------------------------------------------------------------
+
+import { File, Paths } from "expo-file-system";
+
+type FileRead =
+  | { readonly kind: "absent" }
+  | { readonly kind: "text"; readonly text: string }
+  /** Present on disk, but the bytes could not be read back. */
+  | { readonly kind: "unreadable" };
+
+export type JsonTextFile = {
+  read: () => FileRead;
+  /** Replace the whole document. */
+  write: (text: string) => void;
+  /** Move an unreadable document aside so a later write cannot erase it. */
+  quarantine: () => void;
+};
+
+export function createExpoJsonFile(name: string): JsonTextFile {
+  const make = () => new File(Paths.document, name);
+  return {
+    read: () => {
+      const file = make();
+      if (!file.exists) {
+        const temp = new File(Paths.document, `${name}.writing`);
+        if (!temp.exists) return { kind: "absent" };
+        try {
+          const text = temp.textSync();
+          temp.moveSync(make(), { overwrite: true });
+          return { kind: "text", text };
+        } catch {
+          return { kind: "unreadable" };
+        }
+      }
+      try {
+        return { kind: "text", text: file.textSync() };
+      } catch {
+        return { kind: "unreadable" };
+      }
+    },
+    write: (text) => {
+      const temp = new File(Paths.document, `${name}.writing`);
+      temp.create({ intermediates: true, overwrite: true });
+      temp.write(text);
+      temp.moveSync(make(), { overwrite: true });
+    },
+    quarantine: () => {
+      const file = make();
+      if (!file.exists) return;
+      file.moveSync(new File(Paths.document, `${name}.unreadable`), { overwrite: true });
+    },
+  };
+}

--- a/apps/mobile/src/lib/host/__tests__/connection-core.test.ts
+++ b/apps/mobile/src/lib/host/__tests__/connection-core.test.ts
@@ -2,7 +2,12 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { createWsBridge } from "@repo/bridge/ws-bridge";
 import { encodeFrame, parseClientFrame } from "@repo/bridge/ws-protocol";
-import { createHostConnection, type HostSnapshot } from "../connection-core";
+import {
+  createHostConnection,
+  shouldReuseSocket,
+  SOCKET_REUSE_WINDOW_MS,
+  type HostSnapshot,
+} from "../connection-core";
 import type { KnownEnvironment } from "../environment-store";
 import { fakeWebSocketImpl, lastSocket, type FakeSocket } from "./fakes";
 
@@ -31,23 +36,58 @@ function fakeLifecycle() {
 }
 
 // The owner under test drives the REAL createWsBridge over fake sockets, so
-// the statuses it publishes are the bridge's actual transitions.
+// the statuses it publishes are the bridge's actual transitions. The clock is
+// a plain variable the tests advance alongside vitest's fake timers.
 function setup() {
   const { impl, sockets } = fakeWebSocketImpl();
   const lifecycle = fakeLifecycle();
+  const clock = { now: 1_000 };
   const connection = createHostConnection({
     createBridge: (options) => createWsBridge({ ...options, webSocketImpl: impl }),
     lifecycle: lifecycle.port,
+    now: () => clock.now,
+    schedule: (fn, ms) => {
+      const timer = setTimeout(fn, ms);
+      return () => clearTimeout(timer);
+    },
   });
   const statuses: HostSnapshot[] = [];
   connection.subscribe(() => statuses.push(connection.getSnapshot()));
-  return { connection, sockets, lifecycle, statuses };
+  /** Move the injected clock AND the timers together. */
+  const advance = (ms: number) => {
+    clock.now += ms;
+    vi.advanceTimersByTime(ms);
+  };
+  return { connection, sockets, lifecycle, statuses, advance };
 }
 
 function welcome(socket: FakeSocket): void {
   socket.fireOpen();
   socket.fireMessage(encodeFrame({ t: "welcome" }));
 }
+
+describe("shouldReuseSocket", () => {
+  const base = { backgroundedAt: 1_000, windowMs: 10_000 } as const;
+
+  it("keeps a still-connected socket backgrounded inside the window", () => {
+    expect(shouldReuseSocket({ ...base, now: 6_000, status: "connected" })).toBe(true);
+    expect(shouldReuseSocket({ ...base, now: 11_000, status: "connected" })).toBe(true);
+  });
+
+  it("rebuilds once the gap passes the window", () => {
+    expect(shouldReuseSocket({ ...base, now: 11_001, status: "connected" })).toBe(false);
+  });
+
+  it("rebuilds when the socket did not survive the background", () => {
+    expect(shouldReuseSocket({ ...base, now: 2_000, status: "disconnected" })).toBe(false);
+    expect(shouldReuseSocket({ ...base, now: 2_000, status: "connecting" })).toBe(false);
+    expect(shouldReuseSocket({ ...base, now: 2_000, status: "unauthorized" })).toBe(false);
+  });
+
+  it("rebuilds when the clock moved backwards (the gap proves nothing)", () => {
+    expect(shouldReuseSocket({ ...base, now: 500, status: "connected" })).toBe(false);
+  });
+});
 
 describe("createHostConnection", () => {
   beforeEach(() => {
@@ -111,13 +151,14 @@ describe("createHostConnection", () => {
     connection.dispose();
   });
 
-  it("backgrounding disposes the bridge; foregrounding recreates it", () => {
-    const { connection, sockets, lifecycle } = setup();
+  it("a long background disposes the bridge; foregrounding recreates it", () => {
+    const { connection, sockets, lifecycle, advance } = setup();
     connection.start(ENV);
     welcome(lastSocket(sockets));
     expect(connection.getSnapshot().status).toBe("connected");
 
     lifecycle.setState("background");
+    advance(SOCKET_REUSE_WINDOW_MS + 1);
     expect(connection.getSnapshot()).toEqual({ status: "disconnected", envName: "192.168.1.5" });
     expect(connection.getBridge()).toBeNull();
     expect(lastSocket(sockets).closedWith?.code).toBe(1000);
@@ -127,6 +168,64 @@ describe("createHostConnection", () => {
     expect(connection.getSnapshot().status).toBe("connecting");
     welcome(lastSocket(sockets));
     expect(connection.getSnapshot().status).toBe("connected");
+    connection.dispose();
+  });
+
+  it("a brief background keeps the live socket, so nothing in flight is dropped", () => {
+    const { connection, sockets, lifecycle, advance } = setup();
+    connection.start(ENV);
+    welcome(lastSocket(sockets));
+    const bridge = connection.getBridge();
+
+    lifecycle.setState("background");
+    advance(1_000);
+    expect(lastSocket(sockets).closedWith).toBeNull();
+
+    lifecycle.setState("active");
+    advance(SOCKET_REUSE_WINDOW_MS * 2);
+    expect(sockets).toHaveLength(1);
+    expect(connection.getBridge()).toBe(bridge);
+    expect(connection.getSnapshot().status).toBe("connected");
+    connection.dispose();
+  });
+
+  it("a background that outlived the window is not resurrected by a late resume", () => {
+    const { connection, sockets, lifecycle, advance } = setup();
+    connection.start(ENV);
+    welcome(lastSocket(sockets));
+
+    lifecycle.setState("background");
+    advance(SOCKET_REUSE_WINDOW_MS + 1);
+    lifecycle.setState("active");
+    expect(sockets).toHaveLength(2);
+    connection.dispose();
+  });
+
+  it("backgrounding while unauthorized never arms a close that clears it", () => {
+    const { connection, sockets, lifecycle, advance } = setup();
+    connection.start(ENV);
+    lastSocket(sockets).fireClose(4401);
+
+    lifecycle.setState("background");
+    advance(SOCKET_REUSE_WINDOW_MS * 2);
+    expect(connection.getSnapshot().status).toBe("unauthorized");
+
+    lifecycle.setState("active");
+    expect(connection.getSnapshot().status).toBe("unauthorized");
+    expect(sockets).toHaveLength(1);
+    connection.dispose();
+  });
+
+  it("stop() during a background cancels the deferred close", () => {
+    const { connection, sockets, lifecycle, advance } = setup();
+    connection.start(ENV);
+    welcome(lastSocket(sockets));
+    lifecycle.setState("background");
+    connection.stop();
+
+    advance(SOCKET_REUSE_WINDOW_MS * 2);
+    expect(connection.getSnapshot()).toEqual({ status: "none", envName: null });
+    expect(sockets).toHaveLength(1);
     connection.dispose();
   });
 

--- a/apps/mobile/src/lib/host/connection-core.ts
+++ b/apps/mobile/src/lib/host/connection-core.ts
@@ -1,10 +1,17 @@
 // ---------------------------------------------------------------------------
 // The connection owner — one live ws bridge to the saved desktop environment,
-// with app-lifecycle awareness: dispose on background, recreate on foreground
+// with app-lifecycle awareness: drop it on background, recreate on foreground
 // (the bridge's own supervisor handles retries while foregrounded). PURE: the
-// bridge factory and the lifecycle source are injected, so tests drive
-// transitions with fakes; connection.ts binds createWsBridge + React Native's
-// AppState and adds the useSyncExternalStore hook.
+// bridge factory, the lifecycle source, the clock and the timer are injected,
+// so tests drive transitions with fakes; connection.ts binds createWsBridge +
+// React Native's AppState and adds the useSyncExternalStore hook.
+//
+// The background drop is DEFERRED, not immediate. iOS keeps sockets alive
+// briefly across a background (an app switch, a glance at a notification), and
+// tearing the bridge down rejects everything in flight — a chat send made a
+// moment before the phone went to sleep. So `suspend()` records the moment and
+// arms a close; a `resume()` inside the reuse window over a still-connected
+// socket cancels it and keeps the session whole.
 //
 // `unauthorized` is sticky: the host revoked (or lost) our device token, so a
 // foreground resume does NOT re-present the dead credential. The environment
@@ -13,6 +20,7 @@
 // `start()` (fresh pairing, or an explicit retry) clears it.
 // ---------------------------------------------------------------------------
 
+import type { Schedule } from "@repo/bridge/backoff";
 import type { Bridge } from "@repo/bridge/ipc-registry";
 import type { WsBridgeStatus } from "@repo/bridge/ws-bridge";
 import { createExternalStore } from "../external-store";
@@ -20,6 +28,28 @@ import type { KnownEnvironment } from "./environment-store";
 
 /** `none` = no environment started (unpaired or stopped). */
 type HostStatus = "none" | WsBridgeStatus;
+
+/** How long a backgrounded socket is held before it is closed for good. Long
+ * enough to cover an app switch, short enough that a phone left in a pocket
+ * isn't holding a desktop socket open. */
+export const SOCKET_REUSE_WINDOW_MS = 20_000;
+
+/**
+ * May a resume keep the socket it backgrounded with? Only when the gap is
+ * inside the reuse window AND the connection is still up — a socket the OS
+ * (or the host) dropped while we were away must be rebuilt, and a clock that
+ * moved backwards proves nothing, so it rebuilds too.
+ */
+export function shouldReuseSocket(input: {
+  readonly backgroundedAt: number;
+  readonly now: number;
+  readonly windowMs: number;
+  readonly status: HostStatus;
+}): boolean {
+  const gap = input.now - input.backgroundedAt;
+  if (gap < 0 || gap > input.windowMs) return false;
+  return input.status === "connected";
+}
 
 export type HostSnapshot = {
   readonly status: HostStatus;
@@ -59,10 +89,18 @@ export type HostConnection = {
 export function createHostConnection(deps: {
   createBridge: BridgeFactory;
   lifecycle: LifecyclePort;
+  /** Epoch ms. `Date.now` in prod. */
+  now: () => number;
+  /** Timer for the deferred background close. `timeoutSchedule` in prod. */
+  schedule: Schedule;
 }): HostConnection {
   let env: KnownEnvironment | null = null;
   let handle: { bridge: Bridge; dispose: () => void } | null = null;
   let status: HostStatus = "none";
+  /** When the app last went to background with a live bridge; null while
+   * foregrounded. */
+  let backgroundedAt: number | null = null;
+  let cancelDeferredClose: (() => void) | null = null;
   const store = createExternalStore<HostSnapshot>({ status: "none", envName: null });
 
   function publish(): void {
@@ -105,16 +143,51 @@ export function createHostConnection(deps: {
     publish();
   }
 
-  function suspend(): void {
-    if (handle === null) return;
+  /** Drop the deferred-close timer and the background moment it belongs to. */
+  function clearBackground(): void {
+    cancelDeferredClose?.();
+    cancelDeferredClose = null;
+    backgroundedAt = null;
+  }
+
+  function dropBridge(): void {
     closeBridge();
     setStatus("disconnected");
   }
 
+  function suspend(): void {
+    // `unauthorized` keeps its handle (the bridge stops retrying rather than
+    // disposing), so `handle !== null` does not mean there is a live session
+    // to defer. Arming the close there would let it fire and overwrite the
+    // sticky status with `disconnected`, and the next resume would re-present
+    // the credential the host already rejected.
+    if (handle === null || status === "unauthorized" || backgroundedAt !== null) return;
+    backgroundedAt = deps.now();
+    cancelDeferredClose = deps.schedule(() => {
+      cancelDeferredClose = null;
+      dropBridge();
+    }, SOCKET_REUSE_WINDOW_MS);
+  }
+
   function resume(): void {
-    // Recreate only when a started environment is dormant; `unauthorized`
-    // stays terminal until an explicit start().
-    if (env === null || handle !== null || status === "unauthorized") return;
+    const since = backgroundedAt;
+    clearBackground();
+    // `unauthorized` stays terminal until an explicit start().
+    if (env === null || status === "unauthorized") return;
+    if (handle !== null) {
+      // Never suspended (a redundant `active`), or suspended briefly over a
+      // socket that survived — either way there is nothing to rebuild.
+      const keep =
+        since === null ||
+        shouldReuseSocket({
+          backgroundedAt: since,
+          now: deps.now(),
+          windowMs: SOCKET_REUSE_WINDOW_MS,
+          status,
+        });
+      if (keep) return;
+      dropBridge();
+    }
     openBridge(env);
   }
 
@@ -124,6 +197,7 @@ export function createHostConnection(deps: {
   });
 
   function stop(): void {
+    clearBackground();
     closeBridge();
     env = null;
     status = "none";
@@ -132,6 +206,7 @@ export function createHostConnection(deps: {
 
   return {
     start: (nextEnv) => {
+      clearBackground();
       closeBridge();
       env = nextEnv;
       openBridge(nextEnv);

--- a/apps/mobile/src/lib/host/connection.ts
+++ b/apps/mobile/src/lib/host/connection.ts
@@ -1,12 +1,13 @@
 // ---------------------------------------------------------------------------
 // The module-level connection singleton (mirrors ../sync/manager.ts): binds
-// the pure owner in connection-core.ts to the real createWsBridge and the
-// shared app-foreground seam (../app-lifecycle.ts — `active` resumes,
-// `background` suspends), and exposes the React hook.
+// the pure owner in connection-core.ts to the real createWsBridge, the shared
+// app-foreground seam (../app-lifecycle.ts — `active` resumes, `background`
+// suspends) and the platform clock/timer, and exposes the React hook.
 // ---------------------------------------------------------------------------
 
 import { useSyncExternalStore } from "react";
 
+import { timeoutSchedule } from "@repo/bridge/backoff";
 import { createWsBridge } from "@repo/bridge/ws-bridge";
 import type { Bridge } from "@repo/bridge/ipc-registry";
 
@@ -17,6 +18,8 @@ import type { KnownEnvironment } from "./environment-store";
 const connection = createHostConnection({
   createBridge: (options) => createWsBridge(options),
   lifecycle: { subscribe: subscribeAppForeground },
+  now: () => Date.now(),
+  schedule: timeoutSchedule,
 });
 
 /** Connect to a paired environment (replaces any current connection). */
@@ -33,6 +36,17 @@ export function stopHostConnection(): void {
  * Requests made while disconnected queue inside the bridge until reconnect. */
 export function getHostBridge(): Bridge | null {
   return connection.getBridge();
+}
+
+/** The current status + environment name, outside React (the chat outbox
+ * drains off it). */
+export function getHostSnapshot(): HostSnapshot {
+  return connection.getSnapshot();
+}
+
+/** Subscribe to connection changes outside React (the chat outbox). */
+export function subscribeHostStatus(onChange: () => void): () => void {
+  return connection.subscribe(onChange);
 }
 
 /** Subscribe a React component to the connection status + environment name. */

--- a/apps/mobile/src/lib/notes/__tests__/note-save.test.ts
+++ b/apps/mobile/src/lib/notes/__tests__/note-save.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it } from "vitest";
+
+import { saveNote, type NoteIo } from "../note-save";
+
+const STAMP = "2026-07-05T12-34-56-000Z";
+
+function fakeIo(
+  files: Record<string, string>,
+  unreadable: readonly string[] = [],
+): NoteIo & { files: Record<string, string> } {
+  return {
+    files,
+    read: (path) => (unreadable.includes(path) ? null : (files[path] ?? null)),
+    exists: (path) => unreadable.includes(path) || path in files,
+    write: (path, text) => {
+      files[path] = text;
+    },
+  };
+}
+
+function save(io: NoteIo, openedText: string, draft: string, path = "notes/todo.md") {
+  return saveNote({ io, path, openedText, draft, stamp: () => STAMP });
+}
+
+describe("saveNote", () => {
+  it("writes the draft when the file is untouched since it opened", () => {
+    const io = fakeIo({ "notes/todo.md": "one\n" });
+    const outcome = save(io, "one\n", "one\ntwo\n");
+    expect(outcome).toEqual({ kind: "written", text: "one\ntwo\n" });
+    expect(io.files["notes/todo.md"]).toBe("one\ntwo\n");
+  });
+
+  it("recreates a file that vanished while it was open", () => {
+    const io = fakeIo({});
+    expect(save(io, "one\n", "one\ntwo\n").kind).toBe("written");
+    expect(io.files["notes/todo.md"]).toBe("one\ntwo\n");
+  });
+
+  it("keeps a concurrently pulled remote edit when the draft touched another line", () => {
+    // The remote (a sync pass) appended a line while the draft edited the top.
+    const io = fakeIo({ "notes/todo.md": "one\ntwo\nthree\n" });
+    const outcome = save(io, "one\ntwo\n", "ONE\ntwo\n");
+
+    expect(outcome).toEqual({ kind: "merged", text: "ONE\ntwo\nthree\n" });
+    expect(io.files["notes/todo.md"]).toBe("ONE\ntwo\nthree\n");
+  });
+
+  it("unions both tails when the two sides appended to the same note", () => {
+    const io = fakeIo({ "notes/todo.md": "base\nfrom desktop\n" });
+    const outcome = save(io, "base\n", "base\nfrom phone\n");
+
+    expect(outcome.kind).toBe("merged");
+    expect(io.files["notes/todo.md"]).toContain("from desktop");
+    expect(io.files["notes/todo.md"]).toContain("from phone");
+  });
+
+  it("preserves BOTH sides as a conflict copy when the ladder refuses", () => {
+    // Same line rewritten differently on both sides — no rung can fold that.
+    const io = fakeIo({ "notes/todo.md": "the remote line\n" });
+    const outcome = save(io, "the base line\n", "the draft line\n");
+
+    expect(outcome).toEqual({
+      kind: "forked",
+      text: "the remote line\n",
+      copyPath: `notes/todo (conflict ${STAMP}).md`,
+      cause: "unmergeable",
+    });
+    expect(io.files["notes/todo.md"]).toBe("the remote line\n");
+    expect(io.files[`notes/todo (conflict ${STAMP}).md`]).toBe("the draft line\n");
+  });
+
+  it("leaves a present-but-unreadable note alone and preserves the draft beside it", () => {
+    const io = fakeIo({ "notes/todo.md": "unreadable bytes\n" }, ["notes/todo.md"]);
+    const outcome = save(io, "one\n", "one\ntwo\n");
+
+    expect(outcome).toEqual({
+      kind: "forked",
+      text: "one\n",
+      copyPath: `notes/todo (conflict ${STAMP}).md`,
+      cause: "unreadable",
+    });
+    expect(io.files["notes/todo.md"]).toBe("unreadable bytes\n");
+    expect(io.files[`notes/todo (conflict ${STAMP}).md`]).toBe("one\ntwo\n");
+  });
+
+  it("never drops the remote edit, whichever way the save lands", () => {
+    const io = fakeIo({ "notes/todo.md": "remote only\n" });
+    save(io, "opened\n", "draft only\n");
+    const everything = Object.values(io.files).join("\n");
+    expect(everything).toContain("remote only");
+    expect(everything).toContain("draft only");
+  });
+});

--- a/apps/mobile/src/lib/notes/note-save.ts
+++ b/apps/mobile/src/lib/notes/note-save.ts
@@ -1,0 +1,113 @@
+// ---------------------------------------------------------------------------
+// Saving one edited note WITHOUT clobbering a concurrent change to the same
+// file. The editor reads a note's bytes when it opens and writes the draft
+// back on Save; a sync pass landing a newer version in between is invisible to
+// the sync engine — base, local and remote all line up, so the write looks
+// like a clean local edit and the pulled version is simply lost.
+//
+// So the check lives here: re-read at save time and compare against the bytes
+// the editor opened. Unchanged → a plain write. Changed → the SAME merge
+// ladder the engine runs (@repo/notes/sync/merge/ladder) over
+// {openedText, draft, currentDisk}, so the product has ONE merge behaviour;
+// and when the ladder refuses, the engine's own answer — a conflict-copy
+// sibling — rather than picking a side. Nothing is ever overwritten unseen.
+//
+// A file that cannot be READ is not a file that is GONE. Absence means the
+// draft is the only copy of that text anywhere, so it is written; an
+// unreadable file may hold anything, so the draft goes beside it and the note
+// itself is left alone. Collapsing the two overwrites content nobody saw.
+//
+// PURE over an injected `NoteIo` + stamp, so it unit-tests on node; the expo
+// wiring is the caller's (the note screen's vault-access read/write).
+// ---------------------------------------------------------------------------
+
+import { mergeLadder } from "@repo/notes/sync/merge/ladder";
+import { conflictCopyName } from "@repo/notes/sync/reconcile";
+import type { VaultPath } from "@repo/notes/sync/vault-file";
+
+/** The vault operations a save needs, all synchronous. */
+export type NoteIo = {
+  /** Raw file text, or null when it is missing OR unreadable — `exists`
+   * separates those two. */
+  read: (path: VaultPath) => string | null;
+  /** Whether a file is on disk at all, whatever its bytes. */
+  exists: (path: VaultPath) => boolean;
+  /** Write text, creating parent directories as needed. */
+  write: (path: VaultPath, text: string) => void;
+};
+
+/** Why the draft went to a sibling copy instead of into the note. */
+type ForkCause =
+  /** The note changed underneath and no rung of the ladder could fold both. */
+  | "unmergeable"
+  /** The note is on disk but unreadable, so nothing may be assumed about it. */
+  | "unreadable";
+
+export type SaveOutcome =
+  /** No concurrent change: the draft is the file. */
+  | { readonly kind: "written"; readonly text: string }
+  /** The ladder folded both sides together; `text` is what the file now holds. */
+  | { readonly kind: "merged"; readonly text: string }
+  /** The draft is preserved at `copyPath`; `text` is what the screen should now
+   * show at `path` — the concurrent version, or the opened bytes when the file
+   * could not be read. */
+  | {
+      readonly kind: "forked";
+      readonly text: string;
+      readonly copyPath: VaultPath;
+      readonly cause: ForkCause;
+    };
+
+const encoder = new TextEncoder();
+const decoder = new TextDecoder();
+
+export function saveNote(input: {
+  readonly io: NoteIo;
+  readonly path: VaultPath;
+  /** The exact text read when the editor opened — the merge BASE. */
+  readonly openedText: string;
+  readonly draft: string;
+  /** Filesystem-safe timestamp for a conflict-copy name (sync/clock.ts). */
+  readonly stamp: () => string;
+}): SaveOutcome {
+  const { io, path, openedText, draft } = input;
+  const current = io.read(path);
+
+  if (current === null && io.exists(path)) {
+    return fork(input, openedText, "unreadable");
+  }
+
+  // A vanished file is recreated from the draft rather than treated as a
+  // remote delete to honour: the user's unsaved words are the only copy of
+  // that text anywhere, and sync resurrects nothing.
+  if (current === null || current === openedText) {
+    io.write(path, draft);
+    return { kind: "written", text: draft };
+  }
+
+  const merged = mergeLadder({
+    base: { kind: "bytes", bytes: encoder.encode(openedText) },
+    local: encoder.encode(draft),
+    remote: encoder.encode(current),
+  });
+  if (merged.kind === "merged") {
+    const text = decoder.decode(merged.bytes);
+    io.write(path, text);
+    return { kind: "merged", text };
+  }
+
+  // The path keeps the side already on disk — the engine's tiebreak, since
+  // that side is what the other devices converged on — and the draft is
+  // preserved beside it. The note itself is never rewritten here.
+  return fork(input, current, "unmergeable");
+}
+
+function fork(
+  input: { io: NoteIo; path: VaultPath; draft: string; stamp: () => string },
+  text: string,
+  cause: ForkCause,
+): SaveOutcome {
+  const copyPath = conflictCopyName(input.path, input.stamp());
+  input.io.write(copyPath, input.draft);
+  return { kind: "forked", text, copyPath, cause };
+}

--- a/apps/mobile/src/lib/sync/__tests__/fakes.ts
+++ b/apps/mobile/src/lib/sync/__tests__/fakes.ts
@@ -58,6 +58,7 @@ export function memVaultFs(): MemVault {
       for (const [name, isDirectory] of children) entries.push({ name, isDirectory });
       return entries;
     },
+    exists: (path) => files.has(path),
     readBytes: (path) => {
       const bytes = files.get(path);
       if (bytes === undefined) throw new Error(`memVaultFs: read of absent ${path}`);

--- a/apps/mobile/src/lib/sync/__tests__/sync-io.test.ts
+++ b/apps/mobile/src/lib/sync/__tests__/sync-io.test.ts
@@ -134,6 +134,7 @@ describe("incomplete subtree", () => {
       if (relDir === "notes") throw new VaultListingIncompleteError("notes");
       return [];
     },
+    exists: () => false,
     readBytes: () => new Uint8Array(),
     writeBytes: () => {},
     remove: () => {},

--- a/apps/mobile/src/lib/sync/expo-base-file.ts
+++ b/apps/mobile/src/lib/sync/expo-base-file.ts
@@ -1,29 +1,28 @@
 // ---------------------------------------------------------------------------
 // The Expo File-API backing for the BaseStore's `JsonFile` port — a single JSON
 // file at `${Paths.document}/sync-base.json` holding the last-synced base
-// manifest. Uses the synchronous File API; a fresh instance per call so `exists`
-// reflects current state.
+// manifest.
+//
+// The anchor is a pure CACHE of the last sync, so an unreadable file reads the
+// same as an absent one: `null`, and the next pass rebuilds from empty. Only a
+// store holding the user's own words (the chat outbox) needs the two apart.
 // ---------------------------------------------------------------------------
 
-import { File, Paths } from "expo-file-system";
-
 import type { JsonFile } from "@repo/notes/sync/base-store";
+
+import { createExpoJsonFile } from "../expo-json-file";
 
 /** The base-manifest filename under the app's document directory. */
 const BASE_FILE = "sync-base.json";
 
 /** A `JsonFile` backed by Expo's synchronous File API. */
 export function createExpoBaseFile(): JsonFile {
-  const make = () => new File(Paths.document, BASE_FILE);
+  const file = createExpoJsonFile(BASE_FILE);
   return {
     read: () => {
-      const file = make();
-      return file.exists ? file.textSync() : null;
+      const result = file.read();
+      return result.kind === "text" ? result.text : null;
     },
-    write: (text) => {
-      const file = make();
-      file.create({ intermediates: true, overwrite: true });
-      file.write(text);
-    },
+    write: file.write,
   };
 }

--- a/apps/mobile/src/lib/sync/expo-vault-fs.ts
+++ b/apps/mobile/src/lib/sync/expo-vault-fs.ts
@@ -70,6 +70,7 @@ export function createExpoVaultFs(): VaultFs {
         isDirectory: entry instanceof Directory,
       }));
     },
+    exists: (path) => fileFor(path).exists,
     readBytes: (path) => fileFor(path).bytesSync(),
     writeBytes: (path, bytes) => {
       const file = fileFor(path);

--- a/apps/mobile/src/lib/sync/sync-io.ts
+++ b/apps/mobile/src/lib/sync/sync-io.ts
@@ -77,6 +77,10 @@ export type VaultFs = {
    * `VaultListingIncompleteError` for a sub-dir. Either way an empty or partial
    * listing would reconcile as deletions. */
   listDir(relDir: string): readonly VaultEntry[];
+  /** Whether a file is on disk at all, whatever its bytes. Distinct from a
+   * successful `readBytes`: an unreadable file still exists, and treating the
+   * two the same lets a caller overwrite content it never saw. */
+  exists(path: VaultPath): boolean;
   /** Raw bytes of a vault file. */
   readBytes(path: VaultPath): Uint8Array;
   /** Write raw bytes, creating any missing parent directories. */

--- a/apps/mobile/src/lib/sync/vault-access.ts
+++ b/apps/mobile/src/lib/sync/vault-access.ts
@@ -9,7 +9,8 @@ import type { VaultPath } from "@repo/notes/sync/vault-file";
 import { createExpoVaultFs } from "./expo-vault-fs";
 import { createSyncIo, VaultListingIncompleteError, VaultRootMissingError } from "./sync-io";
 
-const io = createSyncIo(createExpoVaultFs());
+const fs = createExpoVaultFs();
+const io = createSyncIo(fs);
 const encoder = new TextEncoder();
 const decoder = new TextDecoder();
 
@@ -31,9 +32,26 @@ export function listVaultFiles(): VaultPath[] {
   }
 }
 
-/** Read a vault file as UTF-8 text. */
-export function readVaultText(path: VaultPath): string {
-  return decoder.decode(io.read(path));
+/** Read a vault file as UTF-8 text, or null when it is missing or unreadable.
+ * Absence is a normal state for every caller here — quick capture seeds from a
+ * template, the note editor treats it as "not on this device yet" — so the
+ * missing case is a value, not a throw. Pair with `vaultFileExists` where the
+ * two failures mean different things. */
+export function readVaultTextOrNull(path: VaultPath): string | null {
+  try {
+    return decoder.decode(io.read(path));
+  } catch {
+    return null;
+  }
+}
+
+/** Whether a vault file is on disk, whatever its bytes. */
+export function vaultFileExists(path: VaultPath): boolean {
+  try {
+    return fs.exists(path);
+  } catch {
+    return false;
+  }
 }
 
 /** Write UTF-8 text to a vault file, creating parent directories as needed. */

--- a/apps/mobile/vitest.config.ts
+++ b/apps/mobile/vitest.config.ts
@@ -4,10 +4,11 @@ import { defineConfig } from "vitest/config";
 // Node-only tests for the PURE modules: the sync adapters (path/recursion,
 // base-store JSON, clock format) plus an end-to-end SyncEngine pass, and the
 // host-connection runtime (environment store, pairing handshake, connection
-// owner over the iso @repo/bridge ws client), and the quick-capture append
-// path (daily-capture over an injected CaptureIo). Tests import only pure
-// modules + @repo/notes + iso @repo/bridge — never the `expo-*` /
-// react-native wiring — so nothing here needs a real device or native module.
+// owner over the iso @repo/bridge ws client), the quick-capture append path
+// (daily-capture over an injected CaptureIo), the chat outbox queue model, and
+// the note-save merge. Tests import only pure modules + @repo/notes + iso
+// @repo/bridge — never the `expo-*` / react-native wiring — so nothing here
+// needs a real device or native module.
 //
 // The engine test reaches @repo/notes's coordinator fake by a relative path that
 // climbs to the monorepo root, so allow fs access up there.
@@ -20,6 +21,8 @@ export default defineConfig({
       "src/lib/sync/__tests__/**/*.test.ts",
       "src/lib/host/__tests__/**/*.test.ts",
       "src/lib/capture/__tests__/**/*.test.ts",
+      "src/lib/chat/__tests__/**/*.test.ts",
+      "src/lib/notes/__tests__/**/*.test.ts",
     ],
     // Monorepo worker budget (see apps/desktop/vitest.config.ts).
     maxWorkers: 1,

--- a/packages/bridge/src/chat-message.ts
+++ b/packages/bridge/src/chat-message.ts
@@ -18,6 +18,11 @@ export type ImageAttachment = Static<typeof ImageAttachmentSchema>;
 const TextWithImagesObject = {
   text: Type.String(),
   images: Type.Optional(Type.Array(ImageAttachmentSchema)),
+  // A sender that may retry (the mobile outbox: a phone backgrounds mid-request
+  // and cannot know whether the host ran the turn) mints this before the first
+  // attempt and reuses it, so the host can drop the repeat instead of running
+  // the message twice. Senders that never retry omit it.
+  clientId: Type.Optional(Type.String({ minLength: 1 })),
 };
 
 /** Messages sent between renderer and agent over the Bridge. */

--- a/packages/notes/package.json
+++ b/packages/notes/package.json
@@ -9,6 +9,7 @@
     "./sync/manifest": "./src/sync/manifest.ts",
     "./sync/sync-port": "./src/sync/sync-port.ts",
     "./sync/reconcile": "./src/sync/reconcile.ts",
+    "./sync/merge/ladder": "./src/sync/merge/ladder.ts",
     "./sync/wire": "./src/sync/wire.ts",
     "./sync/crawl-exclusions": "./src/sync/crawl-exclusions.ts",
     "./sync/testing/in-memory-sync-port": "./src/sync/__tests__/in-memory-sync-port.ts",

--- a/packages/server/src/__tests__/agent-gateway.test.ts
+++ b/packages/server/src/__tests__/agent-gateway.test.ts
@@ -75,6 +75,43 @@ describe("agent-gateway", () => {
     );
   });
 
+  it("runs a repeated clientId only once", async () => {
+    const agent = makeAgent();
+    getAgent.mockReturnValue(agent);
+
+    await gw.dispatchAgentCommand({ type: "user_message", text: "hi", clientId: "m1" });
+    await gw.dispatchAgentCommand({ type: "user_message", text: "hi", clientId: "m1" });
+    await gw.dispatchAgentCommand({ type: "user_message", text: "hi", clientId: "m2" });
+
+    expect(agent.sendMessage).toHaveBeenCalledTimes(2);
+  });
+
+  it("keeps a command retryable when the dispatch itself failed", async () => {
+    const agent = makeAgent();
+    agent.sendMessage.mockRejectedValueOnce(new Error("boom"));
+    getAgent.mockReturnValue(agent);
+
+    await expect(
+      gw.dispatchAgentCommand({ type: "user_message", text: "hi", clientId: "m1" }),
+    ).rejects.toThrow("boom");
+    await gw.dispatchAgentCommand({ type: "user_message", text: "hi", clientId: "m1" });
+
+    expect(agent.sendMessage).toHaveBeenCalledTimes(2);
+  });
+
+  it("forgets the oldest ids rather than remembering every id forever", async () => {
+    const agent = makeAgent();
+    getAgent.mockReturnValue(agent);
+
+    // One past the window, so the first id has been evicted by the last.
+    for (let i = 0; i <= 256; i++) {
+      await gw.dispatchAgentCommand({ type: "user_message", text: "x", clientId: `m${i}` });
+    }
+    await gw.dispatchAgentCommand({ type: "user_message", text: "x", clientId: "m0" });
+
+    expect(agent.sendMessage).toHaveBeenCalledTimes(258);
+  });
+
   it("rejects outside ready even while the old agent is still published (RESET teardown window)", async () => {
     // During RESET the machine flips to setting_up BEFORE the effect stops the
     // agent, so getAgent() still returns the doomed instance — the phase gate

--- a/packages/server/src/app/agent-gateway.ts
+++ b/packages/server/src/app/agent-gateway.ts
@@ -6,6 +6,12 @@
 // the IPC handler never reaches into app-machine directly, and a second writer
 // (mobile relay, widget prompt, external chat) gets one obvious place to
 // reintroduce serialization instead of racing the session.
+//
+// It is also where a RETRY is made safe. A remote sender whose socket dies
+// mid-request cannot know whether the turn ran, so it re-sends under the same
+// `clientId`; delivering it twice would run the message twice. Ids are
+// remembered only once the command actually reached the agent — a rejected
+// dispatch never happened, and must stay retryable.
 // ---------------------------------------------------------------------------
 
 import { getAgent, getAppState } from "./app-machine";
@@ -15,6 +21,21 @@ import type { ImageAttachment, TextChatMessage } from "@repo/bridge/chat-message
 /** Project IPC ImageAttachment payloads to pi-ai's ImageContent block shape. */
 export function toImageContent(images: ImageAttachment[] | undefined): ImageContent[] | undefined {
   return images?.map((i) => ({ type: "image", data: i.data, mimeType: i.mimeType }));
+}
+
+/** How many delivered client ids stay remembered. A retry follows its original
+ * by seconds, so this only has to outlive a reconnect — it is a bounded
+ * window, deliberately not a set that grows for the process lifetime. */
+const DELIVERED_ID_WINDOW = 256;
+
+/** Insertion-ordered, so the oldest id is the one evicted when it overflows. */
+const deliveredIds = new Set<string>();
+
+function rememberDelivered(clientId: string): void {
+  deliveredIds.add(clientId);
+  if (deliveredIds.size <= DELIVERED_ID_WINDOW) return;
+  const oldest = deliveredIds.values().next();
+  if (!oldest.done) deliveredIds.delete(oldest.value);
 }
 
 /** Apply an interactive command to the live agent. The returned promise settles
@@ -33,6 +54,9 @@ export async function dispatchAgentCommand(command: TextChatMessage): Promise<vo
   // briefly null (e.g. mid newSession/stopAgent) didn't reach it, so awaiters
   // must not treat it as submitted.
   if (!agent) throw new Error("Agent unavailable");
+  // An interrupt carries no id: it is idempotent, so a repeat costs nothing.
+  const clientId = command.type === "interrupt" ? undefined : command.clientId;
+  if (clientId !== undefined && deliveredIds.has(clientId)) return;
   switch (command.type) {
     case "user_message":
       await agent.sendMessage(command.text, toImageContent(command.images));
@@ -47,4 +71,5 @@ export async function dispatchAgentCommand(command: TextChatMessage): Promise<vo
       await agent.interrupt();
       break;
   }
+  if (clientId !== undefined) rememberDelivered(clientId);
 }


### PR DESCRIPTION
Closes #517 and #518. Both surfaced by reading our sync path against pingdotgg/t3code's — they are our bugs, not imported patterns.

## #517 — a note edit could be silently overwritten

The mobile editor read a note's bytes once on open and wrote the draft back whole. A version pulled while the note sat open was lost.

**The engine could not catch this, and it is not the engine's fault.** Base, local and remote all line up — the screen hands it a write that looks like a clean local edit. There is nothing to detect. The fix is at the screen.

Save now re-reads and compares against the exact bytes read at open. Unchanged → write as before. Changed → the **same merge ladder the engine uses** (not a second merge implementation). Ladder refuses → the other device's version keeps the path and yours is written to a conflict copy, because a screen should not be more destructive than the engine beneath it.

## #518 — chat sends were dropped on background

The connection owner tears the bridge down on every background by design, and that path rejects queued requests. Phones background constantly.

Messages now persist before dispatch and retry with the shared backoff. Each carries a **client id the host drops on repeat** — that is what makes retrying an ambiguous send safe instead of a way to run the same turn twice. The dedupe window is bounded (256, oldest evicted) and an id is remembered only once the command actually reached the agent, so a rejected dispatch stays retryable.

## What review caught, and why it mattered

Three of the findings were **the same class of bug we were fixing, reintroduced through a different door**:

- **The command kind was frozen at enqueue.** pi's `followUp` does not start a turn — it is delivered at a turn boundary. Agent busy → you send → connection blips → turn ends → reconnect → the outbox delivers `follow_up` to an *idle* agent. The invoke resolves, the entry is removed, the UI looks fine, and the message waits forever. The kind is no longer persisted; the host decides from live state at dispatch.
- **The queue file was empty on disk mid-write**, on every state transition, and the parser read unparseable as `[]`. The durability claim rested on a non-atomic write. Now a temp sibling is renamed over the target; a crash inside the rename leaves the payload at the temp name and the next read adopts it; present-but-unreadable is quarantined and reported rather than silently becoming an empty queue.
- **The transcript showed a message before the host had it**, then lost it when a reconnect replaced the log with the host's history. Queued entries now render as themselves and cross into the log on acknowledgement. A late fix also folds messages acked since the in-flight history request was issued, because the host serves history off the session file while a dispatch has only *fired* the turn — so a history served right after an ack legitimately predates it, and the ordering is a coin flip.

Also fixed: the outbox drained only after `/chat` had been visited; `suspend()` armed a deferred close while `unauthorized`; `saveNote` treated every read failure as "file vanished" and overwrote; the conflict banner stranded the user with a machine-generated filename and no way to their own text.

## Verification

`pnpm verify` exit 0. Mobile suite 119 tests across 11 files. Two review rounds, three reviewer passes.

## Known

The dedupe window is per-process — a host restart forgets every id, so a retry spanning a desktop restart can still duplicate a turn. Persisting it needs a store and a threat model that were out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents losing note edits and chat messages on mobile. Note saves now merge with concurrent changes; chat sends persist, retry, and dedupe on the host.

- **Bug Fixes**
  - Notes: Save re-reads the file and merges via `@repo/notes/sync/merge/ladder`. If unmergeable or unreadable, the on-disk version stays and your draft is saved to a timestamped conflict copy; a sticky banner links to it.
  - Chat delivery: Messages go through a durable outbox loaded at app start, are persisted before dispatch, retried with shared backoff, and render as “queued” until the host ACK. Queue writes are atomic; unreadable files are quarantined and surfaced, not treated as empty.
  - Connection handling: Background socket close is deferred (20s reuse window) and canceled on quick resume; no deferred close while `unauthorized`. The outbox drains even if `/chat` is never opened.
  - Host dedupe: Added optional `clientId` to `@repo/bridge` chat messages; the server drops repeats with a bounded window and remembers IDs only after a successful dispatch.

<sup>Written for commit 70153ac473d931b4ea13eaef83864f7a7f0ccf32. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kyh/inteligir/pull/521?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

