### PR TITLE
feat(desktop): make "Check for Updates" actually update

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -5,8 +5,13 @@
 # zone) permissions.
 name: Deploy
 
+# Gated on CI rather than on the push: a `push` trigger races the test run and
+# can publish from a red tree. `workflow_run` fires only after CI reports, and
+# the jobs below refuse anything but a success.
 on:
-  push:
+  workflow_run:
+    workflows: [CI]
+    types: [completed]
     branches: [main]
 
 # Deploying needs no repo write. The credential that matters is
@@ -22,13 +27,18 @@ concurrency:
 
 jobs:
   detect-changes:
+    if: github.event.workflow_run.conclusion == 'success'
     runs-on: ubuntu-latest
     outputs:
       web: ${{ steps.check.outputs.web }}
     steps:
+      # workflow_run checks out the DEFAULT branch tip unless told otherwise,
+      # which would deploy whatever main happens to be rather than the commit
+      # CI just passed. Pin both to the tested SHA.
       - uses: actions/checkout@v7
         with:
           fetch-depth: 0
+          ref: ${{ github.event.workflow_run.head_sha }}
 
       - uses: pnpm/action-setup@v6
 
@@ -42,7 +52,7 @@ jobs:
       - name: Detect changed apps
         id: check
         run: |
-          BASE="${{ github.event.before }}"
+          BASE="$(git rev-parse "${{ github.event.workflow_run.head_sha }}^" 2>/dev/null || echo 0000000000000000000000000000000000000000)"
           if [ "$BASE" = "0000000000000000000000000000000000000000" ]; then
             echo "web=true" >> "$GITHUB_OUTPUT"
             exit 0
@@ -66,17 +76,17 @@ jobs:
     # environment in repo settings, not in this file. It also gives each run a
     # deployment record pointing at what it published.
     #
-    # It is NOT a CI gate. This workflow and CI both fire on the same `push`
-    # to main and start at the same instant, so a red `pnpm verify` still
-    # reaches inteligir.com. Closing that needs a required status check on
-    # `main` for CI's `check` job — a repo setting no workflow file can apply.
-    # Blast radius is bounded meanwhile: this deploys @repo/web (the marketing
-    # site) only; apps/cloud is manual and owner-only.
+    # It is not the CI gate — the `workflow_run` trigger is, so a red tree
+    # never reaches inteligir.com. This deploys @repo/web (the marketing site)
+    # only; apps/cloud stays manual and owner-only.
     environment:
       name: production
       url: https://inteligir.com
     steps:
+      # The tested commit, not whatever main has moved to since.
       - uses: actions/checkout@v7
+        with:
+          ref: ${{ github.event.workflow_run.head_sha }}
 
       - uses: pnpm/action-setup@v6
 

--- a/apps/desktop/src/main/updater.ts
+++ b/apps/desktop/src/main/updater.ts
@@ -1,10 +1,17 @@
 // ---------------------------------------------------------------------------
 // electron-updater wiring — desktop-shell-only, no Bridge surface. The app
-// checks the update feed on a startup delay and from the "Check for
-// Updates..." menu item; downloads stay off (autoDownload=false) until a UI
-// consumes update state.
+// checks the feed on a startup delay and from the "Check for Updates..." menu
+// item, downloads what it finds, and offers a restart once the bytes are on
+// disk. Declining is not a dead end: `autoInstallOnAppQuit` applies it the
+// next time the app closes, so an update never depends on the user returning
+// to a dialog they dismissed.
+//
+// A dialog rather than a Bridge channel: the startup check can beat the window
+// into existence, and an update is a shell concern rather than a vault one.
+// Staying off the Bridge also keeps it off the surface a paired phone reaches.
 // ---------------------------------------------------------------------------
 
+import { dialog } from "electron";
 import electronUpdater from "electron-updater";
 
 import { toErrorMessage } from "@repo/bridge/wire-helpers";
@@ -24,29 +31,87 @@ export type Updater = {
 
 export function setupAutoUpdater(options: UpdaterOptions): Updater {
   const { isDevelopment } = options;
+  // Only a check the user ASKED for reports "up to date" or an error. The
+  // startup check stays silent on both, or every launch without a release
+  // interrupts to say nothing happened.
+  let userInitiated = false;
+  // Guards against a second check while one is in flight — that would report
+  // twice. Covers the download too, since one check drives both.
+  let checking = false;
 
-  async function checkForUpdates(): Promise<void> {
-    if (isDevelopment) return;
+  function settle(): void {
+    checking = false;
+    userInitiated = false;
+  }
 
+  function report(type: "info" | "warning", message: string, detail?: string): void {
+    if (!userInitiated) return;
+    void dialog.showMessageBox(
+      detail === undefined
+        ? { type, message, buttons: ["OK"] }
+        : { type, message, detail, buttons: ["OK"] },
+    );
+  }
+
+  async function check(): Promise<void> {
+    if (isDevelopment || checking) return;
+    checking = true;
     try {
       await autoUpdater.checkForUpdates();
     } catch (error: unknown) {
-      console.error("[desktop] update check failed:", toErrorMessage(error));
+      const message = toErrorMessage(error);
+      console.error("[desktop] update check failed:", message);
+      report("warning", "Couldn't check for updates.", message);
+      settle();
     }
   }
 
   if (!isDevelopment) {
-    autoUpdater.autoDownload = false;
-    autoUpdater.autoInstallOnAppQuit = false;
+    // Fetch as soon as one is found: a user who asked, or who is about to be
+    // offered a restart, should not wait on a second round trip.
+    autoUpdater.autoDownload = true;
+    // The fallback for declining the restart below, so a dismissed dialog
+    // still lands the update rather than losing it.
+    autoUpdater.autoInstallOnAppQuit = true;
 
     // autoUpdater is an EventEmitter — an unhandled "error" event (flaky
     // network mid-check) would crash the main process, so it stays handled.
     autoUpdater.on("error", (error) => {
       console.error("[desktop] auto-update error:", error.message);
+      report("warning", "Couldn't install the update.", error.message);
+      settle();
     });
 
-    setTimeout(() => void checkForUpdates(), STARTUP_UPDATE_DELAY_MS);
+    autoUpdater.on("update-not-available", () => {
+      report("info", "inteligir is up to date.");
+      settle();
+    });
+
+    autoUpdater.on("update-downloaded", (info) => {
+      settle();
+      void dialog
+        .showMessageBox({
+          type: "info",
+          message: `Version ${info.version} is ready.`,
+          detail: "Restart now to use it, or it will be applied the next time you quit.",
+          buttons: ["Restart now", "Later"],
+          defaultId: 0,
+          cancelId: 1,
+        })
+        .then((result) => {
+          // Replaces the running app — nothing after this runs.
+          if (result.response === 0) autoUpdater.quitAndInstall();
+          return undefined;
+        });
+    });
+
+    setTimeout(() => void check(), STARTUP_UPDATE_DELAY_MS);
   }
 
-  return { checkForUpdates };
+  return {
+    checkForUpdates: async () => {
+      userInitiated = true;
+      await check();
+    },
+  };
 }


### PR DESCRIPTION
Closes #514.

## The updater did nothing

It asked GitHub whether a newer version existed and wrote the answer to a log. `autoDownload = false`, `autoInstallOnAppQuit = false`, and nothing handled `update-available`. A menu item that names an action and performs none is worse than no menu item — it reads as a reassurance.

Now: check → download → offer a restart. Declining is not a dead end, because `autoInstallOnAppQuit` lands it on the next quit. An update never depends on the user coming back to a dialog they dismissed.

**Only a user-initiated check reports "up to date" or an error.** The startup check stays silent on both — otherwise every launch without a release interrupts to say nothing happened.

**A shell dialog, not a Bridge channel.** The startup check can beat the window into existence, and staying off the Bridge keeps updates off the surface a paired phone reaches.

## Deploy no longer races CI

Both workflows fired on the same `push` and started at the same instant, so a red tree could publish the site. The file's own comment called this out and concluded it needed *"a required status check on `main` — a repo setting no workflow file can apply."*

`workflow_run` is the in-file equivalent: deploy fires only after CI reports, and the jobs refuse anything but `conclusion == 'success'`. Both jobs now check out `workflow_run.head_sha` — the tested commit — rather than whatever main has moved to since, and the changed-app detection derives its base from that SHA since a `workflow_run` payload has no `before`.

I corrected the stale comment rather than leaving it asserting something no longer true.

`pnpm verify` exit 0.

## Not verified here

The download/install path needs a real signed build and a newer release on the feed to exercise end to end — that is a release-time check, not something CI or the harness can reach.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes the desktop “Check for Updates” actually update: it downloads new versions, prompts to restart, or installs on next quit. Also gates deploy on CI so a failing build can’t publish and deploys the tested commit.

- **New Features**
  - Enable `electron-updater` auto-download; prompt “Restart now/Later”; apply on quit if deferred.
  - Show “up to date” and errors only for user-initiated checks; startup check stays quiet.
  - Use shell dialogs and guard against duplicate checks; no Bridge surface.

- **Bug Fixes**
  - Deploy runs on CI `workflow_run` and only when conclusion is success.
  - Checkout pins to `workflow_run.head_sha`; change detection bases on that SHA.

<sup>Written for commit 3e7baae8cf1402e4f058a03127db6451bc03c44f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kyh/inteligir/pull/524?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

