### PR TITLE
feat(cloud): device keys for the coordinator, alongside accounts

### DIFF
--- a/apps/cloud/README.md
+++ b/apps/cloud/README.md
@@ -12,9 +12,11 @@ apps/cloud/
   drizzle.config.ts       # drizzle-kit push -> REMOTE D1 (d1-http); *.local.ts -> local miniflare D1
   src/
     index.ts              # Worker entry: /api/auth/* (Better Auth) + /v1/vault/* (sync) + CORS
-    vault-coordinator.ts  # Durable Object: owns the manifest + versions + SSE + R2 writes
+    vault-coordinator.ts  # Durable Object: owns the manifest + versions + SSE + R2 writes + the device roster
     route.ts              # matchRoute(): parse the @repo/notes/sync/wire routes into an ADT
-    hash.ts               # sha256Hex() — server-authoritative content hashing
+    device-assertion.ts   # parse + verify a device assertion — the ONE module the Worker and DO share
+    device-body.ts        # boundary parsers for the enroll/revoke request bodies
+    hash.ts               # sha256Hex()/sha256Bytes() — server-authoritative content hashing
     log.ts                # logUnhandled() — the structured error line both fetch entries emit
     env.d.ts              # types the OPTIONAL runtime vars onto Env (the required one is generated)
     auth/auth.ts          # createAuth(env, baseURL): per-request Better Auth (Drizzle+D1, bearer)
@@ -27,6 +29,8 @@ apps/cloud/
   test/
     sync.test.ts          # miniflare DO + R2 + D1 in-process (@cloudflare/vitest-pool-workers)
     e2e-sync.test.ts      # the real @repo/notes engine against the real Worker, in-process
+    device-identity.test.ts # founding, enrollment, replay, revocation, clock skew, forged headers
+    device-helpers.ts     # a test-side Ed25519 device that mints REAL assertions
     desktop-session.test.ts # the code mint/exchange path (state check, single use, TTL)
     password-reset.test.ts  # request → token → reset over real Better Auth, with a mock EMAIL binding
     apply-schema.ts       # applies the exported schema DDL to each test file's D1
@@ -67,6 +71,47 @@ push` — no migration files (`pnpm db:push:local` / `db:push`).
 - **Ownership** (`vault_owner` table): the first authenticated user to touch a
   `vaultId` claims it. A sync request for a claimed vault by a different user → 403;
   no/invalid bearer token → 401.
+
+### Device keys (`/v1/vault/:vaultId/{enroll-offer,enroll,devices,revoke}`)
+
+The second, account-free identity model, running **alongside** the one above.
+A bearer that parses as a device assertion is judged as one; anything else goes
+to Better Auth. The device routes accept only device credentials, so neither
+model reaches into the other.
+
+- **A vaultId is the fingerprint of its founding key** —
+  `"v1" + base32lower(sha256(rawEd25519PublicKey))`, `^v1[a-z2-7]{52}$`. Claiming
+  someone else's vault is a preimage problem, not a race to be first.
+- **The credential is a self-issued 5-minute assertion**, not a minted token:
+  `base64url({v,vid,dev,iat,exp}) + "." + base64url(Ed25519 signature)` over a
+  domain-separated prefix (`@repo/notes/sync/wire`). It is `Authorization:
+Bearer <string>` like everything else, which is why `HttpSyncPort` needed
+  nothing but `getToken` per request.
+- **Verification is split and neither half trusts the other's word.** The
+  Worker checks shape, signature, the time window and `vid` — statelessly, before
+  `getByName`, which is what stops an unauthenticated caller instantiating DOs by
+  naming strings. The DO re-parses the same raw header and adds the one question
+  only it can answer: is this key on my `devices` roster? There is deliberately
+  no `x-device`-style forwarded verdict to forge.
+- **This is why the DO now authenticates at all.** It holds the ownership record,
+  so it is the only component that can answer membership without an extra hop —
+  a membership question about its own state, not a second credential check.
+- **Founding is arithmetic**: an empty roster admits exactly the key whose
+  digest reproduces the DO's own name. An empty roster also still admits a
+  Better Auth session (that is every vault today); the first device to found
+  takes that door away.
+- **Growth is by signature.** An enrolled device POSTs `enroll-offer` with
+  `sha256hex(secret)` — the server never holds the secret. The joining device
+  POSTs `enroll` with the secret itself, **unauthenticated by design**. Wrong,
+  expired, already-consumed and over-the-attempt-budget all answer an identical
+  `{ok:false}`, so the route is not an offer-existence oracle.
+- **Revocation is a tombstone**, never a `DELETE` — a replayed offer must not
+  resurrect a key — and it **closes every open SSE subscriber**, because the DO
+  cannot tell which stream belongs to the revoked device. Honest ones reconnect
+  and re-authenticate.
+- **Clock skew is a liveness dependency.** A 401's body carries the reason
+  (`assertion-expired`, `assertion-not-yet-valid`, …) so a client can say "check
+  this device's clock" rather than "sign in again" — there is no sign-in to offer.
 
 ### CORS
 

--- a/apps/cloud/README.md
+++ b/apps/cloud/README.md
@@ -16,6 +16,7 @@ apps/cloud/
     route.ts              # matchRoute(): parse the @repo/notes/sync/wire routes into an ADT
     device-assertion.ts   # parse + verify a device assertion — the ONE module the Worker and DO share
     device-body.ts        # boundary parsers for the enroll/revoke request bodies
+    rate-limit.ts         # fixed-window budget over the shared rate_limit D1 table
     hash.ts               # sha256Hex()/sha256Bytes() — server-authoritative content hashing
     log.ts                # logUnhandled() — the structured error line both fetch entries emit
     env.d.ts              # types the OPTIONAL runtime vars onto Env (the required one is generated)
@@ -76,8 +77,11 @@ push` — no migration files (`pnpm db:push:local` / `db:push`).
 
 The second, account-free identity model, running **alongside** the one above.
 A bearer that parses as a device assertion is judged as one; anything else goes
-to Better Auth. The device routes accept only device credentials, so neither
-model reaches into the other.
+to Better Auth — except on a `v1…` vaultId, where a session is refused outright
+(`401 device-credential-required`) so an account cannot claim a vault no device
+founded. Every account-model vaultId is a UUID, so nothing live is affected.
+The device routes accept only device credentials, so neither model reaches into
+the other.
 
 - **A vaultId is the fingerprint of its founding key** —
   `"v1" + base32lower(sha256(rawEd25519PublicKey))`, `^v1[a-z2-7]{52}$`. Claiming
@@ -97,21 +101,54 @@ Bearer <string>` like everything else, which is why `HttpSyncPort` needed
   so it is the only component that can answer membership without an extra hop —
   a membership question about its own state, not a second credential check.
 - **Founding is arithmetic**: an empty roster admits exactly the key whose
-  digest reproduces the DO's own name. An empty roster also still admits a
-  Better Auth session (that is every vault today); the first device to found
-  takes that door away.
+  digest reproduces the DO's own name. The DO also admits a session-authorized
+  request while its roster is empty — reachable only for a UUID vault (that is
+  every vault today), since the Worker refuses a session on a `v1…` id; the
+  first device to found takes that door away too.
+- **A 403 never says whether a vault has been founded.** An unenrolled key and a
+  non-founding key on an empty roster get the SAME `device-not-enrolled`;
+  distinguishing them would make any key holder a prober of founding state.
 - **Growth is by signature.** An enrolled device POSTs `enroll-offer` with
   `sha256hex(secret)` — the server never holds the secret. The joining device
   POSTs `enroll` with the secret itself, **unauthenticated by design**. Wrong,
   expired, already-consumed and over-the-attempt-budget all answer an identical
-  `{ok:false}`, so the route is not an offer-existence oracle.
+  `{ok:false}`, so the route is not an offer-existence oracle. It is gated on
+  the vaultId's shape and on a **10/60s-per-IP budget in the Worker**, both
+  _before_ `getByName`. The secret itself must decode
+  to **≥ 32 bytes** (`MIN_ENROLL_SECRET_BYTES`) — the server cannot check
+  randomness, but a short preimage of the stored `sha256hex(secret)` is
+  searchable, so length is refused at both ends.
+- **A stranger can instantiate an empty Durable Object.** Anyone can generate a
+  keypair offline and self-sign an assertion naming any well-shaped `v1…` id; the
+  signature verifies against the key inside it, so the Worker has nothing to
+  object to and the DO runs before answering `device-not-enrolled`. Closing it
+  would need the roster, which lives in the DO — until it is consulted, an
+  enrolled non-founding device and a stranger are the same request. Accepted: the
+  cost is a DO with three empty tables, never vault access. The shape gate and the
+  enroll budget bound the malformed and credential-free cases only.
+
 - **Revocation is a tombstone**, never a `DELETE` — a replayed offer must not
   resurrect a key — and it **closes every open SSE subscriber**, because the DO
   cannot tell which stream belongs to the revoked device. Honest ones reconnect
-  and re-authenticate.
+  and re-authenticate. Revoking the **last live device is refused**
+  (`{ok:false, reason:"last-device"}`): a vault with no live key can neither
+  authenticate nor enroll, so that one tombstone strands the DO and its R2 prefix
+  permanently. Leaving is a client-side "disconnect this vault", not a revoke.
 - **Clock skew is a liveness dependency.** A 401's body carries the reason
   (`assertion-expired`, `assertion-not-yet-valid`, …) so a client can say "check
   this device's clock" rather than "sign in again" — there is no sign-in to offer.
+- **Accepted residual: an assertion is replayable across routes.** It binds the
+  vault and a ≤5-minute window, but NOT the method, path or body — so a captured
+  `Authorization` header is good on **every route of that vault** until it
+  expires: `GET manifest`, `GET/PUT/DELETE file`, `GET changes`, `POST
+enroll-offer`, `GET devices` and `POST revoke`. Concretely, within those minutes
+  a captured header can read and overwrite any file, mint a pairing offer that
+  enrolls an attacker's key permanently, and tombstone devices (all but the
+  last). TLS is what keeps the header off the wire; the fix, if that stops being
+  enough, is to cover the request in the signature — the seam is
+  `deviceAssertionSignedBytes` in `@repo/notes/sync/wire`, whose
+  domain-separated prefix exists precisely so a second signed shape can be added
+  without either being replayable as the other.
 
 ### CORS
 

--- a/apps/cloud/src/auth/desktop-session.ts
+++ b/apps/cloud/src/auth/desktop-session.ts
@@ -1,8 +1,9 @@
 import { eq, lt } from "drizzle-orm";
 import { createAuth } from "./auth";
 import { createDb } from "../db/client";
-import { desktopAuthCode, rateLimit } from "../db/schema";
+import { desktopAuthCode } from "../db/schema";
 import { sha256Hex } from "../hash";
+import { allowInWindow, callerIp, type RateWindow } from "../rate-limit";
 
 // ---------------------------------------------------------------------------
 // Desktop social-login handoff — the authorization-code pattern over the
@@ -46,8 +47,7 @@ const OPAQUE_PARAM = /^[A-Za-z0-9_-]{16,256}$/;
 
 /** Exchange rate limit — same fixed-window shape (and `rate_limit` D1 table)
  * as Better Auth's own limiter: 10 attempts / 60s per IP. */
-const EXCHANGE_WINDOW_MS = 60_000;
-const EXCHANGE_MAX = 10;
+const EXCHANGE_WINDOW: RateWindow = { max: 10, windowMs: 60_000 };
 const EXCHANGE_RATE_KEY_PREFIX = "desktop-exchange:";
 
 function isRecord(value: unknown): value is Record<string, unknown> {
@@ -153,35 +153,6 @@ export async function handleDesktopCallback(
   );
 }
 
-/** Fixed-window limiter over the shared `rate_limit` table (Better Auth's own
- * database rate-limit store) — the exchange endpoint takes guessable input, so
- * it gets the same 10/60s-per-IP throttle the auth routes have. */
-async function allowExchange(
-  db: ReturnType<typeof createDb>,
-  ip: string,
-  nowMs: number,
-): Promise<boolean> {
-  const key = `${EXCHANGE_RATE_KEY_PREFIX}${ip}`;
-  const row = await db.select().from(rateLimit).where(eq(rateLimit.key, key)).get();
-  if (row === undefined) {
-    await db
-      .insert(rateLimit)
-      .values({ id: crypto.randomUUID(), key, count: 1, lastRequest: nowMs })
-      .onConflictDoNothing();
-    return true;
-  }
-  if (nowMs - row.lastRequest > EXCHANGE_WINDOW_MS) {
-    await db.update(rateLimit).set({ count: 1, lastRequest: nowMs }).where(eq(rateLimit.key, key));
-    return true;
-  }
-  if (row.count >= EXCHANGE_MAX) return false;
-  await db
-    .update(rateLimit)
-    .set({ count: row.count + 1 })
-    .where(eq(rateLimit.key, key));
-  return true;
-}
-
 /** Expected-failure VALUE (same convention as the DO's version conflicts):
  * bad/expired/replayed codes are a 200 `{ok:false}`, not a throw — the desktop
  * surfaces `error` verbatim. Only rate limiting is a transport-level status. */
@@ -200,8 +171,8 @@ const EXCHANGE_FAILED: ExchangeResult = {
 export async function handleSessionExchange(request: Request, env: Env): Promise<Response> {
   const db = createDb(env.DB);
   if (env.RATE_LIMIT_DISABLED !== "true") {
-    const ip = request.headers.get("cf-connecting-ip") ?? "unknown";
-    if (!(await allowExchange(db, ip, Date.now()))) {
+    const key = `${EXCHANGE_RATE_KEY_PREFIX}${callerIp(request)}`;
+    if (!(await allowInWindow(db, key, Date.now(), EXCHANGE_WINDOW))) {
       return new Response("rate limited", { status: 429 });
     }
   }

--- a/apps/cloud/src/device-assertion.ts
+++ b/apps/cloud/src/device-assertion.ts
@@ -1,0 +1,160 @@
+import {
+  ED25519_PUBLIC_KEY_BYTES,
+  HEADER_AUTHORIZATION,
+  isValidVaultId,
+  parseBearer,
+  parseDeviceAssertion,
+  vaultIdFromKeyDigest,
+  type DeviceAssertion,
+} from "@repo/notes/sync/wire";
+import { sha256Bytes } from "./hash";
+
+// ---------------------------------------------------------------------------
+// Device assertions — the ONE module both the Worker and the Durable Object
+// verify credentials with.
+//
+// A device proves itself by SIGNING rather than by presenting something a
+// server minted: the bearer string is a self-issued, 5-minute assertion over
+// `{v, vid, dev, iat, exp}` (see `@repo/notes/sync/wire`). Verification is
+// split in two and the two halves are INDEPENDENT on purpose:
+//
+//   • The Worker (here, statelessly) checks shape, the Ed25519 signature
+//     against the key carried inside the assertion, the time window, and that
+//     `vid` is the vault the path names. A failure is a 401 and the Durable
+//     Object is never instantiated — which is what stops an unauthenticated
+//     caller spinning up DOs by naming arbitrary strings.
+//   • The DO (the authority) re-runs exactly this, then answers the membership
+//     question only it can: is this key on my roster?
+//
+// Both read the RAW `Authorization` header. The tempting optimization — the
+// Worker stamps its conclusion into `x-device` and the DO trusts it — turns one
+// forged request header into full vault access, so there is deliberately no
+// trusted-header seam between them to forge.
+//
+// Only PUBLIC keys are ever imported, so workerd's inability to import a raw
+// Ed25519 private key never applies.
+// ---------------------------------------------------------------------------
+
+/** How long an assertion may claim to live. Longer is refused, not truncated. */
+export const MAX_ASSERTION_LIFETIME_SECONDS = 600;
+
+/**
+ * How far into the future an `iat` may sit before we call the device's clock
+ * broken. This plus the lifetime cap is the whole clock-skew tolerance: a
+ * device more than a minute fast, or more than its assertion's lifetime slow,
+ * cannot authenticate at all.
+ */
+export const MAX_CLOCK_SKEW_SECONDS = 60;
+
+/**
+ * Why a credential was refused. It rides in the 401 BODY because the symptom of
+ * a skewed clock is otherwise indistinguishable from "sync broke": there is no
+ * sign-in to offer, so the client must be able to say "check this device's
+ * clock" instead.
+ */
+export type AssertionRejection =
+  | "missing-credential"
+  | "invalid-vault-id"
+  | "vault-mismatch"
+  | "assertion-lifetime"
+  | "assertion-not-yet-valid"
+  | "assertion-expired"
+  | "bad-signature";
+
+/** A credential that survived every stateless check. Membership is a separate question. */
+export type VerifiedDevice = {
+  /** base64url of the raw public key — the roster's primary key. */
+  readonly publicKey: string;
+  readonly publicKeyBytes: Uint8Array;
+  readonly vaultId: string;
+};
+
+export type AssertionVerdict =
+  | { readonly ok: true; readonly device: VerifiedDevice }
+  | { readonly ok: false; readonly reason: AssertionRejection };
+
+/**
+ * The device assertion this request carries, or `null` when it carries none.
+ *
+ * "None" includes a bearer that simply isn't one — a Better Auth session token,
+ * say — which is how the two credential models coexist: a caller is on the
+ * device path iff its bearer parses as an assertion.
+ */
+export function readDeviceAssertion(headers: Headers): DeviceAssertion | null {
+  const token = parseBearer(headers.get(HEADER_AUTHORIZATION));
+  return token === null ? null : parseDeviceAssertion(token);
+}
+
+/**
+ * Verify an assertion `readDeviceAssertion` produced against `vaultId`.
+ * Stateless: it answers "this key signed this, recently, for this vault" and
+ * nothing about whether the key is enrolled.
+ */
+export async function verifyDeviceAssertion(
+  assertion: DeviceAssertion,
+  vaultId: string,
+  nowSeconds: number,
+): Promise<AssertionVerdict> {
+  if (!isValidVaultId(vaultId)) return { ok: false, reason: "invalid-vault-id" };
+  const { payload } = assertion;
+  if (payload.vid !== vaultId) return { ok: false, reason: "vault-mismatch" };
+
+  // Signature BEFORE the clock, so a reported `assertion-expired` is a claim
+  // the key actually made rather than one an attacker typed.
+  if (!(await verifySignature(assertion))) return { ok: false, reason: "bad-signature" };
+
+  if (payload.exp - payload.iat > MAX_ASSERTION_LIFETIME_SECONDS) {
+    return { ok: false, reason: "assertion-lifetime" };
+  }
+  if (payload.iat > nowSeconds + MAX_CLOCK_SKEW_SECONDS) {
+    return { ok: false, reason: "assertion-not-yet-valid" };
+  }
+  if (payload.exp <= nowSeconds) return { ok: false, reason: "assertion-expired" };
+
+  return {
+    ok: true,
+    device: {
+      publicKey: payload.dev,
+      publicKeyBytes: assertion.devicePublicKey,
+      vaultId,
+    },
+  };
+}
+
+/**
+ * Does this key found `vaultId`? The founding check is arithmetic, not
+ * trust-on-first-use: there is no window in which whoever arrives first wins.
+ */
+export async function keyFoundsVault(
+  publicKeyBytes: Uint8Array,
+  vaultId: string,
+): Promise<boolean> {
+  if (publicKeyBytes.length !== ED25519_PUBLIC_KEY_BYTES) return false;
+  const derived = vaultIdFromKeyDigest(await sha256Bytes(publicKeyBytes));
+  return derived !== null && derived === vaultId;
+}
+
+/** The 401 a refused credential produces, with the reason as its whole body. */
+export function unauthorized(reason: AssertionRejection): Response {
+  return new Response(reason, {
+    status: 401,
+    headers: { "content-type": "text/plain; charset=utf-8" },
+  });
+}
+
+async function verifySignature(assertion: DeviceAssertion): Promise<boolean> {
+  let key: CryptoKey;
+  try {
+    key = await crypto.subtle.importKey(
+      "raw",
+      assertion.devicePublicKey,
+      { name: "Ed25519" },
+      false,
+      ["verify"],
+    );
+  } catch {
+    // A 32-byte string that isn't a valid curve point — shape passed, key didn't.
+    return false;
+  }
+  return crypto.subtle.verify({ name: "Ed25519" }, key, assertion.signature, assertion.signedBytes);
+}

--- a/apps/cloud/src/device-assertion.ts
+++ b/apps/cloud/src/device-assertion.ts
@@ -21,8 +21,9 @@ import { sha256Bytes } from "./hash";
 //   • The Worker (here, statelessly) checks shape, the Ed25519 signature
 //     against the key carried inside the assertion, the time window, and that
 //     `vid` is the vault the path names. A failure is a 401 and the Durable
-//     Object is never instantiated — which is what stops an unauthenticated
-//     caller spinning up DOs by naming arbitrary strings.
+//     Object is never instantiated. That bounds MALFORMED ids only: a
+//     self-signed assertion over a well-shaped id passes every check here,
+//     because the roster it would fail against lives in the DO.
 //   • The DO (the authority) re-runs exactly this, then answers the membership
 //     question only it can: is this key on my roster?
 //
@@ -54,6 +55,8 @@ export const MAX_CLOCK_SKEW_SECONDS = 60;
  */
 export type AssertionRejection =
   | "missing-credential"
+  /** A `v1…` vault was addressed with something that is not a device credential. */
+  | "device-credential-required"
   | "invalid-vault-id"
   | "vault-mismatch"
   | "assertion-lifetime"

--- a/apps/cloud/src/device-body.ts
+++ b/apps/cloud/src/device-body.ts
@@ -2,6 +2,7 @@ import { isRecord } from "@repo/notes/sync/guards";
 import {
   base64UrlDecode,
   ED25519_PUBLIC_KEY_BYTES,
+  MIN_ENROLL_SECRET_BYTES,
   type EnrollOfferRequest,
   type EnrollRequest,
   type RevokeRequest,
@@ -34,7 +35,11 @@ export function parseEnrollOfferRequest(raw: unknown): EnrollOfferRequest | null
 export function parseEnrollRequest(raw: unknown): EnrollRequest | null {
   if (!isRecord(raw)) return null;
   const { s, publicKey, deviceName } = raw;
-  if (typeof s !== "string" || s === "" || base64UrlDecode(s) === null) return null;
+  if (typeof s !== "string") return null;
+  // The floor is the one property of the secret a server can check: it holds
+  // only sha256hex(secret), which a short preimage surrenders to a search.
+  const secret = base64UrlDecode(s);
+  if (secret === null || secret.length < MIN_ENROLL_SECRET_BYTES) return null;
   if (typeof publicKey !== "string" || !isDevicePublicKey(publicKey)) return null;
   if (typeof deviceName !== "string") return null;
   const name = sanitizeDeviceName(deviceName);

--- a/apps/cloud/src/device-body.ts
+++ b/apps/cloud/src/device-body.ts
@@ -1,0 +1,79 @@
+import { isRecord } from "@repo/notes/sync/guards";
+import {
+  base64UrlDecode,
+  ED25519_PUBLIC_KEY_BYTES,
+  type EnrollOfferRequest,
+  type EnrollRequest,
+  type RevokeRequest,
+} from "@repo/notes/sync/wire";
+
+// ---------------------------------------------------------------------------
+// Boundary parsers for the device-identity request bodies. Nothing here trusts
+// the wire: each returns the typed body or `null`, and `null` is a 400.
+//
+// The distinction that matters on the enroll route: a MALFORMED body is a 400,
+// while every offer-related failure (wrong secret, expired, already consumed)
+// is an identical `{ok:false}` at 200. Shape is not a secret; offer existence
+// is, and answering it differently would make the route an oracle.
+// ---------------------------------------------------------------------------
+
+/** Longest device name the roster stores. Display text, so it is merely bounded. */
+const MAX_DEVICE_NAME_CHARS = 64;
+
+/** `enroll_id` is `sha256hex(secret)` — lowercase hex, nothing else. */
+const ENROLL_ID_SHAPE = /^[0-9a-f]{64}$/;
+
+export function parseEnrollOfferRequest(raw: unknown): EnrollOfferRequest | null {
+  if (!isRecord(raw)) return null;
+  const { enrollId, notAfter } = raw;
+  if (typeof enrollId !== "string" || !ENROLL_ID_SHAPE.test(enrollId)) return null;
+  if (!isPositiveInteger(notAfter)) return null;
+  return { enrollId, notAfter };
+}
+
+export function parseEnrollRequest(raw: unknown): EnrollRequest | null {
+  if (!isRecord(raw)) return null;
+  const { s, publicKey, deviceName } = raw;
+  if (typeof s !== "string" || s === "" || base64UrlDecode(s) === null) return null;
+  if (typeof publicKey !== "string" || !isDevicePublicKey(publicKey)) return null;
+  if (typeof deviceName !== "string") return null;
+  const name = sanitizeDeviceName(deviceName);
+  if (name === "") return null;
+  return { s, publicKey, deviceName: name };
+}
+
+export function parseRevokeRequest(raw: unknown): RevokeRequest | null {
+  if (!isRecord(raw)) return null;
+  const { publicKey } = raw;
+  if (typeof publicKey !== "string" || !isDevicePublicKey(publicKey)) return null;
+  return { publicKey };
+}
+
+/** base64url of exactly one raw Ed25519 public key, in its one canonical spelling. */
+function isDevicePublicKey(value: string): boolean {
+  const bytes = base64UrlDecode(value);
+  return bytes !== null && bytes.length === ED25519_PUBLIC_KEY_BYTES;
+}
+
+/** Read a request body as JSON, or `null` when it isn't any. */
+export async function readJsonBody(request: Request): Promise<unknown> {
+  try {
+    return await request.json();
+  } catch {
+    return null;
+  }
+}
+
+/** Collapse whitespace, drop control characters, bound the length. */
+function sanitizeDeviceName(raw: string): string {
+  let name = "";
+  for (const char of raw) {
+    const code = char.codePointAt(0) ?? 0;
+    name += code < 0x20 || code === 0x7f ? " " : char;
+  }
+  return name.replace(/\s+/g, " ").trim().slice(0, MAX_DEVICE_NAME_CHARS);
+}
+
+function isPositiveInteger(value: unknown): value is number {
+  return typeof value === "number" && Number.isSafeInteger(value) && value > 0;
+}

--- a/apps/cloud/src/hash.ts
+++ b/apps/cloud/src/hash.ts
@@ -4,11 +4,15 @@
 // stored. Matches @repo/notes's `Hash`: a lowercase sha-256 hex digest (64 chars).
 // ---------------------------------------------------------------------------
 
+/** Raw sha-256 digest of `bytes` — what the self-certifying vaultId is derived from. */
+export async function sha256Bytes(bytes: Uint8Array): Promise<Uint8Array> {
+  return new Uint8Array(await crypto.subtle.digest("SHA-256", bytes));
+}
+
 /** Lowercase sha-256 hex digest of `bytes` (matches `@repo/notes` `Hash`). */
 export async function sha256Hex(bytes: Uint8Array): Promise<string> {
-  const digest = await crypto.subtle.digest("SHA-256", bytes);
   let hex = "";
-  for (const byte of new Uint8Array(digest)) {
+  for (const byte of await sha256Bytes(bytes)) {
     hex += byte.toString(16).padStart(2, "0");
   }
   return hex;

--- a/apps/cloud/src/index.ts
+++ b/apps/cloud/src/index.ts
@@ -7,6 +7,7 @@ import { createDb } from "./db/client";
 import { vaultOwner } from "./db/schema";
 import { readDeviceAssertion, unauthorized, verifyDeviceAssertion } from "./device-assertion";
 import { logUnhandled } from "./log";
+import { allowInWindow, callerIp, type RateWindow } from "./rate-limit";
 import { isDeviceRoute, matchRoute, type VaultRouteMatch } from "./route";
 import { VaultCoordinator } from "./vault-coordinator";
 
@@ -35,12 +36,27 @@ import { VaultCoordinator } from "./vault-coordinator";
 //     for that vault by a different user is 403.
 //
 // A bearer that PARSES as an assertion is judged as one and never falls back to
-// the session path; anything else goes to Better Auth. The device-identity
-// routes (enroll/devices/revoke) accept only device credentials, so a session
-// can never reach into the device model or the reverse.
+// the session path; anything else goes to Better Auth — EXCEPT on a vaultId of
+// the self-certifying `v1…` shape, which only a key can own. A session reaching
+// one would let an account holder claim and write a vault no device founded,
+// which is the whole property the naming scheme exists to give. Every vaultId
+// the account model ever minted is a UUID, so the refusal costs nothing live.
 //
-// Rejecting a device credential here, before `getByName`, is what stops an
-// unauthenticated caller instantiating Durable Objects by naming strings.
+// The device-identity routes (enroll/devices/revoke) accept only device
+// credentials, so a session can never reach into the device model or the
+// reverse.
+//
+// Rejecting a device credential here, before `getByName`, keeps a MALFORMED id
+// from ever naming a Durable Object, and the enrollment budget bounds `enroll`,
+// the one route that arrives with no credential at all.
+//
+// It does NOT stop a stranger instantiating DOs. Anyone can generate a keypair
+// offline and self-sign an assertion for any well-shaped `v1…` id: the
+// signature verifies against the key inside it, so the Worker has nothing to
+// object to and the DO runs before answering `device-not-enrolled`. Closing
+// that would need the roster, which lives in the DO — an enrolled non-founding
+// device and a stranger are indistinguishable until it is consulted. Accepted
+// residual, recorded in the README; the cost is an empty DO, not vault access.
 //
 // CORS. Desktop (Electron) and mobile (Expo) call cross-origin, so every response
 // (auth + sync) carries CORS headers and `OPTIONS` is answered as a preflight.
@@ -52,6 +68,15 @@ import { VaultCoordinator } from "./vault-coordinator";
 // ---------------------------------------------------------------------------
 
 export { VaultCoordinator };
+
+/**
+ * Enrollment budget on the credential-free redeem route: 10 attempts / 60s per
+ * IP, the same shape the auth routes and the code exchange use. It bounds two
+ * things at once — offer-secret guessing, and the number of Durable Objects an
+ * anonymous caller can bring into existence by naming them.
+ */
+const ENROLL_WINDOW: RateWindow = { max: 10, windowMs: 60_000 };
+const ENROLL_RATE_KEY_PREFIX = "vault-enroll:";
 
 /** Response headers clients must be able to read cross-origin. */
 const EXPOSED_HEADERS = [HEADER_VERSION, HEADER_CONTENT_HASH, "set-auth-token"].join(", ");
@@ -176,7 +201,7 @@ async function authorizeVault(
     // The shape check is load-bearing on the unauthenticated `enroll` route:
     // without it a caller names arbitrary strings and spins up DOs.
     if (!isValidVaultId(match.vaultId)) return unauthorized("invalid-vault-id");
-    if (match.kind === "enroll") return null;
+    if (match.kind === "enroll") return throttleEnroll(request, env);
     if (assertion === null) return unauthorized("missing-credential");
   }
 
@@ -184,6 +209,10 @@ async function authorizeVault(
     const verdict = await verifyDeviceAssertion(assertion, match.vaultId, nowSeconds());
     return verdict.ok ? null : unauthorized(verdict.reason);
   }
+
+  // A self-certifying vaultId belongs to whoever holds its founding key, and to
+  // nobody else — an account may not claim (or write) one, founded or not.
+  if (isValidVaultId(match.vaultId)) return unauthorized("device-credential-required");
 
   // Authenticate: the bearer plugin reads `Authorization: Bearer …`.
   const auth = createAuth(env, origin);
@@ -196,6 +225,17 @@ async function authorizeVault(
     return new Response("forbidden", { status: 403 });
   }
   return null;
+}
+
+/**
+ * Spend one unit of this caller's enrollment budget. `null` forwards the redeem
+ * to the vault's Durable Object; over budget is a 429 that never addresses one.
+ */
+async function throttleEnroll(request: Request, env: Env): Promise<Response | null> {
+  if (env.RATE_LIMIT_DISABLED === "true") return null;
+  const key = `${ENROLL_RATE_KEY_PREFIX}${callerIp(request)}`;
+  if (await allowInWindow(createDb(env.DB), key, Date.now(), ENROLL_WINDOW)) return null;
+  return new Response("rate limited", { status: 429 });
 }
 
 function nowSeconds(): number {

--- a/apps/cloud/src/index.ts
+++ b/apps/cloud/src/index.ts
@@ -1,12 +1,13 @@
-import { HEADER_CONTENT_HASH, HEADER_VERSION } from "@repo/notes/sync/wire";
+import { HEADER_CONTENT_HASH, HEADER_VERSION, isValidVaultId } from "@repo/notes/sync/wire";
 import { eq } from "drizzle-orm";
 import { createAuth, enabledSocialProviders } from "./auth/auth";
 import { handleDesktopCallback, handleSessionExchange } from "./auth/desktop-session";
 import { handleResetPage } from "./auth/reset-page";
 import { createDb } from "./db/client";
 import { vaultOwner } from "./db/schema";
+import { readDeviceAssertion, unauthorized, verifyDeviceAssertion } from "./device-assertion";
 import { logUnhandled } from "./log";
-import { matchRoute } from "./route";
+import { isDeviceRoute, matchRoute, type VaultRouteMatch } from "./route";
 import { VaultCoordinator } from "./vault-coordinator";
 
 // ---------------------------------------------------------------------------
@@ -18,12 +19,28 @@ import { VaultCoordinator } from "./vault-coordinator";
 //   • /v1/vault/*  — the sync routes (`@repo/notes/sync/wire`), forwarded to the
 //     per-vault `VaultCoordinator` Durable Object after auth.
 //
-// AUTH. Clients send `Authorization: Bearer <session-token>` (the token comes
-// back in the `set-auth-token` header on sign-in/up). The bearer plugin lets
-// `auth.api.getSession({ headers })` validate it in-process — no cross-service
-// hop. Ownership is first-writer-wins: the first authenticated user to touch a
-// vaultId claims it in the `vault_owner` table; a later request for that vault by
-// a different user is 403.
+// AUTH. There are TWO credentials on the sync surface, and the bearer string
+// itself says which:
+//
+//   • A DEVICE ASSERTION — self-issued, 5-minute, Ed25519-signed (see
+//     src/device-assertion.ts). Verified statelessly here; the Durable Object
+//     independently re-verifies and answers membership. A vaultId under this
+//     model is the fingerprint of its founding key, so there is no ownership
+//     table to consult and D1 is not touched at all.
+//   • A BETTER AUTH SESSION — `Authorization: Bearer <session-token>` (the
+//     token comes back in the `set-auth-token` header on sign-in/up). The
+//     bearer plugin lets `auth.api.getSession({ headers })` validate it
+//     in-process. Ownership is first-writer-wins: the first authenticated user
+//     to touch a vaultId claims it in the `vault_owner` table; a later request
+//     for that vault by a different user is 403.
+//
+// A bearer that PARSES as an assertion is judged as one and never falls back to
+// the session path; anything else goes to Better Auth. The device-identity
+// routes (enroll/devices/revoke) accept only device credentials, so a session
+// can never reach into the device model or the reverse.
+//
+// Rejecting a device credential here, before `getByName`, is what stops an
+// unauthenticated caller instantiating Durable Objects by naming strings.
 //
 // CORS. Desktop (Electron) and mobile (Expo) call cross-origin, so every response
 // (auth + sync) carries CORS headers and `OPTIONS` is answered as a preflight.
@@ -138,19 +155,49 @@ async function route(request: Request, env: Env, ctx: ExecutionContext): Promise
     return withCors(request, new Response("not found", { status: 404 }));
   }
 
-  // Authenticate: the bearer plugin reads `Authorization: Bearer …`.
-  const auth = createAuth(env, url.origin);
-  const authResult = await auth.api.getSession({ headers: request.headers });
-  if (authResult === null) {
-    return withCors(request, new Response("unauthorized", { status: 401 }));
+  const refusal = await authorizeVault(request, env, url.origin, match);
+  if (refusal !== null) return withCors(request, refusal);
+
+  // `getByName` is `get(idFromName(name))` in one call — same addressing.
+  return withCors(request, await env.VaultCoordinator.getByName(match.vaultId).fetch(request));
+}
+
+/** Refuse the request, or `null` to forward it to the vault's Durable Object. */
+async function authorizeVault(
+  request: Request,
+  env: Env,
+  origin: string,
+  match: VaultRouteMatch,
+): Promise<Response | null> {
+  const assertion = readDeviceAssertion(request.headers);
+
+  // The device-identity routes exist only under the device model.
+  if (isDeviceRoute(match)) {
+    // The shape check is load-bearing on the unauthenticated `enroll` route:
+    // without it a caller names arbitrary strings and spins up DOs.
+    if (!isValidVaultId(match.vaultId)) return unauthorized("invalid-vault-id");
+    if (match.kind === "enroll") return null;
+    if (assertion === null) return unauthorized("missing-credential");
   }
+
+  if (assertion !== null) {
+    const verdict = await verifyDeviceAssertion(assertion, match.vaultId, nowSeconds());
+    return verdict.ok ? null : unauthorized(verdict.reason);
+  }
+
+  // Authenticate: the bearer plugin reads `Authorization: Bearer …`.
+  const auth = createAuth(env, origin);
+  const authResult = await auth.api.getSession({ headers: request.headers });
+  if (authResult === null) return new Response("unauthorized", { status: 401 });
 
   // Authorize: the caller must own (or be the first to claim) this vault.
   const db = createDb(env.DB);
   if (!(await ownsVault(db, match.vaultId, authResult.user.id))) {
-    return withCors(request, new Response("forbidden", { status: 403 }));
+    return new Response("forbidden", { status: 403 });
   }
+  return null;
+}
 
-  // `getByName` is `get(idFromName(name))` in one call — same addressing.
-  return withCors(request, await env.VaultCoordinator.getByName(match.vaultId).fetch(request));
+function nowSeconds(): number {
+  return Math.floor(Date.now() / 1000);
 }

--- a/apps/cloud/src/rate-limit.ts
+++ b/apps/cloud/src/rate-limit.ts
@@ -1,0 +1,53 @@
+import { eq } from "drizzle-orm";
+import type { createDb } from "./db/client";
+import { rateLimit } from "./db/schema";
+
+// ---------------------------------------------------------------------------
+// Fixed-window rate limiting over the shared `rate_limit` D1 table — the same
+// table and the same shape Better Auth's own database limiter uses, so a
+// credential-free route gets the treatment the auth routes already have without
+// a second store to reason about.
+//
+// The callers are the two surfaces that take input from an UNAUTHENTICATED
+// caller: `/v1/auth/exchange` (guessable codes) and `/v1/vault/:id/enroll`
+// (the offer secret is the auth, and the route names a Durable Object).
+// ---------------------------------------------------------------------------
+
+/** A budget: at most `max` requests per `windowMs`, per key. */
+export type RateWindow = { readonly max: number; readonly windowMs: number };
+
+/**
+ * Consume one unit of `key`'s budget; false once the window's budget is spent.
+ * The window is fixed rather than sliding — `lastRequest` marks where it opened
+ * and is only rewritten when a new one does.
+ */
+export async function allowInWindow(
+  db: ReturnType<typeof createDb>,
+  key: string,
+  nowMs: number,
+  window: RateWindow,
+): Promise<boolean> {
+  const row = await db.select().from(rateLimit).where(eq(rateLimit.key, key)).get();
+  if (row === undefined) {
+    await db
+      .insert(rateLimit)
+      .values({ id: crypto.randomUUID(), key, count: 1, lastRequest: nowMs })
+      .onConflictDoNothing();
+    return true;
+  }
+  if (nowMs - row.lastRequest > window.windowMs) {
+    await db.update(rateLimit).set({ count: 1, lastRequest: nowMs }).where(eq(rateLimit.key, key));
+    return true;
+  }
+  if (row.count >= window.max) return false;
+  await db
+    .update(rateLimit)
+    .set({ count: row.count + 1 })
+    .where(eq(rateLimit.key, key));
+  return true;
+}
+
+/** The client IP a limiter keys on, or a shared bucket when the edge sent none. */
+export function callerIp(request: Request): string {
+  return request.headers.get("cf-connecting-ip") ?? "unknown";
+}

--- a/apps/cloud/src/route.ts
+++ b/apps/cloud/src/route.ts
@@ -13,6 +13,10 @@ import type { VaultPath } from "@repo/notes/sync/vault-file";
 //   PUT    /v1/vault/:vaultId/file?path=…      -> putFile
 //   DELETE /v1/vault/:vaultId/file?path=…      -> deleteFile
 //   GET    /v1/vault/:vaultId/changes          -> changes
+//   POST   /v1/vault/:vaultId/enroll-offer     -> enrollOffer
+//   POST   /v1/vault/:vaultId/enroll           -> enroll
+//   GET    /v1/vault/:vaultId/devices          -> devices
+//   POST   /v1/vault/:vaultId/revoke           -> revoke
 // ---------------------------------------------------------------------------
 
 /** A parsed request against the sync contract. `bad-file-path` = a file route
@@ -24,8 +28,30 @@ export type RouteMatch =
   | { readonly kind: "putFile"; readonly vaultId: string; readonly path: VaultPath }
   | { readonly kind: "deleteFile"; readonly vaultId: string; readonly path: VaultPath }
   | { readonly kind: "changes"; readonly vaultId: string }
+  | { readonly kind: "enrollOffer"; readonly vaultId: string }
+  | { readonly kind: "enroll"; readonly vaultId: string }
+  | { readonly kind: "devices"; readonly vaultId: string }
+  | { readonly kind: "revoke"; readonly vaultId: string }
   | { readonly kind: "bad-file-path"; readonly vaultId: string }
   | { readonly kind: "unmatched" };
+
+/** A match that names a vault — everything but `unmatched`. */
+export type VaultRouteMatch = Exclude<RouteMatch, { readonly kind: "unmatched" }>;
+
+/**
+ * The device-identity routes, as opposed to the five sync routes. They are
+ * reachable ONLY with a device credential (`enroll` with an offer secret, the
+ * rest with an assertion) — a Better Auth session authorizes sync and nothing
+ * else, so the two identity models never reach into each other.
+ */
+export function isDeviceRoute(match: RouteMatch): boolean {
+  return (
+    match.kind === "enrollOffer" ||
+    match.kind === "enroll" ||
+    match.kind === "devices" ||
+    match.kind === "revoke"
+  );
+}
 
 const UNMATCHED: RouteMatch = { kind: "unmatched" };
 
@@ -52,6 +78,18 @@ export function matchRoute(method: string, pathname: string, search: string): Ro
   }
   if (sub === "changes") {
     return method === "GET" ? { kind: "changes", vaultId } : UNMATCHED;
+  }
+  if (sub === "enroll-offer") {
+    return method === "POST" ? { kind: "enrollOffer", vaultId } : UNMATCHED;
+  }
+  if (sub === "enroll") {
+    return method === "POST" ? { kind: "enroll", vaultId } : UNMATCHED;
+  }
+  if (sub === "devices") {
+    return method === "GET" ? { kind: "devices", vaultId } : UNMATCHED;
+  }
+  if (sub === "revoke") {
+    return method === "POST" ? { kind: "revoke", vaultId } : UNMATCHED;
   }
   if (sub === "file") {
     const path = parseFilePathParam(search);

--- a/apps/cloud/src/vault-coordinator.ts
+++ b/apps/cloud/src/vault-coordinator.ts
@@ -2,16 +2,36 @@ import type { VaultManifest } from "@repo/notes/sync/manifest";
 import type { DeleteResult, PutResult, VaultChange } from "@repo/notes/sync/sync-port";
 import { ABSENT_VERSION, type VaultFile, type VaultPath } from "@repo/notes/sync/vault-file";
 import {
+  base64UrlDecode,
   CONTENT_TYPE_OCTET_STREAM,
   CONTENT_TYPE_SSE,
   formatChangeFrame,
   formatVersionHeader,
+  isValidVaultId,
   HEADER_BASE_VERSION,
   HEADER_CONTENT_HASH,
   HEADER_VERSION,
   parseVersionHeader,
+  type DeviceListResponse,
+  type DeviceRecord,
+  type EnrollOfferResponse,
+  type EnrollResponse,
+  type RevokeResponse,
 } from "@repo/notes/sync/wire";
 import { DurableObject } from "cloudflare:workers";
+import {
+  keyFoundsVault,
+  readDeviceAssertion,
+  unauthorized,
+  verifyDeviceAssertion,
+  type VerifiedDevice,
+} from "./device-assertion";
+import {
+  parseEnrollOfferRequest,
+  parseEnrollRequest,
+  parseRevokeRequest,
+  readJsonBody,
+} from "./device-body";
 import { sha256Hex } from "./hash";
 import { logUnhandled } from "./log";
 import { matchRoute } from "./route";
@@ -40,6 +60,18 @@ import { matchRoute } from "./route";
 // deleting the R2 object. Either way the manifest never points at a missing
 // blob — the tolerable failure mode is an orphan blob (garbage-collectable),
 // never a dangling pointer.
+//
+// MEMBERSHIP. This DO is also the authority on WHO may touch the vault: the
+// `devices` roster lives here, beside the manifest, because it is the only
+// component that can answer membership without an extra hop. Credential
+// VERIFICATION still happens in the Worker slot (`device-assertion.ts`, run
+// again here over the same raw header — never a forwarded verdict); the DO adds
+// only the question about its own state. Founding is arithmetic: an empty
+// roster admits exactly the key whose SHA-256 reproduces this DO's own name.
+//
+// A vault with an empty roster is a PRE-DEVICE vault, still authorized by the
+// Better Auth session the Worker checked. The first device to found it takes
+// that door away — once a roster exists, a session-only request is 403.
 // ---------------------------------------------------------------------------
 
 /** A row of the DO's `files` manifest table. */
@@ -49,6 +81,24 @@ type FileRow = {
   readonly content_hash: string;
   readonly size: number;
 };
+
+/** A row of the `devices` roster. `revoked_at` non-null is a tombstone. */
+type DeviceRow = {
+  readonly public_key: string;
+  readonly name: string;
+  readonly enrolled_at: number;
+  readonly revoked_at: number | null;
+};
+
+/** Longest offer TTL the coordinator honours; a longer `notAfter` is clamped down. */
+const MAX_OFFER_TTL_SECONDS = 600;
+
+/** Enrollment attempts allowed per `ENROLL_WINDOW_SECONDS`, per live DO instance. */
+const MAX_ENROLL_ATTEMPTS = 10;
+const ENROLL_WINDOW_SECONDS = 60;
+
+/** The roster name a founding device gets; it never sends one on a sync request. */
+const FOUNDER_DEVICE_NAME = "Founding device";
 
 /** sha-256 of zero bytes — the canonical "empty" digest. */
 const EMPTY_SHA256 = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855";
@@ -83,6 +133,9 @@ export class VaultCoordinator extends DurableObject<Env> {
   private readonly encoder = new TextEncoder();
   /** Serializes mutations (see the CONCURRENCY note above). */
   private mutationTail: Promise<void> = Promise.resolve();
+  /** Enrollment attempt budget. Per-vault and single-threaded, so no shared store. */
+  private enrollAttempts = 0;
+  private enrollWindowStart = 0;
 
   constructor(ctx: DurableObjectState, env: Env) {
     super(ctx, env);
@@ -93,6 +146,23 @@ export class VaultCoordinator extends DurableObject<Env> {
            version INTEGER NOT NULL,
            content_hash TEXT NOT NULL,
            size INTEGER NOT NULL
+         )`,
+      );
+      this.ctx.storage.sql.exec(
+        `CREATE TABLE IF NOT EXISTS devices (
+           public_key TEXT PRIMARY KEY,
+           name TEXT NOT NULL,
+           enrolled_at INTEGER NOT NULL,
+           revoked_at INTEGER
+         )`,
+      );
+      // The server holds sha256hex(secret), never the secret — redeeming proves
+      // knowledge of a preimage it could not have learned from us.
+      this.ctx.storage.sql.exec(
+        `CREATE TABLE IF NOT EXISTS enroll_offers (
+           enroll_id TEXT PRIMARY KEY,
+           not_after INTEGER NOT NULL,
+           consumed_at INTEGER
          )`,
       );
     });
@@ -115,6 +185,18 @@ export class VaultCoordinator extends DurableObject<Env> {
   private async route(request: Request): Promise<Response> {
     const url = new URL(request.url);
     const match = matchRoute(request.method, url.pathname, url.search);
+    if (match.kind === "unmatched") return new Response("not found", { status: 404 });
+    if (match.kind === "bad-file-path") {
+      return new Response("missing or malformed ?path", { status: 400 });
+    }
+
+    // The ONE unauthenticated route: the offer secret is the auth, and the
+    // caller is by definition not yet a device.
+    if (match.kind === "enroll") return this.handleEnroll(request);
+
+    const refusal = await this.authorize(request);
+    if (refusal !== null) return refusal;
+
     switch (match.kind) {
       case "manifest":
         return Response.json(this.readManifest(match.vaultId));
@@ -126,11 +208,198 @@ export class VaultCoordinator extends DurableObject<Env> {
         return this.handleDelete(match.vaultId, match.path, request);
       case "changes":
         return this.handleChanges();
-      case "bad-file-path":
-        return new Response("missing or malformed ?path", { status: 400 });
-      case "unmatched":
-        return new Response("not found", { status: 404 });
+      case "enrollOffer":
+        return this.handleEnrollOffer(request);
+      case "devices":
+        return this.handleDevices();
+      case "revoke":
+        return this.handleRevoke(request);
     }
+  }
+
+  // ---- membership ----------------------------------------------------------
+
+  /**
+   * Refuse the request, or `null` to let it through. Re-parses the raw
+   * `Authorization` header rather than trusting anything the Worker concluded,
+   * and binds the assertion to THIS object's name rather than to the path the
+   * request happens to carry.
+   */
+  private async authorize(request: Request): Promise<Response | null> {
+    const assertion = readDeviceAssertion(request.headers);
+    if (assertion === null) {
+      // No device credential. The Worker authorized this some other way (a
+      // Better Auth session), which is legal only until this vault has a roster.
+      return this.deviceCount() === 0 ? null : forbidden("device-credential-required");
+    }
+    const vaultId = this.ctx.id.name;
+    if (vaultId === undefined) return forbidden("unaddressable-vault");
+
+    const verdict = await verifyDeviceAssertion(assertion, vaultId, nowSeconds());
+    if (!verdict.ok) return unauthorized(verdict.reason);
+    return this.admit(verdict.device, vaultId);
+  }
+
+  /** Roster check, with founding as its empty case. `null` = admitted. */
+  private async admit(device: VerifiedDevice, vaultId: string): Promise<Response | null> {
+    const existing = this.readDevice(device.publicKey);
+    if (existing !== null) {
+      return existing.revoked_at === null ? null : forbidden("device-revoked");
+    }
+    if (this.deviceCount() > 0) return forbidden("device-not-enrolled");
+    if (!(await keyFoundsVault(device.publicKeyBytes, vaultId))) return forbidden("not-founder");
+
+    // `OR IGNORE`: two founding requests can race here (this path is outside the
+    // mutation mutex), and they carry the same key, so the loser is a no-op.
+    this.ctx.storage.sql.exec(
+      "INSERT OR IGNORE INTO devices (public_key, name, enrolled_at, revoked_at) VALUES (?, ?, ?, NULL)",
+      device.publicKey,
+      FOUNDER_DEVICE_NAME,
+      nowSeconds(),
+    );
+    return null;
+  }
+
+  private deviceCount(): number {
+    const row = this.ctx.storage.sql
+      .exec<{ n: number }>("SELECT COUNT(*) AS n FROM devices")
+      .toArray()[0];
+    return row?.n ?? 0;
+  }
+
+  private readDevice(publicKey: string): DeviceRow | null {
+    const row = this.ctx.storage.sql
+      .exec<DeviceRow>(
+        "SELECT public_key, name, enrolled_at, revoked_at FROM devices WHERE public_key = ?",
+        publicKey,
+      )
+      .toArray()[0];
+    return row ?? null;
+  }
+
+  // ---- device identity routes ----------------------------------------------
+
+  private async handleEnrollOffer(request: Request): Promise<Response> {
+    const body = parseEnrollOfferRequest(await readJsonBody(request));
+    if (body === null) return new Response("malformed enroll-offer body", { status: 400 });
+
+    const now = nowSeconds();
+    // Clamp rather than trust: the offer's window is the coordinator's policy.
+    const notAfter = Math.min(body.notAfter, now + MAX_OFFER_TTL_SECONDS);
+    if (notAfter <= now) return new Response("offer already expired", { status: 400 });
+
+    return this.runExclusive(async () => {
+      this.ctx.storage.sql.exec("DELETE FROM enroll_offers WHERE not_after <= ?", now);
+      this.ctx.storage.sql.exec(
+        `INSERT INTO enroll_offers (enroll_id, not_after, consumed_at) VALUES (?, ?, NULL)
+         ON CONFLICT(enroll_id) DO UPDATE SET not_after = excluded.not_after`,
+        body.enrollId,
+        notAfter,
+      );
+      const result: EnrollOfferResponse = { notAfter };
+      return Response.json(result);
+    });
+  }
+
+  /**
+   * Redeem an offer. Every offer-related failure — wrong secret, expired,
+   * already consumed, over the attempt budget — answers with the SAME
+   * `{ok:false}` at 200, so this route is not an offer-existence oracle. Only a
+   * malformed body is distinguishable, and a body's shape is not a secret.
+   */
+  private async handleEnroll(request: Request): Promise<Response> {
+    // The Worker gates this too. Re-checking here keeps the DO's independence
+    // total on the ONE route that arrives with no credential: enrollment is a
+    // device-model concept, so a pre-device vault must not offer it a door.
+    const vaultId = this.ctx.id.name;
+    if (vaultId === undefined || !isValidVaultId(vaultId)) {
+      return forbidden("not-a-device-vault");
+    }
+
+    const body = parseEnrollRequest(await readJsonBody(request));
+    if (body === null) return new Response("malformed enroll body", { status: 400 });
+
+    const now = nowSeconds();
+    if (this.enrollThrottled(now)) return Response.json(ENROLL_REFUSED);
+
+    const secret = base64UrlDecode(body.s);
+    if (secret === null) return Response.json(ENROLL_REFUSED);
+    const enrollId = await sha256Hex(secret);
+
+    return this.runExclusive(async () => {
+      const offer = this.ctx.storage.sql
+        .exec<{ enroll_id: string }>(
+          "SELECT enroll_id FROM enroll_offers WHERE enroll_id = ? AND consumed_at IS NULL AND not_after > ?",
+          enrollId,
+          now,
+        )
+        .toArray()[0];
+      if (offer === undefined) return Response.json(ENROLL_REFUSED);
+
+      this.ctx.storage.sql.exec(
+        "UPDATE enroll_offers SET consumed_at = ? WHERE enroll_id = ?",
+        now,
+        enrollId,
+      );
+      // `OR IGNORE` keeps a tombstone a tombstone: a replayed offer naming a
+      // revoked key must not resurrect it.
+      this.ctx.storage.sql.exec(
+        "INSERT OR IGNORE INTO devices (public_key, name, enrolled_at, revoked_at) VALUES (?, ?, ?, NULL)",
+        body.publicKey,
+        body.deviceName,
+        now,
+      );
+      const enrolled = this.readDevice(body.publicKey);
+      const result: EnrollResponse = { ok: enrolled !== null && enrolled.revoked_at === null };
+      return Response.json(result);
+    });
+  }
+
+  private handleDevices(): Response {
+    const rows = this.ctx.storage.sql
+      .exec<DeviceRow>(
+        "SELECT public_key, name, enrolled_at, revoked_at FROM devices ORDER BY enrolled_at, public_key",
+      )
+      .toArray();
+    const result: DeviceListResponse = { devices: rows.map(rowToDevice) };
+    return Response.json(result);
+  }
+
+  private async handleRevoke(request: Request): Promise<Response> {
+    const body = parseRevokeRequest(await readJsonBody(request));
+    if (body === null) return new Response("malformed revoke body", { status: 400 });
+
+    return this.runExclusive(async () => {
+      const existing = this.readDevice(body.publicKey);
+      if (existing === null) {
+        const missing: RevokeResponse = { ok: false, reason: "not-found" };
+        return Response.json(missing);
+      }
+      const revokedAt = existing.revoked_at ?? nowSeconds();
+      if (existing.revoked_at === null) {
+        this.ctx.storage.sql.exec(
+          "UPDATE devices SET revoked_at = ? WHERE public_key = ?",
+          revokedAt,
+          body.publicKey,
+        );
+        // A revoke closes the live socket, not just future auths. We cannot tell
+        // which stream belongs to the revoked key, so every subscriber is closed
+        // and the honest ones reconnect — re-authenticating on the way back in.
+        this.closeSubscribers();
+      }
+      const result: RevokeResponse = { ok: true, revokedAt };
+      return Response.json(result);
+    });
+  }
+
+  /** Consume one enrollment attempt; true once the window's budget is spent. */
+  private enrollThrottled(now: number): boolean {
+    if (now - this.enrollWindowStart >= ENROLL_WINDOW_SECONDS) {
+      this.enrollWindowStart = now;
+      this.enrollAttempts = 0;
+    }
+    this.enrollAttempts += 1;
+    return this.enrollAttempts > MAX_ENROLL_ATTEMPTS;
   }
 
   // ---- reads (no mutex; concurrent) ----------------------------------------
@@ -272,6 +541,18 @@ export class VaultCoordinator extends DurableObject<Env> {
     });
   }
 
+  /** End every open `changes` stream. Honest subscribers reconnect and re-auth. */
+  private closeSubscribers(): void {
+    for (const controller of this.subscribers) {
+      try {
+        controller.close();
+      } catch {
+        // Already closed by the peer — nothing to end.
+      }
+    }
+    this.subscribers.clear();
+  }
+
   private broadcast(change: VaultChange): void {
     const frame = this.encoder.encode(formatChangeFrame(change));
     for (const controller of this.subscribers) {
@@ -299,6 +580,30 @@ export class VaultCoordinator extends DurableObject<Env> {
 
 function objectKey(vaultId: string, path: VaultPath): string {
   return `${vaultId}/${path}`;
+}
+
+/** The one answer every failed redemption gets — see `handleEnroll`. */
+const ENROLL_REFUSED: EnrollResponse = { ok: false };
+
+function rowToDevice(row: DeviceRow): DeviceRecord {
+  return {
+    publicKey: row.public_key,
+    name: row.name,
+    enrolledAt: row.enrolled_at,
+    revokedAt: row.revoked_at,
+  };
+}
+
+/** A membership refusal. The reason is diagnostic text, never a capability. */
+function forbidden(reason: string): Response {
+  return new Response(reason, {
+    status: 403,
+    headers: { "content-type": "text/plain; charset=utf-8" },
+  });
+}
+
+function nowSeconds(): number {
+  return Math.floor(Date.now() / 1000);
 }
 
 /** Parse a `Content-Length` header into a non-negative integer, or `null` when

--- a/apps/cloud/src/vault-coordinator.ts
+++ b/apps/cloud/src/vault-coordinator.ts
@@ -246,8 +246,12 @@ export class VaultCoordinator extends DurableObject<Env> {
     if (existing !== null) {
       return existing.revoked_at === null ? null : forbidden("device-revoked");
     }
-    if (this.deviceCount() > 0) return forbidden("device-not-enrolled");
-    if (!(await keyFoundsVault(device.publicKeyBytes, vaultId))) return forbidden("not-founder");
+    // ONE refusal for both misses. Answering "not-founder" on an empty roster
+    // and "device-not-enrolled" on a populated one turns any key holder into a
+    // prober of whether a given vaultId has been founded yet.
+    if (this.deviceCount() > 0 || !(await keyFoundsVault(device.publicKeyBytes, vaultId))) {
+      return forbidden("device-not-enrolled");
+    }
 
     // `OR IGNORE`: two founding requests can race here (this path is outside the
     // mutation mutex), and they carry the same key, so the loser is a no-op.
@@ -263,6 +267,14 @@ export class VaultCoordinator extends DurableObject<Env> {
   private deviceCount(): number {
     const row = this.ctx.storage.sql
       .exec<{ n: number }>("SELECT COUNT(*) AS n FROM devices")
+      .toArray()[0];
+    return row?.n ?? 0;
+  }
+
+  /** Devices that can still authenticate — tombstones excluded. */
+  private liveDeviceCount(): number {
+    const row = this.ctx.storage.sql
+      .exec<{ n: number }>("SELECT COUNT(*) AS n FROM devices WHERE revoked_at IS NULL")
       .toArray()[0];
     return row?.n ?? 0;
   }
@@ -374,6 +386,14 @@ export class VaultCoordinator extends DurableObject<Env> {
       if (existing === null) {
         const missing: RevokeResponse = { ok: false, reason: "not-found" };
         return Response.json(missing);
+      }
+      // Refuse the one revoke nothing can undo: with no live device left, the
+      // vault can neither authenticate nor enroll (an offer needs an enrolled
+      // signer), so its DO and its R2 prefix are stranded for good. Leaving is
+      // a client-side "disconnect", not a tombstone.
+      if (existing.revoked_at === null && this.liveDeviceCount() <= 1) {
+        const last: RevokeResponse = { ok: false, reason: "last-device" };
+        return Response.json(last);
       }
       const revokedAt = existing.revoked_at ?? nowSeconds();
       if (existing.revoked_at === null) {

--- a/apps/cloud/test/device-helpers.ts
+++ b/apps/cloud/test/device-helpers.ts
@@ -4,6 +4,7 @@ import {
   encodeDeviceAssertionPayload,
   formatBearer,
   formatDeviceAssertion,
+  MIN_ENROLL_SECRET_BYTES,
   vaultIdFromKeyDigest,
 } from "@repo/notes/sync/wire";
 import { sha256Bytes, sha256Hex } from "../src/hash";
@@ -86,8 +87,9 @@ export async function createDevice(): Promise<TestDevice> {
 /** A pairing offer: the secret the joining device presents, and its server-side id. */
 export type EnrollOffer = { readonly s: string; readonly enrollId: string };
 
-/** Mint an offer exactly as the desktop will: 32 CSPRNG bytes, server sees only the hash. */
+/** Mint an offer exactly as the desktop will: CSPRNG bytes at the contract's
+ *  floor, of which the server sees only the hash. */
 export async function createEnrollOffer(): Promise<EnrollOffer> {
-  const secret = crypto.getRandomValues(new Uint8Array(32));
+  const secret = crypto.getRandomValues(new Uint8Array(MIN_ENROLL_SECRET_BYTES));
   return { s: base64UrlEncode(secret), enrollId: await sha256Hex(secret) };
 }

--- a/apps/cloud/test/device-helpers.ts
+++ b/apps/cloud/test/device-helpers.ts
@@ -1,0 +1,93 @@
+import {
+  base64UrlEncode,
+  deviceAssertionSignedBytes,
+  encodeDeviceAssertionPayload,
+  formatBearer,
+  formatDeviceAssertion,
+  vaultIdFromKeyDigest,
+} from "@repo/notes/sync/wire";
+import { sha256Bytes, sha256Hex } from "../src/hash";
+
+// ---------------------------------------------------------------------------
+// Test-side device: an Ed25519 keypair that mints REAL assertions in the same
+// wire format the desktop and mobile clients will. Nothing here is a stub — the
+// suite drives the actual credential the Worker and DO verify.
+// ---------------------------------------------------------------------------
+
+/** Assertion lifetime the real clients mint at. */
+export const ASSERTION_LIFETIME_SECONDS = 300;
+
+export type TestDevice = {
+  /** base64url of the raw public key — the roster's primary key. */
+  readonly publicKey: string;
+  /** The vaultId this key founds: `v1` + base32(sha256(publicKey)). */
+  readonly vaultId: string;
+  /** Mint a bearer assertion. Every timing knob is overridable so skew is testable. */
+  assert(vaultId: string, options?: AssertionOptions): Promise<string>;
+  /** `{ authorization: "Bearer <assertion>" }` for the given vault. */
+  auth(vaultId: string, options?: AssertionOptions): Promise<Record<string, string>>;
+  /** Sign someone else's encoded payload — the primitive a forgery test needs. */
+  signOver(encodedPayload: string): Promise<string>;
+};
+
+export type AssertionOptions = {
+  readonly iat?: number;
+  readonly lifetimeSeconds?: number;
+  /** Sign with a DIFFERENT key than the payload names — forgery. */
+  readonly signWith?: TestDevice;
+};
+
+export function nowSeconds(): number {
+  return Math.floor(Date.now() / 1000);
+}
+
+export async function createDevice(): Promise<TestDevice> {
+  const pair = await crypto.subtle.generateKey({ name: "Ed25519" }, true, ["sign", "verify"]);
+  if (!("privateKey" in pair)) throw new Error("expected an Ed25519 key pair");
+  const exported = await crypto.subtle.exportKey("raw", pair.publicKey);
+  if (!(exported instanceof ArrayBuffer)) throw new Error("expected raw public key bytes");
+  const raw = new Uint8Array(exported);
+  const publicKey = base64UrlEncode(raw);
+  const vaultId = vaultIdFromKeyDigest(await sha256Bytes(raw));
+  if (vaultId === null) throw new Error("public key did not derive a vaultId");
+
+  const sign = async (bytes: Uint8Array): Promise<Uint8Array> =>
+    new Uint8Array(await crypto.subtle.sign({ name: "Ed25519" }, pair.privateKey, bytes));
+
+  const device: TestDevice = {
+    publicKey,
+    vaultId,
+    async assert(targetVaultId, options = {}) {
+      const iat = options.iat ?? nowSeconds();
+      const encoded = encodeDeviceAssertionPayload({
+        v: 1,
+        vid: targetVaultId,
+        dev: publicKey,
+        iat,
+        exp: iat + (options.lifetimeSeconds ?? ASSERTION_LIFETIME_SECONDS),
+      });
+      if (encoded === null) throw new Error("payload rejected by its own encoder");
+      const signer = options.signWith;
+      if (signer !== undefined) {
+        // Re-sign with the forger's key while the payload still names ours.
+        return signer.signOver(encoded);
+      }
+      return formatDeviceAssertion(encoded, await sign(deviceAssertionSignedBytes(encoded)));
+    },
+    async auth(targetVaultId, options) {
+      return { authorization: formatBearer(await device.assert(targetVaultId, options)) };
+    },
+    signOver: async (encodedPayload: string) =>
+      formatDeviceAssertion(encodedPayload, await sign(deviceAssertionSignedBytes(encodedPayload))),
+  };
+  return device;
+}
+
+/** A pairing offer: the secret the joining device presents, and its server-side id. */
+export type EnrollOffer = { readonly s: string; readonly enrollId: string };
+
+/** Mint an offer exactly as the desktop will: 32 CSPRNG bytes, server sees only the hash. */
+export async function createEnrollOffer(): Promise<EnrollOffer> {
+  const secret = crypto.getRandomValues(new Uint8Array(32));
+  return { s: base64UrlEncode(secret), enrollId: await sha256Hex(secret) };
+}

--- a/apps/cloud/test/device-identity.test.ts
+++ b/apps/cloud/test/device-identity.test.ts
@@ -1,0 +1,477 @@
+import {
+  changesPath,
+  devicesPath,
+  enrollOfferPath,
+  enrollPath,
+  formatBearer,
+  manifestPath,
+  revokePath,
+  type DeviceListResponse,
+  type EnrollOfferResponse,
+  type EnrollResponse,
+  type RevokeResponse,
+} from "@repo/notes/sync/wire";
+import { SELF } from "cloudflare:test";
+import { describe, expect, it } from "vitest";
+import { MAX_ASSERTION_LIFETIME_SECONDS, MAX_CLOCK_SKEW_SECONDS } from "../src/device-assertion";
+import {
+  ASSERTION_LIFETIME_SECONDS,
+  createDevice,
+  createEnrollOffer,
+  nowSeconds,
+  type TestDevice,
+} from "./device-helpers";
+
+// ---------------------------------------------------------------------------
+// The device-key identity path, driven against the real in-process Worker + DO.
+// Every credential here is a genuine Ed25519 assertion in the wire format the
+// clients will mint — nothing is stubbed but the TCP hop.
+//
+// D1 and Better Auth are untouched by every test in this file: the device path
+// runs ALONGSIDE the account path, and the account tests in sync.test.ts prove
+// the other half still works.
+// ---------------------------------------------------------------------------
+
+const ORIGIN = "https://inteligir-cloud.workers.dev";
+
+const json = { "content-type": "application/json" };
+
+async function readJson<T>(res: Response): Promise<T> {
+  return (await res.json()) as T;
+}
+
+function manifest(device: TestDevice, vaultId: string): Promise<Response> {
+  return device
+    .auth(vaultId)
+    .then((headers) => SELF.fetch(ORIGIN + manifestPath(vaultId), { headers }));
+}
+
+/** Found `device.vaultId` by touching it once — founding is a side effect of any route. */
+async function found(device: TestDevice): Promise<void> {
+  const res = await manifest(device, device.vaultId);
+  if (res.status !== 200) throw new Error(`founding failed: ${res.status} ${await res.text()}`);
+}
+
+async function offer(host: TestDevice, vaultId: string, notAfter?: number) {
+  const pairing = await createEnrollOffer();
+  const res = await SELF.fetch(ORIGIN + enrollOfferPath(vaultId), {
+    method: "POST",
+    headers: { ...json, ...(await host.auth(vaultId)) },
+    body: JSON.stringify({
+      enrollId: pairing.enrollId,
+      notAfter: notAfter ?? nowSeconds() + 600,
+    }),
+  });
+  return { pairing, res };
+}
+
+function redeem(vaultId: string, s: string, joiner: TestDevice, deviceName = "Phone") {
+  return SELF.fetch(ORIGIN + enrollPath(vaultId), {
+    method: "POST",
+    headers: json,
+    body: JSON.stringify({ s, publicKey: joiner.publicKey, deviceName }),
+  });
+}
+
+describe("founding", () => {
+  it("a device founds the vault its own key names, and lands on the roster", async () => {
+    const desktop = await createDevice();
+    expect(desktop.vaultId).toMatch(/^v1[a-z2-7]{52}$/);
+
+    const res = await manifest(desktop, desktop.vaultId);
+    expect(res.status).toBe(200);
+
+    const roster = await readJson<DeviceListResponse>(
+      await SELF.fetch(ORIGIN + devicesPath(desktop.vaultId), {
+        headers: await desktop.auth(desktop.vaultId),
+      }),
+    );
+    expect(roster.devices).toHaveLength(1);
+    expect(roster.devices[0]?.publicKey).toBe(desktop.publicKey);
+    expect(roster.devices[0]?.revokedAt).toBeNull();
+  });
+
+  it("a device cannot found a vault its key does not name (403)", async () => {
+    const founder = await createDevice();
+    const stranger = await createDevice();
+
+    // The stranger signs a perfectly valid assertion for the founder's vault.
+    const res = await SELF.fetch(ORIGIN + manifestPath(founder.vaultId), {
+      headers: await stranger.auth(founder.vaultId),
+    });
+    expect(res.status).toBe(403);
+    expect(await res.text()).toBe("not-founder");
+  });
+
+  it("a valid signature that is not on the roster is refused (403)", async () => {
+    const founder = await createDevice();
+    await found(founder);
+
+    const outsider = await createDevice();
+    const res = await SELF.fetch(ORIGIN + manifestPath(founder.vaultId), {
+      headers: await outsider.auth(founder.vaultId),
+    });
+    expect(res.status).toBe(403);
+    expect(await res.text()).toBe("device-not-enrolled");
+  });
+});
+
+describe("assertion verification", () => {
+  it("an expired assertion says so, so a skewed clock is diagnosable (401)", async () => {
+    const device = await createDevice();
+    const res = await SELF.fetch(ORIGIN + manifestPath(device.vaultId), {
+      headers: await device.auth(device.vaultId, {
+        iat: nowSeconds() - ASSERTION_LIFETIME_SECONDS - 60,
+      }),
+    });
+    expect(res.status).toBe(401);
+    expect(await res.text()).toBe("assertion-expired");
+  });
+
+  it("an assertion from a device whose clock runs fast is refused", async () => {
+    const device = await createDevice();
+    const res = await SELF.fetch(ORIGIN + manifestPath(device.vaultId), {
+      headers: await device.auth(device.vaultId, {
+        iat: nowSeconds() + MAX_CLOCK_SKEW_SECONDS + 30,
+      }),
+    });
+    expect(res.status).toBe(401);
+    expect(await res.text()).toBe("assertion-not-yet-valid");
+  });
+
+  it("an over-long lifetime is refused rather than truncated", async () => {
+    const device = await createDevice();
+    const res = await SELF.fetch(ORIGIN + manifestPath(device.vaultId), {
+      headers: await device.auth(device.vaultId, {
+        lifetimeSeconds: MAX_ASSERTION_LIFETIME_SECONDS + 1,
+      }),
+    });
+    expect(res.status).toBe(401);
+    expect(await res.text()).toBe("assertion-lifetime");
+  });
+
+  it("an assertion minted for one vault does not work on another", async () => {
+    const alice = await createDevice();
+    const bob = await createDevice();
+    await found(alice);
+    await found(bob);
+
+    // Alice's key, Alice's signature — but bound to Alice's vault, sent to Bob's.
+    const res = await SELF.fetch(ORIGIN + manifestPath(bob.vaultId), {
+      headers: await alice.auth(alice.vaultId),
+    });
+    expect(res.status).toBe(401);
+    expect(await res.text()).toBe("vault-mismatch");
+  });
+
+  it("a payload signed by a different key is refused", async () => {
+    const device = await createDevice();
+    const forger = await createDevice();
+    const res = await SELF.fetch(ORIGIN + manifestPath(device.vaultId), {
+      headers: await device.auth(device.vaultId, { signWith: forger }),
+    });
+    expect(res.status).toBe(401);
+    expect(await res.text()).toBe("bad-signature");
+  });
+
+  it("a forged x-device header buys nothing — both sides read the raw Authorization", async () => {
+    const owner = await createDevice();
+    const attacker = await createDevice();
+    await found(owner);
+
+    // A VALID assertion for the attacker's own vault, plus a header claiming to
+    // be the owner's key. Nothing in the Worker or the DO reads x-device, so the
+    // credential in Authorization is the only thing that counts.
+    const res = await SELF.fetch(ORIGIN + manifestPath(owner.vaultId), {
+      headers: {
+        ...(await attacker.auth(attacker.vaultId)),
+        "x-device": owner.publicKey,
+      },
+    });
+    expect(res.status).toBe(401);
+    expect(await res.text()).toBe("vault-mismatch");
+
+    // And with the assertion correctly bound to the owner's vault it is still
+    // just an unenrolled key.
+    const bound = await SELF.fetch(ORIGIN + manifestPath(owner.vaultId), {
+      headers: {
+        ...(await attacker.auth(owner.vaultId)),
+        "x-device": owner.publicKey,
+      },
+    });
+    expect(bound.status).toBe(403);
+  });
+
+  it("a garbage bearer never reaches a Durable Object (401)", async () => {
+    const device = await createDevice();
+    const res = await SELF.fetch(ORIGIN + manifestPath(device.vaultId), {
+      headers: { authorization: formatBearer("not.an.assertion") },
+    });
+    expect(res.status).toBe(401);
+  });
+});
+
+describe("enrollment", () => {
+  it("an enrolled device offers, the joining device redeems, and then syncs", async () => {
+    const desktop = await createDevice();
+    const phone = await createDevice();
+    await found(desktop);
+
+    const { pairing, res } = await offer(desktop, desktop.vaultId);
+    expect(res.status).toBe(200);
+    const offered = await readJson<EnrollOfferResponse>(res);
+    expect(offered.notAfter).toBeGreaterThan(nowSeconds());
+
+    // Unauthenticated by design: the secret is the auth.
+    const enrolled = await readJson<EnrollResponse>(
+      await redeem(desktop.vaultId, pairing.s, phone),
+    );
+    expect(enrolled.ok).toBe(true);
+
+    // The phone now authenticates on its own key.
+    const res2 = await SELF.fetch(ORIGIN + manifestPath(desktop.vaultId), {
+      headers: await phone.auth(desktop.vaultId),
+    });
+    expect(res2.status).toBe(200);
+
+    const roster = await readJson<DeviceListResponse>(
+      await SELF.fetch(ORIGIN + devicesPath(desktop.vaultId), {
+        headers: await desktop.auth(desktop.vaultId),
+      }),
+    );
+    expect(roster.devices.map((d) => d.publicKey).toSorted()).toEqual(
+      [desktop.publicKey, phone.publicKey].toSorted(),
+    );
+    expect(roster.devices.find((d) => d.publicKey === phone.publicKey)?.name).toBe("Phone");
+  });
+
+  it("a consumed offer cannot be replayed, and the replayer stays off the roster", async () => {
+    const desktop = await createDevice();
+    const phone = await createDevice();
+    const attacker = await createDevice();
+    await found(desktop);
+
+    const { pairing } = await offer(desktop, desktop.vaultId);
+    expect(
+      (await readJson<EnrollResponse>(await redeem(desktop.vaultId, pairing.s, phone))).ok,
+    ).toBe(true);
+
+    const replay = await readJson<EnrollResponse>(
+      await redeem(desktop.vaultId, pairing.s, attacker),
+    );
+    expect(replay.ok).toBe(false);
+
+    const denied = await SELF.fetch(ORIGIN + manifestPath(desktop.vaultId), {
+      headers: await attacker.auth(desktop.vaultId),
+    });
+    expect(denied.status).toBe(403);
+  });
+
+  it("wrong, expired and consumed all answer identically — no offer oracle", async () => {
+    const desktop = await createDevice();
+    await found(desktop);
+
+    const { pairing } = await offer(desktop, desktop.vaultId);
+    const joiner = await createDevice();
+    await redeem(desktop.vaultId, pairing.s, joiner);
+
+    const wrong = await createEnrollOffer();
+    const answers = await Promise.all([
+      redeem(desktop.vaultId, pairing.s, await createDevice()), // consumed
+      redeem(desktop.vaultId, wrong.s, await createDevice()), // never existed
+    ]);
+    for (const answer of answers) {
+      expect(answer.status).toBe(200);
+      expect(await answer.text()).toBe(JSON.stringify({ ok: false }));
+    }
+  });
+
+  it("an offer TTL past the coordinator's maximum is clamped, not honoured", async () => {
+    const desktop = await createDevice();
+    await found(desktop);
+    const now = nowSeconds();
+    const { res } = await offer(desktop, desktop.vaultId, now + 86_400);
+    const offered = await readJson<EnrollOfferResponse>(res);
+    expect(offered.notAfter).toBeLessThanOrEqual(now + 600 + 2);
+  });
+
+  it("an unenrolled device cannot create an offer", async () => {
+    const desktop = await createDevice();
+    const outsider = await createDevice();
+    await found(desktop);
+
+    const pairing = await createEnrollOffer();
+    const res = await SELF.fetch(ORIGIN + enrollOfferPath(desktop.vaultId), {
+      method: "POST",
+      headers: { ...json, ...(await outsider.auth(desktop.vaultId)) },
+      body: JSON.stringify({ enrollId: pairing.enrollId, notAfter: nowSeconds() + 600 }),
+    });
+    expect(res.status).toBe(403);
+  });
+
+  it("the enroll route refuses a vaultId that is not self-certifying", async () => {
+    const joiner = await createDevice();
+    const pairing = await createEnrollOffer();
+    const res = await SELF.fetch(ORIGIN + enrollPath("not-a-self-certifying-id"), {
+      method: "POST",
+      headers: json,
+      body: JSON.stringify({ s: pairing.s, publicKey: joiner.publicKey, deviceName: "Phone" }),
+    });
+    expect(res.status).toBe(401);
+    expect(await res.text()).toBe("invalid-vault-id");
+  });
+
+  it("a malformed enroll body is a 400 — shape is not a secret, offers are", async () => {
+    const desktop = await createDevice();
+    await found(desktop);
+    const res = await SELF.fetch(ORIGIN + enrollPath(desktop.vaultId), {
+      method: "POST",
+      headers: json,
+      body: JSON.stringify({ s: "x", publicKey: "too-short", deviceName: "" }),
+    });
+    expect(res.status).toBe(400);
+  });
+});
+
+describe("revocation", () => {
+  it("a revoked device is refused on the very next request", async () => {
+    const desktop = await createDevice();
+    const phone = await createDevice();
+    await found(desktop);
+    const { pairing } = await offer(desktop, desktop.vaultId);
+    await redeem(desktop.vaultId, pairing.s, phone);
+    expect((await manifest(phone, desktop.vaultId)).status).toBe(200);
+
+    const revoked = await readJson<RevokeResponse>(
+      await SELF.fetch(ORIGIN + revokePath(desktop.vaultId), {
+        method: "POST",
+        headers: { ...json, ...(await desktop.auth(desktop.vaultId)) },
+        body: JSON.stringify({ publicKey: phone.publicKey }),
+      }),
+    );
+    expect(revoked.ok).toBe(true);
+
+    const after = await manifest(phone, desktop.vaultId);
+    expect(after.status).toBe(403);
+    expect(await after.text()).toBe("device-revoked");
+  });
+
+  it("revocation is a tombstone: a replayed offer cannot resurrect the key", async () => {
+    const desktop = await createDevice();
+    const phone = await createDevice();
+    await found(desktop);
+
+    const first = await offer(desktop, desktop.vaultId);
+    await redeem(desktop.vaultId, first.pairing.s, phone);
+    await SELF.fetch(ORIGIN + revokePath(desktop.vaultId), {
+      method: "POST",
+      headers: { ...json, ...(await desktop.auth(desktop.vaultId)) },
+      body: JSON.stringify({ publicKey: phone.publicKey }),
+    });
+
+    // A brand-new, perfectly valid offer redeemed by the revoked key.
+    const second = await offer(desktop, desktop.vaultId);
+    const again = await readJson<EnrollResponse>(
+      await redeem(desktop.vaultId, second.pairing.s, phone),
+    );
+    expect(again.ok).toBe(false);
+    expect((await manifest(phone, desktop.vaultId)).status).toBe(403);
+
+    const roster = await readJson<DeviceListResponse>(
+      await SELF.fetch(ORIGIN + devicesPath(desktop.vaultId), {
+        headers: await desktop.auth(desktop.vaultId),
+      }),
+    );
+    expect(roster.devices.find((d) => d.publicKey === phone.publicKey)?.revokedAt).toBeGreaterThan(
+      0,
+    );
+  });
+
+  it("revoking closes every open changes stream, not just future auths", async () => {
+    const desktop = await createDevice();
+    const phone = await createDevice();
+    await found(desktop);
+    const { pairing } = await offer(desktop, desktop.vaultId);
+    await redeem(desktop.vaultId, pairing.s, phone);
+
+    const stream = await SELF.fetch(ORIGIN + changesPath(desktop.vaultId), {
+      headers: await phone.auth(desktop.vaultId),
+    });
+    expect(stream.status).toBe(200);
+    const body = stream.body;
+    if (body === null) throw new Error("no SSE body");
+    const reader = body.getReader();
+    // The leading comment frame proves the subscription is registered.
+    const first = await reader.read();
+    expect(new TextDecoder().decode(first.value)).toContain(": connected");
+
+    await SELF.fetch(ORIGIN + revokePath(desktop.vaultId), {
+      method: "POST",
+      headers: { ...json, ...(await desktop.auth(desktop.vaultId)) },
+      body: JSON.stringify({ publicKey: phone.publicKey }),
+    });
+
+    const next = await reader.read();
+    expect(next.done).toBe(true);
+  });
+
+  it("revoking a key that was never enrolled is not-found", async () => {
+    const desktop = await createDevice();
+    const stranger = await createDevice();
+    await found(desktop);
+    const result = await readJson<RevokeResponse>(
+      await SELF.fetch(ORIGIN + revokePath(desktop.vaultId), {
+        method: "POST",
+        headers: { ...json, ...(await desktop.auth(desktop.vaultId)) },
+        body: JSON.stringify({ publicKey: stranger.publicKey }),
+      }),
+    );
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error("expected not-found");
+    expect(result.reason).toBe("not-found");
+  });
+});
+
+describe("coexistence with the account path", () => {
+  it("a session bearer cannot reach the device-identity routes", async () => {
+    const desktop = await createDevice();
+    await found(desktop);
+    const res = await SELF.fetch(ORIGIN + devicesPath(desktop.vaultId), {
+      headers: { authorization: formatBearer("a-session-shaped-token") },
+    });
+    expect(res.status).toBe(401);
+    expect(await res.text()).toBe("missing-credential");
+  });
+
+  it("a founded vault stops accepting session-only requests", async () => {
+    const desktop = await createDevice();
+    await found(desktop);
+
+    // Sign up a real account and point it at the founded vault. The Worker's
+    // ownership table has no row, so it claims it — and the DO still refuses,
+    // because the roster is the authority once it exists.
+    const credentials = JSON.stringify({
+      email: "session@example.com",
+      password: "test-password-1234",
+      name: "session",
+    });
+    await SELF.fetch(`${ORIGIN}/api/auth/sign-up/email`, {
+      method: "POST",
+      headers: { ...json, origin: ORIGIN },
+      body: credentials,
+    });
+    const signIn = await SELF.fetch(`${ORIGIN}/api/auth/sign-in/email`, {
+      method: "POST",
+      headers: { ...json, origin: ORIGIN },
+      body: credentials,
+    });
+    const token = signIn.headers.get("set-auth-token");
+    if (token === null) throw new Error("no bearer token");
+
+    const res = await SELF.fetch(ORIGIN + manifestPath(desktop.vaultId), {
+      headers: { authorization: formatBearer(token) },
+    });
+    expect(res.status).toBe(403);
+    expect(await res.text()).toBe("device-credential-required");
+  });
+});

--- a/apps/cloud/test/device-identity.test.ts
+++ b/apps/cloud/test/device-identity.test.ts
@@ -1,17 +1,23 @@
 import {
+  base64UrlEncode,
   changesPath,
   devicesPath,
   enrollOfferPath,
   enrollPath,
+  filePath,
   formatBearer,
+  formatVersionHeader,
+  HEADER_BASE_VERSION,
   manifestPath,
+  MIN_ENROLL_SECRET_BYTES,
   revokePath,
   type DeviceListResponse,
   type EnrollOfferResponse,
   type EnrollResponse,
   type RevokeResponse,
 } from "@repo/notes/sync/wire";
-import { SELF } from "cloudflare:test";
+import { ABSENT_VERSION } from "@repo/notes/sync/vault-file";
+import { env, SELF } from "cloudflare:test";
 import { describe, expect, it } from "vitest";
 import { MAX_ASSERTION_LIFETIME_SECONDS, MAX_CLOCK_SKEW_SECONDS } from "../src/device-assertion";
 import {
@@ -73,6 +79,15 @@ function redeem(vaultId: string, s: string, joiner: TestDevice, deviceName = "Ph
   });
 }
 
+/** `signer` asks the roster to tombstone `publicKey`. */
+async function revoke(signer: TestDevice, vaultId: string, publicKey: string): Promise<Response> {
+  return SELF.fetch(ORIGIN + revokePath(vaultId), {
+    method: "POST",
+    headers: { ...json, ...(await signer.auth(vaultId)) },
+    body: JSON.stringify({ publicKey }),
+  });
+}
+
 describe("founding", () => {
   it("a device founds the vault its own key names, and lands on the roster", async () => {
     const desktop = await createDevice();
@@ -100,7 +115,7 @@ describe("founding", () => {
       headers: await stranger.auth(founder.vaultId),
     });
     expect(res.status).toBe(403);
-    expect(await res.text()).toBe("not-founder");
+    expect(await res.text()).toBe("device-not-enrolled");
   });
 
   it("a valid signature that is not on the roster is refused (403)", async () => {
@@ -113,6 +128,25 @@ describe("founding", () => {
     });
     expect(res.status).toBe(403);
     expect(await res.text()).toBe("device-not-enrolled");
+  });
+
+  it("the refusal is not a founding oracle: founded and unfounded read the same", async () => {
+    const founded = await createDevice();
+    await found(founded);
+    const unfounded = await createDevice();
+    const prober = await createDevice();
+
+    const [onFounded, onUnfounded] = await Promise.all([
+      SELF.fetch(ORIGIN + manifestPath(founded.vaultId), {
+        headers: await prober.auth(founded.vaultId),
+      }),
+      SELF.fetch(ORIGIN + manifestPath(unfounded.vaultId), {
+        headers: await prober.auth(unfounded.vaultId),
+      }),
+    ]);
+    expect([onFounded.status, onUnfounded.status]).toEqual([403, 403]);
+    expect(await onFounded.text()).toBe("device-not-enrolled");
+    expect(await onUnfounded.text()).toBe("device-not-enrolled");
   });
 });
 
@@ -331,6 +365,54 @@ describe("enrollment", () => {
     });
     expect(res.status).toBe(400);
   });
+
+  it("a secret under the entropy floor is refused, well-formed or not", async () => {
+    const desktop = await createDevice();
+    const joiner = await createDevice();
+    await found(desktop);
+
+    const short = base64UrlEncode(
+      crypto.getRandomValues(new Uint8Array(MIN_ENROLL_SECRET_BYTES - 1)),
+    );
+    const res = await SELF.fetch(ORIGIN + enrollPath(desktop.vaultId), {
+      method: "POST",
+      headers: json,
+      body: JSON.stringify({ s: short, publicKey: joiner.publicKey, deviceName: "Phone" }),
+    });
+    expect(res.status).toBe(400);
+    expect((await manifest(joiner, desktop.vaultId)).status).toBe(403);
+  });
+
+  it("the credential-free redeem route is throttled, so DOs are not unbounded", async () => {
+    const joiner = await createDevice();
+    const pairing = await createEnrollOffer();
+    // A budget this test owns: keyed by IP, and nothing else here sends one.
+    const headers = { ...json, "cf-connecting-ip": "203.0.113.7" };
+
+    env.RATE_LIMIT_DISABLED = "false";
+    try {
+      const statuses: number[] = [];
+      for (let attempt = 0; attempt < 12; attempt += 1) {
+        // A different unfounded vaultId each time — the budget, not the vault,
+        // is the thing that has to stop this.
+        const target = await createDevice();
+        const res = await SELF.fetch(ORIGIN + enrollPath(target.vaultId), {
+          method: "POST",
+          headers,
+          body: JSON.stringify({
+            s: pairing.s,
+            publicKey: joiner.publicKey,
+            deviceName: "Phone",
+          }),
+        });
+        statuses.push(res.status);
+      }
+      expect(statuses.slice(0, 10)).toEqual(Array<number>(10).fill(200));
+      expect(statuses.slice(10)).toEqual([429, 429]);
+    } finally {
+      env.RATE_LIMIT_DISABLED = "true";
+    }
+  });
 });
 
 describe("revocation", () => {
@@ -343,11 +425,7 @@ describe("revocation", () => {
     expect((await manifest(phone, desktop.vaultId)).status).toBe(200);
 
     const revoked = await readJson<RevokeResponse>(
-      await SELF.fetch(ORIGIN + revokePath(desktop.vaultId), {
-        method: "POST",
-        headers: { ...json, ...(await desktop.auth(desktop.vaultId)) },
-        body: JSON.stringify({ publicKey: phone.publicKey }),
-      }),
+      await revoke(desktop, desktop.vaultId, phone.publicKey),
     );
     expect(revoked.ok).toBe(true);
 
@@ -363,11 +441,7 @@ describe("revocation", () => {
 
     const first = await offer(desktop, desktop.vaultId);
     await redeem(desktop.vaultId, first.pairing.s, phone);
-    await SELF.fetch(ORIGIN + revokePath(desktop.vaultId), {
-      method: "POST",
-      headers: { ...json, ...(await desktop.auth(desktop.vaultId)) },
-      body: JSON.stringify({ publicKey: phone.publicKey }),
-    });
+    await revoke(desktop, desktop.vaultId, phone.publicKey);
 
     // A brand-new, perfectly valid offer redeemed by the revoked key.
     const second = await offer(desktop, desktop.vaultId);
@@ -405,11 +479,7 @@ describe("revocation", () => {
     const first = await reader.read();
     expect(new TextDecoder().decode(first.value)).toContain(": connected");
 
-    await SELF.fetch(ORIGIN + revokePath(desktop.vaultId), {
-      method: "POST",
-      headers: { ...json, ...(await desktop.auth(desktop.vaultId)) },
-      body: JSON.stringify({ publicKey: phone.publicKey }),
-    });
+    await revoke(desktop, desktop.vaultId, phone.publicKey);
 
     const next = await reader.read();
     expect(next.done).toBe(true);
@@ -420,19 +490,75 @@ describe("revocation", () => {
     const stranger = await createDevice();
     await found(desktop);
     const result = await readJson<RevokeResponse>(
-      await SELF.fetch(ORIGIN + revokePath(desktop.vaultId), {
-        method: "POST",
-        headers: { ...json, ...(await desktop.auth(desktop.vaultId)) },
-        body: JSON.stringify({ publicKey: stranger.publicKey }),
-      }),
+      await revoke(desktop, desktop.vaultId, stranger.publicKey),
     );
     expect(result.ok).toBe(false);
     if (result.ok) throw new Error("expected not-found");
     expect(result.reason).toBe("not-found");
   });
+
+  it("revoking the LAST live device is refused — a vault is never stranded", async () => {
+    const desktop = await createDevice();
+    await found(desktop);
+
+    const result = await readJson<RevokeResponse>(
+      await revoke(desktop, desktop.vaultId, desktop.publicKey),
+    );
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error("expected a refusal");
+    expect(result.reason).toBe("last-device");
+
+    // Untouched: it still authenticates, and it can still grow the roster.
+    expect((await manifest(desktop, desktop.vaultId)).status).toBe(200);
+    const phone = await createDevice();
+    const { pairing } = await offer(desktop, desktop.vaultId);
+    expect(
+      (await readJson<EnrollResponse>(await redeem(desktop.vaultId, pairing.s, phone))).ok,
+    ).toBe(true);
+  });
+
+  it("the floor counts LIVE devices, not roster rows", async () => {
+    const desktop = await createDevice();
+    const phone = await createDevice();
+    await found(desktop);
+    const { pairing } = await offer(desktop, desktop.vaultId);
+    await redeem(desktop.vaultId, pairing.s, phone);
+
+    // Two live devices, so revoking one is fine…
+    expect(
+      (await readJson<RevokeResponse>(await revoke(desktop, desktop.vaultId, phone.publicKey))).ok,
+    ).toBe(true);
+
+    // …and the tombstone it leaves behind does not make the survivor revocable.
+    const last = await readJson<RevokeResponse>(
+      await revoke(desktop, desktop.vaultId, desktop.publicKey),
+    );
+    expect(last.ok).toBe(false);
+    if (last.ok) throw new Error("expected a refusal");
+    expect(last.reason).toBe("last-device");
+  });
 });
 
 describe("coexistence with the account path", () => {
+  /** Sign a real account up + in, and return its Better Auth bearer. */
+  async function sessionToken(email: string): Promise<string> {
+    const credentials = JSON.stringify({ email, password: "test-password-1234", name: "session" });
+    const headers = { ...json, origin: ORIGIN };
+    await SELF.fetch(`${ORIGIN}/api/auth/sign-up/email`, {
+      method: "POST",
+      headers,
+      body: credentials,
+    });
+    const signIn = await SELF.fetch(`${ORIGIN}/api/auth/sign-in/email`, {
+      method: "POST",
+      headers,
+      body: credentials,
+    });
+    const token = signIn.headers.get("set-auth-token");
+    if (token === null) throw new Error("no bearer token");
+    return token;
+  }
+
   it("a session bearer cannot reach the device-identity routes", async () => {
     const desktop = await createDevice();
     await found(desktop);
@@ -446,32 +572,47 @@ describe("coexistence with the account path", () => {
   it("a founded vault stops accepting session-only requests", async () => {
     const desktop = await createDevice();
     await found(desktop);
-
-    // Sign up a real account and point it at the founded vault. The Worker's
-    // ownership table has no row, so it claims it — and the DO still refuses,
-    // because the roster is the authority once it exists.
-    const credentials = JSON.stringify({
-      email: "session@example.com",
-      password: "test-password-1234",
-      name: "session",
-    });
-    await SELF.fetch(`${ORIGIN}/api/auth/sign-up/email`, {
-      method: "POST",
-      headers: { ...json, origin: ORIGIN },
-      body: credentials,
-    });
-    const signIn = await SELF.fetch(`${ORIGIN}/api/auth/sign-in/email`, {
-      method: "POST",
-      headers: { ...json, origin: ORIGIN },
-      body: credentials,
-    });
-    const token = signIn.headers.get("set-auth-token");
-    if (token === null) throw new Error("no bearer token");
+    const token = await sessionToken("session@example.com");
 
     const res = await SELF.fetch(ORIGIN + manifestPath(desktop.vaultId), {
       headers: { authorization: formatBearer(token) },
     });
-    expect(res.status).toBe(403);
+    expect(res.status).toBe(401);
     expect(await res.text()).toBe("device-credential-required");
+  });
+
+  it("an account cannot squat a device-shaped vault nobody founded", async () => {
+    // The key exists; its vault has never been touched, so no roster says no.
+    const unfounded = await createDevice();
+    const token = await sessionToken("squatter@example.com");
+    const bearer = { authorization: formatBearer(token) };
+
+    const read = await SELF.fetch(ORIGIN + manifestPath(unfounded.vaultId), { headers: bearer });
+    expect(read.status).toBe(401);
+    expect(await read.text()).toBe("device-credential-required");
+
+    const write = await SELF.fetch(ORIGIN + filePath(unfounded.vaultId, "squat.md"), {
+      method: "PUT",
+      headers: { ...bearer, [HEADER_BASE_VERSION]: formatVersionHeader(ABSENT_VERSION) },
+      body: new TextEncoder().encode("mine now\n"),
+    });
+    expect(write.status).toBe(401);
+
+    // And the key whose fingerprint the id IS still founds it, on an empty vault.
+    expect((await manifest(unfounded, unfounded.vaultId)).status).toBe(200);
+    const files = await readJson<{ files: unknown[] }>(
+      await SELF.fetch(ORIGIN + manifestPath(unfounded.vaultId), {
+        headers: await unfounded.auth(unfounded.vaultId),
+      }),
+    );
+    expect(files.files).toEqual([]);
+  });
+
+  it("a UUID vault still authenticates on a session — the account path is unchanged", async () => {
+    const token = await sessionToken("uuid-vault@example.com");
+    const res = await SELF.fetch(ORIGIN + manifestPath("6f1a2b3c-0000-4000-8000-000000000000"), {
+      headers: { authorization: formatBearer(token) },
+    });
+    expect(res.status).toBe(200);
   });
 });

--- a/apps/cloud/test/e2e-sync.test.ts
+++ b/apps/cloud/test/e2e-sync.test.ts
@@ -7,11 +7,15 @@ import { createHttpSyncPort } from "@repo/notes/sync/http-sync-port";
 import { isConflictCopyPath } from "@repo/notes/sync/reconcile";
 import { ABSENT_VERSION } from "@repo/notes/sync/vault-file";
 import {
+  enrollOfferPath,
+  enrollPath,
   filePath,
   formatBearer,
   formatVersionHeader,
   HEADER_BASE_VERSION,
+  type EnrollResponse,
 } from "@repo/notes/sync/wire";
+import { createDevice, createEnrollOffer, nowSeconds, type TestDevice } from "./device-helpers";
 
 // ---------------------------------------------------------------------------
 // END-TO-END sync test. Unlike sync.test.ts (which pokes the Worker's routes
@@ -50,6 +54,30 @@ async function signIn(email: string): Promise<string> {
   const token = inRes.headers.get("set-auth-token");
   if (token === null || token === "") throw new Error("no bearer token in set-auth-token header");
   return token;
+}
+
+/**
+ * Enroll `joiner` into `host`'s vault the way the pairing flow will: the host
+ * deposits only `sha256(secret)`, the joiner presents the secret on a route
+ * that takes no credential at all.
+ */
+async function enrollDevice(host: TestDevice, joiner: TestDevice, name: string): Promise<void> {
+  const pairing = await createEnrollOffer();
+  const offered = await SELF.fetch(`${ORIGIN}${enrollOfferPath(host.vaultId)}`, {
+    method: "POST",
+    headers: { "content-type": "application/json", ...(await host.auth(host.vaultId)) },
+    body: JSON.stringify({ enrollId: pairing.enrollId, notAfter: nowSeconds() + 600 }),
+  });
+  if (offered.status !== 200) {
+    throw new Error(`enroll-offer ${offered.status}: ${await offered.text()}`);
+  }
+  const redeemed = await SELF.fetch(`${ORIGIN}${enrollPath(host.vaultId)}`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ s: pairing.s, publicKey: joiner.publicKey, deviceName: name }),
+  });
+  const result = (await redeemed.json()) as EnrollResponse;
+  if (!result.ok) throw new Error("enrollment refused");
 }
 
 /** sha-256 hex over Web Crypto (workerd) — the hasher the engine content-addresses with. */
@@ -92,13 +120,26 @@ function bytes(text: string): Uint8Array {
 }
 
 function engineFor(vaultId: string, token: string, io: SyncIo): SyncEngine {
+  return engineWith(vaultId, () => Promise.resolve(token), io);
+}
+
+/**
+ * The device-path engine. `getToken` mints a FRESH assertion per request, which
+ * is the whole reason the port asks for its credential instead of holding one:
+ * an assertion outlives neither the engine nor the SSE stream.
+ */
+function deviceEngineFor(device: TestDevice, vaultId: string, io: SyncIo): SyncEngine {
+  return engineWith(vaultId, () => device.assert(vaultId), io);
+}
+
+function engineWith(vaultId: string, getToken: () => Promise<string>, io: SyncIo): SyncEngine {
   return new SyncEngine({
     vaultId,
     io,
     port: createHttpSyncPort({
       baseUrl: ORIGIN,
       vaultId,
-      getToken: () => Promise.resolve(token),
+      getToken,
       fetchImpl: fetchSelf,
       hasher: sha256Hex,
     }),
@@ -227,6 +268,60 @@ describe("end-to-end sync", () => {
     // Carol's file is NOT pulled onto Mallory's device.
     expect(outM.status).toBe("error");
     expect(m.has("secret.md")).toBe(false);
+  });
+
+  describe("device keys", () => {
+    it("a founding device and an enrolled one converge, with no account at all", async () => {
+      const desktop = await createDevice();
+      const phone = await createDevice();
+
+      // The desktop founds the vault its own key names, and pushes.
+      const d = deviceVault();
+      d.io.write("notes/hello.md", bytes("# Hello\n"));
+      const pushed = await deviceEngineFor(desktop, desktop.vaultId, d.io).syncOnce();
+      expect(pushed.status).toBe("ok");
+      expect(pushed).toMatchObject({ pushed: 1, pulled: 0, conflicts: 0 });
+
+      await enrollDevice(desktop, phone, "Phone");
+
+      const p = deviceVault();
+      const pulled = await deviceEngineFor(phone, desktop.vaultId, p.io).syncOnce();
+      expect(pulled.status).toBe("ok");
+      expect(pulled).toMatchObject({ pushed: 0, pulled: 1 });
+      expect(p.text("notes/hello.md")).toBe("# Hello\n");
+    });
+
+    it("a device enrolled elsewhere cannot touch this vault (403 -> error, no leak)", async () => {
+      const owner = await createDevice();
+      const o = deviceVault();
+      o.io.write("secret.md", bytes("owner only\n"));
+      expect((await deviceEngineFor(owner, owner.vaultId, o.io).syncOnce()).status).toBe("ok");
+
+      // Mallory founds a vault of her own, so her key IS enrolled — just not here.
+      const mallory = await createDevice();
+      const mine = deviceVault();
+      expect((await deviceEngineFor(mallory, mallory.vaultId, mine.io).syncOnce()).status).toBe(
+        "ok",
+      );
+
+      const m = deviceVault();
+      const outM = await deviceEngineFor(mallory, owner.vaultId, m.io).syncOnce();
+      expect(outM.status).toBe("error");
+      expect(m.has("secret.md")).toBe(false);
+    });
+
+    it("an account session cannot reach a device-founded vault", async () => {
+      const desktop = await createDevice();
+      const d = deviceVault();
+      d.io.write("secret.md", bytes("device only\n"));
+      expect((await deviceEngineFor(desktop, desktop.vaultId, d.io).syncOnce()).status).toBe("ok");
+
+      const mallory = await signIn("mallory-account@example.com");
+      const m = deviceVault();
+      const outM = await engineFor(desktop.vaultId, mallory, m.io).syncOnce();
+      expect(outM.status).toBe("error");
+      expect(m.has("secret.md")).toBe(false);
+    });
   });
 
   // The coordinator's PUT size cap (32 MiB — mirrors the literal in

--- a/apps/cloud/test/e2e-sync.test.ts
+++ b/apps/cloud/test/e2e-sync.test.ts
@@ -98,7 +98,7 @@ function engineFor(vaultId: string, token: string, io: SyncIo): SyncEngine {
     port: createHttpSyncPort({
       baseUrl: ORIGIN,
       vaultId,
-      token,
+      getToken: () => Promise.resolve(token),
       fetchImpl: fetchSelf,
       hasher: sha256Hex,
     }),

--- a/apps/mobile/src/lib/sync/manager.ts
+++ b/apps/mobile/src/lib/sync/manager.ts
@@ -58,7 +58,7 @@ function engineFor(token: string): SyncEngine {
     port: createHttpSyncPort({
       baseUrl: getCoordinatorUrl(),
       vaultId,
-      token,
+      getToken: () => Promise.resolve(token),
       hasher: createExpoHasher(),
     }),
     io: createSyncIo(createExpoVaultFs()),

--- a/apps/mobile/src/lib/sync/realtime-manager.ts
+++ b/apps/mobile/src/lib/sync/realtime-manager.ts
@@ -55,7 +55,7 @@ function openStream(handlers: StreamHandlers): () => void {
   const port = createHttpSyncPort({
     baseUrl: getCoordinatorUrl(),
     vaultId,
-    token,
+    getToken: () => Promise.resolve(token),
     fetchImpl: streamingFetch,
     // Subscribe-only port — no getFile ever runs here, but the hasher is a
     // required part of the contract (getFile verifies bytes against headers).

--- a/packages/notes/src/sync/__tests__/http-sync-port.test.ts
+++ b/packages/notes/src/sync/__tests__/http-sync-port.test.ts
@@ -63,7 +63,7 @@ function newPort(fetchImpl: FetchFn): HttpSyncPort {
   return createHttpSyncPort({
     baseUrl: BASE_URL,
     vaultId: VAULT_ID,
-    token: TOKEN,
+    getToken: () => Promise.resolve(TOKEN),
     fetchImpl,
     hasher: fakeHasher,
   });
@@ -82,6 +82,27 @@ describe("HttpSyncPort", () => {
     expect(result).toEqual(manifest);
     expect(calls[0]?.url).toBe(`${BASE_URL}/v1/vault/${VAULT_ID}/manifest`);
     expect(calls[0]?.headers.get("authorization")).toBe(formatBearer(TOKEN));
+  });
+
+  it("mints a fresh credential per request rather than capturing one", async () => {
+    const { fetchImpl, calls } = fakeFetch(() => Response.json({ ok: true }));
+    let minted = 0;
+    const port = createHttpSyncPort({
+      baseUrl: BASE_URL,
+      vaultId: VAULT_ID,
+      getToken: () => {
+        minted += 1;
+        return Promise.resolve(`${TOKEN}-${minted}`);
+      },
+      fetchImpl,
+      hasher: fakeHasher,
+    });
+
+    await port.deleteFile("a.md", 1);
+    await port.deleteFile("b.md", 1);
+
+    expect(calls[0]?.headers.get("authorization")).toBe(formatBearer(`${TOKEN}-1`));
+    expect(calls[1]?.headers.get("authorization")).toBe(formatBearer(`${TOKEN}-2`));
   });
 
   it("throws on a non-OK manifest response", async () => {

--- a/packages/notes/src/sync/__tests__/wire.test.ts
+++ b/packages/notes/src/sync/__tests__/wire.test.ts
@@ -3,9 +3,13 @@ import { describe, expect, it } from "vitest";
 import type { VaultChange } from "../sync-port";
 import {
   API_VERSION,
+  base32LowerEncode,
   base64UrlDecode,
   base64UrlEncode,
   changesPath,
+  devicesPath,
+  enrollOfferPath,
+  enrollPath,
   DEVICE_ASSERTION_DOMAIN,
   DEVICE_ASSERTION_VERSION,
   deviceAssertionSignedBytes,
@@ -17,13 +21,18 @@ import {
   formatChangeFrame,
   formatDeviceAssertion,
   formatVersionHeader,
+  isValidVaultId,
   manifestPath,
+  parseBearer,
   parseDeviceAssertion,
   parseDeviceAssertionPayload,
   parseFilePathParam,
   parseVersionHeader,
+  revokePath,
   SSE_CHANGE_EVENT,
+  vaultIdFromKeyDigest,
   vaultPath,
+  VAULT_ID_PREFIX,
   type DeviceAssertionPayload,
 } from "../wire";
 
@@ -96,6 +105,21 @@ describe("version header", () => {
 describe("bearer auth", () => {
   it("formats a bearer authorization header value", () => {
     expect(formatBearer("tok123")).toBe("Bearer tok123");
+  });
+
+  it("round-trips through parseBearer, scheme case notwithstanding", () => {
+    expect(parseBearer(formatBearer("tok123"))).toBe("tok123");
+    expect(parseBearer("bearer tok123")).toBe("tok123");
+    expect(parseBearer("BEARER  tok123 ")).toBe("tok123");
+  });
+
+  it("rejects a missing, empty or foreign-scheme header", () => {
+    expect(parseBearer(null)).toBeNull();
+    expect(parseBearer("")).toBeNull();
+    expect(parseBearer("Bearer ")).toBeNull();
+    expect(parseBearer("Bearer   ")).toBeNull();
+    expect(parseBearer("Basic dXNlcjpwYXNz")).toBeNull();
+    expect(parseBearer("tok123")).toBeNull();
   });
 });
 
@@ -222,3 +246,70 @@ function asciiBytes(text: string): Uint8Array {
   for (let i = 0; i < text.length; i += 1) bytes[i] = text.charCodeAt(i);
   return bytes;
 }
+
+describe("device route builders", () => {
+  it("each device sub-resource gets its own path", () => {
+    expect(enrollOfferPath("vid")).toBe(`/${API_VERSION}/vault/vid/enroll-offer`);
+    expect(enrollPath("vid")).toBe(`/${API_VERSION}/vault/vid/enroll`);
+    expect(devicesPath("vid")).toBe(`/${API_VERSION}/vault/vid/devices`);
+    expect(revokePath("vid")).toBe(`/${API_VERSION}/vault/vid/revoke`);
+  });
+});
+
+function ascii(text: string): Uint8Array {
+  const bytes = new Uint8Array(text.length);
+  for (let i = 0; i < text.length; i += 1) bytes[i] = text.charCodeAt(i);
+  return bytes;
+}
+
+function digest(fill: number): Uint8Array {
+  return new Uint8Array(32).fill(fill);
+}
+
+describe("base32LowerEncode", () => {
+  it("matches the RFC 4648 test vectors, lowercased and unpadded", () => {
+    expect(base32LowerEncode(ascii(""))).toBe("");
+    expect(base32LowerEncode(ascii("f"))).toBe("my");
+    expect(base32LowerEncode(ascii("fo"))).toBe("mzxq");
+    expect(base32LowerEncode(ascii("foo"))).toBe("mzxw6");
+    expect(base32LowerEncode(ascii("foob"))).toBe("mzxw6yq");
+    expect(base32LowerEncode(ascii("fooba"))).toBe("mzxw6ytb");
+    expect(base32LowerEncode(ascii("foobar"))).toBe("mzxw6ytboi");
+  });
+
+  it("stays inside the alphabet for arbitrary bytes", () => {
+    const every = new Uint8Array(256);
+    for (let i = 0; i < 256; i += 1) every[i] = i;
+    expect(base32LowerEncode(every)).toMatch(/^[a-z2-7]+$/);
+  });
+});
+
+describe("vault ids", () => {
+  it("derives a 54-character self-certifying id from a 32-byte digest", () => {
+    const id = vaultIdFromKeyDigest(digest(0xab));
+    expect(id).not.toBeNull();
+    if (id === null) throw new Error("unreachable");
+    expect(id).toHaveLength(54);
+    expect(id.startsWith(VAULT_ID_PREFIX)).toBe(true);
+    expect(isValidVaultId(id)).toBe(true);
+  });
+
+  it("different digests derive different ids", () => {
+    expect(vaultIdFromKeyDigest(digest(1))).not.toBe(vaultIdFromKeyDigest(digest(2)));
+  });
+
+  it("refuses anything that is not a sha-256 digest", () => {
+    expect(vaultIdFromKeyDigest(new Uint8Array(31))).toBeNull();
+    expect(vaultIdFromKeyDigest(new Uint8Array(33))).toBeNull();
+  });
+
+  it("rejects ids of the wrong shape — the gate on the unauthenticated enroll route", () => {
+    expect(isValidVaultId("")).toBe(false);
+    expect(isValidVaultId("v1")).toBe(false);
+    expect(isValidVaultId("6f1a2b3c-0000-4000-8000-000000000000")).toBe(false); // today's UUIDs
+    expect(isValidVaultId(`${VAULT_ID_PREFIX}${"a".repeat(51)}`)).toBe(false);
+    expect(isValidVaultId(`${VAULT_ID_PREFIX}${"a".repeat(53)}`)).toBe(false);
+    expect(isValidVaultId(`${VAULT_ID_PREFIX}${"A".repeat(52)}`)).toBe(false); // uppercase
+    expect(isValidVaultId(`${VAULT_ID_PREFIX}${"1".repeat(52)}`)).toBe(false); // 0/1/8/9 aren't base32
+  });
+});

--- a/packages/notes/src/sync/__tests__/wire.test.ts
+++ b/packages/notes/src/sync/__tests__/wire.test.ts
@@ -3,16 +3,28 @@ import { describe, expect, it } from "vitest";
 import type { VaultChange } from "../sync-port";
 import {
   API_VERSION,
+  base64UrlDecode,
+  base64UrlEncode,
   changesPath,
+  DEVICE_ASSERTION_DOMAIN,
+  DEVICE_ASSERTION_VERSION,
+  deviceAssertionSignedBytes,
+  ED25519_PUBLIC_KEY_BYTES,
+  ED25519_SIGNATURE_BYTES,
+  encodeDeviceAssertionPayload,
   filePath,
   formatBearer,
   formatChangeFrame,
+  formatDeviceAssertion,
   formatVersionHeader,
   manifestPath,
+  parseDeviceAssertion,
+  parseDeviceAssertionPayload,
   parseFilePathParam,
   parseVersionHeader,
   SSE_CHANGE_EVENT,
   vaultPath,
+  type DeviceAssertionPayload,
 } from "../wire";
 
 describe("route builders", () => {
@@ -105,3 +117,108 @@ describe("formatChangeFrame", () => {
     );
   });
 });
+
+describe("base64url", () => {
+  it("round-trips every byte-length remainder, unpadded", () => {
+    for (let length = 0; length <= 8; length += 1) {
+      const bytes = new Uint8Array(length);
+      for (let i = 0; i < length; i += 1) bytes[i] = (i * 37 + 11) % 256;
+      const encoded = base64UrlEncode(bytes);
+      expect(encoded).not.toContain("=");
+      expect(base64UrlDecode(encoded)).toEqual(bytes);
+    }
+  });
+
+  it("uses the url-safe alphabet", () => {
+    expect(base64UrlEncode(new Uint8Array([251, 255]))).toBe("-_8");
+  });
+
+  it("rejects a foreign character, an impossible length, and stray trailing bits", () => {
+    expect(base64UrlDecode("ab+c")).toBeNull();
+    expect(base64UrlDecode("abcde")).toBeNull();
+    // "AB" carries a 1 in bits no byte can hold — two spellings of one byte
+    // would otherwise let an assertion's text be mutated in place.
+    expect(base64UrlDecode("AB")).toBeNull();
+    expect(base64UrlDecode("AA")).toEqual(new Uint8Array([0]));
+  });
+});
+
+describe("device assertions", () => {
+  const publicKey = filled(ED25519_PUBLIC_KEY_BYTES, 7);
+  const signature = filled(ED25519_SIGNATURE_BYTES, 3);
+
+  function payload(overrides: Partial<DeviceAssertionPayload> = {}): DeviceAssertionPayload {
+    return {
+      v: DEVICE_ASSERTION_VERSION,
+      vid: "v1abcdef",
+      dev: base64UrlEncode(publicKey),
+      iat: 1_700_000_000,
+      exp: 1_700_000_300,
+      ...overrides,
+    };
+  }
+
+  it("round-trips a payload through its encoding", () => {
+    const encoded = encodeDeviceAssertionPayload(payload());
+    expect(encoded).not.toBeNull();
+    expect(parseDeviceAssertionPayload(encoded ?? "")).toEqual(payload());
+  });
+
+  it("refuses to encode claims the parser would reject", () => {
+    expect(
+      encodeDeviceAssertionPayload(payload({ dev: base64UrlEncode(filled(31, 5)) })),
+    ).toBeNull();
+    expect(encodeDeviceAssertionPayload(payload({ exp: 1_700_000_000 }))).toBeNull();
+    expect(encodeDeviceAssertionPayload(payload({ vid: "vault/one" }))).toBeNull();
+    expect(encodeDeviceAssertionPayload(payload({ iat: 1.5 }))).toBeNull();
+  });
+
+  it("parses a payload's claims out of untrusted text", () => {
+    expect(parseDeviceAssertionPayload("not base64url!")).toBeNull();
+    expect(parseDeviceAssertionPayload(base64UrlEncode(asciiBytes("not json")))).toBeNull();
+    expect(parseDeviceAssertionPayload(base64UrlEncode(asciiBytes("[1,2]")))).toBeNull();
+    const wrongVersion = JSON.stringify({ ...payload(), v: DEVICE_ASSERTION_VERSION + 1 });
+    expect(parseDeviceAssertionPayload(base64UrlEncode(asciiBytes(wrongVersion)))).toBeNull();
+  });
+
+  it("signs over the domain-separated encoded payload", () => {
+    const encoded = encodeDeviceAssertionPayload(payload()) ?? "";
+    expect(new TextDecoder().decode(deviceAssertionSignedBytes(encoded))).toBe(
+      `${DEVICE_ASSERTION_DOMAIN}${encoded}`,
+    );
+  });
+
+  it("round-trips a whole assertion, handing the verifier its bytes", () => {
+    const encoded = encodeDeviceAssertionPayload(payload()) ?? "";
+    const parsed = parseDeviceAssertion(formatDeviceAssertion(encoded, signature));
+
+    expect(parsed?.payload).toEqual(payload());
+    expect(parsed?.signature).toEqual(signature);
+    expect(parsed?.devicePublicKey).toEqual(publicKey);
+    expect(parsed?.signedBytes).toEqual(deviceAssertionSignedBytes(encoded));
+  });
+
+  it("rejects a malformed assertion", () => {
+    const encoded = encodeDeviceAssertionPayload(payload()) ?? "";
+    const assertion = formatDeviceAssertion(encoded, signature);
+
+    expect(parseDeviceAssertion(encoded)).toBeNull();
+    expect(parseDeviceAssertion(`${assertion}.extra`)).toBeNull();
+    expect(parseDeviceAssertion(formatDeviceAssertion(encoded, filled(63, 3)))).toBeNull();
+    expect(parseDeviceAssertion(`tampered.${base64UrlEncode(signature)}`)).toBeNull();
+  });
+});
+
+/** A deterministic byte string of an exact length. */
+function filled(length: number, seed: number): Uint8Array {
+  const bytes = new Uint8Array(length);
+  for (let i = 0; i < length; i += 1) bytes[i] = (i * seed + seed) % 256;
+  return bytes;
+}
+
+/** ASCII text → bytes, mirroring what the module does internally. */
+function asciiBytes(text: string): Uint8Array {
+  const bytes = new Uint8Array(text.length);
+  for (let i = 0; i < text.length; i += 1) bytes[i] = text.charCodeAt(i);
+  return bytes;
+}

--- a/packages/notes/src/sync/http-sync-port.ts
+++ b/packages/notes/src/sync/http-sync-port.ts
@@ -49,8 +49,13 @@ export type HttpSyncPortOptions = {
   baseUrl: string;
   /** The vault this client syncs — scopes every route. */
   vaultId: string;
-  /** Bearer token sent as `Authorization: Bearer <token>` on every request. */
-  token: string;
+  /**
+   * Mints the credential sent as `Authorization: Bearer <token>`. Asked PER
+   * REQUEST rather than captured once, because a port outlives its credential:
+   * the engine holds one across every pass and for the whole SSE stream, while
+   * the credential is a short-lived device assertion (`wire.ts`).
+   */
+  getToken: () => Promise<string>;
   /** Injected `fetch` (tests). Defaults to the global `fetch`. */
   fetchImpl?: FetchFn;
   /**
@@ -66,7 +71,7 @@ export type HttpSyncPortOptions = {
 export class HttpSyncPort implements SyncPort {
   private readonly baseUrl: string;
   private readonly vaultId: string;
-  private readonly token: string;
+  private readonly getToken: () => Promise<string>;
   private readonly fetchImpl: FetchFn;
   private readonly hasher: Hasher;
 
@@ -74,7 +79,7 @@ export class HttpSyncPort implements SyncPort {
     // Trim a trailing slash so `baseUrl + "/v1/..."` never doubles up.
     this.baseUrl = opts.baseUrl.replace(/\/+$/, "");
     this.vaultId = opts.vaultId;
-    this.token = opts.token;
+    this.getToken = opts.getToken;
     this.fetchImpl = opts.fetchImpl ?? fetch;
     this.hasher = opts.hasher;
   }
@@ -82,7 +87,7 @@ export class HttpSyncPort implements SyncPort {
   async listManifest(): Promise<VaultManifest> {
     const res = await this.fetchImpl(this.url(manifestPath(this.vaultId)), {
       method: "GET",
-      headers: this.headers(),
+      headers: await this.headers(),
     });
     if (!res.ok) throw transportError("manifest", res.status);
     const raw: unknown = await res.json();
@@ -94,7 +99,7 @@ export class HttpSyncPort implements SyncPort {
   async getFile(path: VaultPath): Promise<GetResult> {
     const res = await this.fetchImpl(this.url(filePath(this.vaultId, path)), {
       method: "GET",
-      headers: this.headers(),
+      headers: await this.headers(),
     });
     if (res.status === 404) return { ok: false, reason: "not-found" };
     if (!res.ok) throw transportError("getFile", res.status);
@@ -122,7 +127,7 @@ export class HttpSyncPort implements SyncPort {
   ): Promise<PutResult> {
     const res = await this.fetchImpl(this.url(filePath(this.vaultId, path)), {
       method: "PUT",
-      headers: this.headers({
+      headers: await this.headers({
         [HEADER_BASE_VERSION]: formatVersionHeader(expectedBaseVersion),
         "content-type": CONTENT_TYPE_OCTET_STREAM,
       }),
@@ -144,7 +149,9 @@ export class HttpSyncPort implements SyncPort {
   async deleteFile(path: VaultPath, expectedBaseVersion: number): Promise<DeleteResult> {
     const res = await this.fetchImpl(this.url(filePath(this.vaultId, path)), {
       method: "DELETE",
-      headers: this.headers({ [HEADER_BASE_VERSION]: formatVersionHeader(expectedBaseVersion) }),
+      headers: await this.headers({
+        [HEADER_BASE_VERSION]: formatVersionHeader(expectedBaseVersion),
+      }),
     });
     if (!res.ok) throw transportError("deleteFile", res.status);
     const raw: unknown = await res.json();
@@ -175,8 +182,8 @@ export class HttpSyncPort implements SyncPort {
     return `${this.baseUrl}${routePath}`;
   }
 
-  private headers(extra: Record<string, string> = {}): Record<string, string> {
-    return { [HEADER_AUTHORIZATION]: formatBearer(this.token), ...extra };
+  private async headers(extra: Record<string, string> = {}): Promise<Record<string, string>> {
+    return { [HEADER_AUTHORIZATION]: formatBearer(await this.getToken()), ...extra };
   }
 
   /** Read the SSE `changes` stream frame-by-frame, decoding each `VaultChange`.
@@ -189,7 +196,7 @@ export class HttpSyncPort implements SyncPort {
     try {
       const res = await this.fetchImpl(this.url(changesPath(this.vaultId)), {
         method: "GET",
-        headers: this.headers({ accept: CONTENT_TYPE_SSE }),
+        headers: await this.headers({ accept: CONTENT_TYPE_SSE }),
         signal,
       });
       if (!res.ok || res.body === null) return;

--- a/packages/notes/src/sync/wire.ts
+++ b/packages/notes/src/sync/wire.ts
@@ -22,6 +22,10 @@ import { isValidVaultPath, type VaultPath } from "./vault-file";
 //   putFile     PUT    /v1/vault/:vaultId/file?path=…   (body = raw bytes)
 //   deleteFile  DELETE /v1/vault/:vaultId/file?path=…
 //   changes     GET    /v1/vault/:vaultId/changes       (SSE stream)
+//   enrollOffer POST   /v1/vault/:vaultId/enroll-offer  (an enrolled device offers a join)
+//   enroll      POST   /v1/vault/:vaultId/enroll        (the joining device redeems it)
+//   devices     GET    /v1/vault/:vaultId/devices       (the roster)
+//   revoke      POST   /v1/vault/:vaultId/revoke        (tombstone one device)
 //
 // TRANSPORT SHAPE
 //   File bodies are RAW BYTES (`Content-Type: application/octet-stream`): the
@@ -44,7 +48,14 @@ export const API_VERSION = "v1";
 // ---- routes ---------------------------------------------------------------
 
 /** The vault-scoped sub-resources, i.e. the last path segment of a route. */
-export type VaultSubResource = "manifest" | "file" | "changes";
+export type VaultSubResource =
+  | "manifest"
+  | "file"
+  | "changes"
+  | "enroll-offer"
+  | "enroll"
+  | "devices"
+  | "revoke";
 
 /** The query-string key the file routes carry the vault path in (`?path=…`). */
 export const FILE_PATH_PARAM = "path";
@@ -75,6 +86,26 @@ export function filePath(vaultId: string, path: VaultPath): string {
 /** `GET /v1/vault/:vaultId/changes` — the SSE change stream. */
 export function changesPath(vaultId: string): string {
   return vaultPath(vaultId, "changes");
+}
+
+/** `POST /v1/vault/:vaultId/enroll-offer` — an enrolled device offers a join. */
+export function enrollOfferPath(vaultId: string): string {
+  return vaultPath(vaultId, "enroll-offer");
+}
+
+/** `POST /v1/vault/:vaultId/enroll` — the joining device redeems the offer. */
+export function enrollPath(vaultId: string): string {
+  return vaultPath(vaultId, "enroll");
+}
+
+/** `GET /v1/vault/:vaultId/devices` — the enrolled roster, tombstones included. */
+export function devicesPath(vaultId: string): string {
+  return vaultPath(vaultId, "devices");
+}
+
+/** `POST /v1/vault/:vaultId/revoke` — tombstone one device. */
+export function revokePath(vaultId: string): string {
+  return vaultPath(vaultId, "revoke");
 }
 
 /**
@@ -142,6 +173,27 @@ export function parseVersionHeader(raw: string | null): number | null {
 /** Format a bearer authorization header value: `formatBearer(t)` → `"Bearer <t>"`. */
 export function formatBearer(token: string): string {
   return `Bearer ${token}`;
+}
+
+/**
+ * Pull the token out of an `Authorization` header value, or `null` when the
+ * header is absent or isn't a non-empty bearer. The scheme match is
+ * case-insensitive (RFC 7235 says it is).
+ *
+ * This exists so that every verifier reads the SAME raw header. The device
+ * credential is checked twice — once statelessly in the Worker, once against
+ * the roster in the Durable Object — and the tempting shortcut of having the
+ * first stamp its conclusion into a header the second trusts turns one forged
+ * request header into full vault access. Neither side takes a forwarded
+ * verdict; both call this.
+ */
+export function parseBearer(headerValue: string | null): string | null {
+  if (headerValue === null) return null;
+  const scheme = "bearer ";
+  if (headerValue.length <= scheme.length) return null;
+  if (headerValue.slice(0, scheme.length).toLowerCase() !== scheme) return null;
+  const token = headerValue.slice(scheme.length).trim();
+  return token === "" ? null : token;
 }
 
 // ---- content types --------------------------------------------------------
@@ -280,6 +332,123 @@ export function parseDeviceAssertion(raw: string): DeviceAssertion | null {
     signature,
     devicePublicKey,
   };
+}
+
+// ---- vault ids ------------------------------------------------------------
+//
+// A vaultId is SELF-CERTIFYING: it is the fingerprint of the founding device's
+// public key, so "which vault is this" and "whose vault is this" are one
+// question answered by one SHA-256. Claiming someone else's id is a preimage
+// problem, not a race to be first.
+//
+// The digest is injected rather than computed here — @repo/notes carries no
+// crypto, exactly as `Hasher` already establishes for content hashing.
+
+/** Every vaultId minted under the device-key model starts with this. */
+export const VAULT_ID_PREFIX = "v1";
+
+/** `v1` + base32 of a 32-byte digest: 2 + ceil(256/5) = 54 characters. */
+const VAULT_ID_SHAPE = /^v1[a-z2-7]{52}$/;
+
+const SHA256_DIGEST_BYTES = 32;
+
+/**
+ * True for an id of the self-certifying shape. Load-bearing on the Worker's
+ * unauthenticated enroll route: without it a caller instantiates Durable
+ * Objects by naming arbitrary strings.
+ */
+export function isValidVaultId(id: string): boolean {
+  return VAULT_ID_SHAPE.test(id);
+}
+
+/**
+ * Derive the vaultId a device's key founds, from the SHA-256 of that device's
+ * RAW public key bytes. `null` when the digest isn't 32 bytes — the caller
+ * handed us something that is not a SHA-256.
+ */
+export function vaultIdFromKeyDigest(digest: Uint8Array): string | null {
+  if (digest.length !== SHA256_DIGEST_BYTES) return null;
+  return VAULT_ID_PREFIX + base32LowerEncode(digest);
+}
+
+// ---- device enrollment bodies ---------------------------------------------
+//
+// Growth is by signature, never by server grant: only an already-enrolled
+// device can offer a join, and the offer's SECRET never reaches the server —
+// only `sha256hex(secret)`. Redeeming is therefore unauthenticated by design,
+// because the secret IS the auth.
+
+/** One row of the roster. `revokedAt` non-null is a tombstone, never a delete. */
+export type DeviceRecord = {
+  /** base64url of the raw Ed25519 public key — the roster's primary key. */
+  readonly publicKey: string;
+  readonly name: string;
+  readonly enrolledAt: number;
+  readonly revokedAt: number | null;
+};
+
+/** `GET …/devices` — every enrolled key, revoked ones included. */
+export type DeviceListResponse = { readonly devices: readonly DeviceRecord[] };
+
+/** `POST …/enroll-offer` body. `enrollId` is `sha256hex(secret)`, lowercase. */
+export type EnrollOfferRequest = {
+  readonly enrollId: string;
+  /** Epoch seconds. The coordinator clamps it to its own maximum TTL. */
+  readonly notAfter: number;
+};
+
+/** `POST …/enroll-offer` result — the offer's effective (clamped) expiry. */
+export type EnrollOfferResponse = { readonly notAfter: number };
+
+/**
+ * `POST …/enroll` body. `s` is base64url of the offer secret, named to match
+ * the pairing blob field the joining device forwards verbatim.
+ */
+export type EnrollRequest = {
+  readonly s: string;
+  /** base64url of the joining device's raw Ed25519 public key. */
+  readonly publicKey: string;
+  readonly deviceName: string;
+};
+
+/**
+ * `POST …/enroll` result. Deliberately carries NO reason: wrong secret, expired
+ * offer and already-consumed offer answer identically, so the route is not an
+ * offer-existence oracle.
+ */
+export type EnrollResponse = { readonly ok: boolean };
+
+/** `POST …/revoke` body. Any enrolled device may revoke any device, itself included. */
+export type RevokeRequest = { readonly publicKey: string };
+
+/** `POST …/revoke` result. */
+export type RevokeResponse =
+  | { readonly ok: true; readonly revokedAt: number }
+  | { readonly ok: false; readonly reason: "not-found" };
+
+// ---- base32 ---------------------------------------------------------------
+
+const BASE32_LOWER_ALPHABET = "abcdefghijklmnopqrstuvwxyz234567";
+
+/**
+ * Encode bytes as unpadded lowercase base32 (RFC 4648 §6). Lowercase and
+ * digit-restricted so a vaultId survives a case-insensitive filesystem, a URL
+ * path segment and a hand transcription without changing meaning.
+ */
+export function base32LowerEncode(bytes: Uint8Array): string {
+  let out = "";
+  let acc = 0;
+  let bits = 0;
+  for (const byte of bytes) {
+    acc = (acc << 8) | byte;
+    bits += 8;
+    while (bits >= 5) {
+      bits -= 5;
+      out += BASE32_LOWER_ALPHABET.charAt((acc >> bits) & 0b11111);
+    }
+  }
+  if (bits > 0) out += BASE32_LOWER_ALPHABET.charAt((acc << (5 - bits)) & 0b11111);
+  return out;
 }
 
 // ---- base64url ------------------------------------------------------------

--- a/packages/notes/src/sync/wire.ts
+++ b/packages/notes/src/sync/wire.ts
@@ -401,8 +401,17 @@ export type EnrollOfferRequest = {
 export type EnrollOfferResponse = { readonly notAfter: number };
 
 /**
+ * Shortest offer secret a coordinator accepts, in raw bytes — and the length a
+ * device must MINT at. The server holds only `sha256hex(secret)`, so a short
+ * secret is brute-forceable offline against a live offer. Randomness is not
+ * checkable server-side; length is, so the floor is enforced at both ends.
+ */
+export const MIN_ENROLL_SECRET_BYTES = 32;
+
+/**
  * `POST …/enroll` body. `s` is base64url of the offer secret, named to match
- * the pairing blob field the joining device forwards verbatim.
+ * the pairing blob field the joining device forwards verbatim. Mint it as
+ * `MIN_ENROLL_SECRET_BYTES` (or more) of CSPRNG output.
  */
 export type EnrollRequest = {
   readonly s: string;
@@ -421,10 +430,16 @@ export type EnrollResponse = { readonly ok: boolean };
 /** `POST …/revoke` body. Any enrolled device may revoke any device, itself included. */
 export type RevokeRequest = { readonly publicKey: string };
 
-/** `POST …/revoke` result. */
+/**
+ * `POST …/revoke` result. `last-device` is a refusal, not a failure: a
+ * tombstone is permanent and a vault with no live device can neither
+ * authenticate nor enroll (an offer needs an enrolled signer), so the
+ * coordinator will not perform the one revoke that strands it. Clients render
+ * that as "disconnect this vault" rather than as a retryable error.
+ */
 export type RevokeResponse =
   | { readonly ok: true; readonly revokedAt: number }
-  | { readonly ok: false; readonly reason: "not-found" };
+  | { readonly ok: false; readonly reason: "not-found" | "last-device" };
 
 // ---- base32 ---------------------------------------------------------------
 

--- a/packages/notes/src/sync/wire.ts
+++ b/packages/notes/src/sync/wire.ts
@@ -1,4 +1,5 @@
 import type { VaultChange } from "./sync-port";
+import { isRecord } from "./guards";
 import { isValidVaultPath, type VaultPath } from "./vault-file";
 
 // ---------------------------------------------------------------------------
@@ -163,4 +164,214 @@ export const SSE_CHANGE_EVENT = "change";
  */
 export function formatChangeFrame(change: VaultChange): string {
   return `event: ${SSE_CHANGE_EVENT}\ndata: ${JSON.stringify(change)}\n\n`;
+}
+
+// ---- device assertions ----------------------------------------------------
+//
+// The bearer credential is a SELF-ISSUED, short-lived device assertion: a
+// device proves it holds an Ed25519 private key rather than presenting a token
+// some server minted for it.
+//
+//   encodedPayload = base64url(JSON DeviceAssertionPayload)     (ASCII)
+//   assertion      = encodedPayload + "." + base64url(signature)
+//   signature      = Ed25519 over `deviceAssertionSignedBytes(encodedPayload)`
+//
+// Only the ENCODING lives here. Signing and verifying are platform-injected —
+// node crypto, @noble/ed25519, WebCrypto — exactly the seam `Hasher` already
+// uses for content hashing, which is what keeps this package crypto-free.
+//
+// The codecs below are hand-rolled for the same reason `URL` is avoided above:
+// the module carries no global beyond the ES2023 stdlib, so it behaves
+// identically on Hermes, workerd and node. There is nothing to polyfill.
+
+/** The only `v` a payload may carry. Bump alongside `DEVICE_ASSERTION_DOMAIN`. */
+export const DEVICE_ASSERTION_VERSION = 1;
+
+/**
+ * Domain-separation prefix over the signed bytes. A device key signs more than
+ * assertions (an enrollment offer, say), and this prefix is what stops one
+ * signature ever being replayable as another.
+ */
+export const DEVICE_ASSERTION_DOMAIN = "inteligir-device-v1:";
+
+/** Raw Ed25519 public key length — a `dev` decoding to anything else isn't one. */
+export const ED25519_PUBLIC_KEY_BYTES = 32;
+
+/** Raw Ed25519 signature length. */
+export const ED25519_SIGNATURE_BYTES = 64;
+
+/** The claims a device asserts about itself. Timestamps are epoch SECONDS. */
+export type DeviceAssertionPayload = {
+  readonly v: typeof DEVICE_ASSERTION_VERSION;
+  /** The vault this assertion is bound to — a verifier matches it to the route. */
+  readonly vid: string;
+  /** base64url of the raw Ed25519 public key whose signature this carries. */
+  readonly dev: string;
+  readonly iat: number;
+  readonly exp: number;
+};
+
+/** A parsed assertion: the claims, plus every byte string a verifier needs. */
+export type DeviceAssertion = {
+  readonly payload: DeviceAssertionPayload;
+  /** Exactly the bytes the signature covers. */
+  readonly signedBytes: Uint8Array;
+  readonly signature: Uint8Array;
+  /** Raw public key bytes — the decoded `payload.dev`, so verifiers need no second decode. */
+  readonly devicePublicKey: Uint8Array;
+};
+
+/**
+ * base64url the payload's JSON, or `null` when the payload isn't well-formed
+ * (the same predicate the parse side applies, so this can never emit a string
+ * `parseDeviceAssertionPayload` would reject).
+ */
+export function encodeDeviceAssertionPayload(payload: DeviceAssertionPayload): string | null {
+  if (parseDeviceAssertionClaims(payload) === null) return null;
+  return base64UrlEncode(asciiBytes(JSON.stringify(payload)));
+}
+
+/** Decode an encoded payload back into claims, or `null` if anything is off. */
+export function parseDeviceAssertionPayload(encoded: string): DeviceAssertionPayload | null {
+  const bytes = base64UrlDecode(encoded);
+  if (bytes === null) return null;
+  const json = asciiText(bytes);
+  if (json === null) return null;
+  let raw: unknown;
+  try {
+    raw = JSON.parse(json);
+  } catch {
+    return null;
+  }
+  return parseDeviceAssertionClaims(raw);
+}
+
+/**
+ * The bytes a signer signs and a verifier verifies. Returned as bytes rather
+ * than a string so no crypto call site has to decide on an encoding.
+ */
+export function deviceAssertionSignedBytes(encodedPayload: string): Uint8Array {
+  return asciiBytes(DEVICE_ASSERTION_DOMAIN + encodedPayload);
+}
+
+/** Join an encoded payload and its raw signature into the bearer string. */
+export function formatDeviceAssertion(encodedPayload: string, signature: Uint8Array): string {
+  return `${encodedPayload}.${base64UrlEncode(signature)}`;
+}
+
+/**
+ * Parse a bearer string into a `DeviceAssertion`, or `null` for anything
+ * malformed. It proves SHAPE only — the signature is unchecked here, and so are
+ * expiry and vault binding, all of which belong to the verifier's policy.
+ */
+export function parseDeviceAssertion(raw: string): DeviceAssertion | null {
+  const dot = raw.indexOf(".");
+  if (dot === -1 || raw.indexOf(".", dot + 1) !== -1) return null;
+  const encodedPayload = raw.slice(0, dot);
+  const payload = parseDeviceAssertionPayload(encodedPayload);
+  if (payload === null) return null;
+  const signature = base64UrlDecode(raw.slice(dot + 1));
+  if (signature === null || signature.length !== ED25519_SIGNATURE_BYTES) return null;
+  const devicePublicKey = base64UrlDecode(payload.dev);
+  if (devicePublicKey === null) return null;
+  return {
+    payload,
+    signedBytes: deviceAssertionSignedBytes(encodedPayload),
+    signature,
+    devicePublicKey,
+  };
+}
+
+// ---- base64url ------------------------------------------------------------
+
+const BASE64URL_ALPHABET = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_";
+
+// Both codecs shift into a 32-bit `acc` that overflows on any input longer than
+// a few bytes. Only its low 13 bits are ever read back — one group plus the
+// carry — so the high bits JS discards were never going to be looked at.
+
+/** Encode bytes as unpadded base64url (RFC 4648 §5). */
+export function base64UrlEncode(bytes: Uint8Array): string {
+  let out = "";
+  let acc = 0;
+  let bits = 0;
+  for (const byte of bytes) {
+    acc = (acc << 8) | byte;
+    bits += 8;
+    while (bits >= 6) {
+      bits -= 6;
+      out += BASE64URL_ALPHABET.charAt((acc >> bits) & 0b111111);
+    }
+  }
+  if (bits > 0) out += BASE64URL_ALPHABET.charAt((acc << (6 - bits)) & 0b111111);
+  return out;
+}
+
+/**
+ * Decode unpadded base64url, or `null` for a foreign character, an impossible
+ * length, or non-zero trailing bits. That last check is what makes the encoding
+ * canonical: one byte string has exactly one spelling, so nobody can mutate an
+ * assertion's text without changing what it decodes to.
+ */
+export function base64UrlDecode(text: string): Uint8Array | null {
+  if (text.length % 4 === 1) return null;
+  const bytes = new Uint8Array((text.length * 3) >> 2);
+  let acc = 0;
+  let bits = 0;
+  let out = 0;
+  for (const char of text) {
+    const value = BASE64URL_ALPHABET.indexOf(char);
+    if (value === -1) return null;
+    acc = (acc << 6) | value;
+    bits += 6;
+    if (bits >= 8) {
+      bits -= 8;
+      bytes[out] = (acc >> bits) & 0xff;
+      out += 1;
+    }
+  }
+  if ((acc & ((1 << bits) - 1)) !== 0) return null;
+  return bytes;
+}
+
+// ---- internals ------------------------------------------------------------
+
+/**
+ * Validate untrusted claims into a `DeviceAssertionPayload`. `vid` is held to a
+ * conservative opaque-id alphabet rather than any particular vault-id shape —
+ * that binding is the verifier's job — but it must be ASCII, because that plus
+ * the numeric and base64url fields is what makes the serialized JSON ASCII.
+ */
+function parseDeviceAssertionClaims(raw: unknown): DeviceAssertionPayload | null {
+  if (!isRecord(raw)) return null;
+  const { v, vid, dev, iat, exp } = raw;
+  if (v !== DEVICE_ASSERTION_VERSION) return null;
+  if (typeof vid !== "string" || !/^[A-Za-z0-9_-]+$/.test(vid)) return null;
+  if (typeof dev !== "string") return null;
+  const publicKey = base64UrlDecode(dev);
+  if (publicKey === null || publicKey.length !== ED25519_PUBLIC_KEY_BYTES) return null;
+  if (!isEpochSeconds(iat) || !isEpochSeconds(exp) || exp <= iat) return null;
+  return { v: DEVICE_ASSERTION_VERSION, vid, dev, iat, exp };
+}
+
+function isEpochSeconds(value: unknown): value is number {
+  return typeof value === "number" && Number.isSafeInteger(value) && value > 0;
+}
+
+/** ASCII text → bytes. Every caller feeds it validated-ASCII text (see
+ * `parseDeviceAssertionClaims`), which is what spares this module a UTF-8 codec. */
+function asciiBytes(text: string): Uint8Array {
+  const bytes = new Uint8Array(text.length);
+  for (let i = 0; i < text.length; i += 1) bytes[i] = text.charCodeAt(i);
+  return bytes;
+}
+
+/** Bytes → ASCII text, or `null` if any byte is outside ASCII. */
+function asciiText(bytes: Uint8Array): string | null {
+  let text = "";
+  for (const byte of bytes) {
+    if (byte > 0x7f) return null;
+    text += String.fromCharCode(byte);
+  }
+  return text;
 }

--- a/packages/sync/src/sync-coordinator.ts
+++ b/packages/sync/src/sync-coordinator.ts
@@ -88,7 +88,7 @@ const defaultEngineFactory: SyncEngineFactory = (opts) =>
     port: createHttpSyncPort({
       baseUrl: opts.coordinatorUrl,
       vaultId: opts.vaultId,
-      token: opts.token,
+      getToken: () => Promise.resolve(opts.token),
       hasher: createNodeHasher(),
     }),
     vault: createVaultSyncIo(vaultAccessor()),


### PR DESCRIPTION
Steps 1–2 of #515. **Additive and reversible** — the account path is untouched, stays the default, and nothing has cut over. Full design in #515's design comment.

## What lands

**A vault's id is the fingerprint of the key that founded it** — `"v1" + base32(sha256(pubkey))`. That replaces *"first authenticated user to touch a vaultId owns it"*: claiming someone else's vault becomes a preimage problem rather than a race.

**Devices self-sign a 5-minute assertion.** The Worker verifies signature + clock statelessly; the Durable Object verifies membership against a roster only it holds. Both parse the raw `Authorization` header, so there is no seam where one trusts the other's verdict — the tempting optimization (Worker stamps `x-device`, DO trusts it) turns a forged header into full vault access.

**Growth is by signature, never by server grant.** An enrolled device deposits `sha256hex(secret)`; the joiner presents the secret over an unauthenticated route, because the secret *is* the credential. Wrong / expired / consumed / over-budget all answer identically.

## Three findings from the adversarial auth pass

- **Blocking: an account could squat an unfounded `v1…` vault.** Authorization only diverted to the device path when the bearer *parsed* as an assertion; anything else fell through to Better Auth. The preimage guarantee held while the door beside it stood open.
- **Unauthenticated callers could spawn unbounded Durable Objects** via the credential-free `/enroll`. Now shape-gated and budgeted at 10/60s per IP, both before `getByName`.
- **Revoking the last device bricked the vault.** Nothing could then authenticate *or* enroll — offers require an enrolled signer — stranding the DO and its R2 prefix. Refused server-side; the client story is "disconnect this vault", which is purely local.

## Two residuals, written down rather than implied away

A second review pass caught **three comments claiming a property the code did not deliver** — that rejecting a credential before `getByName` stops a stranger instantiating DOs. It does not: anyone can self-sign an assertion for a well-shaped id, and the roster that would refuse them lives *inside* the DO. Corrected in both modules and the README, with the residual recorded: the cost is a DO with three empty tables, never vault access.

The other: an assertion binds a vault and a window but not a method or path, so a captured header is replayable within it. The README now names which routes are in that blast radius.

## The seam

`HttpSyncPortOptions.token: string` → `getToken: () => Promise<string>`. A credential that expires cannot be captured once by a port that outlives it. `@repo/notes` gained the assertion's vocabulary and **none of its cryptography** — that stays platform-injected, exactly like `Hasher`. base64url is hand-rolled because React Native 0.86 ships no `btoa`/`atob`.

## Verification

`pnpm verify` exit 0. 64 cloud tests. `e2e-sync.test.ts` keeps `signIn()` and its cross-vault 403 case intact, and gains three device cases driven through the real `SyncEngine`.

## Not in this PR — deliberately

Steps 4–6: the live cutover, deleting the account code, decommissioning D1. Step 4 writes to your live vault and needs a phone in hand; step 6 is irreversible and the design says do it days later. **Nine questions are open on #515** — the two sharpest being whether to keep *Server URL* (the design argues yes, against the original decision) and whether the UI should ever offer a last-device revoke.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds device-key authentication alongside accounts. Vault IDs are now derived from the founding device’s key, and devices authenticate with 5‑minute Ed25519 assertions verified by both the Worker and Durable Object. Implements steps 1–2 of #515; no cutover yet.

- **New Features**
  - Self-certifying vault IDs: `v1` + base32(sha256(pubkey)).
  - Device assertions (5‑minute, Ed25519) parsed and verified in both Worker and DO using shared logic in `apps/cloud/src/device-assertion.ts` and `@repo/notes/sync/wire`.
  - New device routes: `enroll-offer`, `enroll`, `devices`, `revoke` on `/v1/vault/:id/*`.
  - Enrollment by secret: host stores `sha256(secret)`; joiner presents the secret on an unauthenticated route; wrong/expired/consumed/throttled all return identical `{ ok: false }`.
  - Revocation as a tombstone that closes all open change streams; last-device revoke is refused.
  - Fixed-window rate limits for unauthenticated surfaces (`/v1/auth/exchange`, `/v1/vault/:id/enroll`).
  - Pure wire additions in `@repo/notes/sync/wire` (assertion payload/format, vault ID derivation, base32/base64url); crypto stays platform-injected.
  - Extensive tests added for device identity and end-to-end sync.

- **Migration**
  - `HttpSyncPortOptions.token` → `getToken: () => Promise<string>` in `createHttpSyncPort`.
    - Quick fix: pass `() => Promise.resolve(token)` where a static token is used.
  - No behavioral change for account logins; account path remains the default and untouched.

<sup>Written for commit 12bc24aafd7180c59657e1f66ad38ade7612ac72. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kyh/inteligir/pull/529?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

