### PR TITLE
fix(agent): keep the capability policy current in a seeded file

### DIFF
--- a/packages/agent/src/setup.ts
+++ b/packages/agent/src/setup.ts
@@ -9,7 +9,7 @@ import fs from "node:fs";
 import path from "node:path";
 
 import { listSkills as listSkillsFromDisk } from "@repo/agent/pi/skills";
-import { prependPath, seedContent, seedDirectory } from "@repo/installer/seed";
+import { prependPath, seedDirectory, syncManagedSection } from "@repo/installer/seed";
 import { readCliVersion } from "@repo/installer/install";
 import { renderNeverGrantedSection } from "@repo/bridge/agent-grants";
 
@@ -71,8 +71,15 @@ export function buildRegisterContext(ports: AgentPorts): ExtensionRegisterContex
  * resource file's: what costs context is what gets seeded.
  */
 export function composeAgentInstructions(bundled: string): string {
-  return `${bundled.trimEnd()}\n\n${renderNeverGrantedSection()}`;
+  return `${bundled.trimEnd()}\n\n${POLICY_OPEN}\n${renderNeverGrantedSection().trim()}\n${POLICY_CLOSE}\n`;
 }
+
+/** Marks the generated policy region so a later launch can refresh it without
+ * touching the standing instructions around it — which the user edits and the
+ * agent appends memory to. */
+export const POLICY_MARKER = "inteligir:capability-policy";
+const POLICY_OPEN = `<!-- ${POLICY_MARKER}:start -->`;
+const POLICY_CLOSE = `<!-- ${POLICY_MARKER}:end -->`;
 
 // ---------------------------------------------------------------------------
 // Lifecycle: setup
@@ -112,7 +119,15 @@ export async function seedResources(
     const bundledInstructions = path.join(ctx.bundledResourcesDir, "AGENTS.md");
     if (fs.existsSync(bundledInstructions)) {
       const bundled = fs.readFileSync(bundledInstructions, "utf8");
-      seedContent(path.join(AGENT_DIR, "AGENTS.md"), composeAgentInstructions(bundled));
+      // The policy region tracks the grant table on EVERY launch: an install
+      // predating it would otherwise never learn why a capability is refused,
+      // which is the silence declaring them was meant to end.
+      syncManagedSection(
+        path.join(AGENT_DIR, "AGENTS.md"),
+        POLICY_MARKER,
+        renderNeverGrantedSection(),
+        composeAgentInstructions(bundled),
+      );
     }
   }
 

--- a/packages/installer/src/seed.test.ts
+++ b/packages/installer/src/seed.test.ts
@@ -3,7 +3,7 @@ import os from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 
-import { prependPath, seedDirectory, seedFile } from "./seed";
+import { prependPath, seedDirectory, seedFile, syncManagedSection } from "./seed";
 
 let tmpDirs: string[] = [];
 
@@ -130,5 +130,41 @@ describe("prependPath", () => {
     prependPath("/home/me/.inteligir/bin");
 
     expect(process.env["PATH"]).toBe("/home/me/.inteligir/bin");
+  });
+});
+
+describe("syncManagedSection", () => {
+  it("writes the fallback whole when the file is absent", () => {
+    const dest = path.join(tmpDir(), "absent.md");
+    syncManagedSection(dest, "m", "GEN", "WHOLE FILE");
+    expect(fs.readFileSync(dest, "utf8")).toBe("WHOLE FILE");
+  });
+
+  it("refreshes the marked region and leaves the prose either side", () => {
+    const dest = path.join(tmpDir(), "marked.md");
+    fs.writeFileSync(dest, "mine\n\n<!-- m:start -->\nOLD\n<!-- m:end -->\n\ntail\n");
+    syncManagedSection(dest, "m", "NEW", "unused");
+    const out = fs.readFileSync(dest, "utf8");
+    expect(out).toContain("NEW");
+    expect(out).not.toContain("OLD");
+    expect(out.startsWith("mine")).toBe(true);
+    expect(out.endsWith("tail\n")).toBe(true);
+  });
+
+  it("appends the region to a file that predates it", () => {
+    const dest = path.join(tmpDir(), "legacy.md");
+    fs.writeFileSync(dest, "user prose only\n");
+    syncManagedSection(dest, "m", "GEN", "unused");
+    const out = fs.readFileSync(dest, "utf8");
+    expect(out.startsWith("user prose only")).toBe(true);
+    expect(out).toContain("<!-- m:start -->\nGEN\n<!-- m:end -->");
+  });
+
+  it("leaves the file untouched when the region already matches", () => {
+    const dest = path.join(tmpDir(), "stable.md");
+    syncManagedSection(dest, "m", "GEN", "seed\n\n<!-- m:start -->\nGEN\n<!-- m:end -->\n");
+    const first = fs.statSync(dest).mtimeMs;
+    syncManagedSection(dest, "m", "GEN", "unused");
+    expect(fs.statSync(dest).mtimeMs).toBe(first);
   });
 });

--- a/packages/installer/src/seed.ts
+++ b/packages/installer/src/seed.ts
@@ -55,6 +55,49 @@ export function seedContent(dest: string, content: string): boolean {
 }
 
 /**
+ * Keep a GENERATED region of a file current without touching the rest of it.
+ *
+ * The counterpart to `seedContent` for a file that is part ours and part the
+ * user's: their prose is never rewritten, but a section we generate would
+ * otherwise be frozen at whatever the first launch wrote — so an install that
+ * predates the section never gets it, and one that has it never sees a change.
+ *
+ * Absent file: the caller's `fallback` is written whole. Markers present: only
+ * the span between them is replaced. Markers absent from an existing file: the
+ * section is appended, so a hand-edited file adopts it rather than being
+ * rebuilt.
+ */
+export function syncManagedSection(
+  dest: string,
+  marker: string,
+  section: string,
+  fallback: string,
+): void {
+  const open = `<!-- ${marker}:start -->`;
+  const close = `<!-- ${marker}:end -->`;
+  const block = `${open}\n${section.trim()}\n${close}`;
+
+  let existing: string;
+  try {
+    existing = fs.readFileSync(dest, "utf8");
+  } catch (err) {
+    if (err instanceof Error && "code" in err && err.code === "ENOENT") {
+      seedContent(dest, fallback);
+      return;
+    }
+    throw err;
+  }
+
+  const from = existing.indexOf(open);
+  const to = existing.indexOf(close);
+  const next =
+    from !== -1 && to > from
+      ? existing.slice(0, from) + block + existing.slice(to + close.length)
+      : `${existing.trimEnd()}\n\n${block}\n`;
+  if (next !== existing) fs.writeFileSync(dest, next);
+}
+
+/**
  * Prepend `entry` to the calling process's PATH if it is not already on it.
  * Idempotent. Used so subprocesses spawned by the agent's bash tool can find
  * binaries we install under `~/.inteligir/bin`.


### PR DESCRIPTION
Closes #527, filed while landing #526.

The bundled `AGENTS.md` is seeded once and never overwritten — correct for the user's standing instructions, since they edit that file and the agent appends durable memory to it.

But #526 added a **generated** section to it: the never-granted capability groups and their reasons, rendered from `AGENT_NEVER_GRANTED` so they cannot drift. On an existing install that section never appears, so the model is never told why a capability is refused — precisely the silence declaring them was meant to end.

## How

`syncManagedSection` refreshes a marked region and leaves everything around it untouched:

- **absent file** → the composed fallback, written whole
- **markers present** → only the span between them is replaced
- **markers absent** → the section is appended, so a hand-edited file adopts it rather than being rebuilt
- **region already matches** → the file is not written at all

The user's prose is never rewritten in any branch. Four tests in `@repo/installer` pin each one.

`pnpm verify` exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Keep the capability policy in AGENTS.md up to date by refreshing a marked, generated section on each launch without touching user-edited text. This fixes older installs that never showed reasons for refused capabilities.

- **Bug Fixes**
  - Added `syncManagedSection` in `@repo/installer` to update a marked region while leaving the rest of the file unchanged.
  - Wrapped the generated policy with markers (`inteligir:capability-policy`) in `composeAgentInstructions` and used it during agent setup.
  - Behavior: write the full fallback when the file is absent; replace only the marked span when present; append the section if markers are missing; skip writing when content matches.
  - Added tests in `@repo/installer` covering each case.

<sup>Written for commit f9b917cb3a5490cc5bec4e9a5f0097ed3bd88d79. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kyh/inteligir/pull/528?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

