### PR TITLE
feat(transport): classify remote endpoints, and bind one interface

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -378,10 +378,56 @@ in Settings → Routines (list, add/edit, enable, Run now, Restore last run).
 
 ### Remote access — `packages/server/src/transport/`
 
-Off by default. When enabled (Settings → Remote access) the ws host binds
-0.0.0.0 instead of loopback and a phone pairs with a one-time token, minting a
-revocable device token; `remote-access-manager.ts` owns the device roster, and
-a revoke closes the live socket, not just future auths.
+Off by default. When enabled (Settings → Remote access) the ws host also binds
+the configured `bindAddress` (default 0.0.0.0, every interface) and a phone
+pairs with a one-time token, minting a revocable device token;
+`remote-access-manager.ts` owns the device roster, and a revoke closes the live
+socket, not just future auths.
+
+Loopback ALWAYS gets its own listener, is bound FIRST, and never depends on
+anything after it — the renderer dials 127.0.0.1 every launch, so a pinned
+address that vanished (overlay dropped, laptop roamed) must degrade to a
+loopback-only bind, not take the window offline. Every address after loopback
+is best-effort and reports through `setListening`'s error string. The host list
+is re-resolved from the LIVE interface table on every attempt (`targetBind`
+holds config only, purely for change detection), so a retry can never replay a
+dead host forever; every bind, rebind and retry is serialized by one chain that
+`close()` awaits. One ws server (`noServer`) fed by one HTTP listener per bound
+address keeps client tracking, the liveness sweep and teardown single-sourced.
+
+**The bind REPORTS what it bound; nothing downstream re-derives it.**
+`setListening` carries the addresses that actually came up, the manager keeps
+them as `boundAddresses`, and reachability — the Settings list, the pairing
+offer — is filtered on that alone. Re-resolving the config against the live
+interface table is what let an address the server never bound (booted before
+Tailscale was up) be offered as the one reachable, encrypted URL with nothing
+listening on it. Because the config is only a REQUEST, asking for it again is
+the recovery: an in-memory `revision` on the config makes re-selecting the
+already-pinned address compare as a change, so `sameBind` forces the rebind,
+and Settings offers that as "Listen on it now" beside the pinned-but-unbound
+copy (a different condition from an address the interface table no longer
+holds at all).
+
+`network-endpoints.ts` classifies each IPv4 interface as loopback / lan /
+private-network (IPv4-only is a stated constraint in that module's header, not
+an oversight). private-network requires BOTH the 100.64.0.0/10 CGNAT range AND
+a `255.255.255.255` netmask: 100.64/10 is carrier-grade NAT space, so Starlink,
+carrier tethering and campus/pod networks lease real subnets out of it over
+plaintext hops, and only the /32 corroborates the point-to-point overlay
+(Tailscale). Detected by RANGE + MASK, never by interface name. Only that tier
+reports `encrypted: true`, because plain LAN `ws://` is not, and that flag is
+what the Settings copy tells the user about their security. Hypervisor/container
+adapters (`bridge100`, `vmnet`, `docker`, `veth`…) bind fine but reach nobody,
+so they are flagged `virtual`, ranked last, labelled `(virtual)` — and they
+disqualify the overlay claim outright, since several CNIs hand pods a /32 out of
+100.64/10 and would otherwise reproduce its whole signature over a cleartext
+bridge. Pairing drops virtual endpoints and ORDERS the rest encrypted-first, but
+never filters a real one: a phone off the tailnet still needs the LAN fallback to
+pair at all. Each offered URL is its OWN labelled, select-all line — the
+companion's pairing input takes the first url in the pasted text, so an
+or-joined blob hands a phone on the wrong network an address it cannot reach.
+Binding the overlay address alone is what retires the deferred-TLS story: the
+transport is already encrypted and peer-authenticated.
 
 A paired device is NOT the renderer. It reaches only
 `REMOTE_ALLOWED_METHODS` / `REMOTE_ALLOWED_EVENTS`

--- a/apps/desktop/dev/fixture-bridge.ts
+++ b/apps/desktop/dev/fixture-bridge.ts
@@ -19,7 +19,12 @@ import { GHOST_TEXT_ENABLED_UI_STATE, type AiIntent } from "@repo/bridge/inline-
 import type { ChatHistoryEntry } from "@repo/bridge/chat-log";
 import type { ChatSessionSummary } from "@repo/bridge/chat-sessions";
 import type { Bridge, SkillInfo, VaultEntry } from "@repo/bridge/ipc-registry";
-import type { RemoteAccessState } from "@repo/bridge/remote-access";
+import {
+  BIND_ALL_ADDRESS,
+  endpointAddress,
+  type RemoteAccessState,
+  type RemoteEndpoint,
+} from "@repo/bridge/remote-access";
 import type { ListRoutinesResult, Routine } from "@repo/bridge/routines";
 import {
   DAILY_FOLDER_KEY,
@@ -725,13 +730,65 @@ export function createFixtureBridge(openKnowledgeStore: (root: string) => Knowle
   let syncPasses = 0;
   let syncDeletionsConfirmed = false;
   // Remote access — no ws server runs in a browser tab, so enabling simulates
-  // the listening state and a LAN URL; one pre-paired device makes the device
-  // list + Revoke exercisable out of the box.
+  // the listening state; one endpoint of each reachability makes the bind
+  // picker (and its encrypted/cleartext copy) exercisable, and one pre-paired
+  // device does the same for the device list + Revoke.
+  const fixtureEndpoints: readonly RemoteEndpoint[] = [
+    {
+      wsUrl: "ws://100.101.102.103:47890",
+      reachability: "private-network",
+      encrypted: true,
+      virtual: false,
+      label: "Tailscale",
+    },
+    {
+      wsUrl: "ws://192.168.1.24:47890",
+      reachability: "lan",
+      encrypted: false,
+      virtual: false,
+      label: "en0 192.168.1.24",
+    },
+    {
+      wsUrl: "ws://172.17.0.1:47890",
+      reachability: "lan",
+      encrypted: false,
+      virtual: true,
+      label: "docker0 172.17.0.1 (virtual)",
+    },
+    {
+      wsUrl: "ws://127.0.0.1:47890",
+      reachability: "loopback",
+      encrypted: false,
+      virtual: false,
+      label: "This computer",
+    },
+  ];
+  const FIXTURE_LOOPBACK = "127.0.0.1";
+  // The overlay address stands in for the one that is not up yet when the app
+  // starts listening — the whole reason a pinned address can be reported by
+  // the interface table and still be bound by nothing. Pinning to it binds
+  // nothing; re-selecting it ("Listen on it now") does, which is the recovery
+  // the host buys with the config revision.
+  const FIXTURE_LATE_ADDRESS = "100.101.102.103";
+  let lateAddressBound = false;
+
+  // What a host would report binding for a given config — loopback always, the
+  // pin only when it actually came up. Modelled rather than derived from the
+  // config at read time, which is the disagreement the whole surface turns on.
+  const fixtureBoundAddresses = (enabled: boolean, bindAddress: string): readonly string[] => {
+    if (!enabled || bindAddress === FIXTURE_LOOPBACK) return [FIXTURE_LOOPBACK];
+    if (bindAddress === BIND_ALL_ADDRESS) return [BIND_ALL_ADDRESS];
+    if (bindAddress === FIXTURE_LATE_ADDRESS && !lateAddressBound) return [FIXTURE_LOOPBACK];
+    const held = fixtureEndpoints.some((endpoint) => endpointAddress(endpoint) === bindAddress);
+    return held ? [FIXTURE_LOOPBACK, bindAddress] : [FIXTURE_LOOPBACK];
+  };
   let remoteAccessState: RemoteAccessState = {
     enabled: false,
     port: 47890,
     listening: false,
-    lanUrls: [],
+    endpoints: fixtureEndpoints,
+    bindAddress: BIND_ALL_ADDRESS,
+    boundAddresses: fixtureBoundAddresses(false, BIND_ALL_ADDRESS),
     devices: [
       {
         id: "fixture-device",
@@ -1772,25 +1829,48 @@ export function createFixtureBridge(openKnowledgeStore: (root: string) => Knowle
     onSocialSignInResult: socialResultEvents.subscribe,
 
     // Remote access — simulated ws-server state so the settings section is
-    // drivable: toggling flips listening + LAN URLs, pairing returns a fixed
-    // token, revoking drops the pre-paired fixture device.
+    // drivable: toggling flips listening, the bind selection round-trips
+    // through the same bound-address model the host reports, pairing hands
+    // back every URL those bound addresses can reach (encrypted first, virtual
+    // adapters dropped, like the host does), revoking drops the pre-paired
+    // fixture device.
     getRemoteAccessState: async () => remoteAccessState,
     setRemoteAccessConfig: async (patch) => {
       const enabled = patch.enabled ?? remoteAccessState.enabled;
+      const bindAddress = patch.bindAddress ?? remoteAccessState.bindAddress;
+      // Asking for the address already selected is the forced rebind, and it
+      // is what brings the late address up.
+      lateAddressBound = enabled && bindAddress === remoteAccessState.bindAddress;
       remoteAccessState = {
         ...remoteAccessState,
         enabled,
         listening: enabled,
-        lanUrls: enabled ? [`ws://192.168.1.24:${remoteAccessState.port}`] : [],
+        bindAddress,
+        boundAddresses: fixtureBoundAddresses(enabled, bindAddress),
       };
       emitRemoteAccess();
       return remoteAccessState;
     },
-    createPairingToken: async () => ({
-      token: "fixture-pairing-token",
-      urls: ["ws://127.0.0.1:47890"],
-      expiresAt: new Date(Date.now() + 10 * 60 * 1000).toISOString(),
-    }),
+    createPairingToken: async () => {
+      const { boundAddresses, endpoints } = remoteAccessState;
+      const offered = endpoints
+        .filter(
+          (endpoint) =>
+            endpoint.reachability !== "loopback" &&
+            !endpoint.virtual &&
+            (boundAddresses.includes(BIND_ALL_ADDRESS) ||
+              boundAddresses.includes(endpointAddress(endpoint))),
+        )
+        .toSorted((a, b) => Number(b.encrypted) - Number(a.encrypted));
+      return {
+        token: "fixture-pairing-token",
+        urls:
+          offered.length > 0
+            ? offered.map((endpoint) => ({ wsUrl: endpoint.wsUrl, label: endpoint.label }))
+            : [{ wsUrl: "ws://127.0.0.1:47890", label: "This computer" }],
+        expiresAt: new Date(Date.now() + 10 * 60 * 1000).toISOString(),
+      };
+    },
     revokeRemoteDevice: async ({ id }) => {
       remoteAccessState = {
         ...remoteAccessState,

--- a/apps/desktop/src/renderer/settings/sections/remote-access-section.tsx
+++ b/apps/desktop/src/renderer/settings/sections/remote-access-section.tsx
@@ -1,17 +1,24 @@
 import { useCallback, useEffect, useState } from "react";
 import { Button } from "@repo/ui/components/button";
 import { Label } from "@repo/ui/components/label";
+import { NativeSelect, NativeSelectOption } from "@repo/ui/components/native-select";
 
 import { getBridge } from "@renderer/lib/bridge";
 import { SettingSwitchRow } from "@renderer/settings/sections/setting-switch-row";
-import type { PairingInfo, RemoteAccessState } from "@repo/bridge/remote-access";
+import {
+  BIND_ALL_ADDRESS,
+  endpointAddress,
+  type PairingInfo,
+  type RemoteAccessState,
+} from "@repo/bridge/remote-access";
 
 // Remote access — let other devices (the mobile companion) connect to this
-// computer's ws transport. The host owns everything: the enable toggle flips
-// the server's bind address, devices live in the paired-device store, and
-// pairing tokens are minted host-side. The onRemoteAccessChanged subscription
-// keeps this reactive across config/device/listen changes. Pairing info is
-// kept local (transient) — it's a one-time secret shown once, not state.
+// computer's ws transport. The host owns everything: the enable toggle and the
+// network selection flip the server's bind, devices live in the paired-device
+// store, and pairing tokens are minted host-side. The onRemoteAccessChanged
+// subscription keeps this reactive across config/device/listen changes.
+// Pairing info is kept local (transient) — it's a one-time secret shown once,
+// not state.
 export function RemoteAccessSection() {
   const [state, setState] = useState<RemoteAccessState | null>(null);
   const [pairing, setPairing] = useState<PairingInfo | null>(null);
@@ -36,6 +43,17 @@ export function RemoteAccessSection() {
       setState(updated);
     } catch {
       setError("Failed to update remote access.");
+    }
+  }, []);
+
+  const handleBind = useCallback(async (address: string) => {
+    const bridge = getBridge();
+    setError(null);
+    setPairing(null);
+    try {
+      setState(await bridge.setRemoteAccessConfig({ bindAddress: address }));
+    } catch {
+      setError("Failed to change the network.");
     }
   }, []);
 
@@ -68,8 +86,31 @@ export function RemoteAccessSection() {
 
   const loading = state === null;
   const enabled = state?.enabled === true;
-  const lanUrls = state?.lanUrls ?? [];
   const devices = state?.devices ?? [];
+  const bindAddress = state?.bindAddress ?? BIND_ALL_ADDRESS;
+  // Loopback is always bound and is not a remote choice — offering it would
+  // mean "reachable by nobody", which is what the toggle already says.
+  const bindable = (state?.endpoints ?? []).filter(
+    (endpoint) => endpoint.reachability !== "loopback",
+  );
+  const bindsAll = bindAddress === BIND_ALL_ADDRESS;
+  const selected = bindable.find((endpoint) => endpointAddress(endpoint) === bindAddress) ?? null;
+  // What the host REPORTED binding, never what the selection implies: the two
+  // differ whenever a pinned address was absent when the server came up.
+  const boundAddresses = state?.boundAddresses ?? [];
+  const reachable = bindable.filter(
+    (endpoint) =>
+      boundAddresses.includes(BIND_ALL_ADDRESS) ||
+      boundAddresses.includes(endpointAddress(endpoint)),
+  );
+  const cleartext = reachable.some((endpoint) => !endpoint.encrypted);
+  const encryptedOnly = reachable.find((endpoint) => endpoint.encrypted) ?? null;
+  const missingBind = !bindsAll && selected === null;
+  // Two different failures, two different remedies: `missingBind` means this
+  // computer no longer holds that address at all, `unbound` means it does but
+  // the server never got a socket on it (it came up after the bind).
+  const unbound =
+    enabled && selected !== null && !boundAddresses.includes(endpointAddress(selected));
 
   return (
     <div className="flex flex-col gap-2">
@@ -86,28 +127,70 @@ export function RemoteAccessSection() {
             Let paired devices on your local network connect to this computer. Off keeps the app
             reachable from this computer only.
           </p>
-          <p className="text-[10px] text-muted-foreground">
-            Connections on your local network are unencrypted. Pair devices only on networks you
-            trust.
-          </p>
 
           {enabled && (
             <>
-              {lanUrls.length > 0 && (
-                <div className="flex flex-col gap-1">
-                  <span className="text-[10px] text-muted-foreground">
-                    This computer on your network
-                  </span>
-                  {lanUrls.map((url) => (
-                    <code
-                      key={url}
-                      className="select-all rounded-[8px] bg-card px-2.5 py-1.5 text-[10px] text-foreground"
-                    >
-                      {url}
-                    </code>
+              <p className="text-[10px] text-muted-foreground">
+                {!cleartext && encryptedOnly !== null
+                  ? `Reachable only over ${encryptedOnly.label}, which encrypts and authenticates the connection itself.`
+                  : "Connections on your local network are unencrypted. Pair devices only on networks you trust."}
+              </p>
+
+              <div className="flex flex-col gap-1">
+                <span className="text-[10px] text-muted-foreground">Reachable on</span>
+                <NativeSelect
+                  size="sm"
+                  className="w-full"
+                  aria-label="Reachable on"
+                  value={bindAddress}
+                  disabled={busy || loading}
+                  onChange={(event) => void handleBind(event.target.value)}
+                >
+                  <NativeSelectOption value={BIND_ALL_ADDRESS}>Every network</NativeSelectOption>
+                  {bindable.map((endpoint) => (
+                    <NativeSelectOption
+                      key={endpoint.wsUrl}
+                      value={endpointAddress(endpoint)}
+                    >{`${endpoint.label}${endpoint.encrypted ? " (encrypted)" : ""}`}</NativeSelectOption>
                   ))}
-                </div>
-              )}
+                  {missingBind && (
+                    <NativeSelectOption value={bindAddress}>
+                      {`${bindAddress} (unavailable)`}
+                    </NativeSelectOption>
+                  )}
+                </NativeSelect>
+                {missingBind && (
+                  <span className="text-[10px] text-muted-foreground">
+                    That network isn&apos;t available right now, so only this computer can reach the
+                    app. Pick another to expose it again.
+                  </span>
+                )}
+                {unbound && (
+                  <span className="flex flex-col items-start gap-1 text-[10px] text-muted-foreground">
+                    <span>
+                      That network appeared after the app started listening, so nothing is answering
+                      on it yet.
+                    </span>
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      onClick={() => void handleBind(bindAddress)}
+                      disabled={busy || loading}
+                      className="h-6 px-2 text-[10px]"
+                    >
+                      Listen on it now
+                    </Button>
+                  </span>
+                )}
+                {reachable.map((endpoint) => (
+                  <code
+                    key={endpoint.wsUrl}
+                    className="select-all rounded-[8px] bg-card px-2.5 py-1.5 text-[10px] text-foreground"
+                  >
+                    {endpoint.wsUrl}
+                  </code>
+                ))}
+              </div>
 
               {devices.length > 0 && (
                 <div className="flex flex-col gap-1.5">
@@ -150,11 +233,18 @@ export function RemoteAccessSection() {
                 {pairing && (
                   <div className="flex flex-col gap-1 rounded-[8px] bg-card px-2.5 py-1.5">
                     <span className="text-[10px] text-muted-foreground">
-                      On the other device, connect to{" "}
-                      <code className="select-all text-foreground">
-                        {pairing.urls.join(" or ")}
-                      </code>{" "}
-                      and enter this one-time code:
+                      On the other device, connect to the address for the network it is on:
+                    </span>
+                    {pairing.urls.map((url) => (
+                      <span key={url.wsUrl} className="flex flex-col gap-0.5">
+                        <span className="text-[10px] text-muted-foreground">{url.label}</span>
+                        <code className="select-all rounded-[8px] bg-muted px-2.5 py-1.5 text-[10px] text-foreground">
+                          {url.wsUrl}
+                        </code>
+                      </span>
+                    ))}
+                    <span className="text-[10px] text-muted-foreground">
+                      Then enter this one-time code:
                     </span>
                     <code className="select-all text-xs text-foreground">{pairing.token}</code>
                     <span className="text-[10px] text-muted-foreground">

--- a/apps/desktop/src/renderer/settings/settings-panel.test.tsx
+++ b/apps/desktop/src/renderer/settings/settings-panel.test.tsx
@@ -1,6 +1,7 @@
 // Remote-access section of the settings panel (jsdom): the toggle surfaces a
 // bridge failure as the section's inline error (instead of an unhandled
-// rejection with no feedback), and the plaintext-LAN caveat caption renders.
+// rejection with no feedback), and the plaintext-LAN caveat caption renders
+// only while something is actually reachable.
 // Runs the real SettingsPanel over the dev-harness fixture Bridge, with the
 // one method under test overridden per case.
 
@@ -66,9 +67,16 @@ describe("RemoteAccessSection", () => {
     });
   });
 
-  it("renders the unencrypted-network caveat under the toggle", async () => {
+  // The caveat is a claim about what is reachable, so it only holds once
+  // something is: with the toggle off, nothing off this computer is.
+  it("renders the unencrypted-network caveat once remote access is on", async () => {
     renderPanel(newBridge());
-    await screen.findByRole("switch", { name: "Allow other devices" });
-    expect(screen.getByText(/Connections on your local network are unencrypted\./)).toBeTruthy();
+    const toggle = await screen.findByRole("switch", { name: "Allow other devices" });
+    expect(screen.queryByText(/Connections on your local network are unencrypted\./)).toBeNull();
+    fireEvent.click(toggle);
+
+    await waitFor(() => {
+      expect(screen.getByText(/Connections on your local network are unencrypted\./)).toBeTruthy();
+    });
   });
 });

--- a/packages/bridge/src/ipc-registry.ts
+++ b/packages/bridge/src/ipc-registry.ts
@@ -835,11 +835,14 @@ export const IPC = {
   onSyncStateChanged: event<SyncState>(),
 
   // Remote access — the WS transport's device-pairing surface: an enable
-  // toggle, LAN URLs, paired devices, and one-time pairing tokens. All state
-  // reads/writes go through the remote-access manager.
-  /** Current remote-access state (enabled/port/listening/lanUrls/devices). */
+  // toggle, the classified endpoints and the one the server binds, paired
+  // devices, and one-time pairing tokens. All state reads/writes go through
+  // the remote-access manager.
+  /** Current remote-access state (enabled/port/listening/endpoints/
+   * bindAddress/devices). */
   getRemoteAccessState: invokeVoid<RemoteAccessState>(),
-  /** Patch the remote-access config (enable toggle only; port stays fixed). */
+  /** Patch the remote-access config (enable toggle + bind selection; the port
+   * stays fixed). */
   setRemoteAccessConfig: invoke<typeof RemoteAccessSetConfigSchema, RemoteAccessState>(
     RemoteAccessSetConfigSchema,
   ),

--- a/packages/bridge/src/remote-access.ts
+++ b/packages/bridge/src/remote-access.ts
@@ -12,12 +12,23 @@ import { Type } from "@sinclair/typebox";
 // Payload schemas (renderer → host) — validated at the handler boundary.
 // ---------------------------------------------------------------------------
 
-/** Partial config patch. The port stays fixed for now — only the enable
- * toggle crosses the Bridge. */
+/** Partial config patch. The port stays fixed for now — the enable toggle and
+ * the bind selection are what cross the Bridge. */
 export const RemoteAccessSetConfigSchema = Type.Object(
-  { enabled: Type.Optional(Type.Boolean()) },
+  {
+    enabled: Type.Optional(Type.Boolean()),
+    /** IPv4 address the ws server binds while remote access is enabled;
+     * `BIND_ALL_ADDRESS` means every interface. The host resolves it against
+     * the interfaces that actually exist, so a stale value degrades rather
+     * than failing the bind. */
+    bindAddress: Type.Optional(Type.String({ minLength: 1 })),
+  },
   { additionalProperties: false },
 );
+
+/** The every-interface bind — the default, and what a config-version drop must
+ * land on, since it is the behaviour that predates the field. */
+export const BIND_ALL_ADDRESS = "0.0.0.0";
 
 export const RevokeDeviceSchema = Type.Object(
   { id: Type.String({ minLength: 1 }) },
@@ -38,6 +49,37 @@ export type RemoteDeviceInfo = {
   readonly lastSeenAt: string;
 };
 
+/** How a peer reaches this computer at one address.
+ * - `loopback` — this computer only.
+ * - `lan` — the local network, in the clear.
+ * - `private-network` — a WireGuard-style overlay (Tailscale): an address only
+ *   enrolled, peer-authenticated nodes can route to, carried inside a tunnel
+ *   that is already encrypted underneath the ws transport. */
+export type RemoteEndpointReachability = "loopback" | "lan" | "private-network";
+
+/** One address this computer currently holds. The list is the CANDIDATE set —
+ * which of them the ws server actually answers on is `boundAddresses` on the
+ * state, not a property of the endpoint. */
+export type RemoteEndpoint = {
+  readonly wsUrl: string;
+  readonly reachability: RemoteEndpointReachability;
+  /** True ONLY for `private-network`, where the overlay encrypts and
+   * authenticates the hop underneath us. Plain LAN `ws://` is cleartext and
+   * must say so: this flag is what the settings copy claims about security. */
+  readonly encrypted: boolean;
+  /** A hypervisor/container adapter (docker0, vmnet, bridge100…). It binds
+   * fine and reaches nobody, so it is listed and labelled but never offered
+   * to a device that is trying to pair. */
+  readonly virtual: boolean;
+  /** For humans — "Tailscale", "en0 192.168.1.42", "This computer". */
+  readonly label: string;
+};
+
+/** The bare host of an endpoint — the form `bindAddress` stores. */
+export function endpointAddress(endpoint: RemoteEndpoint): string {
+  return new URL(endpoint.wsUrl).hostname;
+}
+
 /** The reactive remote-access state surfaced to the renderer — the payload of
  * both `getRemoteAccessState` and the `onRemoteAccessChanged` event. */
 export type RemoteAccessState = {
@@ -45,17 +87,36 @@ export type RemoteAccessState = {
   readonly port: number;
   /** Whether the ws server is currently accepting connections. */
   readonly listening: boolean;
-  /** `ws://<lan-addr>:<port>` per non-internal IPv4 interface; empty when
-   * remote access is disabled (the server binds loopback only). */
-  readonly lanUrls: readonly string[];
+  /** Every IPv4 address this computer holds, classified. */
+  readonly endpoints: readonly RemoteEndpoint[];
+  /** The address the ws server binds while remote access is enabled;
+   * `BIND_ALL_ADDRESS` is every interface. Loopback is bound alongside it
+   * whatever this says. This is the REQUEST — see `boundAddresses` for what
+   * came up. */
+  readonly bindAddress: string;
+  /** The addresses the ws server actually holds right now, as the bind itself
+   * reported them (`BIND_ALL_ADDRESS` means every interface; empty while
+   * nothing is listening). Re-deriving this from `bindAddress` and the live
+   * interface table is what let a pinned address that never bound — the
+   * overlay came up after boot — be offered as reachable. */
+  readonly boundAddresses: readonly string[];
   readonly devices: readonly RemoteDeviceInfo[];
+};
+
+/** One address a pairing device may dial. Labelled and offered on its own
+ * line, never joined into a sentence: the companion's pairing input takes the
+ * FIRST url it can find in the pasted text, so a phone off the overlay would
+ * otherwise copy an address it cannot reach. */
+export type PairingUrl = {
+  readonly wsUrl: string;
+  readonly label: string;
 };
 
 /** A freshly minted one-time pairing token, shown to the user for entry on
  * the other device. Single-use; expires 10 minutes after mint. */
 export type PairingInfo = {
   readonly token: string;
-  readonly urls: readonly string[];
+  readonly urls: readonly PairingUrl[];
   /** ISO instant the token stops being redeemable. */
   readonly expiresAt: string;
 };

--- a/packages/server/src/transport/__tests__/network-endpoints.test.ts
+++ b/packages/server/src/transport/__tests__/network-endpoints.test.ts
@@ -1,0 +1,181 @@
+import { describe, expect, it } from "vitest";
+import type os from "node:os";
+
+import { BIND_ALL_ADDRESS } from "@repo/bridge/remote-access";
+import {
+  classifyEndpoints,
+  resolveBindHosts,
+  LOOPBACK_ADDRESS,
+  type InterfaceTable,
+} from "../network-endpoints";
+
+function ipv4(
+  address: string,
+  internal = false,
+  netmask = "255.255.255.0",
+): os.NetworkInterfaceInfo {
+  return {
+    address,
+    netmask,
+    family: "IPv4",
+    mac: "00:00:00:00:00:00",
+    internal,
+    cidr: `${address}/24`,
+  };
+}
+
+/** A point-to-point overlay address: CGNAT range AND a /32. */
+function overlay(address: string): os.NetworkInterfaceInfo {
+  return ipv4(address, false, "255.255.255.255");
+}
+
+const INTERFACES: InterfaceTable = {
+  lo0: [ipv4("127.0.0.1", true)],
+  en0: [ipv4("192.168.1.42")],
+  utun4: [overlay("100.101.102.103")],
+  en1: [
+    {
+      address: "fe80::1",
+      netmask: "ffff:ffff:ffff:ffff::",
+      family: "IPv6",
+      mac: "00:00:00:00:00:00",
+      internal: false,
+      cidr: "fe80::1/64",
+      scopeid: 5,
+    },
+  ],
+};
+
+describe("classifyEndpoints", () => {
+  const endpoints = classifyEndpoints(INTERFACES, 47890);
+
+  it("classifies loopback, LAN and overlay addresses, most private first", () => {
+    expect(endpoints.map((endpoint) => [endpoint.wsUrl, endpoint.reachability])).toEqual([
+      ["ws://100.101.102.103:47890", "private-network"],
+      ["ws://192.168.1.42:47890", "lan"],
+      ["ws://127.0.0.1:47890", "loopback"],
+    ]);
+  });
+
+  it("marks only the private-network endpoint encrypted", () => {
+    for (const endpoint of endpoints) {
+      expect(endpoint.encrypted).toBe(endpoint.reachability === "private-network");
+    }
+  });
+
+  it("never claims a plain LAN address is encrypted, whatever the interface is called", () => {
+    const misleading = classifyEndpoints({ tailscale0: [ipv4("192.168.1.42")] }, 1);
+    expect(misleading).toEqual([
+      {
+        wsUrl: "ws://192.168.1.42:1",
+        reachability: "lan",
+        encrypted: false,
+        virtual: false,
+        label: "tailscale0 192.168.1.42",
+      },
+    ]);
+  });
+
+  it("detects the overlay by address range plus a /32, not by interface name", () => {
+    const [detected] = classifyEndpoints({ eth7: [overlay("100.64.0.1")] }, 1);
+    expect(detected?.reachability).toBe("private-network");
+    expect(detected?.encrypted).toBe(true);
+    // Outside 100.64.0.0/10 — a routable public address that merely starts 100.
+    const [outside] = classifyEndpoints({ eth7: [overlay("100.128.0.1")] }, 1);
+    expect(outside?.reachability).toBe("lan");
+    expect(outside?.encrypted).toBe(false);
+  });
+
+  // 100.64/10 is carrier-grade NAT space, not overlay space: a Starlink dish or
+  // a tethered carrier link leases a real subnet out of it, over a plaintext
+  // hop. Only the /32 an overlay assigns corroborates the claim.
+  it("refuses to call a CGNAT address with a real subnet mask encrypted", () => {
+    const [leased] = classifyEndpoints(
+      { en0: [ipv4("100.88.4.7", false, "255.255.252.0")] },
+      47890,
+    );
+    expect(leased?.reachability).toBe("lan");
+    expect(leased?.encrypted).toBe(false);
+    expect(leased?.label).toBe("en0 100.88.4.7");
+  });
+
+  it("stays cleartext when the netmask is missing rather than assuming an overlay", () => {
+    const [unknown] = classifyEndpoints({ utun9: [ipv4("100.88.4.7", false, "")] }, 47890);
+    expect(unknown?.reachability).toBe("lan");
+    expect(unknown?.encrypted).toBe(false);
+  });
+
+  // Several CNIs hand pods a /32 out of 100.64/10 to conserve RFC1918, which
+  // reproduces the overlay's whole signature over a cleartext bridge on this
+  // host. The adapter it sits on is what tells them apart.
+  it("refuses to call a /32 CGNAT address on a virtual adapter encrypted", () => {
+    for (const name of ["veth0", "docker0"]) {
+      const [pod] = classifyEndpoints({ [name]: [overlay("100.96.1.7")] }, 47890);
+      expect(pod?.reachability).toBe("lan");
+      expect(pod?.encrypted).toBe(false);
+      expect(pod?.virtual).toBe(true);
+    }
+  });
+
+  it("ranks hypervisor and container adapters last, and says so in the label", () => {
+    const ordered = classifyEndpoints(
+      {
+        bridge100: [ipv4("192.168.139.3")],
+        docker0: [ipv4("172.17.0.1")],
+        en0: [ipv4("192.168.1.42")],
+        lo0: [ipv4("127.0.0.1", true)],
+      },
+      47890,
+    );
+    expect(ordered.map((endpoint) => endpoint.label)).toEqual([
+      "en0 192.168.1.42",
+      "This computer",
+      "bridge100 192.168.139.3 (virtual)",
+      "docker0 172.17.0.1 (virtual)",
+    ]);
+  });
+
+  it("labels endpoints for humans", () => {
+    expect(endpoints.map((endpoint) => endpoint.label)).toEqual([
+      "Tailscale",
+      "en0 192.168.1.42",
+      "This computer",
+    ]);
+  });
+
+  it("skips IPv6 addresses", () => {
+    expect(endpoints.some((endpoint) => endpoint.wsUrl.includes("fe80"))).toBe(false);
+  });
+});
+
+describe("resolveBindHosts", () => {
+  it("binds loopback only while remote access is disabled", () => {
+    expect(
+      resolveBindHosts({ enabled: false, bindAddress: "100.101.102.103" }, INTERFACES),
+    ).toEqual([LOOPBACK_ADDRESS]);
+  });
+
+  it("binds every interface with the default bind address", () => {
+    expect(resolveBindHosts({ enabled: true, bindAddress: BIND_ALL_ADDRESS }, INTERFACES)).toEqual([
+      BIND_ALL_ADDRESS,
+    ]);
+  });
+
+  it("keeps loopback FIRST alongside a pinned interface so the renderer still connects", () => {
+    expect(resolveBindHosts({ enabled: true, bindAddress: "100.101.102.103" }, INTERFACES)).toEqual(
+      [LOOPBACK_ADDRESS, "100.101.102.103"],
+    );
+  });
+
+  it("degrades to loopback when the selected address is no longer assigned", () => {
+    expect(resolveBindHosts({ enabled: true, bindAddress: "100.9.9.9" }, INTERFACES)).toEqual([
+      LOOPBACK_ADDRESS,
+    ]);
+  });
+
+  it("collapses a loopback selection to the single loopback bind", () => {
+    expect(resolveBindHosts({ enabled: true, bindAddress: "127.0.0.1" }, INTERFACES)).toEqual([
+      LOOPBACK_ADDRESS,
+    ]);
+  });
+});

--- a/packages/server/src/transport/__tests__/remote-access-manager.test.ts
+++ b/packages/server/src/transport/__tests__/remote-access-manager.test.ts
@@ -1,0 +1,154 @@
+import { afterEach, describe, expect, it } from "vitest";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import { BIND_ALL_ADDRESS } from "@repo/bridge/remote-access";
+import type { InterfaceTable } from "../network-endpoints";
+import { DEFAULT_REMOTE_ACCESS_PORT, RemoteAccessManager } from "../remote-access-manager";
+
+let cleanups: Array<() => void> = [];
+
+afterEach(() => {
+  for (const cleanup of cleanups.toReversed()) cleanup();
+  cleanups = [];
+});
+
+function ipv4(address: string, internal = false, netmask = "255.255.255.0") {
+  return {
+    address,
+    netmask,
+    family: "IPv4" as const,
+    mac: "00:00:00:00:00:00",
+    internal,
+    cidr: `${address}/24`,
+  };
+}
+
+/** Loopback, one LAN address, and one overlay address (CGNAT range + /32). */
+const INTERFACES: InterfaceTable = {
+  lo0: [ipv4("127.0.0.1", true)],
+  en0: [ipv4("192.168.1.42")],
+  utun4: [ipv4("100.101.102.103", false, "255.255.255.255")],
+};
+
+function makeManager(seed?: string, interfaces?: InterfaceTable): RemoteAccessManager {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "remote-access-"));
+  cleanups.push(() => fs.rmSync(dir, { recursive: true, force: true }));
+  const configPath = path.join(dir, "remote-access.json");
+  if (seed !== undefined) fs.writeFileSync(configPath, seed);
+  const manager = new RemoteAccessManager({
+    configPath,
+    devicesPath: path.join(dir, "remote-devices.json"),
+    ...(interfaces === undefined ? {} : { networkInterfaces: () => interfaces }),
+  });
+  cleanups.push(() => manager.close());
+  return manager;
+}
+
+describe("remote-access config", () => {
+  it("defaults to the every-interface bind, disabled", () => {
+    const config = makeManager().getConfig();
+    expect(config).toEqual({
+      enabled: false,
+      port: DEFAULT_REMOTE_ACCESS_PORT,
+      bindAddress: BIND_ALL_ADDRESS,
+      revision: 0,
+    });
+  });
+
+  it("drops a pre-bindAddress config to the safe default rather than an empty bind", () => {
+    const manager = makeManager(
+      JSON.stringify({ version: 1, enabled: true, port: DEFAULT_REMOTE_ACCESS_PORT }),
+    );
+    expect(manager.getConfig()).toEqual({
+      enabled: false,
+      port: DEFAULT_REMOTE_ACCESS_PORT,
+      bindAddress: BIND_ALL_ADDRESS,
+      revision: 0,
+    });
+  });
+
+  // Re-picking the address already pinned is the only recovery an unbound pin
+  // has, so it must read as a change even though every stored field matches.
+  it("bumps the revision on a setConfig that changes nothing", () => {
+    const manager = makeManager();
+    manager.setConfig({ bindAddress: "192.168.1.42" });
+    const first = manager.getConfig().revision;
+    manager.setConfig({ bindAddress: "192.168.1.42" });
+    expect(manager.getConfig().revision).toBeGreaterThan(first);
+  });
+
+  it("round-trips a bind selection and surfaces it on the state", () => {
+    const manager = makeManager();
+    const state = manager.setConfig({ enabled: true, bindAddress: "100.101.102.103" });
+    expect(state.bindAddress).toBe("100.101.102.103");
+    expect(manager.getConfig().bindAddress).toBe("100.101.102.103");
+  });
+
+  it("always reports a loopback endpoint among the candidates", () => {
+    const { endpoints } = makeManager().getState();
+    expect(endpoints.some((endpoint) => endpoint.reachability === "loopback")).toBe(true);
+  });
+
+  it("offers only loopback for pairing while remote access is disabled", () => {
+    const manager = makeManager();
+    manager.setListening(true, DEFAULT_REMOTE_ACCESS_PORT, null, ["127.0.0.1"]);
+    expect(manager.createPairingToken().urls).toEqual([
+      { wsUrl: `ws://127.0.0.1:${DEFAULT_REMOTE_ACCESS_PORT}`, label: "This computer" },
+    ]);
+  });
+});
+
+describe("pairing offers", () => {
+  function listening(bindAddress: string, boundHosts: readonly string[]): RemoteAccessManager {
+    const manager = makeManager(undefined, INTERFACES);
+    manager.setConfig({ enabled: true, bindAddress });
+    manager.setListening(true, DEFAULT_REMOTE_ACCESS_PORT, null, boundHosts);
+    return manager;
+  }
+
+  // Encrypted ORDERS the offer, it never narrows it: a phone that is not on
+  // the tailnet can only reach the LAN address, and handing it the overlay URL
+  // alone would leave it unable to pair at all.
+  it("leads with the encrypted URL but keeps the LAN one as a fallback", () => {
+    expect(listening(BIND_ALL_ADDRESS, [BIND_ALL_ADDRESS]).createPairingToken().urls).toEqual([
+      { wsUrl: `ws://100.101.102.103:${DEFAULT_REMOTE_ACCESS_PORT}`, label: "Tailscale" },
+      { wsUrl: `ws://192.168.1.42:${DEFAULT_REMOTE_ACCESS_PORT}`, label: "en0 192.168.1.42" },
+    ]);
+  });
+
+  it("offers only the pinned address when the bind is pinned", () => {
+    const manager = listening("192.168.1.42", ["127.0.0.1", "192.168.1.42"]);
+    expect(manager.createPairingToken().urls).toEqual([
+      { wsUrl: `ws://192.168.1.42:${DEFAULT_REMOTE_ACCESS_PORT}`, label: "en0 192.168.1.42" },
+    ]);
+  });
+
+  // The overlay came up after the bind did. The address is on the machine, so
+  // re-resolving the config would call it reachable — but no socket answers on
+  // it, and offering it as the ONLY url leaves the phone unable to pair.
+  it("never offers an address the bind did not report, however available it looks", () => {
+    const manager = listening("100.101.102.103", ["127.0.0.1"]);
+    expect(manager.getState().boundAddresses).toEqual(["127.0.0.1"]);
+    expect(manager.createPairingToken().urls).toEqual([
+      { wsUrl: `ws://127.0.0.1:${DEFAULT_REMOTE_ACCESS_PORT}`, label: "This computer" },
+    ]);
+  });
+
+  // A container bridge binds fine and reaches nobody, so it stays a candidate
+  // in the picker while never being handed to a device trying to pair.
+  it("drops virtual adapters from the offer under the every-interface bind", () => {
+    const manager = makeManager(undefined, {
+      ...INTERFACES,
+      docker0: [ipv4("172.17.0.1")],
+    });
+    manager.setConfig({ enabled: true, bindAddress: BIND_ALL_ADDRESS });
+    manager.setListening(true, DEFAULT_REMOTE_ACCESS_PORT, null, [BIND_ALL_ADDRESS]);
+    expect(manager.getState().endpoints.some((endpoint) => endpoint.virtual)).toBe(true);
+    expect(manager.createPairingToken().urls.map((url) => url.wsUrl)).toEqual([
+      `ws://100.101.102.103:${DEFAULT_REMOTE_ACCESS_PORT}`,
+      `ws://192.168.1.42:${DEFAULT_REMOTE_ACCESS_PORT}`,
+    ]);
+  });
+});

--- a/packages/server/src/transport/__tests__/ws-transport.test.ts
+++ b/packages/server/src/transport/__tests__/ws-transport.test.ts
@@ -25,6 +25,7 @@ import {
   type ServerFrame,
 } from "@repo/bridge/ws-protocol";
 import type { WireHandler } from "../../handlers/handler-registry";
+import { LOOPBACK_ADDRESS, type InterfaceTable } from "../network-endpoints";
 import { RemoteAccessManager } from "../remote-access-manager";
 import { startWsHost, type WsHost, type WsHostSource } from "../ws-host";
 
@@ -94,6 +95,7 @@ async function startTestHost(
     manager?: RemoteAccessManager;
     shellHandlers?: Parameters<typeof startWsHost>[0]["shellHandlers"];
     pingIntervalMs?: number;
+    networkInterfaces?: () => InterfaceTable;
   } = {},
 ): Promise<TestHost> {
   const manager = options.manager ?? makeManager(0);
@@ -104,6 +106,9 @@ async function startTestHost(
     manager,
     ...(options.shellHandlers ? { shellHandlers: options.shellHandlers } : {}),
     ...(options.pingIntervalMs === undefined ? {} : { pingIntervalMs: options.pingIntervalMs }),
+    ...(options.networkInterfaces === undefined
+      ? {}
+      : { networkInterfaces: options.networkInterfaces }),
   });
   cleanups.push(() => wsHost.close());
   const port = await listeningPort(wsHost);
@@ -195,6 +200,28 @@ async function freePort(): Promise<number> {
     });
   });
 }
+
+// RFC 5737 TEST-NET-1: never assigned to a real interface anywhere, so a listen
+// on it fails EADDRNOTAVAIL — exactly what a pinned overlay address does the
+// moment the tunnel drops or the laptop roams.
+const VANISHED_ADDRESS = "192.0.2.1";
+
+function ipv4(address: string, internal = false): os.NetworkInterfaceInfo {
+  return {
+    address,
+    netmask: internal ? "255.0.0.0" : "255.255.255.255",
+    family: "IPv4",
+    mac: "00:00:00:00:00:00",
+    internal,
+    cidr: `${address}/32`,
+  };
+}
+
+const LOOPBACK_ONLY: InterfaceTable = { lo0: [ipv4("127.0.0.1", true)] };
+const WITH_VANISHED: InterfaceTable = {
+  lo0: [ipv4("127.0.0.1", true)],
+  utun9: [ipv4(VANISHED_ADDRESS)],
+};
 
 describe("auth", () => {
   it("authenticates with the local token and round-trips invoke + invoke-void", async () => {
@@ -475,6 +502,34 @@ describe("reconnect supervisor", () => {
     },
   );
 
+  // The renderer dials 127.0.0.1 every launch, so pinning remote access to one
+  // interface must not take the local window offline. Any real non-internal
+  // IPv4 address stands in for the Tailscale one (an unassigned address would
+  // just degrade to loopback and prove nothing); a machine with none — an
+  // offline CI box — has nothing to pin, so there is nothing to test.
+  const pinnable = Object.values(os.networkInterfaces())
+    .flatMap((addresses) => addresses ?? [])
+    .filter((info) => info.family === "IPv4" && !info.internal)
+    .map((info) => info.address);
+
+  it.skipIf(pinnable.length === 0)(
+    "keeps loopback reachable when the bind is pinned to one interface",
+    { timeout: 15_000 },
+    async () => {
+      const pinned = pinnable[0] ?? "";
+      const port = await freePort();
+      const manager = makeManager(port);
+      manager.setConfig({ enabled: true, bindAddress: pinned });
+      const host = await startTestHost({ getVaultRoot: () => "/v" }, { manager });
+
+      const local = connectBridge(`ws://127.0.0.1:${host.port}`, manager.getLocalToken());
+      await expect(local.bridge.getVaultRoot()).resolves.toBe("/v");
+
+      const remote = connectBridge(`ws://${pinned}:${host.port}`, manager.getLocalToken());
+      await expect(remote.bridge.getVaultRoot()).resolves.toBe("/v");
+    },
+  );
+
   it("treats a 4401 close as terminal: unauthorized status, no further attempts", async () => {
     const host = await startTestHost({ getVaultRoot: () => "/v" });
     const { bridge, statuses } = connectBridge(host.url, "wrong-token");
@@ -495,6 +550,96 @@ describe("reconnect supervisor", () => {
 });
 
 describe("rebind failure recovery", () => {
+  it("keeps loopback listening when the pinned address refuses to bind", async () => {
+    const port = await freePort();
+    const manager = makeManager(port);
+    manager.setConfig({ enabled: true, bindAddress: VANISHED_ADDRESS });
+    const host = await startTestHost(
+      { getVaultRoot: () => "/v" },
+      { manager, networkInterfaces: () => WITH_VANISHED },
+    );
+
+    // The renderer's own socket is the thing that must survive.
+    const local = connectBridge(`ws://127.0.0.1:${host.port}`, manager.getLocalToken());
+    await expect(local.bridge.getVaultRoot()).resolves.toBe("/v");
+    expect(manager.getState().listening).toBe(true);
+    expect(manager.getListenError()).toContain(VANISHED_ADDRESS);
+    // The pin is still the config's answer, but only loopback is a socket —
+    // and the reported list, not the config, is what pairing may offer.
+    expect(manager.getState().boundAddresses).toEqual([LOOPBACK_ADDRESS]);
+    expect(manager.createPairingToken().urls.map((url) => url.wsUrl)).toEqual([
+      `ws://${LOOPBACK_ADDRESS}:${host.port}`,
+    ]);
+  });
+
+  // A pin whose address was absent at bind time degraded to loopback. Asking
+  // for the SAME address again once the overlay is up is the recovery path, so
+  // it has to reach the bind rather than compare equal and do nothing.
+  it("rebinds when the pinned address is re-selected unchanged", async () => {
+    const port = await freePort();
+    const manager = makeManager(port);
+    manager.setConfig({ enabled: true, bindAddress: VANISHED_ADDRESS });
+    let interfaces: InterfaceTable = LOOPBACK_ONLY;
+    const host = await startTestHost(
+      { getVaultRoot: () => "/v" },
+      { manager, networkInterfaces: () => interfaces },
+    );
+    // Absent from the table, so the pin resolved away and the bind reported
+    // clean — nothing was attempted on it.
+    expect(manager.getListenError()).toBeNull();
+
+    // It appears. Re-selecting it is the same config, so only the forced
+    // rebind can get the host to attempt it at all.
+    interfaces = WITH_VANISHED;
+    manager.setConfig({ bindAddress: VANISHED_ADDRESS });
+    await vi.waitFor(() => {
+      expect(manager.getListenError()).toContain(VANISHED_ADDRESS);
+    });
+    expect(host.wsHost.port()).toBe(port);
+    expect(manager.getState().boundAddresses).toEqual([LOOPBACK_ADDRESS]);
+  });
+
+  it(
+    "re-resolves the host list on every retry instead of replaying a stale one",
+    { timeout: 20_000 },
+    async () => {
+      const portA = await freePort();
+      const manager = makeManager(portA);
+      // Pinned to an address the table does not hold yet, so the first bind
+      // resolves to loopback alone and reports clean.
+      manager.setConfig({ enabled: true, bindAddress: VANISHED_ADDRESS });
+      let interfaces: InterfaceTable = LOOPBACK_ONLY;
+      const host = await startTestHost(
+        { getVaultRoot: () => "/v" },
+        { manager, networkInterfaces: () => interfaces },
+      );
+      expect(manager.getListenError()).toBeNull();
+
+      // Rebind onto an occupied port to put the backoff retry loop in charge.
+      const portB = await freePort();
+      const blocker = net.createServer();
+      await new Promise<void>((resolve) => blocker.listen(portB, "127.0.0.1", resolve));
+      manager.setConfig({ port: portB });
+      await vi.waitFor(() => {
+        expect(manager.getListenError()).not.toBeNull();
+      });
+      expect(host.wsHost.port()).toBeNull();
+
+      // The address appears mid-retry. A retry that replayed the host list
+      // captured at the config change would never attempt it.
+      interfaces = WITH_VANISHED;
+      await new Promise<void>((resolve) => blocker.close(() => resolve()));
+      await vi.waitFor(
+        () => {
+          expect(host.wsHost.port()).toBe(portB);
+        },
+        { timeout: 10_000 },
+      );
+      expect(manager.getState().listening).toBe(true);
+      expect(manager.getListenError()).toContain(VANISHED_ADDRESS);
+    },
+  );
+
   it("retries a failed rebind with backoff until the port frees", { timeout: 20_000 }, async () => {
     const portA = await freePort();
     const manager = makeManager(portA);

--- a/packages/server/src/transport/network-endpoints.ts
+++ b/packages/server/src/transport/network-endpoints.ts
@@ -1,0 +1,163 @@
+// ---------------------------------------------------------------------------
+// Network endpoints — the pure half of the remote-access bind story: turn the
+// OS interface table into classified `RemoteEndpoint`s, and turn the config
+// into the list of addresses the ws server should bind. Both take the
+// interface table as an argument so they are testable against a fixed one.
+//
+// IPv4 ONLY, and deliberately so. Every address here is classified, offered in
+// the settings picker, bound as a literal host, and printed into a
+// `ws://host:port` URL — and each of those needs its own v6 form (a bracketed
+// authority, ULA/link-local classification with a zone index, `::` rather than
+// `0.0.0.0` as the bind-all address, and a v6-aware `hasAddress`). Offering a
+// v6 row before all four exist would mean a picker entry nothing can dial, so
+// the table's v6 rows are skipped rather than half-supported.
+// ---------------------------------------------------------------------------
+
+import type os from "node:os";
+
+import {
+  BIND_ALL_ADDRESS,
+  type RemoteEndpoint,
+  type RemoteEndpointReachability,
+} from "@repo/bridge/remote-access";
+
+/** The shape `os.networkInterfaces()` returns. */
+export type InterfaceTable = NodeJS.Dict<os.NetworkInterfaceInfo[]>;
+
+export const LOOPBACK_ADDRESS = "127.0.0.1";
+export const LOOPBACK_LABEL = "This computer";
+
+const RANK: Record<RemoteEndpointReachability, number> = {
+  "private-network": 0,
+  lan: 1,
+  loopback: 2,
+};
+
+/** The netmask a point-to-point overlay assigns: the node holds exactly its
+ * own address and routes everything else through the tunnel. */
+const SINGLE_HOST_NETMASK = "255.255.255.255";
+
+function isLoopbackAddress(address: string): boolean {
+  return address.startsWith("127.");
+}
+
+function isCarrierGradeNatAddress(address: string): boolean {
+  const match = /^100\.(\d{1,3})\.\d{1,3}\.\d{1,3}$/.exec(address);
+  if (match === null) return false;
+  const second = Number(match[1]);
+  return second >= 64 && second <= 127;
+}
+
+// A WireGuard-style overlay (Tailscale) hands each node a /32 out of the CGNAT
+// block 100.64.0.0/10. BOTH halves are required, because 100.64/10 is
+// carrier-grade NAT space and not overlay space: a Starlink dish, some carrier
+// tethering, and campus/pod networks conserving RFC1918 all lease real subnets
+// out of it, over hops that are plain cleartext. The range alone would let one
+// of those claim `encrypted: true`, which is the one sentence the settings copy
+// makes about the user's security — so a real subnet mask disqualifies it and
+// it stays `lan`. Never detect by interface NAME: that is utun* on macOS,
+// tailscale* on Linux and something else again on Windows, so it is not a
+// contract — it only ever refines the human label.
+function isPrivateNetworkAddress(address: string, netmask: string): boolean {
+  return netmask === SINGLE_HOST_NETMASK && isCarrierGradeNatAddress(address);
+}
+
+function looksLikeTailscale(interfaceName: string): boolean {
+  return /^(tailscale|ts|utun)/i.test(interfaceName);
+}
+
+// Adapters a hypervisor or container runtime owns. They bind successfully, so
+// pinning to one leaves `listening: true` while nothing can ever connect
+// through it — a silent dead end. Ranked last, labelled and flagged rather
+// than hidden: the address is really there, and a table that is nothing but
+// these must not come back empty. Pairing skips them; the picker does not.
+function isVirtualAdapter(interfaceName: string): boolean {
+  return /^(bridge\d|vmnet|vboxnet|docker|veth|virbr)/i.test(interfaceName);
+}
+
+function classify(
+  internal: boolean,
+  address: string,
+  netmask: string,
+  interfaceName: string,
+): RemoteEndpointReachability {
+  if (internal || isLoopbackAddress(address)) return "loopback";
+  // A virtual adapter disqualifies the overlay claim before the range/mask
+  // pair is even consulted: several CNIs hand pods a /32 out of 100.64/10
+  // precisely to conserve RFC1918, which reproduces the overlay's signature
+  // exactly while the hop is a plain cleartext bridge on this host.
+  if (!isVirtualAdapter(interfaceName) && isPrivateNetworkAddress(address, netmask)) {
+    return "private-network";
+  }
+  return "lan";
+}
+
+function labelFor(
+  reachability: RemoteEndpointReachability,
+  interfaceName: string,
+  address: string,
+): string {
+  if (reachability === "loopback") return LOOPBACK_LABEL;
+  if (reachability === "private-network") {
+    return looksLikeTailscale(interfaceName) ? "Tailscale" : "Private network";
+  }
+  return `${interfaceName} ${address}${isVirtualAdapter(interfaceName) ? " (virtual)" : ""}`;
+}
+
+/** Every IPv4 address the machine holds, classified and ordered
+ * private-network → lan → loopback (most private first, so the pairing path
+ * and the settings list both lead with the encrypted option), with virtual
+ * adapters after all of them. */
+export function classifyEndpoints(interfaces: InterfaceTable, port: number): RemoteEndpoint[] {
+  const endpoints: RemoteEndpoint[] = [];
+  for (const [interfaceName, addresses] of Object.entries(interfaces)) {
+    for (const info of addresses ?? []) {
+      if (info.family !== "IPv4") continue;
+      const reachability = classify(info.internal, info.address, info.netmask, interfaceName);
+      endpoints.push({
+        wsUrl: `ws://${info.address}:${port}`,
+        reachability,
+        // Only the overlay carries its own encryption. LAN ws:// is plaintext.
+        encrypted: reachability === "private-network",
+        virtual: isVirtualAdapter(interfaceName),
+        label: labelFor(reachability, interfaceName, info.address),
+      });
+    }
+  }
+  return endpoints.toSorted(
+    (a, b) => Number(a.virtual) - Number(b.virtual) || RANK[a.reachability] - RANK[b.reachability],
+  );
+}
+
+function hasAddress(interfaces: InterfaceTable, address: string): boolean {
+  for (const addresses of Object.values(interfaces)) {
+    for (const info of addresses ?? []) {
+      if (info.family === "IPv4" && info.address === address) return true;
+    }
+  }
+  return false;
+}
+
+/** The addresses the ws server binds, in bind order — LOOPBACK FIRST.
+ *
+ * Loopback is ALWAYS in the list: the desktop's own renderer dials
+ * 127.0.0.1 on every launch, and a listening socket binds exactly one
+ * address — so pinning remote access to a single interface has to leave a
+ * second listener on loopback or it takes the app's own window offline. The
+ * caller binds the head first and commits it before attempting the tail, so
+ * the order here is load-bearing, not cosmetic.
+ * `BIND_ALL_ADDRESS` already covers loopback, so it binds alone. */
+export function resolveBindHosts(
+  config: { readonly enabled: boolean; readonly bindAddress: string },
+  interfaces: InterfaceTable,
+): readonly string[] {
+  if (!config.enabled) return [LOOPBACK_ADDRESS];
+  if (config.bindAddress === BIND_ALL_ADDRESS) return [BIND_ALL_ADDRESS];
+  if (isLoopbackAddress(config.bindAddress)) return [LOOPBACK_ADDRESS];
+  // An address the machine no longer holds (overlay down, laptop moved
+  // networks) fails EADDRNOTAVAIL. Degrade to loopback: the app keeps working
+  // and nothing is exposed. The caller resolves this afresh on every bind, so
+  // an address that comes back is picked up by the next one.
+  if (!hasAddress(interfaces, config.bindAddress)) return [LOOPBACK_ADDRESS];
+  return [LOOPBACK_ADDRESS, config.bindAddress];
+}

--- a/packages/server/src/transport/remote-access-manager.ts
+++ b/packages/server/src/transport/remote-access-manager.ts
@@ -14,9 +14,22 @@ import { type Static, Type } from "@sinclair/typebox";
 import { emitEvent } from "../events";
 import { JsonStore, inteligirPath, type FsAdapter } from "@repo/storage/json-store";
 import { DeviceAuthStore, type PairingRedeemResult, type TokenValidator } from "./device-auth";
-import type { PairingInfo, RemoteAccessState } from "@repo/bridge/remote-access";
+import {
+  classifyEndpoints,
+  LOOPBACK_ADDRESS,
+  LOOPBACK_LABEL,
+  type InterfaceTable,
+} from "./network-endpoints";
+import {
+  BIND_ALL_ADDRESS,
+  endpointAddress,
+  type PairingInfo,
+  type PairingUrl,
+  type RemoteAccessState,
+  type RemoteEndpoint,
+} from "@repo/bridge/remote-access";
 
-const CONFIG_VERSION = 1;
+const CONFIG_VERSION = 2;
 
 export const DEFAULT_REMOTE_ACCESS_PORT = 47890;
 
@@ -25,25 +38,44 @@ const RemoteAccessConfigSchema = Type.Object(
     version: Type.Literal(CONFIG_VERSION),
     enabled: Type.Boolean(),
     port: Type.Number(),
+    bindAddress: Type.String(),
   },
   { additionalProperties: false },
 );
 
 type StoredConfig = Static<typeof RemoteAccessConfigSchema>;
 
+// A version mismatch drops the stored file, so every default here has to be
+// the SAFE post-drop value — for bindAddress that is the every-interface bind,
+// which is what the transport did before the field existed.
 const DEFAULT_CONFIG: StoredConfig = {
   version: CONFIG_VERSION,
   enabled: false,
   port: DEFAULT_REMOTE_ACCESS_PORT,
+  bindAddress: BIND_ALL_ADDRESS,
 };
 
-export type RemoteAccessConfig = { enabled: boolean; port: number };
+export type RemoteAccessConfig = {
+  enabled: boolean;
+  port: number;
+  bindAddress: string;
+  /** Bumped by every `setConfig` call, including one that changes nothing.
+   * The ws host compares configs to decide rebinds, so without this a user
+   * re-picking the address they are already pinned to — the one recovery an
+   * unbound pin has — would compare equal and rebind nothing. Deliberately
+   * in-memory: it orders binds within a process, it is not state. */
+  revision: number;
+};
 
 export type RemoteAccessManagerOptions = {
   fs?: FsAdapter | undefined;
   configPath?: string | undefined;
   devicesPath?: string | undefined;
   now?: (() => number) | undefined;
+  /** The OS interface table, read afresh on every query. Injected so tests can
+   * pin an address list that would otherwise depend on the box's NICs;
+   * production has no reason to set it. */
+  networkInterfaces?: (() => InterfaceTable) | undefined;
 };
 
 export class RemoteAccessManager {
@@ -53,13 +85,23 @@ export class RemoteAccessManager {
   /** The port the ws server actually bound (ephemeral ports differ from
    * config); null while not listening. */
   private boundPort: number | null = null;
-  /** The last bind failure the ws server reported; null while listening (or
-   * before any failure). Lets the shell fail startup fast instead of waiting
-   * out its bind timeout. */
+  /** The last bind failure the ws server reported; null once a bind reports
+   * clean. Lets the shell fail startup fast instead of waiting out its bind
+   * timeout. NOT cleared merely because the server is listening: a pinned
+   * remote address that failed while loopback came up is exactly a listening
+   * server WITH an error to tell the user about. */
   private listenError: string | null = null;
+  /** The addresses the ws server reported binding, as it bound them. NOT
+   * re-derived from the config: the config is a request, and a pinned address
+   * that was absent at bind time (booting before the overlay is up) never
+   * became a socket however available it looks now. */
+  private boundHosts: readonly string[] = [];
+  private revision = 0;
   private readonly changeListeners = new Set<(state: RemoteAccessState) => void>();
+  private readonly readInterfaces: () => InterfaceTable;
 
   constructor(opts: RemoteAccessManagerOptions = {}) {
+    this.readInterfaces = opts.networkInterfaces ?? (() => os.networkInterfaces());
     this.configStore = new JsonStore<StoredConfig>(
       opts.configPath ?? inteligirPath("remote-access.json"),
       RemoteAccessConfigSchema,
@@ -87,37 +129,59 @@ export class RemoteAccessManager {
   }
 
   getConfig(): RemoteAccessConfig {
-    const { enabled, port } = this.configStore.read();
-    return { enabled, port };
+    const { enabled, port, bindAddress } = this.configStore.read();
+    return { enabled, port, bindAddress, revision: this.revision };
   }
 
   getState(): RemoteAccessState {
-    const { enabled, port } = this.getConfig();
+    const { enabled, port, bindAddress } = this.getConfig();
     return {
       enabled,
       port,
+      bindAddress,
+      boundAddresses: this.boundHosts,
       listening: this.listening,
-      lanUrls: enabled ? this.lanUrls() : [],
+      endpoints: this.endpoints(),
       devices: this.devices.listDevices(),
     };
   }
 
-  /** Patch config; an omitted field keeps its current value. Only `enabled`
-   * crosses the Bridge — `port` is for tests and a future settings field. */
-  setConfig(patch: { enabled?: boolean; port?: number }): RemoteAccessState {
+  /** Patch config; an omitted field keeps its current value. `enabled` and
+   * `bindAddress` cross the Bridge — `port` is for tests and a future
+   * settings field. */
+  setConfig(patch: { enabled?: boolean; port?: number; bindAddress?: string }): RemoteAccessState {
+    this.revision += 1;
     this.configStore.update((current) => ({
       version: CONFIG_VERSION,
       enabled: patch.enabled ?? current.enabled,
       port: patch.port ?? current.port,
+      bindAddress: patch.bindAddress ?? current.bindAddress,
     }));
     return this.notify();
   }
 
   createPairingToken(): PairingInfo {
-    const { enabled, port } = this.getConfig();
+    const config = this.getConfig();
     const { token, expiresAt } = this.devices.createPairingToken();
-    const lanUrls = enabled ? this.lanUrls() : [];
-    const urls = lanUrls.length > 0 ? lanUrls : [`ws://127.0.0.1:${this.boundPort ?? port}`];
+    // An encrypted overlay address is the one worth handing out first: pairing
+    // over it keeps the one-time token — and every frame after it — off the LAN
+    // in the clear. It ORDERS the offer, it does not narrow it: a phone that
+    // isn't on the tailnet can only reach the LAN address, and dropping that
+    // would leave it with a single unreachable URL and no way to pair at all.
+    // Virtual adapters are dropped though — they reach nobody at all — and
+    // loopback is the last resort, not an offer.
+    const remote = this.reachableEndpoints()
+      .filter((endpoint) => endpoint.reachability !== "loopback" && !endpoint.virtual)
+      .toSorted((a, b) => Number(b.encrypted) - Number(a.encrypted));
+    const urls: readonly PairingUrl[] =
+      remote.length > 0
+        ? remote.map((endpoint) => ({ wsUrl: endpoint.wsUrl, label: endpoint.label }))
+        : [
+            {
+              wsUrl: `ws://${LOOPBACK_ADDRESS}:${this.boundPort ?? config.port}`,
+              label: LOOPBACK_LABEL,
+            },
+          ];
     return { token, urls, expiresAt: new Date(expiresAt).toISOString() };
   }
 
@@ -140,11 +204,20 @@ export class RemoteAccessManager {
 
   /** The ws server reports its listening state here (actual bound port, which
    * differs from config when the config port is 0/ephemeral). A bind failure
-   * passes its message as `error`; a successful bind clears it. */
-  setListening(listening: boolean, boundPort: number | null, error: string | null = null): void {
+   * passes its message as `error` — including the partial case, where the
+   * primary address is listening but a pinned one is not; a clean bind omits
+   * it and clears the previous one. `boundHosts` is the addresses that came
+   * up, and it is the ONLY authority on what a peer can dial. */
+  setListening(
+    listening: boolean,
+    boundPort: number | null,
+    error: string | null = null,
+    boundHosts: readonly string[] = [],
+  ): void {
     this.listening = listening;
     this.boundPort = boundPort;
-    this.listenError = listening ? null : error;
+    this.listenError = error;
+    this.boundHosts = boundHosts;
     this.notify();
   }
 
@@ -175,19 +248,19 @@ export class RemoteAccessManager {
     this.devices.close();
   }
 
-  /** `ws://<addr>:<port>` per non-internal IPv4 interface — only meaningful
-   * while remote access is enabled (otherwise the server binds loopback). */
-  private lanUrls(): string[] {
-    const port = this.boundPort ?? this.getConfig().port;
-    const urls: string[] = [];
-    for (const addresses of Object.values(os.networkInterfaces())) {
-      for (const address of addresses ?? []) {
-        if (address.family === "IPv4" && !address.internal) {
-          urls.push(`ws://${address.address}:${port}`);
-        }
-      }
-    }
-    return urls;
+  /** Every address this computer holds — the candidate set the settings bind
+   * picker offers, independent of what the server currently binds. */
+  private endpoints(): RemoteEndpoint[] {
+    return classifyEndpoints(this.readInterfaces(), this.boundPort ?? this.getConfig().port);
+  }
+
+  /** The subset a peer can actually dial right now: the candidates narrowed to
+   * the addresses the ws server REPORTED binding. */
+  private reachableEndpoints(): RemoteEndpoint[] {
+    if (this.boundHosts.includes(BIND_ALL_ADDRESS)) return this.endpoints();
+    return this.endpoints().filter((endpoint) =>
+      this.boundHosts.includes(endpointAddress(endpoint)),
+    );
   }
 
   private notify(): RemoteAccessState {

--- a/packages/server/src/transport/ws-host.ts
+++ b/packages/server/src/transport/ws-host.ts
@@ -1,12 +1,15 @@
 // ---------------------------------------------------------------------------
 // WS server fold — serves the host's handler map + event stream over ONE
-// WebSocket server. Binds loopback while remote access is disabled, 0.0.0.0
-// when enabled, and rebinds when the manager's config changes (clients
-// reconnect via their supervisors — that's designed-for). Every socket must
-// authenticate (auth or pair frame) within 10s before any request flows.
+// WebSocket server, fed by one HTTP listener per address the remote-access
+// config resolves to (loopback while disabled; loopback plus the selected
+// interface, or every interface, while enabled). Rebinds when the manager's
+// config changes (clients reconnect via their supervisors — that's
+// designed-for). Every socket must authenticate (auth or pair frame) within
+// 10s before any request flows.
 // ---------------------------------------------------------------------------
 
-import type { IncomingMessage } from "node:http";
+import http, { type IncomingMessage } from "node:http";
+import os from "node:os";
 import { WebSocket, WebSocketServer, type RawData } from "ws";
 
 import { createBackoff, timeoutSchedule } from "@repo/bridge/backoff";
@@ -35,6 +38,7 @@ import { yieldToEventLoop } from "@repo/storage/yield-to-event-loop";
 import type { HostEvents } from "../boot/create-host";
 import type { WireHandler } from "../handlers/handler-registry";
 import { LOCAL_DEVICE_ID, type DeviceSession, type TokenValidator } from "./device-auth";
+import { LOOPBACK_ADDRESS, resolveBindHosts, type InterfaceTable } from "./network-endpoints";
 import type { RemoteAccessManager } from "./remote-access-manager";
 
 // writeVaultAsset ships base64 image bytes in a single frame.
@@ -86,12 +90,23 @@ export type WsHostOptions = {
   /** Liveness ping cadence. Exists so tests can drive the sweep without waiting
    * out the real interval; production has no reason to set it. */
   pingIntervalMs?: number;
+  /** The OS interface table, read afresh on every bind. Injected so tests can
+   * pin an address list that would otherwise depend on the box's NICs;
+   * production has no reason to set it. */
+  networkInterfaces?: () => InterfaceTable;
 };
 
 export type WsHost = {
   /** Actual bound port, or null while not listening. */
   port: () => number | null;
   close: () => Promise<void>;
+};
+
+/** A live bind: the one ws server plus the HTTP listeners feeding it upgrades
+ * (one per bound address — see `listen`). */
+type LiveServer = {
+  readonly wss: WebSocketServer;
+  readonly listeners: readonly http.Server[];
 };
 
 /** The companion surface a paired remote device may reach (see the registry
@@ -148,6 +163,72 @@ function originAllowed(origin: string | undefined): boolean {
   return host === "localhost" || host === "127.0.0.1" || host === "[::1]" || host === "::1";
 }
 
+/** The CONFIG a bind was asked for — never the resolved address list, which is
+ * recomputed from the live interface table on every bind attempt. Comparing
+ * configs is what distinguishes "the user changed something" from "the machine
+ * moved networks under us"; only the former is a rebind. */
+type BindTarget = {
+  readonly enabled: boolean;
+  readonly bindAddress: string;
+  readonly port: number;
+  /** Bumped by every setConfig, so re-selecting the address already pinned
+   * counts as a change. It has to: a pin whose address was absent at bind time
+   * degraded to loopback, and asking for it again is the user's only way to
+   * pick it up once the interface appears. */
+  readonly revision: number;
+};
+
+function sameBind(a: BindTarget, b: BindTarget): boolean {
+  return (
+    a.enabled === b.enabled &&
+    a.bindAddress === b.bindAddress &&
+    a.port === b.port &&
+    a.revision === b.revision
+  );
+}
+
+/** Release the bound ports. `close()` drops the listening handle
+ * synchronously, so the port is free for an immediate rebind; its callback
+ * (which waits on sockets already upgraded away from HTTP) is nothing a
+ * rebind needs to wait for — the ws server's own close covers those. */
+function stopListeners(listeners: readonly http.Server[]): void {
+  for (const listener of listeners) listener.close();
+}
+
+function bindListener(wss: WebSocketServer, host: string, port: number): Promise<http.Server> {
+  return new Promise((resolve, reject) => {
+    const listener = http.createServer((_request, response) => {
+      response.writeHead(426, { "content-type": "text/plain" });
+      response.end("upgrade required");
+    });
+    listener.on("upgrade", (request, socket, head) => {
+      wss.handleUpgrade(request, socket, head, (sock) => {
+        wss.emit("connection", sock, request);
+      });
+    });
+    const onError = (err: Error): void => {
+      listener.removeListener("listening", onListening);
+      listener.close();
+      reject(err);
+    };
+    const onListening = (): void => {
+      listener.removeListener("error", onError);
+      // A BOUND listener with no `error` listener turns any later async error
+      // into an unhandled `error` event, which takes the process down — and
+      // the real teardown handler cannot be attached until every address in
+      // the attempt has resolved. This one holds the gap and stays underneath
+      // it afterwards.
+      listener.on("error", (err) => {
+        console.error(`[ws-host] listener error on ${host}:`, err);
+      });
+      resolve(listener);
+    };
+    listener.once("error", onError);
+    listener.once("listening", onListening);
+    listener.listen(port, host);
+  });
+}
+
 export function startWsHost(options: WsHostOptions): WsHost {
   // One flat dispatch map: host handlers first, shell handlers fill the
   // methods the platform-agnostic host doesn't own.
@@ -199,9 +280,14 @@ export function startWsHost(options: WsHostOptions): WsHost {
     if (sock.readyState === WebSocket.OPEN) sock.send(frame);
   }
 
-  let server: WebSocketServer | null = null;
+  let server: LiveServer | null = null;
   let actualPort: number | null = null;
   let closed = false;
+  // The bind in flight, or null. `server` is only set once the addresses are
+  // bound, so this is what a concurrent caller must AWAIT rather than drop:
+  // returning early would let `close()` resolve — or a rebind proceed — while
+  // an untracked listener is still coming up.
+  let binding: Promise<void> | null = null;
   // Set on the first successful bind: the initial boot bind is fail-fast (the
   // shell surfaces a fatal dialog off the manager's listen error), while a
   // later rebind failure retries with backoff.
@@ -219,17 +305,41 @@ export function startWsHost(options: WsHostOptions): WsHost {
   const responsive = new WeakSet<WebSocket>();
   let preAuthCount = 0;
 
-  function desiredBind(): { host: string; port: number } {
-    const config = options.manager.getConfig();
-    return { host: config.enabled ? "0.0.0.0" : "127.0.0.1", port: config.port };
+  const readInterfaces = options.networkInterfaces ?? (() => os.networkInterfaces());
+
+  function desiredBind(): BindTarget {
+    const { enabled, bindAddress, port, revision } = options.manager.getConfig();
+    return { enabled, bindAddress, port, revision };
   }
 
   /** The bind the CONFIG currently asks for (config values, so an ephemeral
    * `port: 0` stays 0 here) — compared against config on every manager change
-   * to decide rebinds. Deliberately NOT cleared when the live server dies:
-   * recovery from a failed bind is the retry loop's job, and a config change
-   * must still be recognizable as one. */
+   * to decide rebinds, and re-checked after a bind lands so a config change
+   * that raced it is not silently served by the previous target. Deliberately
+   * NOT cleared when the live server dies: recovery from a failed bind is the
+   * retry loop's job, and a config change must still be recognizable as one. */
   let targetBind = desiredBind();
+
+  /** Queue `work` behind everything already queued. EVERY bind and teardown
+   * goes through here — including the backoff retry, which is the one that
+   * used to run outside the chain and could install a listener against a
+   * target the user had already changed. */
+  function enqueue(work: () => Promise<void>): Promise<void> {
+    const previous = rebindChain;
+    const next = (async () => {
+      await previous;
+      await work();
+    })();
+    // The chain the queue and close() both await must never carry a rejection:
+    // one throw would reject every later enqueue and close() itself, wedging
+    // the transport with no way to rebind. Nothing throws today (bindOnce
+    // catches its binds, stopServer always resolves), so this is a guard on
+    // the invariant rather than a live path.
+    rebindChain = next.catch((err: unknown) => {
+      console.error("[ws-host] rebind chain failed:", err);
+    });
+    return next;
+  }
 
   function clearRetry(): void {
     rebindBackoff.cancel();
@@ -238,45 +348,123 @@ export function startWsHost(options: WsHostOptions): WsHost {
 
   function scheduleRetry(): void {
     if (closed) return;
-    rebindBackoff.schedule(listen);
+    rebindBackoff.schedule(() => void enqueue(() => listen()));
   }
 
-  function listen(): void {
-    if (closed || server !== null) return;
-    const bind = targetBind;
+  function tearDown(live: LiveServer, err: unknown): void {
+    console.error("[ws-host] server error:", err);
+    // The server is dead — drop it so a retry (or config change) binds fresh.
+    server = null;
+    actualPort = null;
+    for (const sock of live.wss.clients) sock.terminate();
+    authedSockets.clear();
+    live.wss.close();
+    stopListeners(live.listeners);
+    options.manager.setListening(false, null, toErrorMessage(err));
+    if (everListened) scheduleRetry();
+  }
+
+  /** A bind that came up but has not been committed as `server` yet. */
+  type BindAttempt = {
+    readonly wss: WebSocketServer;
+    readonly listeners: readonly http.Server[];
+    readonly port: number;
+    /** The addresses that actually came up — what `commit` hands the manager,
+     * so nothing downstream has to re-derive reachability from the config. */
+    readonly hosts: readonly string[];
+    /** A non-primary address that failed while the primary one came up.
+     * Reported, never fatal. */
+    readonly extraError: string | null;
+  };
+
+  /** Throw away a ws server + its listeners without touching `server` — for a
+   * bind that must not be kept (closed mid-flight, or superseded). */
+  function discard(attempt: BindAttempt): void {
+    for (const sock of attempt.wss.clients) sock.terminate();
+    attempt.wss.close();
+    stopListeners(attempt.listeners);
+  }
+
+  /** One bind pass, or null if the PRIMARY address failed — already reported,
+   * with a retry scheduled where one is warranted. */
+  async function bindOnce(bind: BindTarget): Promise<BindAttempt | null> {
+    // Resolved HERE, per attempt, against the LIVE interface table — never
+    // from a list captured when the config changed. A pinned address can
+    // vanish between the two (the overlay drops, the laptop sleeps or roams),
+    // and replaying a stale list would rebind the same dead host on every
+    // retry, forever.
+    const hosts = resolveBindHosts(bind, readInterfaces());
+    const [primary = LOOPBACK_ADDRESS, ...extra] = hosts;
+    // One ws server fed by one HTTP listener PER BOUND ADDRESS. A socket binds
+    // exactly one address, and remote access may be pinned to a single
+    // interface (a Tailscale address) while the desktop's own renderer still
+    // dials 127.0.0.1 every launch — so loopback gets its own listener.
+    // `noServer` keeps both listeners upgrading into the SAME ws server, so
+    // client tracking, the liveness sweep and teardown stay single-sourced.
     const wss = new WebSocketServer({
-      host: bind.host,
-      port: bind.port,
+      noServer: true,
       perMessageDeflate: false,
       maxPayload: MAX_PAYLOAD_BYTES,
     });
-    server = wss;
-    wss.on("listening", () => {
-      if (wss !== server) return;
-      everListened = true;
-      clearRetry();
-      const address = wss.address();
-      actualPort = typeof address === "object" && address !== null ? address.port : bind.port;
-      options.manager.setListening(true, actualPort);
-    });
-    wss.on("error", (err) => {
-      if (wss !== server) return;
-      console.error("[ws-host] server error:", err);
-      // The server is dead — drop it so a retry (or config change) binds fresh.
-      server = null;
-      actualPort = null;
-      for (const sock of wss.clients) sock.terminate();
-      authedSockets.clear();
-      wss.close(() => {});
+    // Attached before the first bind: an upgrade can land while a later
+    // address is still binding, and a connection nobody handles is a socket
+    // that never authenticates and never closes.
+    wss.on("connection", handleConnection);
+    const listeners: http.Server[] = [];
+    const bound: string[] = [];
+    let port = bind.port;
+    try {
+      const listener = await bindListener(wss, primary, port);
+      const address = listener.address();
+      // An ephemeral `port: 0` resolves on the FIRST bind; every later
+      // address joins that port so one URL is valid everywhere.
+      if (typeof address === "object" && address !== null) port = address.port;
+      listeners.push(listener);
+      bound.push(primary);
+    } catch (err) {
+      wss.close();
       options.manager.setListening(false, null, toErrorMessage(err));
       if (everListened) scheduleRetry();
-    });
+      return null;
+    }
+    // `resolveBindHosts` puts loopback first, and every address after it is
+    // BEST EFFORT: binding an unassigned IPv4 fails EADDRNOTAVAIL, and the
+    // desktop's own renderer must never lose its socket because a remote
+    // address went away.
+    let extraError: string | null = null;
+    for (const host of extra) {
+      try {
+        listeners.push(await bindListener(wss, host, port));
+        bound.push(host);
+      } catch (err) {
+        extraError = `${host}: ${toErrorMessage(err)}`;
+      }
+    }
+    return { wss, listeners, port, hosts: bound, extraError };
+  }
+
+  function commit(attempt: BindAttempt): void {
+    const live: LiveServer = { wss: attempt.wss, listeners: attempt.listeners };
+    server = live;
+    actualPort = attempt.port;
+    everListened = true;
+    clearRetry();
+    // A post-bind error on ANY listener tears the whole server down, including
+    // loopback — but the retry that follows re-resolves the host list, so a
+    // pinned address that died comes back as a loopback-only bind within a
+    // backoff tick rather than wedging the renderer out.
+    for (const listener of attempt.listeners) {
+      listener.on("error", (err) => {
+        if (server !== live) return;
+        tearDown(live, err);
+      });
+    }
     // Liveness sweep. `responsive` is refreshed by every pong (ws answers our
     // protocol ping automatically on the peer side, so this needs no cooperation
     // from the client protocol). A socket still unmarked one full interval after
     // we pinged it never answered, so it is gone.
     const pingTimer = setInterval(() => {
-      for (const sock of wss.clients) {
+      for (const sock of live.wss.clients) {
         if (!responsive.delete(sock)) {
           sock.terminate();
           continue;
@@ -284,31 +472,68 @@ export function startWsHost(options: WsHostOptions): WsHost {
         sock.ping();
       }
     }, options.pingIntervalMs ?? PING_INTERVAL_MS);
-    // Fires for both teardown paths (stopServer and the error handler both call
+    // Fires for both teardown paths (stopServer and tearDown both call
     // wss.close()), so the timer can never outlive its server.
-    wss.on("close", () => clearInterval(pingTimer));
+    live.wss.on("close", () => clearInterval(pingTimer));
+    options.manager.setListening(true, attempt.port, attempt.extraError, attempt.hosts);
+  }
 
-    wss.on("connection", handleConnection);
+  async function bindUntilCurrent(): Promise<void> {
+    for (;;) {
+      if (closed || server !== null) return;
+      const bind = desiredBind();
+      const attempt = await bindOnce(bind);
+      if (attempt === null) return;
+      if (closed) {
+        discard(attempt);
+        options.manager.setListening(false, null);
+        return;
+      }
+      // A config change that landed mid-bind must not be served by the
+      // listeners the PREVIOUS one asked for: drop them and go round again
+      // against the address the user now wants.
+      if (!sameBind(bind, targetBind)) {
+        discard(attempt);
+        continue;
+      }
+      commit(attempt);
+      return;
+    }
+  }
+
+  /** Bind unless something is already up. A concurrent caller gets the
+   * IN-FLIGHT promise rather than a silent no-op, so `close()` and the rebind
+   * chain always await a bind instead of racing an untracked one. */
+  function listen(): Promise<void> {
+    const inFlight = binding;
+    if (inFlight !== null) return inFlight;
+    const started = bindUntilCurrent().finally(() => {
+      binding = null;
+    });
+    binding = started;
+    return started;
   }
 
   async function stopServer(mode: "rebind" | "final"): Promise<void> {
     clearRetry();
-    const wss = server;
+    const live = server;
     server = null;
     actualPort = null;
     authedSockets.clear();
-    if (wss === null) return;
+    if (live === null) return;
+    // Stop accepting before draining, so nothing new lands mid-teardown.
+    stopListeners(live.listeners);
     let graceTimer: NodeJS.Timeout | null = null;
     if (mode === "final") {
-      for (const sock of wss.clients) sock.terminate();
+      for (const sock of live.wss.clients) sock.terminate();
     } else {
-      for (const sock of wss.clients) sock.close(WS_CLOSE_SERVICE_RESTART, "service restart");
+      for (const sock of live.wss.clients) sock.close(WS_CLOSE_SERVICE_RESTART, "service restart");
       graceTimer = setTimeout(() => {
-        for (const sock of wss.clients) sock.terminate();
+        for (const sock of live.wss.clients) sock.terminate();
       }, REBIND_CLOSE_GRACE_MS);
     }
     await new Promise<void>((resolve) => {
-      wss.close(() => resolve());
+      live.wss.close(() => resolve());
     });
     if (graceTimer !== null) clearTimeout(graceTimer);
     options.manager.setListening(false, null);
@@ -328,19 +553,17 @@ export function startWsHost(options: WsHostOptions): WsHost {
       }
     }
     const bind = desiredBind();
-    if (bind.host === targetBind.host && bind.port === targetBind.port) return;
+    if (sameBind(bind, targetBind)) return;
     targetBind = bind;
-    const previous = rebindChain;
-    rebindChain = (async () => {
-      await previous;
+    void enqueue(async () => {
       // Defer past the current turn's microtasks: the res frame answering the
       // config change that triggered this rebind (and the just-broadcast evt
       // frame) must reach the socket before it starts closing.
       await yieldToEventLoop();
       if (closed) return;
       await stopServer("rebind");
-      listen();
-    })();
+      await listen();
+    });
   });
 
   // Events fan out per SESSION, not to every authed socket: a paired device
@@ -547,7 +770,9 @@ export function startWsHost(options: WsHostOptions): WsHost {
     });
   }
 
-  listen();
+  // Seeds the chain so a config change (or close) queues behind the first bind
+  // instead of racing it.
+  rebindChain = listen();
 
   return {
     port: () => actualPort,


### PR DESCRIPTION
Closes #519.

Remote access advertised `lanUrls: string[]` and bound `0.0.0.0`. A Tailscale address had nowhere to go in a bare string list, so the encrypted-remote story had no shape to land in and stayed deferred.

## What lands

**Typed endpoints** — `{wsUrl, reachability: "loopback"|"lan"|"private-network", encrypted, virtual, label}`.

**`bindAddress`** pins the listener to one interface. Loopback *always* gets its own listener regardless: the renderer dials `127.0.0.1` every launch, so pinning must never unreach the app from itself. One ws server (`noServer`) with an HTTP listener per bound address keeps client tracking, the liveness sweep and teardown single-sourced.

Binding the overlay address alone is what retires the deferred-TLS item — that transport is already encrypted and peer-authenticated.

## The encryption claim needs proof

`100.64.0.0/10` is **carrier-grade NAT**, not Tailscale space. Starlink-direct, carrier tethering, campus networks and k8s pod ranges all hand out real plaintext addresses there. An address is only treated as an overlay when it is in that range **and** carries a `/32` netmask **and** is not on a virtual adapter. Anything short of that is plain LAN.

That matters because the flag is what Settings tells you about your security: *"Reachable only over Tailscale, which encrypts and authenticates the connection itself"* versus *"Connections on your local network are unencrypted."*

## Three rounds of review, three real bugs

- **The app could permanently disconnect from itself.** A failed pinned bind tore down the loopback listener that had already succeeded, and the retry replayed a stale host list forever. Bind is now loopback-first with a best-effort tail, and the host list is re-resolved on every attempt.
- **A listener could outlive being turned off.** The backoff retry was the one bind outside the serialization chain, so it could install itself against a superseded target. Every bind now goes through the chain `close()` awaits.
- **The manager guessed what was bound instead of being told.** Boot before Tailscale is up and the config still named an address nothing was listening on — advertised as reachable *and* encrypted, and offered as the only pairing URL. The host now reports the addresses it actually bound; Settings distinguishes *missing* from *unbound* and offers to bind it.

Pairing lists each URL on its own labelled line, because `parsePairingInput` takes the **first** URL it finds — a single blob led by a tailnet address is unpairable from plain Wi-Fi.

## Verification

`pnpm verify` exit 0. 79 transport tests. Driven in the harness across the pinned-but-unbound state and its recovery.

## Known, and needs a machine with a tailnet

**Nobody has confirmed that a live Tailscale interface reports netmask `255.255.255.255`.** It is the load-bearing assumption for `encrypted`, and it fails *safe* — without it every overlay endpoint downgrades to plain LAN and simply loses the feature rather than lying. Worth confirming on a box with Tailscale up.

Out of scope, deliberately: QR pairing, IPv6 (stated as a constraint in the module header), and installing or managing Tailscale itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Classified remote-access endpoints and added `bindAddress` so the WS host can bind a single interface while always keeping loopback reachable, enabling encrypted Tailscale access and clearer pairing. Closes #519.

- **New Features**
  - Typed endpoints with `reachability` (`loopback` | `lan` | `private-network`), `encrypted`, `virtual`, and `label`; overlay detection requires 100.64.0.0/10 + `/32` and not a virtual adapter (labels “Tailscale”).
  - `bindAddress` (default `BIND_ALL_ADDRESS`) pins the bind; loopback is always bound first; host reports `boundAddresses`. Pairing returns labelled URLs, ordered encrypted-first, drops virtual adapters, and shows each URL on its own line.
  - New `network-endpoints` classifies interfaces and `resolveBindHosts` computes bind order. `ws-host` runs one WS server with an HTTP listener per bound address; rebinds use the live interface table each attempt and serialize behind a single chain.
  - Renderer settings: add a simple “Reachable on” picker, show security copy (encrypted vs cleartext), surface “unavailable” vs “Listen on it now” for late interfaces; pairing UI shows labelled URLs.

- **Bug Fixes**
  - Loopback stays reachable if a pinned address can’t bind; retries re-resolve hosts instead of replaying stale lists.
  - All binds and retries are serialized so a backoff can’t install against a superseded target; `close()` awaits the chain.
  - Manager reports what actually bound (not inferred), so Settings no longer advertises unreachable or misclassified endpoints.

<sup>Written for commit d71accfc0fb915f64f8fc27475d33379228d0247. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kyh/inteligir/pull/522?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

