### PR TITLE
fix(privacy): stop a conflict copy spelling a private note's name

### DIFF
--- a/docs/privacy.md
+++ b/docs/privacy.md
@@ -82,6 +82,12 @@ boundary**. Read the "What it does NOT do" list before relying on it.
   model typed plus the refusal string in `~/.inteligir/sessions/*.jsonl` —
   never the note's content. Content a `bash` bypass obtained WOULD land in
   the transcript (the hole above).
+- **Whole-vault COUNTS are not partitioned (accepted).** Sync's manifest
+  covers every file, private ones included, so the number of files it tracks
+  differenced against a count taken over the public notes alone yields how
+  many private notes exist. A count, never a name or a byte — and the
+  alternative, a manifest that hides private files, is silent data loss on
+  your other devices.
 - **A refusal is an existence oracle (accepted).** The block reason tells
   the model that the path it named exists and is private, so an agent could
   guess filenames and learn which exist-and-are-private — paths only, never

--- a/packages/notes/src/__tests__/knowledge-index.test.ts
+++ b/packages/notes/src/__tests__/knowledge-index.test.ts
@@ -255,3 +255,110 @@ describe("KnowledgeIndex — privacy (excludePrivate)", () => {
     expect(index.notesWithTag("meta", { excludePrivate: true })).toEqual(["public.md"]);
   });
 });
+
+// The whole-vault reads — tasks, tags, wiki targets, graph. Unlike backlinks
+// and search these take no subject path, so an ungated call is a full dump of
+// the vault, and `tasks` dumps verbatim source lines with it.
+function wholeVaultSeeded(): KnowledgeIndex {
+  const index = new KnowledgeIndex();
+  index.setDoc(
+    "secret-plans.md",
+    [
+      "---",
+      "private: true",
+      "tags: [meta, covert]",
+      "---",
+      "# Secret plans",
+      "",
+      "- [ ] Book the Reykjavik room",
+      "",
+      "See [[public]] and [[unwritten codename]].",
+      "",
+    ].join("\n"),
+  );
+  index.setDoc("public.md", "# Public\n\nOrdinary text. #meta\n\n- [ ] Buy milk\n");
+  index.setDoc("broken.md", "---\n[not: valid: yaml\n---\n\n- [ ] Unreadable frontmatter task\n");
+  return index;
+}
+
+describe("KnowledgeIndex — privacy on the whole-vault reads", () => {
+  it("tasks omit private (and unreadable-frontmatter) docs, source line included", () => {
+    const index = wholeVaultSeeded();
+    expect(index.tasks().map((task) => task.path)).toEqual([
+      "broken.md",
+      "public.md",
+      "secret-plans.md",
+    ]);
+
+    const filtered = index.tasks({ excludePrivate: true });
+    expect(filtered.map((task) => task.path)).toEqual(["public.md"]);
+    // The row carries `raw`, so the assertion is on the BYTES, not the path.
+    expect(JSON.stringify(filtered)).not.toContain("Reykjavik");
+    expect(JSON.stringify(filtered)).not.toContain("Unreadable");
+  });
+
+  it("tags drop private-only names and RECOMPUTE the shared counts", () => {
+    const index = wholeVaultSeeded();
+    expect(index.tags()).toEqual([
+      { tag: "meta", count: 2 },
+      { tag: "covert", count: 1 },
+    ]);
+    expect(index.tags({ excludePrivate: true })).toEqual([{ tag: "meta", count: 1 }]);
+  });
+
+  it("a shared tag renders in a PUBLIC note's case under excludePrivate", () => {
+    const index = new KnowledgeIndex();
+    index.setDoc("secret.md", "---\nprivate: true\ntags: [Reykjavik]\n---\n# Secret\n");
+    index.setDoc("open.md", "# Open\n\nText. #reykjavik\n");
+    expect(index.tags()).toEqual([{ tag: "Reykjavik", count: 2 }]);
+    expect(index.tags({ excludePrivate: true })).toEqual([{ tag: "reykjavik", count: 1 }]);
+  });
+
+  it("wiki targets omit private docs entirely", () => {
+    const index = wholeVaultSeeded();
+    index.setOther("diagram.png");
+    expect(index.wikiTargets().map((target) => target.path)).toEqual([
+      "broken.md",
+      "public.md",
+      "secret-plans.md",
+      "diagram.png",
+    ]);
+    expect(index.wikiTargets({ excludePrivate: true }).map((target) => target.path)).toEqual([
+      "public.md",
+      "diagram.png",
+    ]);
+  });
+
+  it("the graph drops private nodes, their edges, and their phantom targets", () => {
+    const index = wholeVaultSeeded();
+    const full = index.graph();
+    expect(full.nodes.map((node) => node.id).toSorted()).toEqual([
+      "broken.md",
+      "phantom:unwritten codename",
+      "public.md",
+      "secret-plans.md",
+    ]);
+    expect(full.edges).toHaveLength(2);
+
+    const filtered = index.graph({ excludePrivate: true });
+    expect(filtered.nodes).toEqual([
+      { id: "public.md", title: "Public", path: "public.md", phantom: false, degree: 0 },
+    ]);
+    expect(filtered.edges).toEqual([]);
+    // The phantom node's id IS the private note's raw link text.
+    expect(JSON.stringify(filtered)).not.toContain("unwritten codename");
+  });
+
+  it("the graph drops an inbound edge from a public note to a private one", () => {
+    const index = new KnowledgeIndex();
+    index.setDoc("secret.md", "---\nprivate: true\n---\n# Secret\n");
+    index.setDoc("open.md", "# Open\n\nSee [[secret]].\n");
+    expect(index.graph().edges).toEqual([
+      { source: "open.md", target: "secret.md", kind: "wiki", count: 1 },
+    ]);
+
+    const filtered = index.graph({ excludePrivate: true });
+    expect(filtered.edges).toEqual([]);
+    expect(filtered.nodes.map((node) => node.degree)).toEqual([0]);
+  });
+});

--- a/packages/notes/src/knowledge/knowledge-index.ts
+++ b/packages/notes/src/knowledge/knowledge-index.ts
@@ -87,12 +87,12 @@ export class KnowledgeIndex {
     return this.linkGraph.forwardLinks(path);
   }
 
-  graph(): LinkGraph {
-    return this.linkGraph.graph();
+  graph(opts?: PrivacyOpts): LinkGraph {
+    return this.linkGraph.graph(opts);
   }
 
-  wikiTargets(): WikiTarget[] {
-    return this.linkGraph.wikiTargets();
+  wikiTargets(opts?: PrivacyOpts): WikiTarget[] {
+    return this.linkGraph.wikiTargets(opts);
   }
 
   search(query: string, limit: number = SEARCH_DEFAULT_LIMIT, opts?: PrivacyOpts): SearchResult[] {
@@ -111,12 +111,12 @@ export class KnowledgeIndex {
     }));
   }
 
-  tags(): TagCount[] {
-    return this.linkGraph.tags();
+  tags(opts?: PrivacyOpts): TagCount[] {
+    return this.linkGraph.tags(opts);
   }
 
-  tasks(): VaultTaskEntry[] {
-    return this.linkGraph.tasks();
+  tasks(opts?: PrivacyOpts): VaultTaskEntry[] {
+    return this.linkGraph.tasks(opts);
   }
 
   notesWithTag(tag: string, opts?: PrivacyOpts): string[] {

--- a/packages/notes/src/knowledge/link-graph-index.ts
+++ b/packages/notes/src/knowledge/link-graph-index.ts
@@ -303,10 +303,19 @@ export class LinkGraphIndex {
     });
   }
 
-  graph(): LinkGraph {
+  /** Under `excludePrivate` a private doc contributes NOTHING: no node (its path
+   * and title), no outgoing edges (a phantom node is its raw `[[link]]` text,
+   * which is body content), and no inbound ones (an edge naming it is its path
+   * again). `degree` then counts over the public graph, so it keeps meaning
+   * "edges touching this node in the graph you were handed". */
+  graph(opts?: PrivacyOpts): LinkGraph {
+    const excludePrivate = opts?.excludePrivate === true;
+    const visible = (path: string): boolean =>
+      !excludePrivate || this.docs.get(path)?.private !== true;
     const { forward } = this.ensureResolved();
     const nodes = new Map<string, GraphNode>();
     for (const [path, record] of this.docs) {
+      if (excludePrivate && record.private) continue;
       nodes.set(path, { id: path, title: record.title, path, phantom: false, degree: 0 });
     }
     const edges: GraphEdge[] = [];
@@ -317,6 +326,7 @@ export class LinkGraphIndex {
     // load-bearing, not tidiness.
     const bySource = new Map<string, GraphEdge>();
     for (const [sourcePath, links] of forward) {
+      if (!visible(sourcePath)) continue;
       bySource.clear();
       const sourceNode = nodes.get(sourcePath);
       for (const { link, targetPath } of links) {
@@ -329,6 +339,7 @@ export class LinkGraphIndex {
         let targetId: string;
         if (targetPath !== null) {
           if (!this.docs.has(targetPath)) continue; // resolved asset target
+          if (!visible(targetPath)) continue;
           targetId = targetPath;
         } else {
           // A dangling target written with a non-doc extension is an asset
@@ -362,13 +373,19 @@ export class LinkGraphIndex {
   }
 
   /** Docs first (title-bearing), assets after — the picker renders them as
-   * two groups in this order. */
-  wikiTargets(): WikiTarget[] {
-    const docs = [...this.docs.entries()].map(([path, record]): WikiTarget => {
+   * two groups in this order. Under `excludePrivate` a private doc is absent
+   * entirely: this is a vault LISTING, so its path, title and aliases are all
+   * the leak. Assets are unfiltered — a non-doc carries no frontmatter, so
+   * nothing can mark one private. */
+  wikiTargets(opts?: PrivacyOpts): WikiTarget[] {
+    const excludePrivate = opts?.excludePrivate === true;
+    const docs: WikiTarget[] = [];
+    for (const [path, record] of this.docs) {
+      if (excludePrivate && record.private) continue;
       const target: WikiTarget = { path, title: record.title, type: "doc" };
       if (record.aliases.length > 0) target.aliases = record.aliases;
-      return target;
-    });
+      docs.push(target);
+    }
     const assets = [...this.others].map(
       (path): WikiTarget => ({ path, title: basenamePath(path), type: "asset" }),
     );
@@ -376,17 +393,29 @@ export class LinkGraphIndex {
   }
 
   /** Every tag in the vault with its note count (most-used first). Fed by both
-   * inline `#tags` and the frontmatter `tags` property, unified case-insensitively. */
-  tags(): TagCount[] {
-    return this.tagIndex.all();
+   * inline `#tags` and the frontmatter `tags` property, unified case-insensitively.
+   *
+   * Under `excludePrivate` the counts are RECOMPUTED over the public notes, so a
+   * tag only private notes carry vanishes (its NAME is the leak) and a shared
+   * one's number describes the public notes alone. */
+  tags(opts?: PrivacyOpts): TagCount[] {
+    if (opts?.excludePrivate !== true) return this.tagIndex.all();
+    return this.tagIndex.all((path) => this.docs.get(path)?.private !== true);
   }
 
   /** Every task in the vault, sorted by path then ordinal — the Tasks view's
    * whole-vault query. A flatten over stored projections, no resolution pass
-   * (tasks don't participate in ensureResolved). */
-  tasks(): VaultTaskEntry[] {
+   * (tasks don't participate in ensureResolved).
+   *
+   * Under `excludePrivate` a private doc contributes no rows at all. This is the
+   * sharpest of the whole-vault reads: every row carries `raw`, the task's
+   * VERBATIM source line, so an ungated answer hands out private note CONTENT
+   * rather than merely paths. */
+  tasks(opts?: PrivacyOpts): VaultTaskEntry[] {
+    const excludePrivate = opts?.excludePrivate === true;
     const out: VaultTaskEntry[] = [];
     for (const [path, record] of [...this.docs.entries()].toSorted(byKey)) {
+      if (excludePrivate && record.private) continue;
       for (const task of record.tasks) {
         out.push({
           path,

--- a/packages/notes/src/knowledge/tag-index.ts
+++ b/packages/notes/src/knowledge/tag-index.ts
@@ -12,7 +12,13 @@
 /** A tag with the number of DISTINCT notes carrying it. `tag` is display case. */
 export type TagCount = { tag: string; count: number };
 
-type TagEntry = { display: string; paths: Set<string> };
+type TagEntry = {
+  /** Display case of the first occurrence among the currently-indexed docs. */
+  display: string;
+  /** path → the display case THAT doc wrote it in, so a scoped view can render
+   * the tag the way a surviving note writes it rather than an excluded one. */
+  paths: Map<string, string>;
+};
 
 export class TagIndex {
   /** lowercased tag → { display case, notes carrying it }. */
@@ -36,10 +42,10 @@ export class TagIndex {
       keys.push(key);
       let entry = this.tags.get(key);
       if (!entry) {
-        entry = { display, paths: new Set() };
+        entry = { display, paths: new Map() };
         this.tags.set(key, entry);
       }
-      entry.paths.add(path);
+      entry.paths.set(path, display);
     }
     if (keys.length > 0) this.docTags.set(path, keys);
   }
@@ -63,13 +69,32 @@ export class TagIndex {
   }
 
   /** Every tag with its note count, most-used first (ties broken alphabetically,
-   * case-insensitively) — the palette's tag list ordering. */
-  all(): TagCount[] {
-    return [...this.tags.values()]
-      .map((entry): TagCount => ({ tag: entry.display, count: entry.paths.size }))
-      .toSorted(
-        (a, b) => b.count - a.count || (a.tag.toLowerCase() < b.tag.toLowerCase() ? -1 : 1),
-      );
+   * case-insensitively) — the palette's tag list ordering.
+   *
+   * `includes` scopes the whole answer to the notes it accepts: the count is
+   * RECOMPUTED over them and a tag no accepted note carries disappears. A caller
+   * cannot get this by filtering the result — the tag list is keyed by tag, so
+   * every surviving count would still be totalling the excluded notes, and the
+   * display case would still be whichever of them was indexed first. */
+  all(includes?: (path: string) => boolean): TagCount[] {
+    const counts: TagCount[] = [];
+    for (const entry of this.tags.values()) {
+      if (includes === undefined) {
+        counts.push({ tag: entry.display, count: entry.paths.size });
+        continue;
+      }
+      let count = 0;
+      let display = "";
+      for (const [path, written] of entry.paths) {
+        if (!includes(path)) continue;
+        if (count === 0) display = written;
+        count += 1;
+      }
+      if (count > 0) counts.push({ tag: display, count });
+    }
+    return counts.toSorted(
+      (a, b) => b.count - a.count || (a.tag.toLowerCase() < b.tag.toLowerCase() ? -1 : 1),
+    );
   }
 
   /** One doc's tags in display case, extraction order (empty when unknown) —
@@ -82,6 +107,6 @@ export class TagIndex {
   /** The notes carrying `tag` (case-insensitive), by path. Empty when unknown. */
   notesWithTag(tag: string): string[] {
     const entry = this.tags.get(tag.trim().toLowerCase());
-    return entry ? [...entry.paths].toSorted() : [];
+    return entry ? [...entry.paths.keys()].toSorted() : [];
   }
 }

--- a/packages/notes/src/sync/__tests__/reconcile.test.ts
+++ b/packages/notes/src/sync/__tests__/reconcile.test.ts
@@ -1,7 +1,13 @@
 import { describe, expect, it } from "vitest";
 
 import type { LocalFile, LocalManifest, VaultManifest } from "../manifest";
-import { conflictCopyName, fsSafeStamp, isConflictCopyPath, reconcile } from "../reconcile";
+import {
+  conflictCopyName,
+  conflictOriginPath,
+  fsSafeStamp,
+  isConflictCopyPath,
+  reconcile,
+} from "../reconcile";
 import type { VaultFile } from "../vault-file";
 
 const VAULT = "vault-1";
@@ -233,5 +239,28 @@ describe("isConflictCopyPath", () => {
 
   it("only inspects the basename — directories cannot fake a match", () => {
     expect(isConflictCopyPath(`dir (conflict ${stamp})/todo.md`)).toBe(false);
+  });
+});
+
+describe("conflictOriginPath", () => {
+  const stamp = fsSafeStamp(new Date("2026-07-05T12:34:56.000Z"));
+
+  it("recovers the exact path every shape forked from", () => {
+    for (const path of ["notes/todo.md", "todo.md", "dir/README", ".gitignore", "a.tar.gz"]) {
+      expect(conflictOriginPath(conflictCopyName(path, stamp))).toBe(path);
+    }
+  });
+
+  it("answers null for anything that is not a copy of this engine's making", () => {
+    expect(conflictOriginPath("notes/todo.md")).toBeNull();
+    expect(conflictOriginPath("todo (conflict).md")).toBeNull();
+    expect(conflictOriginPath(`dir (conflict ${stamp})/todo.md`)).toBeNull();
+  });
+
+  it("peels ONE level, so a copy of a copy still answers a copy", () => {
+    const once = conflictCopyName("todo.md", stamp);
+    const twice = conflictCopyName(once, stamp);
+    expect(conflictOriginPath(twice)).toBe(once);
+    expect(conflictOriginPath(once)).toBe("todo.md");
   });
 });

--- a/packages/notes/src/sync/reconcile.ts
+++ b/packages/notes/src/sync/reconcile.ts
@@ -169,22 +169,36 @@ export function conflictCopyName(path: VaultPath, isoTimestamp: string): VaultPa
 const CONFLICT_STAMP_RE = /^\d{4}-\d{2}-\d{2}T\d{2}-\d{2}-\d{2}-\d{3}Z$/;
 
 /**
- * The reverse of `conflictCopyName`: does `path` name a conflict copy this
- * engine could have produced? Core owns the naming BOTH ways so UIs (listing
- * unresolved conflicts) and the naming scheme can never drift apart. Matches
- * exactly the `conflictCopyName(path, fsSafeStamp(date))` shape — a
- * ` (conflict <fs-safe stamp>)` suffix on the stem — and nothing looser.
+ * The inverse of `conflictCopyName`: the path a conflict copy forked FROM, or
+ * `null` when `path` does not name a copy this engine could have produced —
+ * `"notes/todo (conflict 2026-07-05T12-34-56-000Z).md"` → `"notes/todo.md"`.
+ * Core owns the naming BOTH ways so UIs (listing unresolved conflicts, hiding a
+ * copy whose origin is private) and the naming scheme can never drift apart.
+ * Matches exactly the `conflictCopyName(path, fsSafeStamp(date))` shape — a
+ * ` (conflict <fs-safe stamp>)` suffix on the stem — and nothing looser, so a
+ * user file that merely reads that way is left alone.
+ *
+ * One inversion per call: a copy OF a copy inverts to a copy, and a caller that
+ * cares about the whole ancestry re-applies this until it answers null.
  */
-export function isConflictCopyPath(path: string): boolean {
+export function conflictOriginPath(path: string): string | null {
   const slash = path.lastIndexOf("/");
+  const dir = slash === -1 ? "" : path.slice(0, slash + 1);
   const name = slash === -1 ? path : path.slice(slash + 1);
   const dot = name.lastIndexOf(".");
   const hasExt = dot > 0; // mirror conflictCopyName: a leading dot is a dotfile
   const stem = hasExt ? name.slice(0, dot) : name;
+  const ext = hasExt ? name.slice(dot) : "";
   const marker = stem.lastIndexOf(" (conflict ");
-  if (marker === -1 || !stem.endsWith(")")) return false;
+  if (marker === -1 || !stem.endsWith(")")) return null;
   const stamp = stem.slice(marker + " (conflict ".length, -1);
-  return CONFLICT_STAMP_RE.test(stamp);
+  if (!CONFLICT_STAMP_RE.test(stamp)) return null;
+  return `${dir}${stem.slice(0, marker)}${ext}`;
+}
+
+/** Does `path` name a conflict copy this engine could have produced? */
+export function isConflictCopyPath(path: string): boolean {
+  return conflictOriginPath(path) !== null;
 }
 
 // ---- internals ------------------------------------------------------------

--- a/packages/server/src/__tests__/knowledge-privacy.test.ts
+++ b/packages/server/src/__tests__/knowledge-privacy.test.ts
@@ -1,12 +1,15 @@
 // ---------------------------------------------------------------------------
-// Outbound-payload guarantee for the agent knowledge tools — asserted on the
-// bytes the model would actually receive, not on the port's return values: run
-// the REAL search_vault / get_backlinks / get_links / related_notes execute()
-// closures over the REAL privacy-filtered port and a real core index,
-// stringify every result the model would receive, and assert the private
-// note's path, title, and body text never appear — including via
-// backlinks-from-a-private-source, links-TO-a-private-target, and the
-// index-lag TOCTOU case (public in the index, private on disk NOW).
+// Outbound-payload guarantee for the agent-facing projections — asserted on the
+// bytes the model would actually receive, not on the port's return values.
+//
+// Two halves, one rule. The KNOWLEDGE half runs the REAL search_vault /
+// get_backlinks / get_links / related_notes execute() closures over the REAL
+// privacy-filtered port and a real core index. The VAULT half has no tools yet
+// (that is the next stage), so it stringifies the projections themselves. Both
+// assert the same thing: the private note's path, title, tasks and body text
+// never appear — including via backlinks-from-a-private-source,
+// links-TO-a-private-target, a conflict copy that spells a private note's name,
+// and the index-lag TOCTOU case (public in the index, private on disk NOW).
 // ---------------------------------------------------------------------------
 
 import { describe, expect, it } from "vitest";
@@ -15,26 +18,65 @@ import { KnowledgeIndex } from "@repo/notes/knowledge/knowledge-index";
 import { notePrivacy } from "@repo/notes/markdown/frontmatter";
 
 import knowledgeExtension from "@repo/agent/knowledge-tools/extension";
-import { buildAgentKnowledgePort } from "../boot/agent-knowledge-port";
+import { buildAgentKnowledgePort, buildAgentVaultPort } from "../boot/agent-knowledge-port";
+import type { AgentVaultPort, VaultReads } from "../boot/agent-knowledge-port";
 import type { AgentPorts, KnowledgePort, PrivacyProbe } from "@repo/agent/extension";
+import type { VaultEntry } from "@repo/bridge/ipc-registry";
 import type { ExtensionAPI } from "@repo/agent/pi/pi-types";
+import type { SyncSummary } from "../boot/agent-knowledge-port";
+import type { Delegation } from "@repo/bridge/delegation";
+import type { SyncStatus } from "@repo/notes/sync/status";
 
 // Distinctive markers that exist ONLY in the private note — any of these in a
 // tool result is a leak.
 const PRIVATE_PATH = "secret-plans.md";
 const PRIVATE_TITLE = "Umbrella Codename";
 const PRIVATE_BODY = "TOP-SECRET umbrella rocket equations";
+// A second private note, in a folder, carrying its own markers — the one the
+// folder-scoped listing must not surface.
+const PRIVATE_JOURNAL = "journal/2026-08-03.md";
+// A conflict copy of the private note: sync named it after the note it forked
+// from, and its own bytes are perfectly public. The copy is a real file on
+// disk, so nothing but the NAME gives it away. It is deliberately a search hit,
+// a tag carrier and a backlink source, so every projection has to drop it on
+// its own.
+const PRIVATE_CONFLICT_COPY = "secret-plans (conflict 2026-08-01T00-00-00-000Z).md";
+// A conflict copy OF that copy. Inverting its name ONCE lands on a file that
+// reads public, so a single-step origin check emits it — and its name spells
+// the private stem anyway.
+const DOUBLE_CONFLICT_COPY =
+  "secret-plans (conflict 2026-08-01T00-00-00-000Z) (conflict 2026-08-02T00-00-00-000Z).md";
+// A copy whose origin is ABSENT — the private note it forked from was renamed,
+// moved or trashed. Fail-closed: the surviving copy must not un-hide the name.
+const ORPHANED_CONFLICT_COPY = "moved-away (conflict 2026-08-01T00-00-00-000Z).md";
 
 // The vault as bytes — the index is fed from it AND the live probe reads it,
 // so index and disk agree except where a test overrides the disk.
 const VAULT: Record<string, string> = {
-  [PRIVATE_PATH]: `---\nprivate: true\ntags: [meta]\n---\n# ${PRIVATE_TITLE}\n\n${PRIVATE_BODY}\n\n[[open-notes]]\n`,
+  [PRIVATE_PATH]: `---\nprivate: true\ntags: [meta]\n---\n# ${PRIVATE_TITLE}\n\n${PRIVATE_BODY}\n\n- [ ] fuel the rocket\n\n[[open-notes]]\n`,
   "open-notes.md": "# Open notes\n\npublic umbrella research #meta\n\n[[secret-plans]]\n",
   "other.md": "# Other\n\numbrella stand shopping list\n",
   // Private and RELATED to open-notes without any direct link (shared #meta
   // tag + a lexical hit) — the related_notes candidate that must never show.
+  // `classified` is a frontmatter tag NO public note carries: the tag list must
+  // lose the name entirely, not merely report it with a smaller count.
   "hidden-lab.md":
-    "---\nprivate: true\ntags: [meta]\n---\n# Hidden Lab\n\nclassified centrifuge notes\n",
+    "---\nprivate: true\ntags: [meta, classified]\n---\n# Hidden Lab\n\nclassified centrifuge notes\n\n- [ ] spin the centrifuge\n",
+  [PRIVATE_JOURNAL]: "---\nprivate: true\n---\n# Stakeout\n\nthe rendezvous is at dawn\n",
+  [PRIVATE_CONFLICT_COPY]:
+    "# Remote copy\n\nnothing sensitive in these bytes, umbrella included #logistics\n\n[[open-notes]]\n",
+  [DOUBLE_CONFLICT_COPY]: "# Second fork\n\nalso nothing sensitive\n",
+  [ORPHANED_CONFLICT_COPY]: "# Moved away\n\nthe note this forked from is gone\n",
+  // The same shape over a PUBLIC note — the conflict-name rule must drop only
+  // the copies whose origin is private, never every conflict copy.
+  "other (conflict 2026-08-01T00-00-00-000Z).md": "# Other (remote)\n\nthe losing side\n",
+  // Public task + tag carrier, deliberately lexically distinct from the notes
+  // above so it perturbs neither the search nor the related_notes fixtures. Its
+  // self-link is the graph's self-edge case.
+  "chores.md":
+    "# Chores\n\n#logistics\n\n- [ ] fold the laundry\n- [x] water the plants\n\nSee [[chores]].\n",
+  "journal/2026-08-01.md": "# Groceries\n\nbuy oat milk\n",
+  "journal/2026-08-02.md": "# Errands\n\nreturn the drill\n",
   // Public tagmate so related_notes(open-notes) has a legitimate survivor.
   "meta-index.md": "# Meta index\n\n#meta\n",
   // The get_links subject, carrying all three outcomes at once: a resolved
@@ -47,9 +89,14 @@ const VAULT: Record<string, string> = {
   "link-hub.md": "# Link hub\n\nSee [[meta-index]], [[hidden-lab]] and [[nowhere]].\n",
 };
 
+// Non-doc vault files. They carry no frontmatter, so nothing can mark one
+// private — the projections pass them through unprobed, and these pin that.
+const ASSETS = ["assets/diagram.png"];
+
 function seededIndex(): KnowledgeIndex {
   const index = new KnowledgeIndex();
   for (const [path, content] of Object.entries(VAULT)) index.setDoc(path, content);
+  for (const path of ASSETS) index.setOther(path);
   return index;
 }
 
@@ -117,6 +164,12 @@ function expectNoLeak(payload: string): void {
   expect(payload).not.toContain("hidden-lab");
   expect(payload).not.toContain("Hidden Lab");
   expect(payload).not.toContain("centrifuge");
+  expect(payload).not.toContain(PRIVATE_JOURNAL);
+  expect(payload).not.toContain("Stakeout");
+  expect(payload).not.toContain("rendezvous");
+  // The conflict copy's own bytes are public; its NAME is the leak, and
+  // "secret-plans" is a prefix of both it and PRIVATE_PATH.
+  expect(payload).not.toContain("secret-plans");
 }
 
 describe("agent knowledge tools — private notes never reach the model", () => {
@@ -231,6 +284,18 @@ describe("agent knowledge tools — private notes never reach the model", () => 
     expectNoLeak(payload);
   });
 
+  it("search_vault by tag drops a conflict copy whose origin is private", async () => {
+    // The copy's own bytes are public and it really does carry #logistics, so
+    // the index hands it over and only the origin check takes it out.
+    expect(seededIndex().notesWithTag("logistics", { excludePrivate: true })).toContain(
+      PRIVATE_CONFLICT_COPY,
+    );
+    const tools = captureTools(buildPort());
+    const payload = await outbound(tools, "search_vault", { tag: "logistics" });
+    expectNoLeak(payload);
+    expect(payload).toContain("chores.md");
+  });
+
   it("related_notes TOCTOU: a candidate public in the index but private on disk NOW drops", async () => {
     const tools = captureTools(
       buildPort({ "meta-index.md": "---\nprivate: true\n---\n# Meta index\n\n#meta\n" }),
@@ -238,5 +303,375 @@ describe("agent knowledge tools — private notes never reach the model", () => 
     const payload = await outbound(tools, "related_notes", { path: "open-notes.md" });
     expect(payload).not.toContain("meta-index.md");
     expectNoLeak(payload);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// The vault port — whole-vault listings and host state. No tools exist for
+// these yet, so the projections themselves are stringified and held to the
+// SAME expectNoLeak rule the tool payloads above are.
+// ---------------------------------------------------------------------------
+
+const SYNC_EMAIL = "vault-owner@example.com";
+const COORDINATOR_URL = "https://vault-sync.example.workers.dev";
+const PUBLIC_CONFLICT_COPY = "other (conflict 2026-08-01T00-00-00-000Z).md";
+
+/** The sync source as the HOST really hands it over: the full Bridge state,
+ * account fields and all. It is declared wide and then narrowed on assignment
+ * to the port's `SyncSummary`, which is the point — the extra fields are
+ * present at runtime for the projection to leak if it ever spread them, and
+ * absent from the type so it cannot name them. (The account vocabulary itself
+ * is fenced out of this file by account-boundary.test.ts, which is why the
+ * signed-in flag never appears here or in the port.) */
+function syncSourceWith(status: SyncStatus = { phase: "idle" }): SyncSummary {
+  const hostState = {
+    enabled: true,
+    email: SYNC_EMAIL,
+    coordinatorUrl: COORDINATOR_URL,
+    status,
+    conflicts: [{ path: PUBLIC_CONFLICT_COPY }, { path: PRIVATE_CONFLICT_COPY }],
+  };
+  return hostState;
+}
+
+/** A field the stored record does not carry today — standing in for whatever
+ * the Bridge's `Delegation` grows next. Present at runtime, absent from the
+ * type, exactly like syncSourceWith's account fields. */
+const HOST_ONLY_DELEGATION_FIELD = "~/.inteligir/sessions/background.jsonl";
+
+function delegationOn(sourceFile: string, lineText: string): Delegation {
+  const record = {
+    transcriptPath: HOST_ONLY_DELEGATION_FIELD,
+    id: `delegation-${sourceFile}`,
+    sourceFile,
+    anchor: { ordinal: 0, text: lineText, heading: null },
+    lineText,
+    status: "done" as const,
+    createdAt: 1,
+    startedAt: 2,
+    finishedAt: 3,
+    resultSummary: "handled it",
+    error: null,
+    hasSnapshot: true,
+    restoredAt: null,
+  };
+  return record;
+}
+
+const DELEGATIONS: Delegation[] = [
+  delegationOn("chores.md", "- [ ] fold the laundry"),
+  delegationOn(PRIVATE_PATH, "- [ ] fuel the rocket"),
+];
+
+/** The vault as the crawl + the file reads see it, sharing the disk overrides
+ * with the probe so a TOCTOU case moves both together. */
+function diskVault(overrides: Record<string, string> = {}): VaultReads {
+  const files: Record<string, string> = { ...VAULT, ...overrides };
+  return {
+    list: () =>
+      [...Object.keys(files), ...ASSETS].toSorted().map(
+        (path): VaultEntry => ({
+          path,
+          name: path.slice(path.lastIndexOf("/") + 1),
+          kind: ASSETS.includes(path) ? "other" : "doc",
+        }),
+      ),
+    readText: (rel) => {
+      const content = files[rel];
+      if (content === undefined) throw new Error(`ENOENT: ${rel}`);
+      return content;
+    },
+    fileFacts: (rel) => {
+      const content = files[rel];
+      return content === undefined ? null : { sizeBytes: content.length, modifiedMs: 1 };
+    },
+  };
+}
+
+function buildVaultPort(
+  opts: {
+    overrides?: Record<string, string>;
+    sync?: SyncSummary;
+    delegations?: Delegation[];
+  } = {},
+): AgentVaultPort {
+  const index = seededIndex();
+  const overrides = opts.overrides ?? {};
+  return buildAgentVaultPort({
+    queries: () => index,
+    probe: diskProbe(overrides),
+    vault: () => diskVault(overrides),
+    sync: () => opts.sync ?? syncSourceWith(),
+    delegations: () => opts.delegations ?? DELEGATIONS,
+  });
+}
+
+describe("agent vault port — private notes never reach the model", () => {
+  it("listVault drops private docs and passes attachments through", () => {
+    // Non-vacuity: the crawl itself really does carry every private path, so
+    // the assertions below are the port's doing, not the fixture's.
+    expect(
+      diskVault()
+        .list()
+        .map((entry) => entry.path),
+    ).toContain(PRIVATE_PATH);
+    const entries = buildVaultPort().listVault();
+    const paths = entries.map((entry) => entry.path);
+    expectNoLeak(JSON.stringify(entries));
+    expect(paths).toContain("chores.md");
+    // An attachment carries no frontmatter, so nothing can mark it private and
+    // the port never probes it.
+    expect(paths).toContain("assets/diagram.png");
+    // A conflict copy of a PUBLIC note is an ordinary public file.
+    expect(paths).toContain(PUBLIC_CONFLICT_COPY);
+  });
+
+  it("listVault walks the WHOLE conflict chain, and fails closed on a lost origin", () => {
+    // Non-vacuity: both copies are real files whose own bytes read public, and
+    // the intermediate one the double copy inverts to reads public too — one
+    // step of origin checking clears it.
+    expect(diskProbe()(DOUBLE_CONFLICT_COPY)).toBe("public");
+    expect(diskProbe()(PRIVATE_CONFLICT_COPY)).toBe("public");
+    expect(diskProbe()(ORPHANED_CONFLICT_COPY)).toBe("public");
+    const paths = buildVaultPort()
+      .listVault()
+      .map((entry) => entry.path);
+    expect(paths).not.toContain(DOUBLE_CONFLICT_COPY);
+    // The origin is gone, so nothing confirms it was ever private — which is
+    // exactly why this drops: renaming or trashing a private note must not
+    // un-hide its name through the copy that outlived it.
+    expect(paths).not.toContain(ORPHANED_CONFLICT_COPY);
+  });
+
+  it("listVault scopes to a folder, and the limit bounds the PROBE window", () => {
+    // Three entries live under journal/, one of them private: the window of
+    // three is what gets read, and the page comes back short — which is the
+    // trade listVault states, not a claim of silence.
+    const entries = buildVaultPort().listVault({ folder: "journal", limit: 3 });
+    expect(entries.map((entry) => entry.path)).toEqual([
+      "journal/2026-08-01.md",
+      "journal/2026-08-02.md",
+    ]);
+    expectNoLeak(JSON.stringify(entries));
+  });
+
+  it("listVault honours a smaller limit", () => {
+    expect(buildVaultPort().listVault({ limit: 1 })).toHaveLength(1);
+  });
+
+  it("readVaultDoc reads a private note as absent, and public bytes verbatim", () => {
+    const port = buildVaultPort();
+    expect(port.readVaultDoc(PRIVATE_PATH)).toBeNull();
+    // Same null a missing file gives, so a refusal confirms nothing.
+    expect(port.readVaultDoc("no-such-note.md")).toBeNull();
+    expect(port.readVaultDoc("other.md")).toContain("umbrella stand");
+  });
+
+  it("readVaultDoc TOCTOU: privacy is decided on the bytes being returned", () => {
+    const port = buildVaultPort({
+      overrides: { "other.md": "---\nprivate: true\n---\n# Other\n\numbrella stand\n" },
+    });
+    expect(port.readVaultDoc("other.md")).toBeNull();
+  });
+
+  it("readVaultDoc reads docs only, and refuses one too large for a transcript", () => {
+    const port = buildVaultPort({
+      overrides: {
+        // Readable bytes behind the attachment path, so the null below is the
+        // doc gate and not a missing file.
+        "assets/diagram.png": "PNG\r\n\n binary payload",
+        "huge.md": `# Huge\n\n${"padding ".repeat(40_000)}`,
+      },
+    });
+    expect(port.readVaultDoc("assets/diagram.png")).toBeNull();
+    expect(port.readVaultDoc("huge.md")).toBeNull();
+    expect(port.readVaultDoc("other.md")).toContain("umbrella stand");
+  });
+
+  it("getVaultFileFacts returns nothing for a private note", () => {
+    const port = buildVaultPort();
+    expect(port.getVaultFileFacts(PRIVATE_PATH)).toBeNull();
+    expect(port.getVaultFileFacts("chores.md")).not.toBeNull();
+  });
+
+  it("listVaultTasks drops private rows — the verbatim source line included", () => {
+    // Non-vacuity: unfiltered, the private note's task line IS in the result.
+    expect(JSON.stringify(seededIndex().tasks())).toContain("fuel the rocket");
+    const tasks = buildVaultPort().listVaultTasks();
+    const payload = JSON.stringify(tasks);
+    expectNoLeak(payload);
+    expect(payload).toContain("fold the laundry");
+    expect(payload).toContain("water the plants");
+  });
+
+  it("listVaultTasks and listWikiTargets bound the page they probe", () => {
+    const port = buildVaultPort();
+    // Tasks come sorted by path, so this page's head is a public row and the
+    // page is exactly its limit.
+    expect(port.listVaultTasks({ limit: 1 })).toHaveLength(1);
+    // Both page rows the index has ALREADY filtered, so a page is short only
+    // where the live probe drops something the index still believed public.
+    expect(port.listWikiTargets({ limit: 2 })).toHaveLength(2);
+    expect(port.listWikiTargets().length).toBeGreaterThan(2);
+  });
+
+  it("listTags recomputes counts and loses a private-only tag entirely", () => {
+    // Unfiltered, #meta has four carriers, two of them private.
+    expect(seededIndex().tags()).toContainEqual({ tag: "meta", count: 4 });
+    const tags = buildVaultPort().listTags();
+    expectNoLeak(JSON.stringify(tags));
+    // The tag NAME is the leak, so a tag no public note carries disappears
+    // rather than surviving with a smaller number.
+    expect(tags.map((entry) => entry.tag)).not.toContain("classified");
+    expect(tags).toContainEqual({ tag: "meta", count: 2 });
+    expect(tags).toContainEqual({ tag: "logistics", count: 1 });
+  });
+
+  it("listTags TOCTOU: a carrier public in the index but private on disk NOW is uncounted", () => {
+    const tags = buildVaultPort({
+      overrides: { "meta-index.md": "---\nprivate: true\n---\n# Meta index\n\n#meta\n" },
+    }).listTags();
+    expect(tags).toContainEqual({ tag: "meta", count: 1 });
+  });
+
+  it("listWikiTargets drops private docs (path, title and aliases alike)", () => {
+    const targets = buildVaultPort().listWikiTargets();
+    const payload = JSON.stringify(targets);
+    expectNoLeak(payload);
+    expect(payload).toContain("meta-index.md");
+    expect(payload).toContain("assets/diagram.png");
+  });
+
+  it("getLinkGraph answers derived, over the public graph only", () => {
+    // Non-vacuity: the raw graph really does carry the private notes as nodes.
+    expect(JSON.stringify(seededIndex().graph())).toContain(PRIVATE_PATH);
+    const summary = buildVaultPort().getLinkGraph();
+    expectNoLeak(JSON.stringify(summary));
+    // open-notes, other, chores, journal/01, journal/02, meta-index, link-hub
+    // and the public conflict copy — the three private notes and the conflict
+    // copy that spells one of their names are all absent from the COUNT too.
+    expect(summary.totalNotes).toBe(8);
+    // link-hub → meta-index is the only edge left standing: its link to the
+    // private note is gone, and its dangling one was never a note.
+    expect(summary.totalLinks).toBe(1);
+    expect(summary.clusters).toEqual([{ size: 2, members: ["link-hub.md", "meta-index.md"] }]);
+    // open-notes' only link points at the private note, so in the graph the
+    // model is handed it stands alone.
+    expect(summary.orphans).toContain("open-notes.md");
+    expect(summary.hubs.map((hub) => hub.path)).toEqual(["link-hub.md", "meta-index.md"]);
+  });
+
+  it("getLinkGraph counts a self-link nowhere", () => {
+    // Non-vacuity: the raw graph really does carry the self-edge.
+    expect(seededIndex().graph().edges).toContainEqual({
+      source: "chores.md",
+      target: "chores.md",
+      kind: "wiki",
+      count: 1,
+    });
+    const summary = buildVaultPort().getLinkGraph();
+    // A note linked to itself is connected to nothing, so counting the edge in
+    // the total but not in the degree would render it an orphan with a link.
+    expect(summary.totalLinks).toBe(1);
+    expect(summary.orphans).toContain("chores.md");
+  });
+
+  it("getSyncState strips the account email and the coordinator address", () => {
+    const state = buildVaultPort().getSyncState();
+    const payload = JSON.stringify(state);
+    expect(payload).not.toContain(SYNC_EMAIL);
+    expect(payload).not.toContain(COORDINATOR_URL);
+    expect(state.enabled).toBe(true);
+  });
+
+  it("getSyncState drops a conflict copy that spells a private note's name", () => {
+    const state = buildVaultPort().getSyncState();
+    expectNoLeak(JSON.stringify(state));
+    // The dropped copy's own bytes are public — only its NAME, taken from the
+    // note it forked from, gives it away. The public note's copy survives, so
+    // this is the origin check working and not a blanket refusal.
+    expect(state.conflicts).toEqual([PUBLIC_CONFLICT_COPY]);
+  });
+
+  it("getSyncState filters the held-pass sample and drops the error message", () => {
+    const held = buildVaultPort({
+      sync: syncSourceWith({
+        phase: "held",
+        deletions: 3,
+        baseCount: 40,
+        sample: [PRIVATE_PATH, "chores.md"],
+      }),
+    }).getSyncState();
+    expectNoLeak(JSON.stringify(held));
+    expect(held.status).toEqual({
+      phase: "held",
+      deletions: 3,
+      baseCount: 40,
+      sample: ["chores.md"],
+    });
+
+    const failed = buildVaultPort({
+      sync: syncSourceWith({
+        phase: "error",
+        message: `PUT ${COORDINATOR_URL}/v1/vault/${PRIVATE_PATH} failed`,
+      }),
+    }).getSyncState();
+    // A host-generated message routinely embeds the coordinator URL and a vault
+    // path; there is no sanitizing an arbitrary string, so only the phase goes.
+    expect(failed.status).toEqual({ phase: "error" });
+    expectNoLeak(JSON.stringify(failed));
+  });
+
+  it("getSyncState enumerates the ok phase rather than passing the status through", () => {
+    // Declared wide, narrowed on assignment — the extra field is there at
+    // runtime for a pass-through to carry, and absent from the type.
+    const hostStatus = {
+      phase: "ok" as const,
+      pushed: 1,
+      pulled: 2,
+      deleted: 0,
+      conflicts: 1,
+      merged: 3,
+      message: `PUT ${COORDINATOR_URL} retried`,
+    };
+    const status: SyncStatus = hostStatus;
+    const state = buildVaultPort({ sync: syncSourceWith(status) }).getSyncState();
+    expect(state.status).toEqual({
+      phase: "ok",
+      pushed: 1,
+      pulled: 2,
+      deleted: 0,
+      conflicts: 1,
+      merged: 3,
+    });
+    expect(JSON.stringify(state)).not.toContain(COORDINATOR_URL);
+  });
+
+  it("listDelegations drops the whole record for a note that turned private", () => {
+    const records = buildVaultPort().listDelegations();
+    const payload = JSON.stringify(records);
+    // The record was created while the note was public and stores a raw line
+    // of it; privacy is never re-checked on read, so the drop happens here.
+    expectNoLeak(payload);
+    expect(records.map((record) => record.sourceFile)).toEqual(["chores.md"]);
+  });
+
+  it("listDelegations rebuilds the record field by field", () => {
+    const records = buildVaultPort().listDelegations();
+    expect(records.map((record) => Object.keys(record).toSorted())).toEqual([
+      [
+        "createdAt",
+        "error",
+        "finishedAt",
+        "id",
+        "lineText",
+        "resultSummary",
+        "sourceFile",
+        "startedAt",
+        "status",
+      ],
+    ]);
+    // The stored record's host-side bookkeeping stays host-side.
+    expect(JSON.stringify(records)).not.toContain(HOST_ONLY_DELEGATION_FIELD);
   });
 });

--- a/packages/server/src/boot/agent-knowledge-port.ts
+++ b/packages/server/src/boot/agent-knowledge-port.ts
@@ -1,10 +1,17 @@
 // ---------------------------------------------------------------------------
-// The agent-facing KnowledgePort — the ONE choke point where index results
-// become model-visible text (search_vault / get_backlinks / get_links), plus
-// the port's single mutation, rename (rename_note — same rewrite pipeline as
-// user renames; see renameNote below). SECURITY-CRITICAL: a private note's
-// PATH and SNIPPET are both leaks, so non-public hits are dropped ENTIRELY,
-// never annotated.
+// The agent-facing projections — the ONE choke point where host state becomes
+// model-visible text. Two ports live here: the KnowledgePort (search_vault /
+// get_backlinks / get_links / related_notes) plus its single mutation, rename
+// (rename_note — same rewrite pipeline as user renames; see renameNote below),
+// and the AgentVaultPort, which projects the WHOLE-VAULT and host-state reads
+// (listing, tasks, tags, wiki targets, link graph, sync state, delegations).
+//
+// The two exist for the same reason: the handlers those reads serve are
+// privacy-BLIND on purpose — the user looking at their own vault must see
+// everything — so a tool generated from a window handler reads every
+// `private: true` note silently, with nothing in the interface to notice.
+// SECURITY-CRITICAL: a private note's PATH and SNIPPET are both leaks, so
+// non-public rows are dropped ENTIRELY, never annotated.
 //
 // Two layers, both required:
 //  (1) index prefilter — every query runs with { excludePrivate: true } (the
@@ -27,21 +34,49 @@
 // This lives on its own, outside agent-wiring, so the guarantee is testable
 // without host singletons — __tests__/knowledge-privacy.test.ts stringifies
 // real tool results and asserts the private note never appears.
+//
+// COST is part of the contract here. Layer (2) is a full file read per path, so
+// a projection over a whole-vault read is O(vault) disk reads unless the probed
+// WINDOW is bounded first. Three of them are: `listVault`, `listVaultTasks` and
+// `listWikiTargets` each take a hard limit, so the probed window is one page
+// rather than the vault.
+// Two are NOT, for the same reason as each other: `listTags` and `getLinkGraph`
+// report numbers over the whole corpus (counts, totals, degrees, cluster sizes),
+// and a number computed over a truncated window would disagree with the list
+// beside it — which is itself a private-note oracle. Both pay the full sweep,
+// both say so at their definitions, and both belong on a tool a model calls
+// once, never in a loop.
 // ---------------------------------------------------------------------------
 
 import type { SearchResult } from "@repo/notes/knowledge/knowledge-index";
-import type { BacklinkEntry, ForwardLinkEntry } from "@repo/notes/knowledge/link-graph-index";
+import type {
+  BacklinkEntry,
+  ForwardLinkEntry,
+  LinkGraph,
+  VaultTaskEntry,
+  WikiTarget,
+} from "@repo/notes/knowledge/link-graph-index";
 import type { PrivacyOpts } from "@repo/notes/knowledge/link-graph-index";
 import type { RelatedNoteEntry, RelatedNotesOpts } from "@repo/notes/knowledge/related-notes";
+import type { TagCount } from "@repo/notes/knowledge/tag-index";
 import { checkNoteName, noteNameErrorMessage } from "@repo/notes/knowledge/note-name";
 import { basenamePath } from "@repo/notes/knowledge/vault-path";
+import { isDocPath } from "@repo/notes/knowledge/doc-file";
+import { notePrivacy } from "@repo/notes/markdown/frontmatter";
+import { conflictOriginPath } from "@repo/notes/sync/reconcile";
+import type { SyncStatus } from "@repo/notes/sync/status";
 
 import { renameWithLinkRewrite } from "../knowledge/rename-rewrite";
 import type { KnowledgePort, PrivacyProbe, RenameNoteResult } from "@repo/agent/extension";
+import type { Delegation } from "@repo/bridge/delegation";
+import type { SyncConflict } from "@repo/bridge/sync";
+import type { VaultEntry, VaultFileFacts } from "@repo/bridge/ipc-registry";
 import type { VaultManager } from "@repo/vault/vault";
 
-/** The queries the port wraps — KnowledgeManager (production) and core's
- * KnowledgeIndex (tests) both satisfy it structurally. */
+/** The subject-scoped queries the KnowledgePort wraps — KnowledgeManager
+ * (production) and core's KnowledgeIndex (tests) both satisfy it structurally.
+ * Split from `VaultQueries` so neither port can name a query it does not
+ * project, and a test stub carries no inert members. */
 export type KnowledgeQueries = {
   search(query: string, limit?: number, opts?: PrivacyOpts): SearchResult[];
   backlinks(path: string, opts?: PrivacyOpts): BacklinkEntry[];
@@ -57,7 +92,85 @@ export type KnowledgeQueries = {
   notesWithTag(tag: string, opts?: PrivacyOpts): string[];
 };
 
+/** The whole-vault reads the AgentVaultPort projects. Each one is a LISTING of
+ * the entire corpus, so an ungated call hands over every private note at once
+ * rather than one guessed path at a time — which is why the vault port below is
+ * the only agent-facing caller they have. `notesWithTag` appears in both types:
+ * it answers a tag, but `listTags` needs it to give every count a path behind
+ * it to re-probe. */
+export type VaultQueries = {
+  notesWithTag(tag: string, opts?: PrivacyOpts): string[];
+  tasks(opts?: PrivacyOpts): VaultTaskEntry[];
+  tags(opts?: PrivacyOpts): TagCount[];
+  wikiTargets(opts?: PrivacyOpts): WikiTarget[];
+  graph(opts?: PrivacyOpts): LinkGraph;
+};
+
+/** The vault reads the listing projections need. `VaultManager` satisfies it
+ * structurally, so the port stays constructible over an in-memory fake. */
+export type VaultReads = {
+  list(): VaultEntry[];
+  readText(rel: string): string;
+  fileFacts(rel: string): VaultFileFacts | null;
+};
+
 const EXCLUDE: PrivacyOpts = { excludePrivate: true };
+
+/** One memo, scoped to ONE port call. The probe is a full file read plus a
+ * realpath of the target, and a single query can name the same note many times
+ * over — a hub note that links its index twenty times would otherwise pay
+ * twenty identical disk round-trips inside one call. Sound because a filter
+ * runs to completion synchronously: no write can interleave within a call, so
+ * the memo can never answer something the un-memoized probe would not have. It
+ * must NOT outlive the call — that is the whole point of the live re-probe
+ * (layer 2 in the header). */
+function openProbe(probe: (rel: string) => PrivacyProbe): {
+  verdict: (rel: string) => PrivacyProbe;
+  isPublic: (rel: string) => boolean;
+  emittable: (rel: string) => boolean;
+} {
+  const memo = new Map<string, PrivacyProbe>();
+  const verdict = (rel: string): PrivacyProbe => {
+    const seen = memo.get(rel);
+    if (seen !== undefined) return seen;
+    const fresh = probe(rel);
+    memo.set(rel, fresh);
+    return fresh;
+  };
+  const isPublic = (rel: string): boolean => verdict(rel) === "public";
+  // Emitting a path is a strictly stronger question than reading one, and the
+  // difference is the conflict copy: sync names it after the note it forked
+  // from, so `secret-plans (conflict …).md` SPELLS a private note's name even
+  // when the copy itself holds public bytes. A path the port VOLUNTEERS
+  // therefore has to clear its whole ancestry; a path the CALLER already named
+  // (readVaultDoc, getVaultFileFacts, and the SUBJECT of backlinks/forwardLinks/
+  // relatedNotes) tells it nothing it didn't have, so those keep the plain
+  // public check.
+  //
+  // The walk runs to the root of the chain because one step is not enough: a
+  // copy of a copy inverts to another copy, which reads public itself and would
+  // spell the private stem anyway. Every ancestor must read public NOW — an
+  // absent one fails closed like every other branch here, since moving,
+  // renaming or trashing a private note must not un-hide its name through the
+  // copy that outlived it. Terminates: each inversion strictly shortens the
+  // path.
+  //
+  // This is the one check here that fails OPEN on drift: change the conflict
+  // stamp format and `conflictOriginPath` stops recognizing copies, so every
+  // ancestry silently clears. The round-trip against `conflictCopyName` in
+  // notes/src/sync/__tests__/reconcile.test.ts is what holds the two halves
+  // together — keep them in the same module and keep that test.
+  const emittable = (rel: string): boolean => {
+    if (!isPublic(rel)) return false;
+    let origin = conflictOriginPath(rel);
+    while (origin !== null) {
+      if (!isPublic(origin)) return false;
+      origin = conflictOriginPath(origin);
+    }
+    return true;
+  };
+  return { verdict, isPublic, emittable };
+}
 
 export function buildAgentKnowledgePort(deps: {
   queries: () => KnowledgeQueries;
@@ -72,48 +185,26 @@ export function buildAgentKnowledgePort(deps: {
    * user-facing rename handler uses, injected so the two paths can't drift. */
   afterRename: (from: string, to: string) => void;
 }): KnowledgePort {
-  /** One memo, scoped to ONE port call. The probe is a full file read plus a
-   * realpath of the target, and a single query can name the same note many
-   * times over — a hub note that links its index twenty times would otherwise
-   * pay twenty identical disk round-trips inside one call. Sound because a
-   * filter runs to completion synchronously: no write can interleave within a
-   * call, so the memo can never answer something the un-memoized probe would
-   * not have. It must NOT outlive the call — that is the whole point of the
-   * live re-probe (layer 2 above). */
-  const openProbe = (): {
-    verdict: (rel: string) => PrivacyProbe;
-    isPublic: (rel: string) => boolean;
-  } => {
-    const memo = new Map<string, PrivacyProbe>();
-    const verdict = (rel: string): PrivacyProbe => {
-      const seen = memo.get(rel);
-      if (seen !== undefined) return seen;
-      const fresh = deps.probe(rel);
-      memo.set(rel, fresh);
-      return fresh;
-    };
-    return { verdict, isPublic: (rel) => verdict(rel) === "public" };
-  };
   return {
     search: (query, limit) => {
-      const live = openProbe();
+      const live = openProbe(deps.probe);
       return deps
         .queries()
         .search(query, limit, EXCLUDE)
-        .filter((hit) => live.isPublic(hit.path));
+        .filter((hit) => live.emittable(hit.path));
     },
     backlinks: (path) => {
-      const live = openProbe();
+      const live = openProbe(deps.probe);
       // A private/unreadable TARGET yields [] — silently (see header).
       const target = live.verdict(path);
       if (target === "private" || target === "indeterminate") return [];
       return deps
         .queries()
         .backlinks(path, EXCLUDE)
-        .filter((entry) => live.isPublic(entry.sourcePath));
+        .filter((entry) => live.emittable(entry.sourcePath));
     },
     forwardLinks: (path) => {
-      const live = openProbe();
+      const live = openProbe(deps.probe);
       // A private/unreadable SUBJECT yields [] — silently, exactly like
       // backlinks (see header).
       const subject = live.verdict(path);
@@ -130,17 +221,17 @@ export function buildAgentKnowledgePort(deps: {
       //
       // A DANGLING entry (targetPath null) passes through untouched: no file
       // stands behind it, so there is nothing to be private, and the tool
-      // renders it as explicitly unresolved. "absent" fails the public check
-      // too, so a target deleted since the last index pass drops exactly the
-      // way a private one does — that ambiguity is what keeps the omission
-      // from being a privacy oracle.
+      // renders it as explicitly unresolved. "absent" fails the check too, so a
+      // target deleted since the last index pass drops exactly the way a
+      // private one does — that ambiguity is what keeps the omission from being
+      // a privacy oracle.
       return deps
         .queries()
         .forwardLinks(path)
-        .filter((entry) => entry.targetPath === null || live.isPublic(entry.targetPath));
+        .filter((entry) => entry.targetPath === null || live.emittable(entry.targetPath));
     },
     relatedNotes: (path) => {
-      const live = openProbe();
+      const live = openProbe(deps.probe);
       // A private/unreadable SUBJECT yields [] — silently, exactly like
       // backlinks (see header): "no related notes" never confirms a path.
       const target = live.verdict(path);
@@ -148,14 +239,14 @@ export function buildAgentKnowledgePort(deps: {
       return deps
         .queries()
         .relatedNotes(path, EXCLUDE)
-        .filter((entry) => live.isPublic(entry.path));
+        .filter((entry) => live.emittable(entry.path));
     },
     notesWithTag: (tag) => {
-      const live = openProbe();
+      const live = openProbe(deps.probe);
       return deps
         .queries()
         .notesWithTag(tag, EXCLUDE)
-        .filter((path) => live.isPublic(path));
+        .filter((path) => live.emittable(path));
     },
     rename: (from, to) => renameNote(deps, from, to),
   };
@@ -206,4 +297,464 @@ function renameNote(
   // Parity with the user-facing rename: repoint delegations + checkpoints.
   deps.afterRename(from, to);
   return { ok: true, from, to, linksRewritten: result.docsRewritten };
+}
+
+// ---------------------------------------------------------------------------
+// AgentVaultPort — the whole-vault and host-state reads.
+//
+// Method names mirror the Bridge methods they project (listVault,
+// listVaultTasks, getLinkGraph, …) so a grant table reads as one bridge method
+// ↔ one projection, and a method with no projection is visibly ungranted.
+// ---------------------------------------------------------------------------
+
+/** Hard ceiling on one probed page — `listVault`, `listVaultTasks`,
+ * `listWikiTargets` — and its default. The privacy check is a full file read per
+ * DOC row, so an unbounded page reads the whole vault: a 50k-note vault would
+ * stall the host for seconds on one tool call. The cap is on the window that
+ * gets PROBED, not on the survivors (see listVault). */
+const MAX_PAGE_ENTRIES = 200;
+
+/** Clamp a caller's page size into the probe budget. */
+function pageLimit(limit: number | undefined): number {
+  return Math.min(Math.max(limit ?? MAX_PAGE_ENTRIES, 1), MAX_PAGE_ENTRIES);
+}
+
+/** The largest doc `readVaultDoc` will hand back. Everything the port returns
+ * lands verbatim in the session transcript and is re-sent with every subsequent
+ * turn, so one oversized note is a recurring cost for the whole session. Over
+ * the cap reads as absent, like a private note: there is no "too large" in the
+ * return type, and a silent truncation would be worse — the model would edit
+ * against bytes it thinks are the whole file. */
+const MAX_DOC_CHARS = 128 * 1024;
+
+/** Transfer caps for the derived graph answer. Each list is explicitly a
+ * SAMPLE, never a complete enumeration, which is also what keeps a privacy drop
+ * invisible: a list shorter than its cap is the normal case, so a missing row
+ * cannot be read as "something was withheld". */
+const MAX_ORPHANS = 50;
+const MAX_HUBS = 20;
+const MAX_CLUSTERS = 10;
+const MAX_CLUSTER_MEMBERS = 20;
+
+// The result/param shapes below stay module-private: `AgentVaultPort` is the
+// whole surface a consumer needs today, and nothing outside this file names one
+// yet. Export them when the tool layer has to.
+
+/** One bounded page. `limit` is clamped to MAX_PAGE_ENTRIES. */
+type AgentPageOpts = { limit?: number | undefined };
+
+/** A `listVault` page request. `folder` is a vault-relative prefix ("" / absent
+ * = the whole vault). */
+type AgentListingOpts = AgentPageOpts & { folder?: string | undefined };
+
+/** A well-connected note. `degree` counts note-to-note edges over the PUBLIC
+ * graph, so it means "connections in the graph you were handed". */
+type AgentGraphHub = { path: string; title: string; degree: number };
+
+/** One connected component. `size` is its true size over the public graph;
+ * `members` is a capped sample of it, so `size > members.length` is ordinary. */
+type AgentGraphCluster = { size: number; members: string[] };
+
+/** The DERIVED graph answer — never the raw node/edge blob, which is ~42MB of
+ * JSON on a large vault and unreadable to a model anyway. Every number here is
+ * computed over the same public node set the paths come from. */
+type AgentLinkGraph = {
+  totalNotes: number;
+  /** Connections BETWEEN two public notes — the same edges `degree` and the
+   * clusters count, self-links excluded from all three. */
+  totalLinks: number;
+  /** Notes with no resolved link to ANOTHER note, in either direction (capped
+   * sample) — a self-link leaves a note here, since it connects it to nothing. */
+  orphans: string[];
+  hubs: AgentGraphHub[];
+  clusters: AgentGraphCluster[];
+};
+
+/** Sync status minus the free-form failure message: a host-generated error
+ * string routinely embeds the coordinator URL or a vault path, and there is no
+ * way to sanitize an arbitrary message, so the projection reports THAT the last
+ * pass failed and not why. A model cannot act on a network error regardless.
+ *
+ * The pass-through phases stay `Extract`ed from the shared `SyncStatus` on
+ * purpose: `projectSyncStatus` builds every variant field by field, so a field
+ * the Bridge adds to `ok` lands here as a typecheck failure at the construction
+ * site rather than as a silent new disclosure. */
+type AgentSyncStatus =
+  | Extract<SyncStatus, { phase: "idle" | "syncing" | "ok" }>
+  | { phase: "held"; deletions: number; baseCount: number; sample: string[] }
+  | { phase: "error" };
+
+/** The sync state the projection may SEE — deliberately narrower than the
+ * Bridge's `SyncState`, which production hands it structurally.
+ *
+ * The account fields — the email and the session flag — are absent by TYPE
+ * rather than dropped by discipline: __tests__/account-boundary.test.ts fences
+ * that vocabulary to the sync layer (the account gates cloud saves and nothing
+ * else), and a port that cannot name them cannot leak them. The coordinator
+ * address goes the same way for a plainer reason — it is infrastructure the
+ * model can do nothing with, and everything it sees lands in a transcript. */
+export type SyncSummary = {
+  enabled: boolean;
+  status: SyncStatus;
+  conflicts: readonly SyncConflict[];
+};
+
+type AgentSyncState = {
+  enabled: boolean;
+  status: AgentSyncStatus;
+  /** Vault paths of unresolved conflict COPIES, privacy-filtered. */
+  conflicts: string[];
+};
+
+/** One delegation as the model may see it — built field by field, never the
+ * Bridge's `Delegation` whole. That record is the persisted dock state, and
+ * anything it grows next (an agent's raw output, a transcript excerpt, a
+ * workspace path) would otherwise reach the model with no code change here and
+ * no failing test. The host-side bookkeeping it already carries — the anchor
+ * locator, whose `text` is a second copy of a note's line, plus the snapshot
+ * flags — is dropped: a model can act on none of it. */
+type AgentDelegation = {
+  id: string;
+  sourceFile: string;
+  /** The delegated `- [ ] …` line, verbatim from a note that reads public NOW. */
+  lineText: string;
+  status: Delegation["status"];
+  createdAt: number;
+  startedAt: number | null;
+  finishedAt: number | null;
+  resultSummary: string | null;
+  error: string | null;
+};
+
+export type AgentVaultPort = {
+  listVault(opts?: AgentListingOpts): VaultEntry[];
+  readVaultDoc(path: string): string | null;
+  getVaultFileFacts(path: string): VaultFileFacts | null;
+  listVaultTasks(opts?: AgentPageOpts): VaultTaskEntry[];
+  listTags(): TagCount[];
+  listWikiTargets(opts?: AgentPageOpts): WikiTarget[];
+  getLinkGraph(): AgentLinkGraph;
+  getSyncState(): AgentSyncState;
+  listDelegations(): AgentDelegation[];
+};
+
+export function buildAgentVaultPort(deps: {
+  queries: () => VaultQueries;
+  /** LIVE disk probe — the SAME one the KnowledgePort takes. Only "public"
+   * passes; absent/indeterminate/private all drop, fail-closed. */
+  probe: (rel: string) => PrivacyProbe;
+  vault: () => VaultReads;
+  sync: () => SyncSummary;
+  delegations: () => readonly Delegation[];
+}): AgentVaultPort {
+  return {
+    // A PAGE of the listing: the prefix and the cap are applied to the crawl
+    // BEFORE any probing, so the page is `limit` rows no matter how many of them
+    // turn out to be private — one read each, plus the conflict ancestry a
+    // conflict-named row costs (`emittable`), which is a handful at most.
+    //
+    // Slicing before filtering is what buys that bound, and it costs something
+    // real, stated rather than hidden: the page comes back SHORT, so a caller
+    // that asked for a full one learns a row was withheld and can bracket it
+    // between its lexicographic neighbours — existence and position, never a
+    // name or content. Accepted (docs/privacy.md): the agent's `bash ls` already
+    // reads every filename in the vault outright.
+    //
+    // A non-doc entry passes through UNPROBED and carries only what the crawl
+    // knows (path, name, kind): an attachment has no frontmatter, so nothing
+    // can mark one private — the same rule wikiTargets applies to assets. It
+    // still counts against the limit, so the window stays one flat bounded page.
+    listVault: (opts) => {
+      const live = openProbe(deps.probe);
+      const prefix = normalizeFolder(opts?.folder);
+      return deps
+        .vault()
+        .list()
+        .filter((entry) => entry.path.startsWith(prefix))
+        .toSorted((a, b) => (a.path < b.path ? -1 : a.path > b.path ? 1 : 0))
+        .slice(0, pageLimit(opts?.limit))
+        .filter((entry) => entry.kind !== "doc" || live.emittable(entry.path));
+    },
+
+    // The privacy verdict is taken on the BYTES BEING RETURNED, not on a
+    // second read of the path. Probe-then-read leaves a window in which the
+    // file turns private between the two syscalls and the bytes handed back
+    // were never the bytes checked — the one place the port can close its own
+    // TOCTOU completely rather than merely narrow it.
+    //
+    // Missing, non-doc, oversized and private all read as null: "absent" is
+    // already the normal answer, so a refusal is indistinguishable from a file
+    // that isn't there.
+    //
+    // The doc gate is not privacy — it is what the method MEANS. The vault
+    // confines the path either way, but an attachment read as text is a binary
+    // decoded as UTF-8: mojibake in the answer and megabytes in the transcript,
+    // for a file no privacy flag can ever guard because it carries no
+    // frontmatter. MAX_DOC_CHARS bounds the same cost for a doc.
+    readVaultDoc: (path) => {
+      if (!isDocPath(path)) return null;
+      let text: string;
+      try {
+        text = deps.vault().readText(path);
+      } catch {
+        return null;
+      }
+      if (text.length > MAX_DOC_CHARS) return null;
+      return notePrivacy(text) === "public" ? text : null;
+    },
+
+    // Size + mtime for one file. null for a private note, which is what a
+    // missing file already returns.
+    getVaultFileFacts: (path) => {
+      const live = openProbe(deps.probe);
+      if (!live.isPublic(path)) return null;
+      return deps.vault().fileFacts(path);
+    },
+
+    // The sharpest whole-vault read: every row carries `raw`, the task's
+    // VERBATIM source line, so an ungated answer hands out private note CONTENT
+    // rather than merely paths. A bounded page, sliced before probing on the
+    // index's own path-then-ordinal order. The window is rows layer (1) already
+    // filtered, so unlike listVault's crawl the page is short only where the
+    // live probe overrules the index.
+    listVaultTasks: (opts) => {
+      const live = openProbe(deps.probe);
+      return deps
+        .queries()
+        .tasks(EXCLUDE)
+        .slice(0, pageLimit(opts?.limit))
+        .filter((task) => live.emittable(task.path));
+    },
+
+    // Counts are RECOMPUTED over the notes that read public on disk NOW, not
+    // filtered: a tag only private notes carry disappears (its NAME is the
+    // leak) and a shared one's number describes the public notes alone.
+    //
+    // One of the two UNBOUNDED sweeps (getLinkGraph is the other): it costs a
+    // probe per distinct carrier, and a page cannot fix that — a count taken
+    // over a truncated carrier list is simply a wrong count, and the gap
+    // between it and the notes behind it is the oracle the recomputation
+    // exists to close. The per-call memo makes a note carrying ten tags one
+    // read, not ten.
+    //
+    // The index cannot do this half alone: it filters at index time, so a note
+    // saved `private: true` within the refresh debounce still contributes its
+    // tag and its +1 with no path for a caller to re-probe. Intersecting
+    // against notesWithTag is what gives every count a path behind it.
+    //
+    // Residual, stated rather than hidden: the DISPLAY CASE still comes from
+    // whichever carrier the index saw first among the public ones. If that note
+    // turned private in the last ~100ms, the surviving entry renders its
+    // capitalization — letter case only, never a path or a count.
+    listTags: () => {
+      const queries = deps.queries();
+      const live = openProbe(deps.probe);
+      const counted: TagCount[] = [];
+      for (const { tag } of queries.tags(EXCLUDE)) {
+        const count = queries
+          .notesWithTag(tag, EXCLUDE)
+          .filter((path) => live.emittable(path)).length;
+        if (count > 0) counted.push({ tag, count });
+      }
+      // Mirrors the tag index's own ordering (most-used first, ties
+      // alphabetical case-insensitively) — recomputing counts reorders it.
+      return counted.toSorted(
+        (a, b) => b.count - a.count || (a.tag.toLowerCase() < b.tag.toLowerCase() ? -1 : 1),
+      );
+    },
+
+    // A vault LISTING: a doc's path, title and aliases are all the leak, so a
+    // non-public doc drops whole. Assets pass unprobed (no frontmatter). A
+    // bounded page over the index's own order (docs first, then assets), sliced
+    // before probing — the same window rule as listVaultTasks.
+    listWikiTargets: (opts) => {
+      const live = openProbe(deps.probe);
+      return deps
+        .queries()
+        .wikiTargets(EXCLUDE)
+        .slice(0, pageLimit(opts?.limit))
+        .filter((target) => target.type !== "doc" || live.emittable(target.path));
+    },
+
+    // The second unbounded sweep, and for listTags' reason in its sharpest
+    // form: every number it reports (totals, degrees, cluster sizes) must be
+    // computed over the same node set its paths come from, or the difference
+    // between a count and a list becomes a private-note oracle. So it is
+    // O(notes) disk reads per call — expensive on purpose, and the reason this
+    // belongs on a tool a model calls once, never in a loop.
+    getLinkGraph: () => {
+      const live = openProbe(deps.probe);
+      return summarizeGraph(deps.queries().graph(EXCLUDE), live.emittable);
+    },
+
+    getSyncState: () => {
+      const live = openProbe(deps.probe);
+      const state = deps.sync();
+      // Named field by field, never spread: a spread would carry whatever the
+      // Bridge's SyncState grows next straight through to the model.
+      return {
+        enabled: state.enabled,
+        status: projectSyncStatus(state.status, live.emittable),
+        conflicts: state.conflicts
+          .map((conflict) => conflict.path)
+          .filter((path) => live.emittable(path)),
+      };
+    },
+
+    // A delegation record stores `lineText` and `anchor.text` — a raw line
+    // lifted from the note when it was created. Privacy is checked at create
+    // and at run, NEVER at read, so a note that became private afterwards would
+    // otherwise keep a path AND a line of its content readable forever. The
+    // whole record drops; the survivors are rebuilt field by field into
+    // AgentDelegation, never handed over as the stored record.
+    listDelegations: () => {
+      const live = openProbe(deps.probe);
+      return deps
+        .delegations()
+        .filter((record) => live.emittable(record.sourceFile))
+        .map(
+          (record): AgentDelegation => ({
+            id: record.id,
+            sourceFile: record.sourceFile,
+            lineText: record.lineText,
+            status: record.status,
+            createdAt: record.createdAt,
+            startedAt: record.startedAt,
+            finishedAt: record.finishedAt,
+            resultSummary: record.resultSummary,
+            error: record.error,
+          }),
+        );
+    },
+  };
+}
+
+/** Normalize a caller's folder argument to a vault-relative prefix ending in
+ * "/" (or "" for the whole vault), dropping traversal and empty segments. The
+ * prefix only NARROWS a listing the vault already confined, so this is a
+ * usability normalization, not the containment boundary. */
+function normalizeFolder(folder: string | undefined): string {
+  const segments = (folder ?? "")
+    .split(/[/\\]/)
+    .filter((segment) => segment !== "" && segment !== "." && segment !== "..");
+  return segments.length > 0 ? `${segments.join("/")}/` : "";
+}
+
+/** Derive the graph answer over the notes that read public on disk NOW.
+ *
+ * Phantom nodes are dropped whole: a phantom is a dangling `[[link]]` whose id
+ * and title ARE the raw link text from a note's body, it names no file that can
+ * be opened, and counting one would make a note whose only links dangle look
+ * connected. So an orphan here means "no resolved link to another note", which
+ * is the question the word is asking. */
+function summarizeGraph(graph: LinkGraph, emittable: (rel: string) => boolean): AgentLinkGraph {
+  const titles = new Map<string, string>();
+  for (const node of graph.nodes) {
+    if (node.phantom) continue;
+    const path = node.path;
+    if (path === undefined || !emittable(path)) continue;
+    titles.set(node.id, node.title);
+  }
+  const degree = new Map<string, number>();
+  const adjacency = new Map<string, string[]>();
+  for (const id of titles.keys()) {
+    degree.set(id, 0);
+    adjacency.set(id, []);
+  }
+  let totalLinks = 0;
+  for (const edge of graph.edges) {
+    if (!titles.has(edge.source) || !titles.has(edge.target)) continue;
+    // A self-link connects a note to nothing, so it counts nowhere: counting it
+    // in the total but not in the degree renders a self-linking note as an
+    // orphan that somehow has a link.
+    if (edge.source === edge.target) continue;
+    totalLinks += 1;
+    degree.set(edge.source, (degree.get(edge.source) ?? 0) + 1);
+    degree.set(edge.target, (degree.get(edge.target) ?? 0) + 1);
+    adjacency.get(edge.source)?.push(edge.target);
+    adjacency.get(edge.target)?.push(edge.source);
+  }
+  const orphans = [...titles.keys()].filter((id) => (degree.get(id) ?? 0) === 0).toSorted();
+  const hubs = [...titles.entries()]
+    .map(([path, title]): AgentGraphHub => ({ path, title, degree: degree.get(path) ?? 0 }))
+    .filter((hub) => hub.degree > 0)
+    .toSorted((a, b) => b.degree - a.degree || (a.path < b.path ? -1 : 1))
+    .slice(0, MAX_HUBS);
+  return {
+    totalNotes: titles.size,
+    totalLinks,
+    orphans: orphans.slice(0, MAX_ORPHANS),
+    hubs,
+    clusters: findClusters(adjacency),
+  };
+}
+
+/** Connected components over the public note-to-note adjacency, largest first.
+ * Singletons are omitted — they are exactly the orphans, already reported. */
+function findClusters(adjacency: Map<string, string[]>): AgentGraphCluster[] {
+  const seen = new Set<string>();
+  const clusters: AgentGraphCluster[] = [];
+  for (const start of adjacency.keys()) {
+    if (seen.has(start)) continue;
+    const members: string[] = [];
+    const stack = [start];
+    seen.add(start);
+    while (stack.length > 0) {
+      const current = stack.pop();
+      if (current === undefined) continue;
+      members.push(current);
+      for (const neighbour of adjacency.get(current) ?? []) {
+        if (seen.has(neighbour)) continue;
+        seen.add(neighbour);
+        stack.push(neighbour);
+      }
+    }
+    if (members.length < 2) continue;
+    clusters.push({
+      size: members.length,
+      members: members.toSorted().slice(0, MAX_CLUSTER_MEMBERS),
+    });
+  }
+  return clusters.toSorted((a, b) => b.size - a.size).slice(0, MAX_CLUSTERS);
+}
+
+/** The held-pass `sample` is a list of vault paths about to be deleted, so it
+ * is filtered like any other path list; it is already a SAMPLE, so a drop reads
+ * as the cap doing its job. `deletions` / `baseCount` stay — they are counts
+ * over the whole manifest, and a manifest is not privacy-partitioned (sync
+ * carries private notes like any other file), which is the accepted hole
+ * docs/privacy.md records.
+ *
+ * Exhaustive with NO default: every variant is enumerated field by field, so a
+ * phase or a field the Bridge adds is a typecheck failure here rather than a
+ * silent new disclosure. A `default: return status` would be a spread wearing a
+ * switch. */
+function projectSyncStatus(
+  status: SyncStatus,
+  emittable: (rel: string) => boolean,
+): AgentSyncStatus {
+  switch (status.phase) {
+    case "idle":
+      return { phase: "idle" };
+    case "syncing":
+      return { phase: "syncing" };
+    case "ok":
+      return {
+        phase: "ok",
+        pushed: status.pushed,
+        pulled: status.pulled,
+        deleted: status.deleted,
+        conflicts: status.conflicts,
+        merged: status.merged,
+      };
+    case "held":
+      return {
+        phase: "held",
+        deletions: status.deletions,
+        baseCount: status.baseCount,
+        sample: status.sample.filter((path) => emittable(path)),
+      };
+    case "error":
+      return { phase: "error" };
+  }
 }

--- a/packages/server/src/knowledge/knowledge-manager.ts
+++ b/packages/server/src/knowledge/knowledge-manager.ts
@@ -46,6 +46,7 @@ import {
   type RelatedNoteEntry,
   type RelatedNotesOpts,
 } from "@repo/notes/knowledge/related-notes";
+import type { TagCount } from "@repo/notes/knowledge/tag-index";
 import type { StoredFingerprint } from "@repo/notes/knowledge/knowledge-store";
 import type { HydrationCursor, SqlKnowledgeStore } from "@repo/notes/knowledge/sql-knowledge-store";
 import { projectDoc, type DocProjection } from "@repo/notes/knowledge/projection";
@@ -125,9 +126,9 @@ export class KnowledgeManager {
     return this.linkGraph.forwardLinks(vaultPath);
   }
 
-  graph(): LinkGraph {
+  graph(opts?: PrivacyOpts): LinkGraph {
     this.ensureBuilt();
-    return this.linkGraph.graph();
+    return this.linkGraph.graph(opts);
   }
 
   search(query: string, limit?: number, opts?: PrivacyOpts): SearchResult[] {
@@ -144,14 +145,23 @@ export class KnowledgeManager {
     }
   }
 
-  wikiTargets(): WikiTarget[] {
+  wikiTargets(opts?: PrivacyOpts): WikiTarget[] {
     this.ensureBuilt();
-    return this.linkGraph.wikiTargets();
+    return this.linkGraph.wikiTargets(opts);
   }
 
-  tasks(): VaultTaskEntry[] {
+  tasks(opts?: PrivacyOpts): VaultTaskEntry[] {
     this.ensureBuilt();
-    return this.linkGraph.tasks();
+    return this.linkGraph.tasks(opts);
+  }
+
+  /** Every tag with its note count. No renderer surface reads this — the
+   * palette composes text ∧ tag through `search` instead — but the agent vault
+   * port's listTags projection needs the whole-vault list, and the manager is
+   * the only place production can get it from. */
+  tags(opts?: PrivacyOpts): TagCount[] {
+    this.ensureBuilt();
+    return this.linkGraph.tags(opts);
   }
 
   notesWithTag(tag: string, opts?: PrivacyOpts): string[] {


### PR DESCRIPTION
Stage 1 of #513 — the privacy projection that gates the whole agent grant. **No tools are wired and no grant table exists yet**; that is deliberate, because mixing them would make both unreviewable.

## A leak that is live on main

A sync conflict copy holds the **losing** side's bytes. Those can be public while the note itself is now private — mark a note private on device A while device B edits its body. The copy's filename still carries the private note's stem, and the agent's five shipped tools filtered on the copy's own bytes, so `search_vault`, `get_backlinks`, `related_notes` and tag lookups all volunteered it.

Narrow to reach (sync is off by default and it needs that specific sequence) but real, and pre-existing — this work discovered it rather than introducing it.

A path the port **volunteers** must now clear its whole ancestry, walked to the root: a copy of a copy inverts to another copy that reads public itself and would spell the stem anyway. An absent ancestor **fails closed**, because moving or trashing a private note must not un-hide its name through the copy that outlived it. A path the **caller named** keeps the plain check — it tells them nothing they did not already have.

The inverse of the conflict-copy name now lives beside `conflictCopyName` with a round-trip test, instead of a second regex in the port. Two parsers of one format drift, and this one fails *open* when it does — which is why the port's comment points at that test.

## The widening

Nine projections, each keeping the established shape — index prefilter, live disk re-probe of survivors, drop silently:

`listVaultTasks` (the worst: every row carries the verbatim source line) · `listTags` · `listVault` · `readVaultDoc` · `getVaultFileFacts` · `listWikiTargets` · `getLinkGraph` · `getSyncState` · `listDelegations`

Two things worth calling out. **Tag counts are recomputed, not filtered**, so a number never describes a note the caller cannot see. And **`getLinkGraph` grants derived answers only** — orphans, hubs, clusters — with private nodes and every edge touching them dropped *before* anything is trimmed, because a total alone reveals how many private notes exist.

The core-index agent also found and closed a second-order leak nobody asked about: tag **display case** was global and first-seen, so a private `#Reykjavik` set the capitalization a public `#reykjavik` rendered with.

Sync state and delegations are rebuilt field by field against narrow types, so a field added to the Bridge tomorrow reaches nobody until someone names it.

## Accepted, and now written down

Three residuals stay open and are recorded in `docs/privacy.md` rather than implied to be closed: the private-note **count** derivable by differencing sync's `baseCount` against the graph's `totalNotes`; the existence-and-position signal in a short `listVault` page (a deliberate trade that bounds probe cost, and `bash ls` reaches the same thing); and a tag's capitalization surviving ~100ms after its note turns private.

Two comments that claimed guarantees the code did not deliver were corrected rather than kept — a header saying only the graph was unbounded when four projections sweep the vault, and a `listVault` comment claiming a short page was indistinguishable from a full one.

## Verification

`pnpm verify` exit 0. Non-vacuity checked by hand: neutering `emittable` back to the old check fails **9** tests across search, backlinks, TOCTOU, listing, tags, wiki targets, graph and sync conflicts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a live privacy leak where conflict copies could reveal private note names, and adds a privacy projection that filters all agent-visible data with index prefilter + live disk re-probe and conflict-ancestry checks. Stage 1 of Linear #513 for the agent grant.

- New Features
  - Added `AgentVaultPort` with privacy-aware projections:
    - `listVault` (folder scope, capped page), `readVaultDoc` (docs only, size cap), `getVaultFileFacts`
    - `listVaultTasks` (capped; guards verbatim task lines), `listTags` (RECOMPUTED over public notes), `listWikiTargets` (docs filtered; assets pass)
    - `getLinkGraph` (derived summary over the public graph: totals, orphans, hubs, clusters)
    - `getSyncState` (field-by-field; drops email/URL/messages; filters conflicts/samples)
    - `listDelegations` (drops private sources; rebuilds a minimal record)
  - Extended core queries to accept `{ excludePrivate: true }` for `graph`, `wikiTargets`, `tags`, and `tasks`.

- Bug Fixes
  - Stopped conflict copies from spelling private stems: paths the port emits must clear their entire conflict ancestry via `conflictOriginPath`; missing ancestors fail closed.
  - Applied ancestry-aware checks across tools and listings: `search_vault`, `get_backlinks`, `get_links`, `related_notes`, tasks, tags, wiki targets, sync conflicts.
  - Recomputed tag counts/display case over public notes only; fixed global-case bleed from private tags.
  - Tightened TOCTOU: `readVaultDoc` decides on the bytes being returned; every survivor is re-probed live.
  - Documented accepted residuals in `docs/privacy.md` (manifest-based counts; short-page existence signal).

<sup>Written for commit e36c37940e9b4102c638f67811eaeeeca53f14cf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kyh/inteligir/pull/525?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

